### PR TITLE
chore: trim comment bloat across docker configs, sidecars and radio.liq

### DIFF
--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -7,26 +7,16 @@
 
 
 // docker-compose.yml
-export const COMPOSE_YML = `# SUB/WAVE — production orchestration.
-# Only Caddy is exposed on the host. Cloudflare terminates TLS in front.
-# Broadcast (icecast2 + liquidsoap), Controller, and Web are all internal-only
-# and reachable via Caddy's reverse proxy under one origin (/api, /stream.mp3, /).
-#
-# Image-first: every service pulls its baked image from GHCR by default. The
-# build: blocks let \`docker compose build\` rebuild locally from a checkout,
-# but the standard install never needs to clone — operators just need this
-# file and a 3-line .env to boot.
-#
-# State persists in <repo>/state by default (override with STATE_DIR). It is a
-# bind mount, so \`docker compose down -v\` (named-volume wipe) won't touch it —
-# but it lives inside the project dir, so keep it clear of \`git clean -dffx\`.
+export const COMPOSE_YML = `# SUB/WAVE — production orchestration. Only Caddy binds a host port; Cloudflare
+# terminates TLS in front. Image-first: services pull baked GHCR images (the
+# build: blocks let a checkout rebuild locally). State persists in <repo>/state
+# (override with STATE_DIR) — a bind mount, so \`down -v\` won't touch it, but
+# keep it clear of \`git clean -dffx\`.
 
 x-state: &state-mount \${STATE_DIR:-./state}:/var/sub-wave
 
-# Cap container log growth. Without this the default json-file driver keeps an
-# unbounded log per container, which on a long-running station eventually fills
-# the host disk. 10m × 3 files = ~30MB ceiling per service. Applied to every
-# service below via \`logging: *default-logging\`.
+# Cap container log growth (10m × 3 ≈ 30MB/service) — the default json-file
+# driver is unbounded and eventually fills the host disk.
 x-logging: &default-logging
   driver: json-file
   options:
@@ -47,8 +37,7 @@ services:
     logging: *default-logging
     depends_on:
       # web has no healthcheck (static Next.js server) — started is enough.
-      # controller + broadcast expose one, so gate the edge on them being
-      # healthy so Caddy doesn't 502 the first requests after a cold \`up -d\`.
+      # Gate the edge on controller + broadcast health to avoid cold-boot 502s.
       web:
         condition: service_started
       controller:
@@ -62,12 +51,10 @@ services:
       - caddy-config:/config
 
   # -------------------------------------------------------------------------
-  # BROADCAST — icecast2 endpoint + liquidsoap mixer in one container
+  # BROADCAST — icecast2 + liquidsoap in one container
   # -------------------------------------------------------------------------
-  # The supervisor entrypoint resolves ICECAST_*_PASSWORD on first boot
-  # (writing them to state/icecast-secrets.env for visibility), then launches
-  # icecast2 and liquidsoap together. If either process dies the container
-  # exits and compose restarts the pair as a unit.
+  # The entrypoint resolves ICECAST_* passwords, renders icecast.xml, and
+  # launches both; if either dies the container exits and restarts the pair.
   broadcast:
     image: ghcr.io/perminder-klair/subwave-broadcast:\${SUBWAVE_VERSION:-latest}
     build:
@@ -77,31 +64,26 @@ services:
     restart: unless-stopped
     logging: *default-logging
     environment:
-      # All three are optional — leave blank in .env and the image generates
-      # random values on first boot, persisting them to state/icecast-secrets.env.
-      # To rotate: delete that file and restart broadcast + controller (the
-      # controller doesn't actually source the file, but a settings reload
-      # picks up any URL change cleanly).
+      # Optional — blank means random values generated on first boot and
+      # persisted to state/icecast-secrets.env (delete that file + restart
+      # broadcast to rotate).
       - ICECAST_SOURCE_PASSWORD=\${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=\${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=\${ICECAST_RELAY_PASSWORD:-}
-      # Concurrent-listener ceiling for icecast (<limits><clients>).
-      # Empty/unset → 100 (the historical default).
+      # Concurrent-listener ceiling (<limits><clients>). Empty → 100.
       - ICECAST_MAX_CLIENTS=\${ICECAST_MAX_CLIENTS:-}
-      # Reverse proxies whose X-Forwarded-For icecast should believe, so admin
-      # → Listeners shows real listener IPs rather than the edge's container
-      # address. Unset resolves the bundled \`caddy\` by name at render time,
-      # which lands on every restart but misses the very first cold boot (caddy
-      # can't be running yet — it waits on this service's healthcheck). Set
-      # ICECAST_TRUSTED_PROXY_IPS to a pinned address for first-boot accuracy.
+      # Proxies whose X-Forwarded-For icecast should believe (real listener IPs
+      # in admin → Listeners). Unset resolves the bundled \`caddy\` by name at
+      # render time — lands on every restart but misses the very first cold
+      # boot (caddy waits on this service's healthcheck). Pin an IP here for
+      # first-boot accuracy.
       - ICECAST_TRUSTED_PROXY_IPS=\${ICECAST_TRUSTED_PROXY_IPS:-}
       - ICECAST_TRUSTED_PROXY_HOSTS=\${ICECAST_TRUSTED_PROXY_HOSTS:-}
       # Keeps the hourly archive paths (%Y-%m-%d/%H-00.mp3) on local wall time.
       - TZ=\${TZ:-Europe/London}
     extra_hosts:
-      # Lets Liquidsoap fetch Subsonic stream URLs that point at host services
-      # (e.g. NAVIDROME_URL=http://host.docker.internal:4533) without leaking
-      # the lookup to public DNS.
+      # Liquidsoap fetching Subsonic URLs that point at host services
+      # (e.g. NAVIDROME_URL=http://host.docker.internal:4533).
       - "host.docker.internal:host-gateway"
     volumes:
       - *state-mount
@@ -122,8 +104,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.controller
       args:
-        # Version reported by the controller (backup manifest). Same source as
-        # the web build arg below; unset → falls back to controller/package.json.
+        # Version reported by the controller; unset → controller/package.json.
         - SUBWAVE_BUILD_VERSION=\${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-controller
     restart: unless-stopped
@@ -131,49 +112,37 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
-      # Bring the socket-proxy up whenever the controller is (re)created — even a
-      # selective \`up -d controller\` — so the Stats system panel works without a
-      # separate full \`up -d\`. Remove this entry too if you drop the proxy below.
+      # So a selective \`up -d controller\` also brings the socket-proxy up.
+      # Remove this entry too if you drop the proxy below.
       docker-socket-proxy:
         condition: service_started
     environment:
-      # Enables the production-only admin gate: refuses to boot unless
-      # ADMIN_USER + ADMIN_PASS are set in .env.
+      # Enables the production-only admin gate (refuses to boot without
+      # ADMIN_USER + ADMIN_PASS).
       - NODE_ENV=production
-      # Schedule slots are stored by day-of-week + hour; resolveActiveShow()
-      # reads them with date.getHours(). Without TZ the container runs in UTC
-      # and fires shows an hour early during BST.
+      # Schedule slots are day-of-week + hour via date.getHours(); without TZ
+      # the container runs UTC and fires shows an hour early during BST.
       - TZ=\${TZ:-Europe/London}
-      # In-container path of the *state-mount below.
       - STATE_DIR=/var/sub-wave
-      # In-container path of the sounds COPY'd into the image at build time.
       - SOUNDS_DIR=/sounds
-      # Optional sidecar for Chatterbox + PocketTTS. The tts-heavy service
-      # below is gated by \`--profile tts-heavy\`; when off, the URL is
-      # unreachable and audio/chatterbox.ts + audio/pocketTts.ts silently
-      # fall back to Piper (same behaviour as the default image today).
+      # Optional Chatterbox/PocketTTS sidecar (--profile tts-heavy). When the
+      # profile is off the URL is unreachable and TTS falls back to Piper.
       - TTS_HEAVY_URL=\${TTS_HEAVY_URL:-http://tts-heavy:8080}
-      # Acoustic-analysis sidecar (the \`analyzer\` service below, default-on).
-      # The controller probes this, then a local venv — falling through cleanly
-      # to NULL analysis if neither is reachable. (tts-heavy is TTS-only; it no
-      # longer carries the analyzer.) See music/analyzer.ts.
+      # Acoustic-analysis sidecar (default-on below). Probed first, then a
+      # local venv; falls through to NULL analysis. See music/analyzer.ts.
       - ANALYZE_URL=\${ANALYZE_URL:-http://analyzer:8080}
-      # Per-container CPU/memory for the admin Stats page (GET /system) is read
-      # from the docker-socket-proxy sidecar over TCP — the controller never
-      # touches the raw Docker socket. Unset this to disable the panel.
+      # Per-container stats for the admin Stats panel, via the socket-proxy —
+      # the controller never touches the raw Docker socket. Unset to disable.
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
     env_file:
-      # All controller config (Navidrome creds, LLM keys, ADMIN_*, etc.) lives
-      # in the root .env. Vars not set are simply absent — settings.json takes
-      # over for everything the first-run wizard manages.
+      # All controller config (Navidrome creds, LLM keys, ADMIN_*, …). Unset
+      # vars are simply absent — settings.json covers what the wizard manages.
       - ./.env
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
       - *state-mount
-    # curl is present in the controller image (see docker/Dockerfile.controller).
-    # /health is served at the router root on :7701 (routes/public.ts). Lets web
-    # + caddy gate on the controller being ready via depends_on: service_healthy.
+    # curl is in the controller image; /health is served at the router root.
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:7701/health > /dev/null"]
       interval: 10s
@@ -184,14 +153,9 @@ services:
   # -------------------------------------------------------------------------
   # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
   # -------------------------------------------------------------------------
-  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
-  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
-  # other section refused by default). The controller reads per-container
-  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
-  # controller image itself never holds the socket. No host port — only
-  # reachable on the internal compose network. Optional: remove this service
-  # (plus the controller's DOCKER_HOST and its docker-socket-proxy depends_on
-  # entry above) to drop the Stats system panel.
+  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only,
+  # CONTAINERS-section-only slice over internal TCP. Optional: remove it (plus
+  # the controller's DOCKER_HOST + depends_on entry) to drop the Stats panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy
@@ -211,192 +175,134 @@ services:
       context: .
       dockerfile: web/Dockerfile
       args:
-        # Belt-and-suspenders for source builds only — every route that emits
-        # absolute URLs renders per-request off the RUNTIME env below.
+        # Source builds only — absolute URLs render off the RUNTIME env below.
         - SITE_URL=\${SITE_URL:-}
         # NEXT_PUBLIC_* is inlined into the client bundle at BUILD time.
         - NEXT_PUBLIC_GA_ID=\${NEXT_PUBLIC_GA_ID:-}
-        # Version shown in the admin console footer, inlined at BUILD time.
-        # scripts/update.sh sets it from \`git describe\`; unset → falls back to
-        # web/package.json (see web/next.config.js).
+        # Admin footer version; unset → web/package.json (web/next.config.js).
         - SUBWAVE_BUILD_VERSION=\${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-web
     restart: unless-stopped
     logging: *default-logging
     depends_on:
-      # Wait for the controller to pass its healthcheck — the homepage renders
-      # per-request against the controller (CONTROLLER_INTERNAL_URL below), so
-      # starting web before the controller is ready serves broken first pages.
+      # The homepage renders per-request against the controller — starting web
+      # before it is healthy serves broken first pages.
       controller:
         condition: service_healthy
     environment:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=\${SUBWAVE_HOMEPAGE:-player}
-      # The RUNTIME source of truth for absolute URLs: canonicals, og:url,
-      # robots.txt, and sitemap.xml all render per-request from this env, so
-      # the generic published image serves the operator's real domain. Define
-      # SITE_URL once in .env.
+      # RUNTIME source of truth for absolute URLs (canonicals, og:url,
+      # robots.txt, sitemap.xml) — the generic image serves any domain.
       - SITE_URL=\${SITE_URL:-}
-      # Google Analytics Measurement ID at RUNTIME (web/lib/ga.ts). Plumbs the
-      # operator's NEXT_PUBLIC_GA_ID from .env into a runtime var, so analytics
-      # turn on with a \`web\` recreate — no image rebuild. The build-arg above
-      # still bakes it for images built with a value.
+      # GA Measurement ID at RUNTIME (web/lib/ga.ts) — analytics turn on with a
+      # \`web\` recreate, no rebuild. The build-arg above still bakes it.
       - GA_ID=\${NEXT_PUBLIC_GA_ID:-}
-      # Server-side base URL for generateMetadata on the force-dynamic homepage
-      # to read the live station name from the controller. Internal compose
-      # network name — not exposed to the browser (which uses /api via Caddy).
+      # Server-side base URL for generateMetadata; internal compose name, not
+      # exposed to the browser (which uses /api via Caddy).
       - CONTROLLER_INTERNAL_URL=http://controller:7701
 
   # -------------------------------------------------------------------------
   # TTS-HEAVY (optional) — sidecar for Chatterbox + PocketTTS
   # -------------------------------------------------------------------------
-  # Heavy PyTorch engines pulled out of the controller image so operators on
-  # the pre-built ghcr.io images can opt into them without a custom rebuild
-  # (issue #103). NOT started by default. Enable with:
-  #
-  #   docker compose --profile tts-heavy up -d
-  #
-  # The controller is wired with TTS_HEAVY_URL pointing here unconditionally;
-  # when the profile is off the URL is unreachable and chatterbox.ts /
-  # pocketTts.ts report unavailable, so the dispatcher falls back to Piper —
-  # same behaviour as the default image today.
-  #
-  # See docker/Dockerfile.tts-heavy + docker/tts-heavy/server.py.
+  # Heavy PyTorch engines kept out of the controller image (#103). NOT started
+  # by default: \`docker compose --profile tts-heavy up -d\`. With the profile
+  # off, TTS_HEAVY_URL is unreachable and the dispatcher falls back to Piper.
   tts-heavy:
     image: ghcr.io/perminder-klair/subwave-tts-heavy:\${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.tts-heavy
       args:
-        # GPU opt-in: point the Chatterbox venv's torch install at a CUDA wheel
-        # index to build a GPU-capable image. Defaults to CPU wheels; override
-        # with e.g. CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124
-        # and layer on docker-compose.tts-heavy-gpu.yml (device reservation +
-        # TTS_HEAVY_DEVICE=cuda). Source build only. See docs/gpu-tts.md.
+        # GPU opt-in (source build only): point at a CUDA wheel index and layer
+        # on docker-compose.tts-heavy-gpu.yml. See docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: \${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
-        # RTX 50-series (Blackwell) only: chatterbox-tts pins torch==2.6.0, which
-        # has no sm_120 kernels. Set a newer spec to override the pin, paired with
-        # a cu128 index above, e.g. CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1".
+        # RTX 50-series only: override chatterbox's torch==2.6.0 pin (no sm_120
+        # kernels), e.g. CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1".
         CHATTERBOX_TORCH_SPEC: \${CHATTERBOX_TORCH_SPEC:-}
-    # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
-    # on arm64 hosts. The other services are multi-arch and auto-select.
+    # amd64-only image; pinned so it runs under emulation on arm64 hosts.
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway model load (a huge
-    # reference WAV, a wedged PyTorch allocation) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast
-    # or the controller down with it. Default is generous — real Chatterbox +
-    # PocketTTS peaks sit well under it. Raise/lower via TTS_HEAVY_MEM_LIMIT in .env.
+    # OOM containment: a runaway model load dies here instead of triggering the
+    # host OOM-killer and taking broadcast/controller down. Default is generous.
     mem_limit: \${TTS_HEAVY_MEM_LIMIT:-10g}
     profiles: ["tts-heavy"]
     environment:
-      # 'cpu' or 'cuda'. The default image is CPU-only — cuda needs a GPU
-      # host + nvidia runtime; the server gracefully falls back to cpu when
-      # CUDA isn't actually available.
+      # 'cpu' or 'cuda'; the server falls back to cpu when CUDA is absent.
       - TTS_HEAVY_DEVICE=\${TTS_HEAVY_DEVICE:-cpu}
-      # Default voice id used by PocketTTS when a persona doesn't override it.
+      # Default PocketTTS voice when a persona doesn't override it.
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
-      # Which heavy engines to actually load. Both are baked into the image;
-      # each costs RAM + a first-boot weight download + startup time, so set
-      # this to a single engine if you only use one. Comma-separated.
-      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      # Which engines to load (comma-separated). Each costs RAM + a first-boot
+      # weight download; set a single engine if you only use one.
       - TTS_HEAVY_ENGINES=\${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
-      # Optional — enables PocketTTS zero-shot voice CLONING (issue #238). The
-      # cloning weights (kyutai/pocket-tts) are gated on Hugging Face; without a
-      # token the engine loads the open weights and cloned .wav voices revert to
-      # a built-in. Accept the model terms on huggingface.co/kyutai/pocket-tts,
-      # then put HF_TOKEN=hf_... in your root .env. Built-in voices need no token.
+      # Optional — PocketTTS voice CLONING (#238): the cloning weights are
+      # gated on HF; accept the terms at huggingface.co/kyutai/pocket-tts and
+      # set HF_TOKEN. Without it, cloned .wav voices revert to a built-in.
       - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
-      # Same shared mount as the controller — the sidecar writes WAVs into
-      # /var/sub-wave/voice/* and the controller hands the path to Liquidsoap.
+      # Shared with the controller — WAVs land in /var/sub-wave/voice/*.
       - *state-mount
-      # Persist the per-engine Hugging Face caches across container recreates.
-      # Weights download at boot (the workers load the model before reporting
-      # ready) — without these volumes that multi-GB fetch repeats on every
-      # \`up -d --build\` / image pull / update. With them it happens once.
+      # Persist HF caches across recreates, or the multi-GB boot-time weight
+      # fetch repeats on every pull/rebuild.
       - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
       - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
 
   # -------------------------------------------------------------------------
-  # ANALYZER — acoustic-analysis sidecar (bpm / key / intro / loudness;
-  # + CLAP "sounds-like" embeddings and Demucs vocal-activity ranges).
+  # ANALYZER — acoustic-analysis sidecar (bpm/key/intro/loudness; optional
+  # CLAP "sounds-like" embeddings + Demucs vocal ranges)
   # -------------------------------------------------------------------------
-  # Starts by default alongside the core services (like controller/web). The
-  # controller resolves its analysis backend from ANALYZE_URL (this service),
-  # then a local venv. Only the heavy *voices* (Chatterbox/PocketTTS) stay
-  # opt-in — under the separate \`tts-heavy\` profile; acoustic analysis is
-  # default-on here. To skip it, \`docker compose stop analyzer\` after boot.
-  #
-  # The default image is LEAN (bpm/key/intro/loudness, multi-arch). The CLAP
-  # "sounds-like" + Demucs vocal dimensions are the heavy opt-in: set
-  # ANALYZER_HEAVY=1 in .env to pull \`subwave-analyzer-heavy\` instead.
+  # Starts by default (only the tts-heavy voices stay opt-in). To skip it,
+  # \`docker compose stop analyzer\` after boot.
   analyzer:
-    # Default: the LEAN, multi-arch image (librosa — bpm/key/intro/loudness).
-    # Set ANALYZER_HEAVY=1 in .env to switch to the CLAP "sounds-like" + Demucs
-    # vocal image (\`subwave-analyzer-heavy\`, amd64-only). No platform pin here so
-    # the lean image runs natively on arm64; if you set ANALYZER_HEAVY=1 on an
-    # arm64 host, also set DOCKER_DEFAULT_PLATFORM=linux/amd64 (runs emulated).
+    # Default: LEAN multi-arch image. ANALYZER_HEAVY=1 in .env switches to the
+    # CLAP + Demucs \`subwave-analyzer-heavy\` image (amd64-only; on arm64 also
+    # set DOCKER_DEFAULT_PLATFORM=linux/amd64 to run emulated).
     image: ghcr.io/perminder-klair/subwave-analyzer\${ANALYZER_HEAVY:+-heavy}:\${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.analyzer
       args:
-        # Local \`docker compose build analyzer\` mirrors the pulled image: lean
-        # unless ANALYZER_HEAVY is set, then it builds the CLAP + Demucs stack.
+        # Local build mirrors the pulled image: lean unless ANALYZER_HEAVY set.
         WITH_CLAP: \${ANALYZER_HEAVY:+1}
         WITH_DEMUCS: \${ANALYZER_HEAVY:+1}
     container_name: sub-wave-analyzer
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway analysis (a long track,
-    # a CLAP/Demucs allocation spike on the heavy image) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast or
-    # the controller down with it. Default is generous — librosa passes sit well
-    # under it, and even CLAP + Demucs on the heavy image fit. Raise/lower via
-    # ANALYZER_MEM_LIMIT in .env.
+    # OOM containment: a runaway analysis dies here instead of triggering the
+    # host OOM-killer and taking broadcast/controller down. Default is generous.
     mem_limit: \${ANALYZER_MEM_LIMIT:-6g}
     environment:
-      # Force CLAP embeddings / Demucs vocal ranges on for the whole analyze
-      # pass. Usually unnecessary — the admin toggles drive these per request.
+      # Force CLAP / Demucs on for the whole pass. Usually unnecessary — the
+      # admin toggles drive these per request.
       - ANALYZE_AUDIO_EMBEDDING=\${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=\${ANALYZE_VOCAL_ACTIVITY:-}
       # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
-      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
-      # cpu-wheel images always resolve to cpu.
+      # meaningful on the cuda flavour; cpu-wheel images resolve to cpu.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
-      # Seconds of no CLAP/Demucs use before the worker drops the models
-      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
-      # 1800 on cpu — one backfill or sound search loads them into the
-      # long-lived worker and nothing else ever releases them, so on a small
-      # host they end up parked in swap (#1204).
+      # Idle seconds before the worker drops CLAP/Demucs models (0 = never).
+      # Default 300 on cuda (frees VRAM), 1800 on cpu — otherwise one backfill
+      # parks ~GBs in swap on a small host (#1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
-      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
-      # whole worker process — the full-memory reclaim behind the model release
-      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
-      # return (default 3600; 0 = never). Requests racing a recycle queue
-      # behind the respawn rather than failing.
+      # Idle seconds before the sidecar recycles the whole worker process —
+      # reclaims the ~1GB of scratch a model release can't return (default
+      # 3600; 0 = never). Requests racing a recycle queue behind the respawn.
       - ANALYZE_RECYCLE_IDLE_S=\${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
-      # Demucs model + analysis-window overrides (worker reads both; see
-      # .env.example "Optional model overrides").
+      # Demucs model + analysis-window overrides (see .env.example).
       - DEMUCS_MODEL=\${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=\${ANALYZE_SECONDS:-}
       - ANALYZE_CLAP_WINDOWS=\${ANALYZE_CLAP_WINDOWS:-}
       - ANALYZE_OUTRO_SECONDS=\${ANALYZE_OUTRO_SECONDS:-}
-      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
-      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
-      # and both sidecars pick it up.
+      # CLAP isn't gated, but anonymous HF downloads are rate-limited. Same var
+      # as tts-heavy — set once and both sidecars pick it up.
       - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
-      # Shared mount with the controller — reads tracks the controller
-      # pre-fetched into /var/sub-wave/analyze-tmp.
+      # Shared mount — reads tracks pre-fetched into /var/sub-wave/analyze-tmp.
       - *state-mount
-      # Persist the CLAP/Demucs HF cache across recreates (weights download
-      # lazily on the first analyze pass that needs them).
+      # Persist the CLAP/Demucs HF cache across recreates.
       - analyzer-cache:/opt/analyzer/hf-cache
 
 volumes:
@@ -408,53 +314,35 @@ volumes:
 `;
 
 // docker-compose.byo.yml
-export const COMPOSE_BYO_YML = `# SUB/WAVE — production orchestration without a bundled reverse proxy.
-# Use this variant if you already run Traefik, nginx, an existing Caddy, or any
-# other reverse proxy in front of your homelab. The three user-facing services
-# bind directly to host ports and your proxy fronts them.
+export const COMPOSE_BYO_YML = `# SUB/WAVE — production without the bundled reverse proxy. Use this when you
+# already run Traefik/nginx/Caddy: web, controller, and broadcast bind host
+# ports (\${WEB_PORT:-7700} / \${CONTROLLER_PORT:-7701} / \${ICECAST_PORT:-7702})
+# and your proxy fronts them. Liquidsoap stays internal to the broadcast
+# container.
 #
-# Default host ports (override via root .env or your shell):
-#   \${WEB_PORT:-7700}        → Next.js listener UI
-#   \${CONTROLLER_PORT:-7701} → controller HTTP API
-#   \${ICECAST_PORT:-7702}    → Icecast MP3 broadcast endpoint
+# Ports bind 0.0.0.0 by default; if your proxy runs on THIS host, set
+# BIND_ADDRESS=127.0.0.1 in .env so the services are only reachable on loopback.
 #
-# Bind address: these three ports bind 0.0.0.0 (all interfaces) by default. If
-# your reverse proxy runs on THIS host, set BIND_ADDRESS=127.0.0.1 in .env so the
-# services (including the controller's admin API) are reachable only from the
-# proxy on loopback, not directly from the network. Leave it unset for a proxy
-# on a different host.
-#
-# Liquidsoap stays internal-only — it lives inside the broadcast container
-# alongside icecast and has no public surface.
-#
-# The web UI assumes same-origin routing for /api and /stream.mp3 by default
-# (it's baked into the image at build time). To keep that working, point your
-# proxy at a single hostname and replicate the route table from docker/Caddyfile:
-#   /api/listener-auth → 404 / deny         (see below — do this one first)
+# The web image is baked for same-origin /api + /stream.mp3, so point your proxy
+# at ONE hostname and replicate docker/Caddyfile's route table:
+#   /api/listener-auth → 404 / deny         (do this one FIRST — see below)
 #   /stream.mp3  → host:\${ICECAST_PORT}      (disable buffering for live audio)
 #   /api/*       → host:\${CONTROLLER_PORT}   (strip the /api prefix)
 #   everything   → host:\${WEB_PORT}
+# Split hostnames need a web rebuild with NEXT_PUBLIC_API_URL /
+# NEXT_PUBLIC_STREAM_URL (baked at build time).
 #
-# Block /api/listener-auth at your proxy. It is Icecast's URL-auth callback and
-# answers 200/401 on the shared privacy.password, so exposing it hands the
-# internet a password oracle for the same secret that guards the private player
-# (#478). Icecast reaches the controller directly over the compose network, so
-# it never needs to come through your proxy. The controller slows repeated
-# failures as a backstop, but not routing the path is the real fix.
+# Block /api/listener-auth at your proxy: it is Icecast's URL-auth callback and
+# answers 200/401 on the shared privacy.password, so routing it hands the
+# internet a password oracle (#478). Icecast reaches the controller directly
+# over the compose network and never needs it through the proxy.
 #
-# If you need separate hostnames per surface, you'll have to rebuild the web
-# image with NEXT_PUBLIC_API_URL / NEXT_PUBLIC_STREAM_URL set — those are
-# baked at build time, not runtime.
-#
-# State persists in <repo>/state by default (override with STATE_DIR). It is a
-# bind mount, so \`docker compose down -v\` won't touch it.
+# State persists in <repo>/state (override with STATE_DIR); bind mount, so
+# \`docker compose down -v\` won't touch it.
 
 x-state: &state-mount \${STATE_DIR:-./state}:/var/sub-wave
 
-# Cap container log growth. Without this the default json-file driver keeps an
-# unbounded log per container, which on a long-running station eventually fills
-# the host disk. 10m × 3 files = ~30MB ceiling per service. Applied to every
-# service below via \`logging: *default-logging\`.
+# Cap container log growth (10m × 3 ≈ 30MB/service).
 x-logging: &default-logging
   driver: json-file
   options:
@@ -465,8 +353,6 @@ services:
   # -------------------------------------------------------------------------
   # BROADCAST — icecast2 + liquidsoap in one container
   # -------------------------------------------------------------------------
-  # The icecast HTTP port is bound to the host so the operator's reverse
-  # proxy can front /stream.mp3. Liquidsoap is internal to this container.
   broadcast:
     image: ghcr.io/perminder-klair/subwave-broadcast:\${SUBWAVE_VERSION:-latest}
     build:
@@ -479,19 +365,15 @@ services:
       - ICECAST_SOURCE_PASSWORD=\${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=\${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=\${ICECAST_RELAY_PASSWORD:-}
-      # Concurrent-listener ceiling for icecast (<limits><clients>).
-      # Empty/unset → 100 (the historical default).
+      # Concurrent-listener ceiling (<limits><clients>). Empty → 100.
       - ICECAST_MAX_CLIENTS=\${ICECAST_MAX_CLIENTS:-}
-      # There is no bundled edge in this shape, so nothing resolves by default
-      # and listener rows show whatever peer reaches icecast — the operator's
-      # own proxy. Set this to that proxy's address (as icecast sees it) to get
-      # real listener IPs in admin → Listeners. See docs/deployment.md.
+      # No bundled edge here, so nothing resolves by default and listener rows
+      # show your proxy's address. Set this to that proxy's IP (as icecast sees
+      # it) for real listener IPs in admin → Listeners. See docs/deployment.md.
       - ICECAST_TRUSTED_PROXY_IPS=\${ICECAST_TRUSTED_PROXY_IPS:-}
       - ICECAST_TRUSTED_PROXY_HOSTS=\${ICECAST_TRUSTED_PROXY_HOSTS:-}
       - TZ=\${TZ:-Europe/London}
     ports:
-      # BIND_ADDRESS defaults to 0.0.0.0; set 127.0.0.1 in .env for a same-host
-      # proxy (see header comment).
       - "\${BIND_ADDRESS:-0.0.0.0}:\${ICECAST_PORT:-7702}:7702"
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -514,8 +396,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.controller
       args:
-        # Version reported by the controller (backup manifest). Same source as
-        # the web build arg below; unset → falls back to controller/package.json.
+        # Version reported by the controller; unset → controller/package.json.
         - SUBWAVE_BUILD_VERSION=\${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-controller
     restart: unless-stopped
@@ -523,9 +404,8 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
-      # Bring the socket-proxy up whenever the controller is (re)created — even a
-      # selective \`up -d controller\` — so the Stats system panel works without a
-      # separate full \`up -d\`. Remove this entry too if you drop the proxy below.
+      # So a selective \`up -d controller\` also brings the socket-proxy up.
+      # Remove this entry too if you drop the proxy below.
       docker-socket-proxy:
         condition: service_started
     environment:
@@ -533,30 +413,24 @@ services:
       - TZ=\${TZ:-Europe/London}
       - STATE_DIR=/var/sub-wave
       - SOUNDS_DIR=/sounds
-      # Optional sidecar for Chatterbox + PocketTTS. Gated by --profile tts-heavy
-      # below; unreachable URL → fall back to Piper (no harm done).
+      # Optional Chatterbox/PocketTTS sidecar (--profile tts-heavy);
+      # unreachable URL → fall back to Piper.
       - TTS_HEAVY_URL=\${TTS_HEAVY_URL:-http://tts-heavy:8080}
-      # Acoustic-analysis sidecar (the \`analyzer\` service below, default-on).
-      # Probed, then a local venv; falls through cleanly to NULL analysis if
-      # neither is reachable. (tts-heavy is TTS-only; no analyzer there.)
+      # Acoustic-analysis sidecar (default-on below). Probed, then local venv.
       - ANALYZE_URL=\${ANALYZE_URL:-http://analyzer:8080}
-      # Per-container CPU/memory for the admin Stats page (GET /system) is read
-      # from the docker-socket-proxy sidecar over TCP — the controller never
-      # touches the raw Docker socket. Unset this to disable the panel.
+      # Admin Stats panel via the socket-proxy — the controller never touches
+      # the raw Docker socket. Unset to disable.
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
     env_file:
       - ./.env
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
-      # Set BIND_ADDRESS=127.0.0.1 in .env to keep the admin API off the network
-      # when the proxy is same-host (see header comment).
+      # BIND_ADDRESS=127.0.0.1 keeps the admin API off the network when the
+      # proxy is same-host (see header).
       - "\${BIND_ADDRESS:-0.0.0.0}:\${CONTROLLER_PORT:-7701}:7701"
     volumes:
       - *state-mount
-    # curl is present in the controller image (see docker/Dockerfile.controller).
-    # /health is served at the router root on :7701 (routes/public.ts). Lets web
-    # gate on the controller being ready via depends_on: service_healthy.
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:7701/health > /dev/null"]
       interval: 10s
@@ -567,14 +441,9 @@ services:
   # -------------------------------------------------------------------------
   # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
   # -------------------------------------------------------------------------
-  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
-  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
-  # other section refused by default). The controller reads per-container
-  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
-  # controller image itself never holds the socket. No host port — only
-  # reachable on the internal compose network. Optional: remove this service
-  # (plus the controller's DOCKER_HOST and its docker-socket-proxy depends_on
-  # entry above) to drop the Stats system panel.
+  # Read-only, GET-only, CONTAINERS-section-only slice of the Docker API over
+  # internal TCP. Optional: remove it (plus the controller's DOCKER_HOST +
+  # depends_on entry) to drop the Stats panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy
@@ -596,158 +465,112 @@ services:
       args:
         - SITE_URL=\${SITE_URL:-}
         - NEXT_PUBLIC_GA_ID=\${NEXT_PUBLIC_GA_ID:-}
-        # Version shown in the admin console footer, inlined at BUILD time.
-        # scripts/update.sh sets it from \`git describe\`; unset → falls back to
-        # web/package.json (see web/next.config.js).
+        # Admin footer version; unset → web/package.json (web/next.config.js).
         - SUBWAVE_BUILD_VERSION=\${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-web
     restart: unless-stopped
     logging: *default-logging
     depends_on:
-      # Wait for the controller to pass its healthcheck — the homepage renders
-      # per-request against the controller (CONTROLLER_INTERNAL_URL below), so
-      # starting web before the controller is ready serves broken first pages.
+      # The homepage renders per-request against the controller — starting web
+      # before it is healthy serves broken first pages.
       controller:
         condition: service_healthy
     environment:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=\${SUBWAVE_HOMEPAGE:-player}
       - SITE_URL=\${SITE_URL:-}
-      # Google Analytics Measurement ID at RUNTIME (web/lib/ga.ts). Plumbs the
-      # operator's NEXT_PUBLIC_GA_ID from .env into a runtime var, so analytics
-      # turn on with a \`web\` recreate — no image rebuild. The build-arg still
-      # bakes it for images built with a value.
+      # GA Measurement ID at RUNTIME (web/lib/ga.ts) — analytics turn on with a
+      # \`web\` recreate, no rebuild.
       - GA_ID=\${NEXT_PUBLIC_GA_ID:-}
-      # Server-side base URL for generateMetadata on the force-dynamic homepage
-      # to read the live station name from the controller. Internal compose
-      # network name — not exposed to the browser (which uses /api via Caddy).
+      # Server-side base URL for generateMetadata; internal compose name.
       - CONTROLLER_INTERNAL_URL=http://controller:7701
     ports:
-      # BIND_ADDRESS defaults to 0.0.0.0; 127.0.0.1 for a same-host proxy.
       - "\${BIND_ADDRESS:-0.0.0.0}:\${WEB_PORT:-7700}:7700"
-    # Same-origin (/api, /stream.mp3) is the default baked into the image.
-    # Your external proxy is responsible for routing those paths to controller
-    # and broadcast — see the header comment for the route table.
 
   # -------------------------------------------------------------------------
   # TTS-HEAVY (optional) — sidecar for Chatterbox + PocketTTS
   # -------------------------------------------------------------------------
-  # See docker-compose.yml for the full rationale (issue #103). NOT started
-  # by default. Enable with \`docker compose -f docker-compose.byo.yml \\
-  #   --profile tts-heavy up -d\`. The controller falls back to Piper when
-  # the URL is unreachable.
+  # NOT started by default (#103):
+  #   docker compose -f docker-compose.byo.yml --profile tts-heavy up -d
+  # With the profile off, the controller falls back to Piper.
   tts-heavy:
     image: ghcr.io/perminder-klair/subwave-tts-heavy:\${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.tts-heavy
       args:
-        # GPU opt-in for Chatterbox — point torch at a CUDA wheel index (e.g.
-        # CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124) and
-        # layer on docker-compose.tts-heavy-gpu.yml. Defaults to CPU wheels.
-        # Source build only. See docs/gpu-tts.md.
+        # GPU opt-in (source build only) — see docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: \${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
-        # RTX 50-series (Blackwell) only: override chatterbox-tts's torch==2.6.0
-        # pin (no sm_120 kernels) with a newer spec + a cu128 index above, e.g.
-        # CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1". See docs/gpu-tts.md.
+        # RTX 50-series only: override chatterbox's torch==2.6.0 pin.
         CHATTERBOX_TORCH_SPEC: \${CHATTERBOX_TORCH_SPEC:-}
-    # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
-    # on arm64 hosts. The other services are multi-arch and auto-select.
+    # amd64-only image; pinned so it runs under emulation on arm64 hosts.
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway model load (a huge
-    # reference WAV, a wedged PyTorch allocation) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast
-    # or the controller down with it. Default is generous — real Chatterbox +
-    # PocketTTS peaks sit well under it. Raise/lower via TTS_HEAVY_MEM_LIMIT in .env.
+    # OOM containment: a runaway model load dies here, not via the host
+    # OOM-killer taking broadcast/controller with it.
     mem_limit: \${TTS_HEAVY_MEM_LIMIT:-10g}
     profiles: ["tts-heavy"]
     environment:
       - TTS_HEAVY_DEVICE=\${TTS_HEAVY_DEVICE:-cpu}
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
-      # Which heavy engines to actually load. Both are baked into the image;
-      # each costs RAM + a first-boot weight download + startup time, so set
-      # this to a single engine if you only use one. Comma-separated.
-      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      # Which engines to load (comma-separated); each costs RAM + weights.
       - TTS_HEAVY_ENGINES=\${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
-      # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
-      # are gated on Hugging Face; accept the terms at
-      # huggingface.co/kyutai/pocket-tts and set HF_TOKEN in your root .env.
-      # Built-in voices need no token.
+      # Optional — PocketTTS voice cloning (#238): accept the terms at
+      # huggingface.co/kyutai/pocket-tts and set HF_TOKEN.
       - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
       - *state-mount
-      # Persist the per-engine Hugging Face caches across container recreates.
-      # Weights download at boot (the workers load the model before reporting
-      # ready) — without these volumes that multi-GB fetch repeats on every
-      # \`up -d --build\` / image pull / update. With them it happens once.
+      # Persist HF caches across recreates, or the multi-GB weight fetch
+      # repeats every time.
       - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
       - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
 
   # -------------------------------------------------------------------------
-  # ANALYZER — acoustic-analysis sidecar (bpm / key / intro / loudness;
-  # + CLAP "sounds-like" embeddings and Demucs vocal-activity ranges).
+  # ANALYZER — acoustic-analysis sidecar (bpm/key/intro/loudness; optional
+  # CLAP "sounds-like" embeddings + Demucs vocal ranges)
   # -------------------------------------------------------------------------
-  # Starts by default alongside the core services. The controller probes
-  # ANALYZE_URL (this service), then a local venv. Only the heavy *voices*
-  # (Chatterbox/PocketTTS) stay opt-in under the \`tts-heavy\` profile; acoustic
-  # analysis is default-on. To skip it, \`docker compose stop analyzer\`.
+  # Starts by default; only the tts-heavy voices stay opt-in. To skip it,
+  # \`docker compose stop analyzer\`.
   analyzer:
-    # Default: the LEAN, multi-arch image. ANALYZER_HEAVY=1 in .env switches to
-    # the CLAP + Demucs \`subwave-analyzer-heavy\` image (amd64-only; on arm64 also
-    # set DOCKER_DEFAULT_PLATFORM=linux/amd64).
+    # Default: LEAN multi-arch. ANALYZER_HEAVY=1 in .env → CLAP + Demucs heavy
+    # image (amd64-only; on arm64 also set DOCKER_DEFAULT_PLATFORM=linux/amd64).
     image: ghcr.io/perminder-klair/subwave-analyzer\${ANALYZER_HEAVY:+-heavy}:\${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.analyzer
       args:
-        # Local build mirrors the pulled image: lean unless ANALYZER_HEAVY is set.
+        # Local build mirrors the pulled image: lean unless ANALYZER_HEAVY set.
         WITH_CLAP: \${ANALYZER_HEAVY:+1}
         WITH_DEMUCS: \${ANALYZER_HEAVY:+1}
     container_name: sub-wave-analyzer
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway analysis (a long track,
-    # a CLAP/Demucs allocation spike on the heavy image) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast or
-    # the controller down with it. Default is generous — librosa passes sit well
-    # under it, and even CLAP + Demucs on the heavy image fit. Raise/lower via
-    # ANALYZER_MEM_LIMIT in .env.
+    # OOM containment: a runaway analysis dies here, not via the host
+    # OOM-killer taking broadcast/controller with it.
     mem_limit: \${ANALYZER_MEM_LIMIT:-6g}
     environment:
-      # Force CLAP / Demucs on for the whole pass. Usually unnecessary — the
-      # admin toggles drive these per request.
+      # Force CLAP / Demucs on for the whole pass; usually the admin toggles
+      # drive these per request.
       - ANALYZE_AUDIO_EMBEDDING=\${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=\${ANALYZE_VOCAL_ACTIVITY:-}
-      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
-      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
-      # cpu-wheel images always resolve to cpu.
+      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
-      # Seconds of no CLAP/Demucs use before the worker drops the models
-      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
-      # 1800 on cpu — one backfill or sound search loads them into the
-      # long-lived worker and nothing else ever releases them, so on a small
-      # host they end up parked in swap (#1204).
+      # Idle seconds before the worker drops CLAP/Demucs models (0 = never;
+      # default 300 cuda / 1800 cpu — see #1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
-      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
-      # whole worker process — the full-memory reclaim behind the model release
-      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
-      # return (default 3600; 0 = never). Requests racing a recycle queue
-      # behind the respawn rather than failing.
+      # Idle seconds before the sidecar recycles the whole worker process
+      # (default 3600; 0 = never).
       - ANALYZE_RECYCLE_IDLE_S=\${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
-      # Demucs model + analysis-window overrides (worker reads both; see
-      # .env.example "Optional model overrides").
+      # Demucs model + analysis-window overrides (see .env.example).
       - DEMUCS_MODEL=\${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=\${ANALYZE_SECONDS:-}
       - ANALYZE_CLAP_WINDOWS=\${ANALYZE_CLAP_WINDOWS:-}
       - ANALYZE_OUTRO_SECONDS=\${ANALYZE_OUTRO_SECONDS:-}
-      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
-      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
-      # and both sidecars pick it up.
+      # Anonymous HF downloads are rate-limited; same var as tts-heavy.
       - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
       - *state-mount
@@ -760,17 +583,13 @@ volumes:
 `;
 
 // docker-compose.dev.yml
-export const COMPOSE_DEV_YML = `# SUB/WAVE — dev compose (local smoke test).
-# Runs: Broadcast (icecast2 + liquidsoap) + Controller. The Next.js listener
-# UI runs separately via \`cd web && npm run dev\` so JSX changes hot-reload.
-#
-# State + sounds + radio.liq are bind-mounted from the repo so dev cycles
-# don't need image rebuilds. The prod composes bake them into images instead.
+export const COMPOSE_DEV_YML = `# SUB/WAVE — dev compose (local smoke test): Broadcast + Controller only.
+# The Next.js UI runs separately via \`cd web && npm run dev\` for hot reload.
+# State + sounds + radio.liq are bind-mounted so dev cycles need no rebuilds.
 
 x-state: &state-mount \${STATE_DIR:-./state}:/var/sub-wave
 
-# Cap container log growth so a long dev session can't fill the host disk.
-# 10m × 3 files = ~30MB ceiling per service. Applied via \`logging: *default-logging\`.
+# Cap container log growth (10m × 3 ≈ 30MB/service).
 x-logging: &default-logging
   driver: json-file
   options:
@@ -781,48 +600,40 @@ services:
   # -------------------------------------------------------------------------
   # BROADCAST — icecast2 + liquidsoap in one container
   # -------------------------------------------------------------------------
-  # Icecast HTTP exposed on :7702 for direct dev access (curl the stream,
-  # hit /status-json.xsl, etc.). Liquidsoap is internal to this container.
+  # Icecast exposed on :7702 for direct dev access; liquidsoap stays internal.
   broadcast:
     image: ghcr.io/perminder-klair/subwave-broadcast:\${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.broadcast
-    # No \`platform:\` pin in dev. On Apple Silicon, forcing linux/amd64 routes
-    # liquidsoap through Rosetta/QEMU emulation where its clock_nanosleep
-    # syscall fails with \`Unix.Unix_error(EUNKNOWNERR 0, "", "")\` — the
-    # clock loop dies on every boot and Icecast ends up with no source.
-    # The savonet/liquidsoap:v2.2.5 base is multi-arch, so building natively
-    # (arm64 on M-series Macs, amd64 on Linux dev hosts) just works. The prod
-    # composes don't pin broadcast/controller platform either — the GHCR images
-    # are multi-arch and auto-select per host.
+    # No \`platform:\` pin. On Apple Silicon, forcing linux/amd64 routes
+    # liquidsoap through emulation where clock_nanosleep fails
+    # (\`Unix.Unix_error(EUNKNOWNERR 0)\`) — the clock loop dies on every boot
+    # and Icecast gets no source. The base is multi-arch; build natively.
     container_name: sub-wave-broadcast
     restart: unless-stopped
     logging: *default-logging
     ports:
       - "7702:7702"
     environment:
-      # All three are optional — leave blank in .env and the image generates
-      # random values on first boot, writing them to state/icecast-secrets.env.
+      # Optional — blank means random values generated on first boot and
+      # persisted to state/icecast-secrets.env.
       - ICECAST_SOURCE_PASSWORD=\${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=\${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=\${ICECAST_RELAY_PASSWORD:-}
-      # Concurrent-listener ceiling for icecast (<limits><clients>).
-      # Empty/unset → 100 (the historical default).
+      # Concurrent-listener ceiling (<limits><clients>). Empty → 100.
       - ICECAST_MAX_CLIENTS=\${ICECAST_MAX_CLIENTS:-}
-      # Dev has no edge in front of icecast (the browser hits it directly), so
-      # this stays empty and listener rows already show the real peer.
+      # Dev has no edge in front of icecast, so these stay empty and listener
+      # rows already show the real peer.
       - ICECAST_TRUSTED_PROXY_IPS=\${ICECAST_TRUSTED_PROXY_IPS:-}
       - ICECAST_TRUSTED_PROXY_HOSTS=\${ICECAST_TRUSTED_PROXY_HOSTS:-}
       - TZ=\${TZ:-Europe/London}
     extra_hosts:
-      # Lets Liquidsoap fetch Subsonic stream URLs that point at host services
-      # (e.g. NAVIDROME_URL=http://host.docker.internal:4533) without leaking
-      # the lookup to public DNS.
+      # Liquidsoap fetching Subsonic URLs that point at host services.
       - "host.docker.internal:host-gateway"
     volumes:
-      # Bind-mounts override the baked-in copies so dev edits to radio.liq and
-      # new sounds appear on the next restart without an image rebuild.
+      # Bind-mounts override the baked-in copies — radio.liq edits and new
+      # sounds land on the next restart, no rebuild.
       - ./liquidsoap/radio.liq:/etc/liquidsoap/radio.liq:ro
       - ./sounds:/sounds:ro
       - *state-mount
@@ -843,9 +654,8 @@ services:
       context: .
       dockerfile: docker/Dockerfile.controller
       args:
-        # Version reported by the controller (backup manifest); unset → falls
-        # back to controller/package.json. The dev web UI runs \`npm run dev\`
-        # outside Docker, where next.config.js resolves it via \`git describe\`.
+        # Version reported by the controller; unset → controller/package.json.
+        # The dev web UI resolves its own via \`git describe\` (next.config.js).
         - SUBWAVE_BUILD_VERSION=\${SUBWAVE_BUILD_VERSION:-}
     platform: linux/amd64
     container_name: sub-wave-controller
@@ -854,53 +664,41 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
-      # Bring the socket-proxy up whenever the controller is (re)created — even a
-      # selective \`up -d controller\` — so the Stats system panel works without a
-      # separate full \`up -d\`. Remove this entry too if you drop the proxy below.
+      # So a selective \`up -d controller\` also brings the socket-proxy up.
+      # Remove this entry too if you drop the proxy below.
       docker-socket-proxy:
         condition: service_started
     environment:
       - TZ=\${TZ:-Europe/London}
       - STATE_DIR=/var/sub-wave
       - SOUNDS_DIR=/sounds
-      # Optional sidecar for Chatterbox + PocketTTS. Gated by --profile tts-heavy
-      # below; unreachable URL → fall back to Piper. Dev usage:
-      #   docker compose -f docker-compose.dev.yml --profile tts-heavy up -d
+      # Optional Chatterbox/PocketTTS sidecar (--profile tts-heavy);
+      # unreachable URL → fall back to Piper.
       - TTS_HEAVY_URL=\${TTS_HEAVY_URL:-http://tts-heavy:8080}
-      # Acoustic-analysis sidecar (the \`analyzer\` service below, default-on).
-      # Probed, then a local venv. (tts-heavy is TTS-only — no analyzer there.)
+      # Acoustic-analysis sidecar (default-on below). Probed, then local venv.
       - ANALYZE_URL=\${ANALYZE_URL:-http://analyzer:8080}
-      # Per-container CPU/memory for the admin Stats page (GET /system) is read
-      # from the docker-socket-proxy sidecar over TCP — the controller never
-      # touches the raw Docker socket. Unset this to disable the panel.
+      # Admin Stats panel via the socket-proxy — the controller never touches
+      # the raw Docker socket. Unset to disable.
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
     ports:
       - "7701:7701"
     env_file:
-      # All controller config (Navidrome creds, LLM keys, ADMIN_*, etc.) lives
-      # in the root .env. Vars not set are simply absent — settings.json takes
-      # over for everything the wizard manages.
+      # All controller config (Navidrome creds, LLM keys, ADMIN_*, …). Unset
+      # vars are simply absent — settings.json covers what the wizard manages.
       - ./.env
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    # Dev mode runs the controller under \`tsx watch\` against bind-mounted
-    # source, so edits to controller/src/** restart the process inside the
-    # container without a \`docker compose build\`. node_modules stays baked
-    # into the image — we override src/ and scripts/ only. Prod composes
-    # use the image's default CMD (\`tsx src/server.ts\`, no watch).
+    # Dev runs \`tsx watch\` against bind-mounted source so controller/src/**
+    # edits restart in-place. Prod uses the image's default CMD (no watch).
     command: ["node_modules/.bin/tsx", "watch", "src/server.ts"]
     volumes:
-      # State + sounds are bind-mounted in dev so changes don't need rebuilds.
       - *state-mount
       - ./sounds:/sounds:ro
-      # Source bind-mounts for hot reload. \`tsx watch\` picks up changes via
-      # inotify. Don't mount the whole controller/ dir — that would shadow
-      # /app/node_modules with the (possibly empty) host node_modules.
+      # Mount src/ and scripts/ only — mounting the whole controller/ dir
+      # would shadow /app/node_modules with the (possibly empty) host one.
       - ./controller/src:/app/src
       - ./controller/scripts:/app/scripts
-    # curl is present in the controller image (see docker/Dockerfile.controller).
-    # /health is served at the router root on :7701 (routes/public.ts). start_period
-    # is generous here: dev runs under \`tsx watch\`, which is slower to first boot.
+    # start_period is generous: \`tsx watch\` is slower to first boot.
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:7701/health > /dev/null"]
       interval: 10s
@@ -911,13 +709,9 @@ services:
   # -------------------------------------------------------------------------
   # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
   # -------------------------------------------------------------------------
-  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
-  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
-  # other section refused by default). The controller reads per-container
-  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
-  # controller never holds the socket. No host port. Optional: remove this
-  # service (plus the controller's DOCKER_HOST and its docker-socket-proxy
-  # depends_on entry above) to drop the Stats panel.
+  # Read-only, GET-only, CONTAINERS-section-only slice of the Docker API over
+  # internal TCP. Optional: remove it (plus the controller's DOCKER_HOST +
+  # depends_on entry) to drop the Stats panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy
@@ -931,115 +725,81 @@ services:
   # -------------------------------------------------------------------------
   # TTS-HEAVY (optional) — sidecar for Chatterbox + PocketTTS
   # -------------------------------------------------------------------------
-  # NOT started by default. Enable with:
+  # NOT started by default:
   #   docker compose -f docker-compose.dev.yml --profile tts-heavy up -d
-  # See docker/Dockerfile.tts-heavy + docker/tts-heavy/server.py. First build
-  # downloads ~3-4GB of model weights from Hugging Face — be patient.
+  # First boot downloads ~3-4GB of model weights.
   tts-heavy:
     image: ghcr.io/perminder-klair/subwave-tts-heavy:\${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.tts-heavy
       args:
-        # GPU opt-in for Chatterbox — point torch at a CUDA wheel index (e.g.
-        # CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124) and
-        # layer on docker-compose.tts-heavy-gpu.yml. Defaults to CPU wheels.
-        # Source build only. See docs/gpu-tts.md.
+        # GPU opt-in (source build only) — see docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: \${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
-        # RTX 50-series (Blackwell) only: override chatterbox-tts's torch==2.6.0
-        # pin (no sm_120 kernels) with a newer spec + a cu128 index above, e.g.
-        # CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1". See docs/gpu-tts.md.
+        # RTX 50-series only: override chatterbox's torch==2.6.0 pin.
         CHATTERBOX_TORCH_SPEC: \${CHATTERBOX_TORCH_SPEC:-}
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway model load (a huge
-    # reference WAV, a wedged PyTorch allocation) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast
-    # or the controller down with it. Default is generous — real Chatterbox +
-    # PocketTTS peaks sit well under it. Raise/lower via TTS_HEAVY_MEM_LIMIT in .env.
+    # OOM containment: a runaway model load dies here, not via the host
+    # OOM-killer taking broadcast/controller with it.
     mem_limit: \${TTS_HEAVY_MEM_LIMIT:-10g}
     profiles: ["tts-heavy"]
     environment:
       - TTS_HEAVY_DEVICE=\${TTS_HEAVY_DEVICE:-cpu}
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
-      # Which heavy engines to actually load. Both are baked into the image;
-      # each costs RAM + a first-boot weight download + startup time, so set
-      # this to a single engine if you only use one. Comma-separated.
-      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      # Which engines to load (comma-separated); each costs RAM + weights.
       - TTS_HEAVY_ENGINES=\${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
-      # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
-      # are gated; accept terms at huggingface.co/kyutai/pocket-tts and set
-      # HF_TOKEN in your .env. Built-in voices need no token.
+      # Optional — PocketTTS voice cloning (#238); weights gated on HF.
       - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
       - *state-mount
-      # Persist the per-engine Hugging Face caches across container recreates.
-      # Weights download at boot (the workers load the model before reporting
-      # ready) — without these volumes that multi-GB fetch repeats on every
-      # recreate. With them it happens once.
+      # Persist HF caches across recreates, or the multi-GB weight fetch
+      # repeats every time.
       - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
       - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
 
   # -------------------------------------------------------------------------
-  # ANALYZER — acoustic-analysis sidecar (bpm / key / intro / loudness;
-  # + CLAP "sounds-like" embeddings and Demucs vocal-activity ranges).
+  # ANALYZER — acoustic-analysis sidecar (bpm/key/intro/loudness; optional
+  # CLAP "sounds-like" embeddings + Demucs vocal ranges)
   # -------------------------------------------------------------------------
-  # Starts by default alongside the core services. The controller probes
-  # ANALYZE_URL (this service), then a local venv. Only the heavy voices
-  # (Chatterbox/PocketTTS) stay opt-in under \`tts-heavy\`; analysis is default-on.
-  # (tts-heavy is TTS-only — no analyzer there.)
+  # Starts by default; only the tts-heavy voices stay opt-in.
   analyzer:
-    # Default: LEAN, multi-arch. ANALYZER_HEAVY=1 → CLAP + Demucs heavy image.
+    # Default: LEAN multi-arch. ANALYZER_HEAVY=1 → CLAP + Demucs heavy image.
     image: ghcr.io/perminder-klair/subwave-analyzer\${ANALYZER_HEAVY:+-heavy}:\${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.analyzer
       args:
-        # Local build mirrors the pulled image: lean unless ANALYZER_HEAVY is set.
+        # Local build mirrors the pulled image: lean unless ANALYZER_HEAVY set.
         WITH_CLAP: \${ANALYZER_HEAVY:+1}
         WITH_DEMUCS: \${ANALYZER_HEAVY:+1}
     container_name: sub-wave-analyzer
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway analysis (a long track,
-    # a CLAP/Demucs allocation spike on the heavy image) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast or
-    # the controller down with it. Default is generous — librosa passes sit well
-    # under it, and even CLAP + Demucs on the heavy image fit. Raise/lower via
-    # ANALYZER_MEM_LIMIT in .env.
+    # OOM containment: a runaway analysis dies here, not via the host
+    # OOM-killer taking broadcast/controller with it.
     mem_limit: \${ANALYZER_MEM_LIMIT:-6g}
     environment:
       - ANALYZE_AUDIO_EMBEDDING=\${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=\${ANALYZE_VOCAL_ACTIVITY:-}
-      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
-      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
-      # cpu-wheel images always resolve to cpu.
+      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda.
       - ANALYZE_DEVICE=\${ANALYZE_DEVICE:-}
-      # Seconds of no CLAP/Demucs use before the worker drops the models
-      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
-      # 1800 on cpu — one backfill or sound search loads them into the
-      # long-lived worker and nothing else ever releases them, so on a small
-      # host they end up parked in swap (#1204).
+      # Idle seconds before the worker drops CLAP/Demucs models (0 = never;
+      # default 300 cuda / 1800 cpu — see #1204).
       - ANALYZE_IDLE_UNLOAD_S=\${ANALYZE_IDLE_UNLOAD_S:-}
-      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
-      # whole worker process — the full-memory reclaim behind the model release
-      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
-      # return (default 3600; 0 = never). Requests racing a recycle queue
-      # behind the respawn rather than failing.
+      # Idle seconds before the sidecar recycles the whole worker process
+      # (default 3600; 0 = never).
       - ANALYZE_RECYCLE_IDLE_S=\${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=\${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=\${CLAP_MODEL_PATH:-}
-      # Demucs model + analysis-window overrides (worker reads both; see
-      # .env.example "Optional model overrides").
+      # Demucs model + analysis-window overrides (see .env.example).
       - DEMUCS_MODEL=\${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=\${ANALYZE_SECONDS:-}
       - ANALYZE_CLAP_WINDOWS=\${ANALYZE_CLAP_WINDOWS:-}
       - ANALYZE_OUTRO_SECONDS=\${ANALYZE_OUTRO_SECONDS:-}
-      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
-      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
-      # and both sidecars pick it up.
+      # Anonymous HF downloads are rate-limited; same var as tts-heavy.
       - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
       - *state-mount
@@ -1052,46 +812,36 @@ volumes:
 `;
 
 // docker-compose.tts-heavy-gpu.yml
-export const COMPOSE_TTS_HEAVY_GPU_YML = `# GPU opt-in overlay for the tts-heavy sidecar — runs Chatterbox on CUDA.
-#
-# The default tts-heavy image is CPU-only on purpose: a GPU device reservation
-# can't live in the base compose because \`docker compose up\` errors on a host
-# without the NVIDIA runtime, which would break every CPU install. This overlay
-# adds the reservation, switches the engine to cuda, and forces a local build
-# (the published image ships CPU-only torch).
-#
-# Layer it on top of your prod compose file, with the CUDA wheel index set:
+export const COMPOSE_TTS_HEAVY_GPU_YML = `# GPU opt-in overlay for the tts-heavy sidecar — Chatterbox on CUDA.
+# A device reservation can't live in the base compose (\`up\` errors on hosts
+# without the NVIDIA runtime). This overlay adds it, switches the engine to
+# cuda, and forces a local build (the published image ships CPU-only torch).
 #
 #   echo 'CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124' >> .env
 #   docker compose -f docker-compose.yml -f docker-compose.tts-heavy-gpu.yml \\
 #     --profile tts-heavy up -d --build
+#   (BYO hosts: swap in docker-compose.byo.yml.)
 #
-# (BYO reverse-proxy hosts: swap docker-compose.yml for docker-compose.byo.yml.)
-#
-# RTX 50-series (Blackwell / sm_120): chatterbox-tts pins torch==2.6.0, which has
-# no sm_120 kernels, so the default cu124 build loads but 500s at synthesis. Use
-# a cu128 index AND override the pin:
+# RTX 50-series (Blackwell / sm_120): chatterbox-tts pins torch==2.6.0, which
+# has no sm_120 kernels — the cu124 build loads but 500s at synthesis. Use a
+# cu128 index AND override the pin:
 #
 #   echo 'CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128' >> .env
 #   echo 'CHATTERBOX_TORCH_SPEC=torch==2.9.1 torchaudio==2.9.1' >> .env
 #
-# Requirements: an NVIDIA GPU with the driver + NVIDIA Container Toolkit
-# installed. Pick the cuXXX wheel tag that matches your driver — see
-# https://pytorch.org/get-started/locally/. Full guide: docs/gpu-tts.md.
+# Requirements: NVIDIA driver + Container Toolkit; pick the cuXXX wheel tag
+# matching your driver (https://pytorch.org/get-started/locally/). Full guide:
+# docs/gpu-tts.md.
 services:
   tts-heavy:
     # Build the CUDA image locally instead of pulling the published CPU one.
     pull_policy: build
     environment:
-      # Load the Chatterbox model onto the GPU. The worker falls back to cpu if
-      # CUDA isn't actually visible, so a misconfigured host degrades, not fails.
+      # The worker falls back to cpu if CUDA isn't actually visible.
       - TTS_HEAVY_DEVICE=cuda
-    # Hand the GPU into the container (needs the NVIDIA Container Toolkit).
-    #
-    # The deploy.resources reservation below is the modern (CDI) path. On hosts
-    # where the NVIDIA runtime is registered in LEGACY mode, that reservation
-    # fails with "could not select device driver nvidia"; there, delete the
-    # \`deploy:\` block and instead use the legacy runtime:
+    # The deploy.resources reservation is the modern (CDI) path. On hosts where
+    # the NVIDIA runtime is registered in LEGACY mode it fails with "could not
+    # select device driver nvidia"; there, delete the \`deploy:\` block and use:
     #
     #   runtime: nvidia
     #   environment:
@@ -1108,50 +858,37 @@ services:
 `;
 
 // docker-compose.analyzer-gpu.yml
-export const COMPOSE_ANALYZER_GPU_YML = `# GPU opt-in overlay for the analyzer — runs CLAP + Demucs on CUDA (#1099).
-#
-# The default analyzer flavours are CPU-only on purpose: a GPU device
-# reservation can't live in the base compose because \`docker compose up\` errors
-# on a host without the NVIDIA runtime, which would break every CPU install.
-# This overlay swaps the \`analyzer\` service to the published
-# \`subwave-analyzer-cuda\` image (the heavy CLAP + Demucs stack on cu124 torch
-# wheels) and reserves the GPU. ANALYZER_HEAVY in .env is irrelevant while this
-# overlay is applied — the image is overridden outright.
-#
-# Layer it on top of your prod compose file:
+export const COMPOSE_ANALYZER_GPU_YML = `# GPU opt-in overlay for the analyzer — CLAP + Demucs on CUDA (#1099).
+# A device reservation can't live in the base compose (\`up\` errors on hosts
+# without the NVIDIA runtime), so this overlay swaps in the published
+# \`subwave-analyzer-cuda\` image and reserves the GPU. ANALYZER_HEAVY is
+# irrelevant while applied — the image is overridden outright.
 #
 #   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+#   (BYO hosts: swap in docker-compose.byo.yml.)
 #
-# (BYO reverse-proxy hosts: swap docker-compose.yml for docker-compose.byo.yml.)
+# Requirements: NVIDIA driver + Container Toolkit only (cu124 wheels vendor the
+# CUDA runtime). The worker picks the device itself (ANALYZE_DEVICE=auto: cuda
+# when torch sees a GPU, else cpu with a warning — a misconfigured host
+# degrades, not fails). ANALYZE_DEVICE=cpu in .env forces CPU without dropping
+# the overlay.
 #
-# Requirements: an NVIDIA GPU with the driver + NVIDIA Container Toolkit
-# installed — nothing else; the cu124 wheels vendor the CUDA runtime. The
-# worker picks the device itself (ANALYZE_DEVICE defaults to auto: cuda when
-# torch sees a GPU, else cpu with a logged warning — a misconfigured host
-# degrades, not fails). To force CPU temporarily without dropping the overlay,
-# set ANALYZE_DEVICE=cpu in your root .env (the base compose passes it through).
-#
-# VRAM etiquette: after ~5 idle minutes with no CLAP/Demucs use the worker
-# drops its models out of VRAM so a co-resident TTS/LLM gets the card back
-# between passes (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models
-# resident). A few hundred MB of CUDA context remain until the container stops.
-# The same release runs on CPU with a longer default window (#1204).
+# After ~5 idle minutes the worker drops its models out of VRAM so a
+# co-resident TTS/LLM gets the card back (ANALYZE_IDLE_UNLOAD_S tunes it;
+# 0 keeps them resident). A few hundred MB of CUDA context remain until the
+# container stops.
 services:
   analyzer:
     image: ghcr.io/perminder-klair/subwave-analyzer-cuda:\${SUBWAVE_VERSION:-latest}
-    # Local \`docker compose build analyzer\` with this overlay applied mirrors
-    # the published cuda image.
+    # Local build with this overlay applied mirrors the published cuda image.
     build:
       args:
         WITH_CLAP: 1
         WITH_DEMUCS: 1
         WITH_CUDA: 1
-    # Hand the GPU into the container (needs the NVIDIA Container Toolkit).
-    #
-    # The deploy.resources reservation below is the modern (CDI) path. On hosts
-    # where the NVIDIA runtime is registered in LEGACY mode, that reservation
-    # fails with "could not select device driver nvidia"; there, delete the
-    # \`deploy:\` block and instead use the legacy runtime:
+    # The deploy.resources reservation is the modern (CDI) path. On hosts where
+    # the NVIDIA runtime is registered in LEGACY mode it fails with "could not
+    # select device driver nvidia"; there, delete the \`deploy:\` block and use:
     #
     #   runtime: nvidia
     #   environment:

--- a/docker-compose.analyzer-gpu.yml
+++ b/docker-compose.analyzer-gpu.yml
@@ -1,47 +1,34 @@
-# GPU opt-in overlay for the analyzer — runs CLAP + Demucs on CUDA (#1099).
-#
-# The default analyzer flavours are CPU-only on purpose: a GPU device
-# reservation can't live in the base compose because `docker compose up` errors
-# on a host without the NVIDIA runtime, which would break every CPU install.
-# This overlay swaps the `analyzer` service to the published
-# `subwave-analyzer-cuda` image (the heavy CLAP + Demucs stack on cu124 torch
-# wheels) and reserves the GPU. ANALYZER_HEAVY in .env is irrelevant while this
-# overlay is applied — the image is overridden outright.
-#
-# Layer it on top of your prod compose file:
+# GPU opt-in overlay for the analyzer — CLAP + Demucs on CUDA (#1099).
+# A device reservation can't live in the base compose (`up` errors on hosts
+# without the NVIDIA runtime), so this overlay swaps in the published
+# `subwave-analyzer-cuda` image and reserves the GPU. ANALYZER_HEAVY is
+# irrelevant while applied — the image is overridden outright.
 #
 #   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
+#   (BYO hosts: swap in docker-compose.byo.yml.)
 #
-# (BYO reverse-proxy hosts: swap docker-compose.yml for docker-compose.byo.yml.)
+# Requirements: NVIDIA driver + Container Toolkit only (cu124 wheels vendor the
+# CUDA runtime). The worker picks the device itself (ANALYZE_DEVICE=auto: cuda
+# when torch sees a GPU, else cpu with a warning — a misconfigured host
+# degrades, not fails). ANALYZE_DEVICE=cpu in .env forces CPU without dropping
+# the overlay.
 #
-# Requirements: an NVIDIA GPU with the driver + NVIDIA Container Toolkit
-# installed — nothing else; the cu124 wheels vendor the CUDA runtime. The
-# worker picks the device itself (ANALYZE_DEVICE defaults to auto: cuda when
-# torch sees a GPU, else cpu with a logged warning — a misconfigured host
-# degrades, not fails). To force CPU temporarily without dropping the overlay,
-# set ANALYZE_DEVICE=cpu in your root .env (the base compose passes it through).
-#
-# VRAM etiquette: after ~5 idle minutes with no CLAP/Demucs use the worker
-# drops its models out of VRAM so a co-resident TTS/LLM gets the card back
-# between passes (ANALYZE_IDLE_UNLOAD_S in .env tunes it; 0 keeps models
-# resident). A few hundred MB of CUDA context remain until the container stops.
-# The same release runs on CPU with a longer default window (#1204).
+# After ~5 idle minutes the worker drops its models out of VRAM so a
+# co-resident TTS/LLM gets the card back (ANALYZE_IDLE_UNLOAD_S tunes it;
+# 0 keeps them resident). A few hundred MB of CUDA context remain until the
+# container stops.
 services:
   analyzer:
     image: ghcr.io/perminder-klair/subwave-analyzer-cuda:${SUBWAVE_VERSION:-latest}
-    # Local `docker compose build analyzer` with this overlay applied mirrors
-    # the published cuda image.
+    # Local build with this overlay applied mirrors the published cuda image.
     build:
       args:
         WITH_CLAP: 1
         WITH_DEMUCS: 1
         WITH_CUDA: 1
-    # Hand the GPU into the container (needs the NVIDIA Container Toolkit).
-    #
-    # The deploy.resources reservation below is the modern (CDI) path. On hosts
-    # where the NVIDIA runtime is registered in LEGACY mode, that reservation
-    # fails with "could not select device driver nvidia"; there, delete the
-    # `deploy:` block and instead use the legacy runtime:
+    # The deploy.resources reservation is the modern (CDI) path. On hosts where
+    # the NVIDIA runtime is registered in LEGACY mode it fails with "could not
+    # select device driver nvidia"; there, delete the `deploy:` block and use:
     #
     #   runtime: nvidia
     #   environment:

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -1,50 +1,32 @@
-# SUB/WAVE — production orchestration without a bundled reverse proxy.
-# Use this variant if you already run Traefik, nginx, an existing Caddy, or any
-# other reverse proxy in front of your homelab. The three user-facing services
-# bind directly to host ports and your proxy fronts them.
+# SUB/WAVE — production without the bundled reverse proxy. Use this when you
+# already run Traefik/nginx/Caddy: web, controller, and broadcast bind host
+# ports (${WEB_PORT:-7700} / ${CONTROLLER_PORT:-7701} / ${ICECAST_PORT:-7702})
+# and your proxy fronts them. Liquidsoap stays internal to the broadcast
+# container.
 #
-# Default host ports (override via root .env or your shell):
-#   ${WEB_PORT:-7700}        → Next.js listener UI
-#   ${CONTROLLER_PORT:-7701} → controller HTTP API
-#   ${ICECAST_PORT:-7702}    → Icecast MP3 broadcast endpoint
+# Ports bind 0.0.0.0 by default; if your proxy runs on THIS host, set
+# BIND_ADDRESS=127.0.0.1 in .env so the services are only reachable on loopback.
 #
-# Bind address: these three ports bind 0.0.0.0 (all interfaces) by default. If
-# your reverse proxy runs on THIS host, set BIND_ADDRESS=127.0.0.1 in .env so the
-# services (including the controller's admin API) are reachable only from the
-# proxy on loopback, not directly from the network. Leave it unset for a proxy
-# on a different host.
-#
-# Liquidsoap stays internal-only — it lives inside the broadcast container
-# alongside icecast and has no public surface.
-#
-# The web UI assumes same-origin routing for /api and /stream.mp3 by default
-# (it's baked into the image at build time). To keep that working, point your
-# proxy at a single hostname and replicate the route table from docker/Caddyfile:
-#   /api/listener-auth → 404 / deny         (see below — do this one first)
+# The web image is baked for same-origin /api + /stream.mp3, so point your proxy
+# at ONE hostname and replicate docker/Caddyfile's route table:
+#   /api/listener-auth → 404 / deny         (do this one FIRST — see below)
 #   /stream.mp3  → host:${ICECAST_PORT}      (disable buffering for live audio)
 #   /api/*       → host:${CONTROLLER_PORT}   (strip the /api prefix)
 #   everything   → host:${WEB_PORT}
+# Split hostnames need a web rebuild with NEXT_PUBLIC_API_URL /
+# NEXT_PUBLIC_STREAM_URL (baked at build time).
 #
-# Block /api/listener-auth at your proxy. It is Icecast's URL-auth callback and
-# answers 200/401 on the shared privacy.password, so exposing it hands the
-# internet a password oracle for the same secret that guards the private player
-# (#478). Icecast reaches the controller directly over the compose network, so
-# it never needs to come through your proxy. The controller slows repeated
-# failures as a backstop, but not routing the path is the real fix.
+# Block /api/listener-auth at your proxy: it is Icecast's URL-auth callback and
+# answers 200/401 on the shared privacy.password, so routing it hands the
+# internet a password oracle (#478). Icecast reaches the controller directly
+# over the compose network and never needs it through the proxy.
 #
-# If you need separate hostnames per surface, you'll have to rebuild the web
-# image with NEXT_PUBLIC_API_URL / NEXT_PUBLIC_STREAM_URL set — those are
-# baked at build time, not runtime.
-#
-# State persists in <repo>/state by default (override with STATE_DIR). It is a
-# bind mount, so `docker compose down -v` won't touch it.
+# State persists in <repo>/state (override with STATE_DIR); bind mount, so
+# `docker compose down -v` won't touch it.
 
 x-state: &state-mount ${STATE_DIR:-./state}:/var/sub-wave
 
-# Cap container log growth. Without this the default json-file driver keeps an
-# unbounded log per container, which on a long-running station eventually fills
-# the host disk. 10m × 3 files = ~30MB ceiling per service. Applied to every
-# service below via `logging: *default-logging`.
+# Cap container log growth (10m × 3 ≈ 30MB/service).
 x-logging: &default-logging
   driver: json-file
   options:
@@ -55,8 +37,6 @@ services:
   # -------------------------------------------------------------------------
   # BROADCAST — icecast2 + liquidsoap in one container
   # -------------------------------------------------------------------------
-  # The icecast HTTP port is bound to the host so the operator's reverse
-  # proxy can front /stream.mp3. Liquidsoap is internal to this container.
   broadcast:
     image: ghcr.io/perminder-klair/subwave-broadcast:${SUBWAVE_VERSION:-latest}
     build:
@@ -69,19 +49,15 @@ services:
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=${ICECAST_RELAY_PASSWORD:-}
-      # Concurrent-listener ceiling for icecast (<limits><clients>).
-      # Empty/unset → 100 (the historical default).
+      # Concurrent-listener ceiling (<limits><clients>). Empty → 100.
       - ICECAST_MAX_CLIENTS=${ICECAST_MAX_CLIENTS:-}
-      # There is no bundled edge in this shape, so nothing resolves by default
-      # and listener rows show whatever peer reaches icecast — the operator's
-      # own proxy. Set this to that proxy's address (as icecast sees it) to get
-      # real listener IPs in admin → Listeners. See docs/deployment.md.
+      # No bundled edge here, so nothing resolves by default and listener rows
+      # show your proxy's address. Set this to that proxy's IP (as icecast sees
+      # it) for real listener IPs in admin → Listeners. See docs/deployment.md.
       - ICECAST_TRUSTED_PROXY_IPS=${ICECAST_TRUSTED_PROXY_IPS:-}
       - ICECAST_TRUSTED_PROXY_HOSTS=${ICECAST_TRUSTED_PROXY_HOSTS:-}
       - TZ=${TZ:-Europe/London}
     ports:
-      # BIND_ADDRESS defaults to 0.0.0.0; set 127.0.0.1 in .env for a same-host
-      # proxy (see header comment).
       - "${BIND_ADDRESS:-0.0.0.0}:${ICECAST_PORT:-7702}:7702"
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -104,8 +80,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.controller
       args:
-        # Version reported by the controller (backup manifest). Same source as
-        # the web build arg below; unset → falls back to controller/package.json.
+        # Version reported by the controller; unset → controller/package.json.
         - SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-controller
     restart: unless-stopped
@@ -113,9 +88,8 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
-      # Bring the socket-proxy up whenever the controller is (re)created — even a
-      # selective `up -d controller` — so the Stats system panel works without a
-      # separate full `up -d`. Remove this entry too if you drop the proxy below.
+      # So a selective `up -d controller` also brings the socket-proxy up.
+      # Remove this entry too if you drop the proxy below.
       docker-socket-proxy:
         condition: service_started
     environment:
@@ -123,30 +97,24 @@ services:
       - TZ=${TZ:-Europe/London}
       - STATE_DIR=/var/sub-wave
       - SOUNDS_DIR=/sounds
-      # Optional sidecar for Chatterbox + PocketTTS. Gated by --profile tts-heavy
-      # below; unreachable URL → fall back to Piper (no harm done).
+      # Optional Chatterbox/PocketTTS sidecar (--profile tts-heavy);
+      # unreachable URL → fall back to Piper.
       - TTS_HEAVY_URL=${TTS_HEAVY_URL:-http://tts-heavy:8080}
-      # Acoustic-analysis sidecar (the `analyzer` service below, default-on).
-      # Probed, then a local venv; falls through cleanly to NULL analysis if
-      # neither is reachable. (tts-heavy is TTS-only; no analyzer there.)
+      # Acoustic-analysis sidecar (default-on below). Probed, then local venv.
       - ANALYZE_URL=${ANALYZE_URL:-http://analyzer:8080}
-      # Per-container CPU/memory for the admin Stats page (GET /system) is read
-      # from the docker-socket-proxy sidecar over TCP — the controller never
-      # touches the raw Docker socket. Unset this to disable the panel.
+      # Admin Stats panel via the socket-proxy — the controller never touches
+      # the raw Docker socket. Unset to disable.
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
     env_file:
       - ./.env
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
-      # Set BIND_ADDRESS=127.0.0.1 in .env to keep the admin API off the network
-      # when the proxy is same-host (see header comment).
+      # BIND_ADDRESS=127.0.0.1 keeps the admin API off the network when the
+      # proxy is same-host (see header).
       - "${BIND_ADDRESS:-0.0.0.0}:${CONTROLLER_PORT:-7701}:7701"
     volumes:
       - *state-mount
-    # curl is present in the controller image (see docker/Dockerfile.controller).
-    # /health is served at the router root on :7701 (routes/public.ts). Lets web
-    # gate on the controller being ready via depends_on: service_healthy.
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:7701/health > /dev/null"]
       interval: 10s
@@ -157,14 +125,9 @@ services:
   # -------------------------------------------------------------------------
   # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
   # -------------------------------------------------------------------------
-  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
-  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
-  # other section refused by default). The controller reads per-container
-  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
-  # controller image itself never holds the socket. No host port — only
-  # reachable on the internal compose network. Optional: remove this service
-  # (plus the controller's DOCKER_HOST and its docker-socket-proxy depends_on
-  # entry above) to drop the Stats system panel.
+  # Read-only, GET-only, CONTAINERS-section-only slice of the Docker API over
+  # internal TCP. Optional: remove it (plus the controller's DOCKER_HOST +
+  # depends_on entry) to drop the Stats panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy
@@ -186,158 +149,112 @@ services:
       args:
         - SITE_URL=${SITE_URL:-}
         - NEXT_PUBLIC_GA_ID=${NEXT_PUBLIC_GA_ID:-}
-        # Version shown in the admin console footer, inlined at BUILD time.
-        # scripts/update.sh sets it from `git describe`; unset → falls back to
-        # web/package.json (see web/next.config.js).
+        # Admin footer version; unset → web/package.json (web/next.config.js).
         - SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-web
     restart: unless-stopped
     logging: *default-logging
     depends_on:
-      # Wait for the controller to pass its healthcheck — the homepage renders
-      # per-request against the controller (CONTROLLER_INTERNAL_URL below), so
-      # starting web before the controller is ready serves broken first pages.
+      # The homepage renders per-request against the controller — starting web
+      # before it is healthy serves broken first pages.
       controller:
         condition: service_healthy
     environment:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=${SUBWAVE_HOMEPAGE:-player}
       - SITE_URL=${SITE_URL:-}
-      # Google Analytics Measurement ID at RUNTIME (web/lib/ga.ts). Plumbs the
-      # operator's NEXT_PUBLIC_GA_ID from .env into a runtime var, so analytics
-      # turn on with a `web` recreate — no image rebuild. The build-arg still
-      # bakes it for images built with a value.
+      # GA Measurement ID at RUNTIME (web/lib/ga.ts) — analytics turn on with a
+      # `web` recreate, no rebuild.
       - GA_ID=${NEXT_PUBLIC_GA_ID:-}
-      # Server-side base URL for generateMetadata on the force-dynamic homepage
-      # to read the live station name from the controller. Internal compose
-      # network name — not exposed to the browser (which uses /api via Caddy).
+      # Server-side base URL for generateMetadata; internal compose name.
       - CONTROLLER_INTERNAL_URL=http://controller:7701
     ports:
-      # BIND_ADDRESS defaults to 0.0.0.0; 127.0.0.1 for a same-host proxy.
       - "${BIND_ADDRESS:-0.0.0.0}:${WEB_PORT:-7700}:7700"
-    # Same-origin (/api, /stream.mp3) is the default baked into the image.
-    # Your external proxy is responsible for routing those paths to controller
-    # and broadcast — see the header comment for the route table.
 
   # -------------------------------------------------------------------------
   # TTS-HEAVY (optional) — sidecar for Chatterbox + PocketTTS
   # -------------------------------------------------------------------------
-  # See docker-compose.yml for the full rationale (issue #103). NOT started
-  # by default. Enable with `docker compose -f docker-compose.byo.yml \
-  #   --profile tts-heavy up -d`. The controller falls back to Piper when
-  # the URL is unreachable.
+  # NOT started by default (#103):
+  #   docker compose -f docker-compose.byo.yml --profile tts-heavy up -d
+  # With the profile off, the controller falls back to Piper.
   tts-heavy:
     image: ghcr.io/perminder-klair/subwave-tts-heavy:${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.tts-heavy
       args:
-        # GPU opt-in for Chatterbox — point torch at a CUDA wheel index (e.g.
-        # CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124) and
-        # layer on docker-compose.tts-heavy-gpu.yml. Defaults to CPU wheels.
-        # Source build only. See docs/gpu-tts.md.
+        # GPU opt-in (source build only) — see docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: ${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
-        # RTX 50-series (Blackwell) only: override chatterbox-tts's torch==2.6.0
-        # pin (no sm_120 kernels) with a newer spec + a cu128 index above, e.g.
-        # CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1". See docs/gpu-tts.md.
+        # RTX 50-series only: override chatterbox's torch==2.6.0 pin.
         CHATTERBOX_TORCH_SPEC: ${CHATTERBOX_TORCH_SPEC:-}
-    # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
-    # on arm64 hosts. The other services are multi-arch and auto-select.
+    # amd64-only image; pinned so it runs under emulation on arm64 hosts.
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway model load (a huge
-    # reference WAV, a wedged PyTorch allocation) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast
-    # or the controller down with it. Default is generous — real Chatterbox +
-    # PocketTTS peaks sit well under it. Raise/lower via TTS_HEAVY_MEM_LIMIT in .env.
+    # OOM containment: a runaway model load dies here, not via the host
+    # OOM-killer taking broadcast/controller with it.
     mem_limit: ${TTS_HEAVY_MEM_LIMIT:-10g}
     profiles: ["tts-heavy"]
     environment:
       - TTS_HEAVY_DEVICE=${TTS_HEAVY_DEVICE:-cpu}
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
-      # Which heavy engines to actually load. Both are baked into the image;
-      # each costs RAM + a first-boot weight download + startup time, so set
-      # this to a single engine if you only use one. Comma-separated.
-      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      # Which engines to load (comma-separated); each costs RAM + weights.
       - TTS_HEAVY_ENGINES=${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
-      # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
-      # are gated on Hugging Face; accept the terms at
-      # huggingface.co/kyutai/pocket-tts and set HF_TOKEN in your root .env.
-      # Built-in voices need no token.
+      # Optional — PocketTTS voice cloning (#238): accept the terms at
+      # huggingface.co/kyutai/pocket-tts and set HF_TOKEN.
       - HF_TOKEN=${HF_TOKEN:-}
     volumes:
       - *state-mount
-      # Persist the per-engine Hugging Face caches across container recreates.
-      # Weights download at boot (the workers load the model before reporting
-      # ready) — without these volumes that multi-GB fetch repeats on every
-      # `up -d --build` / image pull / update. With them it happens once.
+      # Persist HF caches across recreates, or the multi-GB weight fetch
+      # repeats every time.
       - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
       - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
 
   # -------------------------------------------------------------------------
-  # ANALYZER — acoustic-analysis sidecar (bpm / key / intro / loudness;
-  # + CLAP "sounds-like" embeddings and Demucs vocal-activity ranges).
+  # ANALYZER — acoustic-analysis sidecar (bpm/key/intro/loudness; optional
+  # CLAP "sounds-like" embeddings + Demucs vocal ranges)
   # -------------------------------------------------------------------------
-  # Starts by default alongside the core services. The controller probes
-  # ANALYZE_URL (this service), then a local venv. Only the heavy *voices*
-  # (Chatterbox/PocketTTS) stay opt-in under the `tts-heavy` profile; acoustic
-  # analysis is default-on. To skip it, `docker compose stop analyzer`.
+  # Starts by default; only the tts-heavy voices stay opt-in. To skip it,
+  # `docker compose stop analyzer`.
   analyzer:
-    # Default: the LEAN, multi-arch image. ANALYZER_HEAVY=1 in .env switches to
-    # the CLAP + Demucs `subwave-analyzer-heavy` image (amd64-only; on arm64 also
-    # set DOCKER_DEFAULT_PLATFORM=linux/amd64).
+    # Default: LEAN multi-arch. ANALYZER_HEAVY=1 in .env → CLAP + Demucs heavy
+    # image (amd64-only; on arm64 also set DOCKER_DEFAULT_PLATFORM=linux/amd64).
     image: ghcr.io/perminder-klair/subwave-analyzer${ANALYZER_HEAVY:+-heavy}:${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.analyzer
       args:
-        # Local build mirrors the pulled image: lean unless ANALYZER_HEAVY is set.
+        # Local build mirrors the pulled image: lean unless ANALYZER_HEAVY set.
         WITH_CLAP: ${ANALYZER_HEAVY:+1}
         WITH_DEMUCS: ${ANALYZER_HEAVY:+1}
     container_name: sub-wave-analyzer
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway analysis (a long track,
-    # a CLAP/Demucs allocation spike on the heavy image) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast or
-    # the controller down with it. Default is generous — librosa passes sit well
-    # under it, and even CLAP + Demucs on the heavy image fit. Raise/lower via
-    # ANALYZER_MEM_LIMIT in .env.
+    # OOM containment: a runaway analysis dies here, not via the host
+    # OOM-killer taking broadcast/controller with it.
     mem_limit: ${ANALYZER_MEM_LIMIT:-6g}
     environment:
-      # Force CLAP / Demucs on for the whole pass. Usually unnecessary — the
-      # admin toggles drive these per request.
+      # Force CLAP / Demucs on for the whole pass; usually the admin toggles
+      # drive these per request.
       - ANALYZE_AUDIO_EMBEDDING=${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=${ANALYZE_VOCAL_ACTIVITY:-}
-      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
-      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
-      # cpu-wheel images always resolve to cpu.
+      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
-      # Seconds of no CLAP/Demucs use before the worker drops the models
-      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
-      # 1800 on cpu — one backfill or sound search loads them into the
-      # long-lived worker and nothing else ever releases them, so on a small
-      # host they end up parked in swap (#1204).
+      # Idle seconds before the worker drops CLAP/Demucs models (0 = never;
+      # default 300 cuda / 1800 cpu — see #1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
-      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
-      # whole worker process — the full-memory reclaim behind the model release
-      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
-      # return (default 3600; 0 = never). Requests racing a recycle queue
-      # behind the respawn rather than failing.
+      # Idle seconds before the sidecar recycles the whole worker process
+      # (default 3600; 0 = never).
       - ANALYZE_RECYCLE_IDLE_S=${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
-      # Demucs model + analysis-window overrides (worker reads both; see
-      # .env.example "Optional model overrides").
+      # Demucs model + analysis-window overrides (see .env.example).
       - DEMUCS_MODEL=${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=${ANALYZE_SECONDS:-}
       - ANALYZE_CLAP_WINDOWS=${ANALYZE_CLAP_WINDOWS:-}
       - ANALYZE_OUTRO_SECONDS=${ANALYZE_OUTRO_SECONDS:-}
-      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
-      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
-      # and both sidecars pick it up.
+      # Anonymous HF downloads are rate-limited; same var as tts-heavy.
       - HF_TOKEN=${HF_TOKEN:-}
     volumes:
       - *state-mount

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,14 +1,10 @@
-# SUB/WAVE — dev compose (local smoke test).
-# Runs: Broadcast (icecast2 + liquidsoap) + Controller. The Next.js listener
-# UI runs separately via `cd web && npm run dev` so JSX changes hot-reload.
-#
-# State + sounds + radio.liq are bind-mounted from the repo so dev cycles
-# don't need image rebuilds. The prod composes bake them into images instead.
+# SUB/WAVE — dev compose (local smoke test): Broadcast + Controller only.
+# The Next.js UI runs separately via `cd web && npm run dev` for hot reload.
+# State + sounds + radio.liq are bind-mounted so dev cycles need no rebuilds.
 
 x-state: &state-mount ${STATE_DIR:-./state}:/var/sub-wave
 
-# Cap container log growth so a long dev session can't fill the host disk.
-# 10m × 3 files = ~30MB ceiling per service. Applied via `logging: *default-logging`.
+# Cap container log growth (10m × 3 ≈ 30MB/service).
 x-logging: &default-logging
   driver: json-file
   options:
@@ -19,48 +15,40 @@ services:
   # -------------------------------------------------------------------------
   # BROADCAST — icecast2 + liquidsoap in one container
   # -------------------------------------------------------------------------
-  # Icecast HTTP exposed on :7702 for direct dev access (curl the stream,
-  # hit /status-json.xsl, etc.). Liquidsoap is internal to this container.
+  # Icecast exposed on :7702 for direct dev access; liquidsoap stays internal.
   broadcast:
     image: ghcr.io/perminder-klair/subwave-broadcast:${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.broadcast
-    # No `platform:` pin in dev. On Apple Silicon, forcing linux/amd64 routes
-    # liquidsoap through Rosetta/QEMU emulation where its clock_nanosleep
-    # syscall fails with `Unix.Unix_error(EUNKNOWNERR 0, "", "")` — the
-    # clock loop dies on every boot and Icecast ends up with no source.
-    # The savonet/liquidsoap:v2.2.5 base is multi-arch, so building natively
-    # (arm64 on M-series Macs, amd64 on Linux dev hosts) just works. The prod
-    # composes don't pin broadcast/controller platform either — the GHCR images
-    # are multi-arch and auto-select per host.
+    # No `platform:` pin. On Apple Silicon, forcing linux/amd64 routes
+    # liquidsoap through emulation where clock_nanosleep fails
+    # (`Unix.Unix_error(EUNKNOWNERR 0)`) — the clock loop dies on every boot
+    # and Icecast gets no source. The base is multi-arch; build natively.
     container_name: sub-wave-broadcast
     restart: unless-stopped
     logging: *default-logging
     ports:
       - "7702:7702"
     environment:
-      # All three are optional — leave blank in .env and the image generates
-      # random values on first boot, writing them to state/icecast-secrets.env.
+      # Optional — blank means random values generated on first boot and
+      # persisted to state/icecast-secrets.env.
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=${ICECAST_RELAY_PASSWORD:-}
-      # Concurrent-listener ceiling for icecast (<limits><clients>).
-      # Empty/unset → 100 (the historical default).
+      # Concurrent-listener ceiling (<limits><clients>). Empty → 100.
       - ICECAST_MAX_CLIENTS=${ICECAST_MAX_CLIENTS:-}
-      # Dev has no edge in front of icecast (the browser hits it directly), so
-      # this stays empty and listener rows already show the real peer.
+      # Dev has no edge in front of icecast, so these stay empty and listener
+      # rows already show the real peer.
       - ICECAST_TRUSTED_PROXY_IPS=${ICECAST_TRUSTED_PROXY_IPS:-}
       - ICECAST_TRUSTED_PROXY_HOSTS=${ICECAST_TRUSTED_PROXY_HOSTS:-}
       - TZ=${TZ:-Europe/London}
     extra_hosts:
-      # Lets Liquidsoap fetch Subsonic stream URLs that point at host services
-      # (e.g. NAVIDROME_URL=http://host.docker.internal:4533) without leaking
-      # the lookup to public DNS.
+      # Liquidsoap fetching Subsonic URLs that point at host services.
       - "host.docker.internal:host-gateway"
     volumes:
-      # Bind-mounts override the baked-in copies so dev edits to radio.liq and
-      # new sounds appear on the next restart without an image rebuild.
+      # Bind-mounts override the baked-in copies — radio.liq edits and new
+      # sounds land on the next restart, no rebuild.
       - ./liquidsoap/radio.liq:/etc/liquidsoap/radio.liq:ro
       - ./sounds:/sounds:ro
       - *state-mount
@@ -81,9 +69,8 @@ services:
       context: .
       dockerfile: docker/Dockerfile.controller
       args:
-        # Version reported by the controller (backup manifest); unset → falls
-        # back to controller/package.json. The dev web UI runs `npm run dev`
-        # outside Docker, where next.config.js resolves it via `git describe`.
+        # Version reported by the controller; unset → controller/package.json.
+        # The dev web UI resolves its own via `git describe` (next.config.js).
         - SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION:-}
     platform: linux/amd64
     container_name: sub-wave-controller
@@ -92,53 +79,41 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
-      # Bring the socket-proxy up whenever the controller is (re)created — even a
-      # selective `up -d controller` — so the Stats system panel works without a
-      # separate full `up -d`. Remove this entry too if you drop the proxy below.
+      # So a selective `up -d controller` also brings the socket-proxy up.
+      # Remove this entry too if you drop the proxy below.
       docker-socket-proxy:
         condition: service_started
     environment:
       - TZ=${TZ:-Europe/London}
       - STATE_DIR=/var/sub-wave
       - SOUNDS_DIR=/sounds
-      # Optional sidecar for Chatterbox + PocketTTS. Gated by --profile tts-heavy
-      # below; unreachable URL → fall back to Piper. Dev usage:
-      #   docker compose -f docker-compose.dev.yml --profile tts-heavy up -d
+      # Optional Chatterbox/PocketTTS sidecar (--profile tts-heavy);
+      # unreachable URL → fall back to Piper.
       - TTS_HEAVY_URL=${TTS_HEAVY_URL:-http://tts-heavy:8080}
-      # Acoustic-analysis sidecar (the `analyzer` service below, default-on).
-      # Probed, then a local venv. (tts-heavy is TTS-only — no analyzer there.)
+      # Acoustic-analysis sidecar (default-on below). Probed, then local venv.
       - ANALYZE_URL=${ANALYZE_URL:-http://analyzer:8080}
-      # Per-container CPU/memory for the admin Stats page (GET /system) is read
-      # from the docker-socket-proxy sidecar over TCP — the controller never
-      # touches the raw Docker socket. Unset this to disable the panel.
+      # Admin Stats panel via the socket-proxy — the controller never touches
+      # the raw Docker socket. Unset to disable.
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
     ports:
       - "7701:7701"
     env_file:
-      # All controller config (Navidrome creds, LLM keys, ADMIN_*, etc.) lives
-      # in the root .env. Vars not set are simply absent — settings.json takes
-      # over for everything the wizard manages.
+      # All controller config (Navidrome creds, LLM keys, ADMIN_*, …). Unset
+      # vars are simply absent — settings.json covers what the wizard manages.
       - ./.env
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    # Dev mode runs the controller under `tsx watch` against bind-mounted
-    # source, so edits to controller/src/** restart the process inside the
-    # container without a `docker compose build`. node_modules stays baked
-    # into the image — we override src/ and scripts/ only. Prod composes
-    # use the image's default CMD (`tsx src/server.ts`, no watch).
+    # Dev runs `tsx watch` against bind-mounted source so controller/src/**
+    # edits restart in-place. Prod uses the image's default CMD (no watch).
     command: ["node_modules/.bin/tsx", "watch", "src/server.ts"]
     volumes:
-      # State + sounds are bind-mounted in dev so changes don't need rebuilds.
       - *state-mount
       - ./sounds:/sounds:ro
-      # Source bind-mounts for hot reload. `tsx watch` picks up changes via
-      # inotify. Don't mount the whole controller/ dir — that would shadow
-      # /app/node_modules with the (possibly empty) host node_modules.
+      # Mount src/ and scripts/ only — mounting the whole controller/ dir
+      # would shadow /app/node_modules with the (possibly empty) host one.
       - ./controller/src:/app/src
       - ./controller/scripts:/app/scripts
-    # curl is present in the controller image (see docker/Dockerfile.controller).
-    # /health is served at the router root on :7701 (routes/public.ts). start_period
-    # is generous here: dev runs under `tsx watch`, which is slower to first boot.
+    # start_period is generous: `tsx watch` is slower to first boot.
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:7701/health > /dev/null"]
       interval: 10s
@@ -149,13 +124,9 @@ services:
   # -------------------------------------------------------------------------
   # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
   # -------------------------------------------------------------------------
-  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
-  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
-  # other section refused by default). The controller reads per-container
-  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
-  # controller never holds the socket. No host port. Optional: remove this
-  # service (plus the controller's DOCKER_HOST and its docker-socket-proxy
-  # depends_on entry above) to drop the Stats panel.
+  # Read-only, GET-only, CONTAINERS-section-only slice of the Docker API over
+  # internal TCP. Optional: remove it (plus the controller's DOCKER_HOST +
+  # depends_on entry) to drop the Stats panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy
@@ -169,115 +140,81 @@ services:
   # -------------------------------------------------------------------------
   # TTS-HEAVY (optional) — sidecar for Chatterbox + PocketTTS
   # -------------------------------------------------------------------------
-  # NOT started by default. Enable with:
+  # NOT started by default:
   #   docker compose -f docker-compose.dev.yml --profile tts-heavy up -d
-  # See docker/Dockerfile.tts-heavy + docker/tts-heavy/server.py. First build
-  # downloads ~3-4GB of model weights from Hugging Face — be patient.
+  # First boot downloads ~3-4GB of model weights.
   tts-heavy:
     image: ghcr.io/perminder-klair/subwave-tts-heavy:${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.tts-heavy
       args:
-        # GPU opt-in for Chatterbox — point torch at a CUDA wheel index (e.g.
-        # CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124) and
-        # layer on docker-compose.tts-heavy-gpu.yml. Defaults to CPU wheels.
-        # Source build only. See docs/gpu-tts.md.
+        # GPU opt-in (source build only) — see docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: ${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
-        # RTX 50-series (Blackwell) only: override chatterbox-tts's torch==2.6.0
-        # pin (no sm_120 kernels) with a newer spec + a cu128 index above, e.g.
-        # CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1". See docs/gpu-tts.md.
+        # RTX 50-series only: override chatterbox's torch==2.6.0 pin.
         CHATTERBOX_TORCH_SPEC: ${CHATTERBOX_TORCH_SPEC:-}
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway model load (a huge
-    # reference WAV, a wedged PyTorch allocation) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast
-    # or the controller down with it. Default is generous — real Chatterbox +
-    # PocketTTS peaks sit well under it. Raise/lower via TTS_HEAVY_MEM_LIMIT in .env.
+    # OOM containment: a runaway model load dies here, not via the host
+    # OOM-killer taking broadcast/controller with it.
     mem_limit: ${TTS_HEAVY_MEM_LIMIT:-10g}
     profiles: ["tts-heavy"]
     environment:
       - TTS_HEAVY_DEVICE=${TTS_HEAVY_DEVICE:-cpu}
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
-      # Which heavy engines to actually load. Both are baked into the image;
-      # each costs RAM + a first-boot weight download + startup time, so set
-      # this to a single engine if you only use one. Comma-separated.
-      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      # Which engines to load (comma-separated); each costs RAM + weights.
       - TTS_HEAVY_ENGINES=${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
-      # Optional — enables PocketTTS voice CLONING (issue #238). Cloning weights
-      # are gated; accept terms at huggingface.co/kyutai/pocket-tts and set
-      # HF_TOKEN in your .env. Built-in voices need no token.
+      # Optional — PocketTTS voice cloning (#238); weights gated on HF.
       - HF_TOKEN=${HF_TOKEN:-}
     volumes:
       - *state-mount
-      # Persist the per-engine Hugging Face caches across container recreates.
-      # Weights download at boot (the workers load the model before reporting
-      # ready) — without these volumes that multi-GB fetch repeats on every
-      # recreate. With them it happens once.
+      # Persist HF caches across recreates, or the multi-GB weight fetch
+      # repeats every time.
       - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
       - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
 
   # -------------------------------------------------------------------------
-  # ANALYZER — acoustic-analysis sidecar (bpm / key / intro / loudness;
-  # + CLAP "sounds-like" embeddings and Demucs vocal-activity ranges).
+  # ANALYZER — acoustic-analysis sidecar (bpm/key/intro/loudness; optional
+  # CLAP "sounds-like" embeddings + Demucs vocal ranges)
   # -------------------------------------------------------------------------
-  # Starts by default alongside the core services. The controller probes
-  # ANALYZE_URL (this service), then a local venv. Only the heavy voices
-  # (Chatterbox/PocketTTS) stay opt-in under `tts-heavy`; analysis is default-on.
-  # (tts-heavy is TTS-only — no analyzer there.)
+  # Starts by default; only the tts-heavy voices stay opt-in.
   analyzer:
-    # Default: LEAN, multi-arch. ANALYZER_HEAVY=1 → CLAP + Demucs heavy image.
+    # Default: LEAN multi-arch. ANALYZER_HEAVY=1 → CLAP + Demucs heavy image.
     image: ghcr.io/perminder-klair/subwave-analyzer${ANALYZER_HEAVY:+-heavy}:${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.analyzer
       args:
-        # Local build mirrors the pulled image: lean unless ANALYZER_HEAVY is set.
+        # Local build mirrors the pulled image: lean unless ANALYZER_HEAVY set.
         WITH_CLAP: ${ANALYZER_HEAVY:+1}
         WITH_DEMUCS: ${ANALYZER_HEAVY:+1}
     container_name: sub-wave-analyzer
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway analysis (a long track,
-    # a CLAP/Demucs allocation spike on the heavy image) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast or
-    # the controller down with it. Default is generous — librosa passes sit well
-    # under it, and even CLAP + Demucs on the heavy image fit. Raise/lower via
-    # ANALYZER_MEM_LIMIT in .env.
+    # OOM containment: a runaway analysis dies here, not via the host
+    # OOM-killer taking broadcast/controller with it.
     mem_limit: ${ANALYZER_MEM_LIMIT:-6g}
     environment:
       - ANALYZE_AUDIO_EMBEDDING=${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=${ANALYZE_VOCAL_ACTIVITY:-}
-      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
-      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
-      # cpu-wheel images always resolve to cpu.
+      # Torch device for CLAP/Demucs: auto (default) / cpu / cuda.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
-      # Seconds of no CLAP/Demucs use before the worker drops the models
-      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
-      # 1800 on cpu — one backfill or sound search loads them into the
-      # long-lived worker and nothing else ever releases them, so on a small
-      # host they end up parked in swap (#1204).
+      # Idle seconds before the worker drops CLAP/Demucs models (0 = never;
+      # default 300 cuda / 1800 cpu — see #1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
-      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
-      # whole worker process — the full-memory reclaim behind the model release
-      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
-      # return (default 3600; 0 = never). Requests racing a recycle queue
-      # behind the respawn rather than failing.
+      # Idle seconds before the sidecar recycles the whole worker process
+      # (default 3600; 0 = never).
       - ANALYZE_RECYCLE_IDLE_S=${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
-      # Demucs model + analysis-window overrides (worker reads both; see
-      # .env.example "Optional model overrides").
+      # Demucs model + analysis-window overrides (see .env.example).
       - DEMUCS_MODEL=${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=${ANALYZE_SECONDS:-}
       - ANALYZE_CLAP_WINDOWS=${ANALYZE_CLAP_WINDOWS:-}
       - ANALYZE_OUTRO_SECONDS=${ANALYZE_OUTRO_SECONDS:-}
-      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
-      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
-      # and both sidecars pick it up.
+      # Anonymous HF downloads are rate-limited; same var as tts-heavy.
       - HF_TOKEN=${HF_TOKEN:-}
     volumes:
       - *state-mount

--- a/docker-compose.tts-heavy-gpu.yml
+++ b/docker-compose.tts-heavy-gpu.yml
@@ -1,43 +1,33 @@
-# GPU opt-in overlay for the tts-heavy sidecar — runs Chatterbox on CUDA.
-#
-# The default tts-heavy image is CPU-only on purpose: a GPU device reservation
-# can't live in the base compose because `docker compose up` errors on a host
-# without the NVIDIA runtime, which would break every CPU install. This overlay
-# adds the reservation, switches the engine to cuda, and forces a local build
-# (the published image ships CPU-only torch).
-#
-# Layer it on top of your prod compose file, with the CUDA wheel index set:
+# GPU opt-in overlay for the tts-heavy sidecar — Chatterbox on CUDA.
+# A device reservation can't live in the base compose (`up` errors on hosts
+# without the NVIDIA runtime). This overlay adds it, switches the engine to
+# cuda, and forces a local build (the published image ships CPU-only torch).
 #
 #   echo 'CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124' >> .env
 #   docker compose -f docker-compose.yml -f docker-compose.tts-heavy-gpu.yml \
 #     --profile tts-heavy up -d --build
+#   (BYO hosts: swap in docker-compose.byo.yml.)
 #
-# (BYO reverse-proxy hosts: swap docker-compose.yml for docker-compose.byo.yml.)
-#
-# RTX 50-series (Blackwell / sm_120): chatterbox-tts pins torch==2.6.0, which has
-# no sm_120 kernels, so the default cu124 build loads but 500s at synthesis. Use
-# a cu128 index AND override the pin:
+# RTX 50-series (Blackwell / sm_120): chatterbox-tts pins torch==2.6.0, which
+# has no sm_120 kernels — the cu124 build loads but 500s at synthesis. Use a
+# cu128 index AND override the pin:
 #
 #   echo 'CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu128' >> .env
 #   echo 'CHATTERBOX_TORCH_SPEC=torch==2.9.1 torchaudio==2.9.1' >> .env
 #
-# Requirements: an NVIDIA GPU with the driver + NVIDIA Container Toolkit
-# installed. Pick the cuXXX wheel tag that matches your driver — see
-# https://pytorch.org/get-started/locally/. Full guide: docs/gpu-tts.md.
+# Requirements: NVIDIA driver + Container Toolkit; pick the cuXXX wheel tag
+# matching your driver (https://pytorch.org/get-started/locally/). Full guide:
+# docs/gpu-tts.md.
 services:
   tts-heavy:
     # Build the CUDA image locally instead of pulling the published CPU one.
     pull_policy: build
     environment:
-      # Load the Chatterbox model onto the GPU. The worker falls back to cpu if
-      # CUDA isn't actually visible, so a misconfigured host degrades, not fails.
+      # The worker falls back to cpu if CUDA isn't actually visible.
       - TTS_HEAVY_DEVICE=cuda
-    # Hand the GPU into the container (needs the NVIDIA Container Toolkit).
-    #
-    # The deploy.resources reservation below is the modern (CDI) path. On hosts
-    # where the NVIDIA runtime is registered in LEGACY mode, that reservation
-    # fails with "could not select device driver nvidia"; there, delete the
-    # `deploy:` block and instead use the legacy runtime:
+    # The deploy.resources reservation is the modern (CDI) path. On hosts where
+    # the NVIDIA runtime is registered in LEGACY mode it fails with "could not
+    # select device driver nvidia"; there, delete the `deploy:` block and use:
     #
     #   runtime: nvidia
     #   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,13 @@
-# SUB/WAVE — production orchestration.
-# Only Caddy is exposed on the host. Cloudflare terminates TLS in front.
-# Broadcast (icecast2 + liquidsoap), Controller, and Web are all internal-only
-# and reachable via Caddy's reverse proxy under one origin (/api, /stream.mp3, /).
-#
-# Image-first: every service pulls its baked image from GHCR by default. The
-# build: blocks let `docker compose build` rebuild locally from a checkout,
-# but the standard install never needs to clone — operators just need this
-# file and a 3-line .env to boot.
-#
-# State persists in <repo>/state by default (override with STATE_DIR). It is a
-# bind mount, so `docker compose down -v` (named-volume wipe) won't touch it —
-# but it lives inside the project dir, so keep it clear of `git clean -dffx`.
+# SUB/WAVE — production orchestration. Only Caddy binds a host port; Cloudflare
+# terminates TLS in front. Image-first: services pull baked GHCR images (the
+# build: blocks let a checkout rebuild locally). State persists in <repo>/state
+# (override with STATE_DIR) — a bind mount, so `down -v` won't touch it, but
+# keep it clear of `git clean -dffx`.
 
 x-state: &state-mount ${STATE_DIR:-./state}:/var/sub-wave
 
-# Cap container log growth. Without this the default json-file driver keeps an
-# unbounded log per container, which on a long-running station eventually fills
-# the host disk. 10m × 3 files = ~30MB ceiling per service. Applied to every
-# service below via `logging: *default-logging`.
+# Cap container log growth (10m × 3 ≈ 30MB/service) — the default json-file
+# driver is unbounded and eventually fills the host disk.
 x-logging: &default-logging
   driver: json-file
   options:
@@ -38,8 +28,7 @@ services:
     logging: *default-logging
     depends_on:
       # web has no healthcheck (static Next.js server) — started is enough.
-      # controller + broadcast expose one, so gate the edge on them being
-      # healthy so Caddy doesn't 502 the first requests after a cold `up -d`.
+      # Gate the edge on controller + broadcast health to avoid cold-boot 502s.
       web:
         condition: service_started
       controller:
@@ -53,12 +42,10 @@ services:
       - caddy-config:/config
 
   # -------------------------------------------------------------------------
-  # BROADCAST — icecast2 endpoint + liquidsoap mixer in one container
+  # BROADCAST — icecast2 + liquidsoap in one container
   # -------------------------------------------------------------------------
-  # The supervisor entrypoint resolves ICECAST_*_PASSWORD on first boot
-  # (writing them to state/icecast-secrets.env for visibility), then launches
-  # icecast2 and liquidsoap together. If either process dies the container
-  # exits and compose restarts the pair as a unit.
+  # The entrypoint resolves ICECAST_* passwords, renders icecast.xml, and
+  # launches both; if either dies the container exits and restarts the pair.
   broadcast:
     image: ghcr.io/perminder-klair/subwave-broadcast:${SUBWAVE_VERSION:-latest}
     build:
@@ -68,31 +55,26 @@ services:
     restart: unless-stopped
     logging: *default-logging
     environment:
-      # All three are optional — leave blank in .env and the image generates
-      # random values on first boot, persisting them to state/icecast-secrets.env.
-      # To rotate: delete that file and restart broadcast + controller (the
-      # controller doesn't actually source the file, but a settings reload
-      # picks up any URL change cleanly).
+      # Optional — blank means random values generated on first boot and
+      # persisted to state/icecast-secrets.env (delete that file + restart
+      # broadcast to rotate).
       - ICECAST_SOURCE_PASSWORD=${ICECAST_SOURCE_PASSWORD:-}
       - ICECAST_ADMIN_PASSWORD=${ICECAST_ADMIN_PASSWORD:-}
       - ICECAST_RELAY_PASSWORD=${ICECAST_RELAY_PASSWORD:-}
-      # Concurrent-listener ceiling for icecast (<limits><clients>).
-      # Empty/unset → 100 (the historical default).
+      # Concurrent-listener ceiling (<limits><clients>). Empty → 100.
       - ICECAST_MAX_CLIENTS=${ICECAST_MAX_CLIENTS:-}
-      # Reverse proxies whose X-Forwarded-For icecast should believe, so admin
-      # → Listeners shows real listener IPs rather than the edge's container
-      # address. Unset resolves the bundled `caddy` by name at render time,
-      # which lands on every restart but misses the very first cold boot (caddy
-      # can't be running yet — it waits on this service's healthcheck). Set
-      # ICECAST_TRUSTED_PROXY_IPS to a pinned address for first-boot accuracy.
+      # Proxies whose X-Forwarded-For icecast should believe (real listener IPs
+      # in admin → Listeners). Unset resolves the bundled `caddy` by name at
+      # render time — lands on every restart but misses the very first cold
+      # boot (caddy waits on this service's healthcheck). Pin an IP here for
+      # first-boot accuracy.
       - ICECAST_TRUSTED_PROXY_IPS=${ICECAST_TRUSTED_PROXY_IPS:-}
       - ICECAST_TRUSTED_PROXY_HOSTS=${ICECAST_TRUSTED_PROXY_HOSTS:-}
       # Keeps the hourly archive paths (%Y-%m-%d/%H-00.mp3) on local wall time.
       - TZ=${TZ:-Europe/London}
     extra_hosts:
-      # Lets Liquidsoap fetch Subsonic stream URLs that point at host services
-      # (e.g. NAVIDROME_URL=http://host.docker.internal:4533) without leaking
-      # the lookup to public DNS.
+      # Liquidsoap fetching Subsonic URLs that point at host services
+      # (e.g. NAVIDROME_URL=http://host.docker.internal:4533).
       - "host.docker.internal:host-gateway"
     volumes:
       - *state-mount
@@ -113,8 +95,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.controller
       args:
-        # Version reported by the controller (backup manifest). Same source as
-        # the web build arg below; unset → falls back to controller/package.json.
+        # Version reported by the controller; unset → controller/package.json.
         - SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-controller
     restart: unless-stopped
@@ -122,49 +103,37 @@ services:
     depends_on:
       broadcast:
         condition: service_healthy
-      # Bring the socket-proxy up whenever the controller is (re)created — even a
-      # selective `up -d controller` — so the Stats system panel works without a
-      # separate full `up -d`. Remove this entry too if you drop the proxy below.
+      # So a selective `up -d controller` also brings the socket-proxy up.
+      # Remove this entry too if you drop the proxy below.
       docker-socket-proxy:
         condition: service_started
     environment:
-      # Enables the production-only admin gate: refuses to boot unless
-      # ADMIN_USER + ADMIN_PASS are set in .env.
+      # Enables the production-only admin gate (refuses to boot without
+      # ADMIN_USER + ADMIN_PASS).
       - NODE_ENV=production
-      # Schedule slots are stored by day-of-week + hour; resolveActiveShow()
-      # reads them with date.getHours(). Without TZ the container runs in UTC
-      # and fires shows an hour early during BST.
+      # Schedule slots are day-of-week + hour via date.getHours(); without TZ
+      # the container runs UTC and fires shows an hour early during BST.
       - TZ=${TZ:-Europe/London}
-      # In-container path of the *state-mount below.
       - STATE_DIR=/var/sub-wave
-      # In-container path of the sounds COPY'd into the image at build time.
       - SOUNDS_DIR=/sounds
-      # Optional sidecar for Chatterbox + PocketTTS. The tts-heavy service
-      # below is gated by `--profile tts-heavy`; when off, the URL is
-      # unreachable and audio/chatterbox.ts + audio/pocketTts.ts silently
-      # fall back to Piper (same behaviour as the default image today).
+      # Optional Chatterbox/PocketTTS sidecar (--profile tts-heavy). When the
+      # profile is off the URL is unreachable and TTS falls back to Piper.
       - TTS_HEAVY_URL=${TTS_HEAVY_URL:-http://tts-heavy:8080}
-      # Acoustic-analysis sidecar (the `analyzer` service below, default-on).
-      # The controller probes this, then a local venv — falling through cleanly
-      # to NULL analysis if neither is reachable. (tts-heavy is TTS-only; it no
-      # longer carries the analyzer.) See music/analyzer.ts.
+      # Acoustic-analysis sidecar (default-on below). Probed first, then a
+      # local venv; falls through to NULL analysis. See music/analyzer.ts.
       - ANALYZE_URL=${ANALYZE_URL:-http://analyzer:8080}
-      # Per-container CPU/memory for the admin Stats page (GET /system) is read
-      # from the docker-socket-proxy sidecar over TCP — the controller never
-      # touches the raw Docker socket. Unset this to disable the panel.
+      # Per-container stats for the admin Stats panel, via the socket-proxy —
+      # the controller never touches the raw Docker socket. Unset to disable.
       - DOCKER_HOST=tcp://docker-socket-proxy:2375
     env_file:
-      # All controller config (Navidrome creds, LLM keys, ADMIN_*, etc.) lives
-      # in the root .env. Vars not set are simply absent — settings.json takes
-      # over for everything the first-run wizard manages.
+      # All controller config (Navidrome creds, LLM keys, ADMIN_*, …). Unset
+      # vars are simply absent — settings.json covers what the wizard manages.
       - ./.env
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
       - *state-mount
-    # curl is present in the controller image (see docker/Dockerfile.controller).
-    # /health is served at the router root on :7701 (routes/public.ts). Lets web
-    # + caddy gate on the controller being ready via depends_on: service_healthy.
+    # curl is in the controller image; /health is served at the router root.
     healthcheck:
       test: ["CMD-SHELL", "curl -fsS http://localhost:7701/health > /dev/null"]
       interval: 10s
@@ -175,14 +144,9 @@ services:
   # -------------------------------------------------------------------------
   # DOCKER-SOCKET-PROXY — locked-down Docker API for the Stats system panel
   # -------------------------------------------------------------------------
-  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only slice
-  # of the Docker Engine API over TCP (CONTAINERS section only; POST and every
-  # other section refused by default). The controller reads per-container
-  # CPU/memory through it via DOCKER_HOST=tcp://docker-socket-proxy:2375, so the
-  # controller image itself never holds the socket. No host port — only
-  # reachable on the internal compose network. Optional: remove this service
-  # (plus the controller's DOCKER_HOST and its docker-socket-proxy depends_on
-  # entry above) to drop the Stats system panel.
+  # Owns the real /var/run/docker.sock and exposes a read-only, GET-only,
+  # CONTAINERS-section-only slice over internal TCP. Optional: remove it (plus
+  # the controller's DOCKER_HOST + depends_on entry) to drop the Stats panel.
   docker-socket-proxy:
     image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
     container_name: sub-wave-docker-proxy
@@ -202,192 +166,134 @@ services:
       context: .
       dockerfile: web/Dockerfile
       args:
-        # Belt-and-suspenders for source builds only — every route that emits
-        # absolute URLs renders per-request off the RUNTIME env below.
+        # Source builds only — absolute URLs render off the RUNTIME env below.
         - SITE_URL=${SITE_URL:-}
         # NEXT_PUBLIC_* is inlined into the client bundle at BUILD time.
         - NEXT_PUBLIC_GA_ID=${NEXT_PUBLIC_GA_ID:-}
-        # Version shown in the admin console footer, inlined at BUILD time.
-        # scripts/update.sh sets it from `git describe`; unset → falls back to
-        # web/package.json (see web/next.config.js).
+        # Admin footer version; unset → web/package.json (web/next.config.js).
         - SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION:-}
     container_name: sub-wave-web
     restart: unless-stopped
     logging: *default-logging
     depends_on:
-      # Wait for the controller to pass its healthcheck — the homepage renders
-      # per-request against the controller (CONTROLLER_INTERNAL_URL below), so
-      # starting web before the controller is ready serves broken first pages.
+      # The homepage renders per-request against the controller — starting web
+      # before it is healthy serves broken first pages.
       controller:
         condition: service_healthy
     environment:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=${SUBWAVE_HOMEPAGE:-player}
-      # The RUNTIME source of truth for absolute URLs: canonicals, og:url,
-      # robots.txt, and sitemap.xml all render per-request from this env, so
-      # the generic published image serves the operator's real domain. Define
-      # SITE_URL once in .env.
+      # RUNTIME source of truth for absolute URLs (canonicals, og:url,
+      # robots.txt, sitemap.xml) — the generic image serves any domain.
       - SITE_URL=${SITE_URL:-}
-      # Google Analytics Measurement ID at RUNTIME (web/lib/ga.ts). Plumbs the
-      # operator's NEXT_PUBLIC_GA_ID from .env into a runtime var, so analytics
-      # turn on with a `web` recreate — no image rebuild. The build-arg above
-      # still bakes it for images built with a value.
+      # GA Measurement ID at RUNTIME (web/lib/ga.ts) — analytics turn on with a
+      # `web` recreate, no rebuild. The build-arg above still bakes it.
       - GA_ID=${NEXT_PUBLIC_GA_ID:-}
-      # Server-side base URL for generateMetadata on the force-dynamic homepage
-      # to read the live station name from the controller. Internal compose
-      # network name — not exposed to the browser (which uses /api via Caddy).
+      # Server-side base URL for generateMetadata; internal compose name, not
+      # exposed to the browser (which uses /api via Caddy).
       - CONTROLLER_INTERNAL_URL=http://controller:7701
 
   # -------------------------------------------------------------------------
   # TTS-HEAVY (optional) — sidecar for Chatterbox + PocketTTS
   # -------------------------------------------------------------------------
-  # Heavy PyTorch engines pulled out of the controller image so operators on
-  # the pre-built ghcr.io images can opt into them without a custom rebuild
-  # (issue #103). NOT started by default. Enable with:
-  #
-  #   docker compose --profile tts-heavy up -d
-  #
-  # The controller is wired with TTS_HEAVY_URL pointing here unconditionally;
-  # when the profile is off the URL is unreachable and chatterbox.ts /
-  # pocketTts.ts report unavailable, so the dispatcher falls back to Piper —
-  # same behaviour as the default image today.
-  #
-  # See docker/Dockerfile.tts-heavy + docker/tts-heavy/server.py.
+  # Heavy PyTorch engines kept out of the controller image (#103). NOT started
+  # by default: `docker compose --profile tts-heavy up -d`. With the profile
+  # off, TTS_HEAVY_URL is unreachable and the dispatcher falls back to Piper.
   tts-heavy:
     image: ghcr.io/perminder-klair/subwave-tts-heavy:${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.tts-heavy
       args:
-        # GPU opt-in: point the Chatterbox venv's torch install at a CUDA wheel
-        # index to build a GPU-capable image. Defaults to CPU wheels; override
-        # with e.g. CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cu124
-        # and layer on docker-compose.tts-heavy-gpu.yml (device reservation +
-        # TTS_HEAVY_DEVICE=cuda). Source build only. See docs/gpu-tts.md.
+        # GPU opt-in (source build only): point at a CUDA wheel index and layer
+        # on docker-compose.tts-heavy-gpu.yml. See docs/gpu-tts.md.
         CHATTERBOX_TORCH_INDEX_URL: ${CHATTERBOX_TORCH_INDEX_URL:-https://download.pytorch.org/whl/cpu}
-        # RTX 50-series (Blackwell) only: chatterbox-tts pins torch==2.6.0, which
-        # has no sm_120 kernels. Set a newer spec to override the pin, paired with
-        # a cu128 index above, e.g. CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1".
+        # RTX 50-series only: override chatterbox's torch==2.6.0 pin (no sm_120
+        # kernels), e.g. CHATTERBOX_TORCH_SPEC="torch==2.9.1 torchaudio==2.9.1".
         CHATTERBOX_TORCH_SPEC: ${CHATTERBOX_TORCH_SPEC:-}
-    # amd64-only image (heavy PyTorch stack); pinned so it runs under emulation
-    # on arm64 hosts. The other services are multi-arch and auto-select.
+    # amd64-only image; pinned so it runs under emulation on arm64 hosts.
     platform: linux/amd64
     container_name: sub-wave-tts-heavy
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway model load (a huge
-    # reference WAV, a wedged PyTorch allocation) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast
-    # or the controller down with it. Default is generous — real Chatterbox +
-    # PocketTTS peaks sit well under it. Raise/lower via TTS_HEAVY_MEM_LIMIT in .env.
+    # OOM containment: a runaway model load dies here instead of triggering the
+    # host OOM-killer and taking broadcast/controller down. Default is generous.
     mem_limit: ${TTS_HEAVY_MEM_LIMIT:-10g}
     profiles: ["tts-heavy"]
     environment:
-      # 'cpu' or 'cuda'. The default image is CPU-only — cuda needs a GPU
-      # host + nvidia runtime; the server gracefully falls back to cpu when
-      # CUDA isn't actually available.
+      # 'cpu' or 'cuda'; the server falls back to cpu when CUDA is absent.
       - TTS_HEAVY_DEVICE=${TTS_HEAVY_DEVICE:-cpu}
-      # Default voice id used by PocketTTS when a persona doesn't override it.
+      # Default PocketTTS voice when a persona doesn't override it.
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
-      # Which heavy engines to actually load. Both are baked into the image;
-      # each costs RAM + a first-boot weight download + startup time, so set
-      # this to a single engine if you only use one. Comma-separated.
-      # e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only (no Chatterbox).
+      # Which engines to load (comma-separated). Each costs RAM + a first-boot
+      # weight download; set a single engine if you only use one.
       - TTS_HEAVY_ENGINES=${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
-      # Optional — enables PocketTTS zero-shot voice CLONING (issue #238). The
-      # cloning weights (kyutai/pocket-tts) are gated on Hugging Face; without a
-      # token the engine loads the open weights and cloned .wav voices revert to
-      # a built-in. Accept the model terms on huggingface.co/kyutai/pocket-tts,
-      # then put HF_TOKEN=hf_... in your root .env. Built-in voices need no token.
+      # Optional — PocketTTS voice CLONING (#238): the cloning weights are
+      # gated on HF; accept the terms at huggingface.co/kyutai/pocket-tts and
+      # set HF_TOKEN. Without it, cloned .wav voices revert to a built-in.
       - HF_TOKEN=${HF_TOKEN:-}
     volumes:
-      # Same shared mount as the controller — the sidecar writes WAVs into
-      # /var/sub-wave/voice/* and the controller hands the path to Liquidsoap.
+      # Shared with the controller — WAVs land in /var/sub-wave/voice/*.
       - *state-mount
-      # Persist the per-engine Hugging Face caches across container recreates.
-      # Weights download at boot (the workers load the model before reporting
-      # ready) — without these volumes that multi-GB fetch repeats on every
-      # `up -d --build` / image pull / update. With them it happens once.
+      # Persist HF caches across recreates, or the multi-GB boot-time weight
+      # fetch repeats on every pull/rebuild.
       - tts-heavy-chatterbox-cache:/opt/chatterbox/hf-cache
       - tts-heavy-pocket-cache:/opt/pocket-tts/hf-cache
 
   # -------------------------------------------------------------------------
-  # ANALYZER — acoustic-analysis sidecar (bpm / key / intro / loudness;
-  # + CLAP "sounds-like" embeddings and Demucs vocal-activity ranges).
+  # ANALYZER — acoustic-analysis sidecar (bpm/key/intro/loudness; optional
+  # CLAP "sounds-like" embeddings + Demucs vocal ranges)
   # -------------------------------------------------------------------------
-  # Starts by default alongside the core services (like controller/web). The
-  # controller resolves its analysis backend from ANALYZE_URL (this service),
-  # then a local venv. Only the heavy *voices* (Chatterbox/PocketTTS) stay
-  # opt-in — under the separate `tts-heavy` profile; acoustic analysis is
-  # default-on here. To skip it, `docker compose stop analyzer` after boot.
-  #
-  # The default image is LEAN (bpm/key/intro/loudness, multi-arch). The CLAP
-  # "sounds-like" + Demucs vocal dimensions are the heavy opt-in: set
-  # ANALYZER_HEAVY=1 in .env to pull `subwave-analyzer-heavy` instead.
+  # Starts by default (only the tts-heavy voices stay opt-in). To skip it,
+  # `docker compose stop analyzer` after boot.
   analyzer:
-    # Default: the LEAN, multi-arch image (librosa — bpm/key/intro/loudness).
-    # Set ANALYZER_HEAVY=1 in .env to switch to the CLAP "sounds-like" + Demucs
-    # vocal image (`subwave-analyzer-heavy`, amd64-only). No platform pin here so
-    # the lean image runs natively on arm64; if you set ANALYZER_HEAVY=1 on an
-    # arm64 host, also set DOCKER_DEFAULT_PLATFORM=linux/amd64 (runs emulated).
+    # Default: LEAN multi-arch image. ANALYZER_HEAVY=1 in .env switches to the
+    # CLAP + Demucs `subwave-analyzer-heavy` image (amd64-only; on arm64 also
+    # set DOCKER_DEFAULT_PLATFORM=linux/amd64 to run emulated).
     image: ghcr.io/perminder-klair/subwave-analyzer${ANALYZER_HEAVY:+-heavy}:${SUBWAVE_VERSION:-latest}
     build:
       context: .
       dockerfile: docker/Dockerfile.analyzer
       args:
-        # Local `docker compose build analyzer` mirrors the pulled image: lean
-        # unless ANALYZER_HEAVY is set, then it builds the CLAP + Demucs stack.
+        # Local build mirrors the pulled image: lean unless ANALYZER_HEAVY set.
         WITH_CLAP: ${ANALYZER_HEAVY:+1}
         WITH_DEMUCS: ${ANALYZER_HEAVY:+1}
     container_name: sub-wave-analyzer
     restart: unless-stopped
     logging: *default-logging
-    # OOM containment: cap the resident set so a runaway analysis (a long track,
-    # a CLAP/Demucs allocation spike on the heavy image) is killed inside this
-    # container instead of triggering the host OOM-killer and taking broadcast or
-    # the controller down with it. Default is generous — librosa passes sit well
-    # under it, and even CLAP + Demucs on the heavy image fit. Raise/lower via
-    # ANALYZER_MEM_LIMIT in .env.
+    # OOM containment: a runaway analysis dies here instead of triggering the
+    # host OOM-killer and taking broadcast/controller down. Default is generous.
     mem_limit: ${ANALYZER_MEM_LIMIT:-6g}
     environment:
-      # Force CLAP embeddings / Demucs vocal ranges on for the whole analyze
-      # pass. Usually unnecessary — the admin toggles drive these per request.
+      # Force CLAP / Demucs on for the whole pass. Usually unnecessary — the
+      # admin toggles drive these per request.
       - ANALYZE_AUDIO_EMBEDDING=${ANALYZE_AUDIO_EMBEDDING:-}
       - ANALYZE_VOCAL_ACTIVITY=${ANALYZE_VOCAL_ACTIVITY:-}
       # Torch device for CLAP/Demucs: auto (default) / cpu / cuda. Only
-      # meaningful on the cuda analyzer flavour (docker-compose.analyzer-gpu.yml);
-      # cpu-wheel images always resolve to cpu.
+      # meaningful on the cuda flavour; cpu-wheel images resolve to cpu.
       - ANALYZE_DEVICE=${ANALYZE_DEVICE:-}
-      # Seconds of no CLAP/Demucs use before the worker drops the models
-      # (0 = never). Applies on BOTH devices: default 300 on cuda (frees VRAM),
-      # 1800 on cpu — one backfill or sound search loads them into the
-      # long-lived worker and nothing else ever releases them, so on a small
-      # host they end up parked in swap (#1204).
+      # Idle seconds before the worker drops CLAP/Demucs models (0 = never).
+      # Default 300 on cuda (frees VRAM), 1800 on cpu — otherwise one backfill
+      # parks ~GBs in swap on a small host (#1204).
       - ANALYZE_IDLE_UNLOAD_S=${ANALYZE_IDLE_UNLOAD_S:-}
-      # Seconds of no heavy (CLAP/Demucs) use before the sidecar recycles the
-      # whole worker process — the full-memory reclaim behind the model release
-      # above, catching the ~1GB of librosa/numba/torch scratch a release can't
-      # return (default 3600; 0 = never). Requests racing a recycle queue
-      # behind the respawn rather than failing.
+      # Idle seconds before the sidecar recycles the whole worker process —
+      # reclaims the ~1GB of scratch a model release can't return (default
+      # 3600; 0 = never). Requests racing a recycle queue behind the respawn.
       - ANALYZE_RECYCLE_IDLE_S=${ANALYZE_RECYCLE_IDLE_S:-}
       - CLAP_MODEL=${CLAP_MODEL:-}
       - CLAP_MODEL_PATH=${CLAP_MODEL_PATH:-}
-      # Demucs model + analysis-window overrides (worker reads both; see
-      # .env.example "Optional model overrides").
+      # Demucs model + analysis-window overrides (see .env.example).
       - DEMUCS_MODEL=${DEMUCS_MODEL:-}
       - ANALYZE_SECONDS=${ANALYZE_SECONDS:-}
       - ANALYZE_CLAP_WINDOWS=${ANALYZE_CLAP_WINDOWS:-}
       - ANALYZE_OUTRO_SECONDS=${ANALYZE_OUTRO_SECONDS:-}
-      # CLAP isn't gated, but an anonymous HF Hub download is rate-limited and
-      # slow. Same var as tts-heavy — set HF_TOKEN=hf_... in your root .env once
-      # and both sidecars pick it up.
+      # CLAP isn't gated, but anonymous HF downloads are rate-limited. Same var
+      # as tts-heavy — set once and both sidecars pick it up.
       - HF_TOKEN=${HF_TOKEN:-}
     volumes:
-      # Shared mount with the controller — reads tracks the controller
-      # pre-fetched into /var/sub-wave/analyze-tmp.
+      # Shared mount — reads tracks pre-fetched into /var/sub-wave/analyze-tmp.
       - *state-mount
-      # Persist the CLAP/Demucs HF cache across recreates (weights download
-      # lazily on the first analyze pass that needs them).
+      # Persist the CLAP/Demucs HF cache across recreates.
       - analyzer-cache:/opt/analyzer/hf-cache
 
 volumes:

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -1,33 +1,22 @@
-# Caddy edge router for SUB/WAVE production.
-# Cloudflare terminates TLS in front, so we speak plain HTTP on :80 only.
-# All listener-facing traffic lands here and is routed to internal services
-# by URL prefix. Broadcast (icecast2 + liquidsoap), controller, and web
-# have no host port bindings — they're only reachable through this proxy.
+# Caddy edge router for SUB/WAVE production. Cloudflare terminates TLS in
+# front, so plain HTTP on :80 only; broadcast/controller/web have no host ports
+# and are routed by URL prefix.
 {
 	auto_https off
-	# Trust Cloudflare's X-Forwarded-* headers so logs and rate-limits see real IPs.
-	# This list is hardcoded and must be refreshed by hand when Cloudflare changes
-	# its ranges — pull the canonical lists from:
-	#   https://www.cloudflare.com/ips-v4  and  https://www.cloudflare.com/ips-v6
+	# Trust Cloudflare's X-Forwarded-* so logs and rate-limits see real IPs.
+	# Hardcoded — refresh by hand from https://www.cloudflare.com/ips-v4 and
+	# /ips-v6. These are the peers that CONNECT TO CADDY, which with proxied
+	# DNS really are Cloudflare edges.
 	#
-	# These are the addresses of the machines that CONNECT TO CADDY, which is why
-	# the list is Cloudflare's public ranges: with proxied DNS, the peer really is
-	# a Cloudflare edge. A Cloudflare TUNNEL is different — `cloudflared` runs as
-	# a container beside this one, so the peer is a private Docker address, no
-	# entry here matches, and Caddy discards the forwarded header it arrived
-	# with. Tunnel operators need to append `private_ranges` to the list below.
-	#
-	# It is not the default because it is a real trust decision: trusting private
-	# ranges means anything that can reach this Caddy from private address space
-	# can forge X-Forwarded-For, which both fakes rows in admin → Listeners and
-	# defeats the controller's per-IP limits — the request caps, the admin
-	# brute-force lockout, the station-password throttle and like dedup all key
-	# on the address middleware/ratelimit.ts resolves, and X-Forwarded-For is
-	# what it reads unless TRUST_CF_CONNECTING_IP is set. Keeping the list to
-	# Cloudflare's ranges is what makes that read sound: for any other peer Caddy
-	# replaces the header with the real connecting address. Safe when the tunnel
-	# is the only ingress; not safe when the host port is also reachable from a
-	# shared LAN. See docs/deployment.md for the full recipe.
+	# A Cloudflare TUNNEL is different: cloudflared is a container beside this
+	# one, so the peer is a private Docker address and Caddy discards the
+	# forwarded header — tunnel operators must append `private_ranges`. That is
+	# NOT the default because it's a real trust decision: anything reaching
+	# Caddy from private address space could then forge X-Forwarded-For, faking
+	# admin → Listeners rows and defeating every per-IP limit in
+	# middleware/ratelimit.ts (request caps, admin lockout, station-password
+	# throttle, like dedup). Safe when the tunnel is the only ingress; not when
+	# the host port is also reachable from a shared LAN. See docs/deployment.md.
 	servers {
 		trusted_proxies static \
  173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 \
@@ -40,35 +29,23 @@
 }
 
 :80 {
-	# -------------------------------------------------------------------------
-	# Security response headers — applied to every response (streams, /api, web)
-	# -------------------------------------------------------------------------
-	# These are inert metadata headers: they don't buffer or rewrite the body, so
-	# they don't interfere with the streams' `flush_interval -1` live path or the
-	# /api reverse proxy. X-Frame-Options SAMEORIGIN is safe — the app never
-	# embeds itself cross-origin (no iframe/postMessage embedding in web/).
+	# Security headers on every response — inert metadata, so they don't fight
+	# the streams' flush_interval -1 live path. SAMEORIGIN is safe: the app
+	# never embeds itself cross-origin.
 	header {
-		# Drop Caddy's default `Server: Caddy` banner (don't advertise the edge).
+		# Don't advertise the edge.
 		-Server
 		X-Content-Type-Options nosniff
 		Referrer-Policy strict-origin-when-cross-origin
 		X-Frame-Options SAMEORIGIN
-		# HSTS — opt-in. Cloudflare terminates TLS in front of this origin, so
-		# HSTS at the edge is only meaningful when the site is served https-only.
-		# Uncomment to force HTTPS in browsers for a year (operator's call; be
-		# sure every subdomain is https before enabling includeSubDomains):
+		# HSTS — opt-in (Cloudflare terminates TLS; only meaningful https-only,
+		# and every subdomain must be https before includeSubDomains):
 		# Strict-Transport-Security "max-age=31536000; includeSubDomains"
 	}
 
-	# -------------------------------------------------------------------------
-	# /stream.mp3 + /stream.opus + /stream.flac + /stream.aac — Icecast endpoints
-	# -------------------------------------------------------------------------
-	# All mounts are served by the same Icecast on broadcast:7702 (Liquidsoap
-	# encodes the same source bus into MP3, Ogg-Opus, Ogg-FLAC lossless and
-	# AAC-LC in parallel; Opus/FLAC/AAC are off by default and their bitrates
-	# are operator-configurable). flush_interval -1 disables buffering so the
-	# audio stays live. Query strings (e.g. ?t=12345 cache-busters) pass
-	# through automatically.
+	# Icecast mounts. Opus/FLAC/AAC are off by default but must be listed or
+	# they fall through to the Next.js catch-all and 404. flush_interval -1
+	# disables buffering so the audio stays live.
 	@streams path /stream.mp3 /stream.opus /stream.flac /stream.aac
 	handle @streams {
 		reverse_proxy broadcast:7702 {
@@ -81,51 +58,34 @@
 		}
 	}
 
-	# -------------------------------------------------------------------------
-	# /api/listener-auth — NOT reachable from the internet
-	# -------------------------------------------------------------------------
-	# The Icecast URL-auth callback (#478). Icecast lives in the broadcast
-	# container and calls the controller DIRECTLY over the compose network
-	# (http://controller:7701/listener-auth — see docker/broadcast-entrypoint.sh),
-	# so it never needs the edge. Exposing it through /api/* handed the internet
-	# an unthrottled password oracle: it answers 200/401 on the shared
-	# privacy.password, while POST /station-auth throttles that SAME password at
-	# 20 tries / 15 min. Must be declared BEFORE the /api/* handler — Caddy sorts
-	# by specificity, but keeping it adjacent makes the pairing obvious.
+	# Icecast's URL-auth callback (#478) — NOT reachable from the internet.
+	# Icecast calls the controller directly over the compose network, so the
+	# edge never needs it; exposed through /api/* it is an unthrottled password
+	# oracle for the shared privacy.password that POST /station-auth throttles.
 	handle /api/listener-auth {
 		respond 404
 	}
 
-	# -------------------------------------------------------------------------
-	# /api/* — Controller REST API
-	# -------------------------------------------------------------------------
-	# handle_path strips the /api prefix before forwarding, so the controller
-	# keeps its existing routes (/now-playing, /state, /request, /skip, /health).
+	# Controller REST API. handle_path strips the /api prefix, so the
+	# controller keeps its existing routes.
 	handle_path /api/* {
 		reverse_proxy controller:7701
 	}
 
-	# -------------------------------------------------------------------------
-	# /listen.pls + /listen.m3u — one-paste tune-in files (VLC, Sonos, hardware)
-	# -------------------------------------------------------------------------
-	# Served by the controller at its root (NOT under /api), so use a plain
-	# handle with no path stripping. Without this they fall through to the
-	# Next.js catch-all below and 404.
+	# One-paste tune-in files (VLC, Sonos, hardware) — served by the controller
+	# at its root (NOT under /api), so plain handle, no path stripping.
 	@listen path /listen.pls /listen.m3u
 	handle @listen {
 		reverse_proxy controller:7701
 	}
 
-	# -------------------------------------------------------------------------
-	# Everything else → Next.js web UI
-	# -------------------------------------------------------------------------
+	# Everything else → Next.js web UI.
 	handle {
 		reverse_proxy web:7700
 	}
 
-	# Don't compress the live audio mounts — MP3/Opus/FLAC/AAC are already
-	# compressed (gzip just burns CPU on incompressible data) and an encoder
-	# layer on the never-ending body fights the `flush_interval -1` live path.
+	# Don't compress the live audio mounts — already-compressed data, and an
+	# encoder layer on the never-ending body fights flush_interval -1.
 	@compressible not path /stream.mp3 /stream.opus /stream.flac /stream.aac
 	encode @compressible gzip zstd
 

--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -1,31 +1,15 @@
-# SUB/WAVE all-in-one image — the entire stack in a single container.
+# SUB/WAVE all-in-one image — the entire stack in one container, supervised by
+# docker/aio/supervisor.sh behind a loopback Caddy on :80. Exists because
+# Unraid's Community Applications catalogue is one container per template (also
+# handy for Synology / plain-VPS `docker run`). The split-stack images remain
+# the canonical deployment; nothing here forks app behaviour — internal URLs
+# are just repointed at loopback.
 #
-# Why this exists: Unraid's Community Applications catalogue is strictly one
-# container per template, so the five-service compose stack can't be listed
-# there directly. This image collapses icecast2 + liquidsoap (broadcast), the
-# controller, the Next.js web UI, and Caddy into one container supervised by
-# docker/aio/supervisor.sh, exposing a single port (80, fronted by Caddy). It's
-# also handy anywhere you'd rather run `docker run` once than orchestrate five
-# services (Synology, a plain VPS, Portainer one-shot).
-#
-# The split-stack images (subwave-{caddy,broadcast,controller,web}) remain the
-# canonical deployment. This is an additional packaging of the same source —
-# nothing here forks app behaviour; it only repoints internal URLs at loopback
-# (see docker/aio/supervisor.sh) and bakes in a loopback Caddyfile.
-#
-# NOT bundled (to keep the image lean): the optional tts-heavy engines
-# (Chatterbox / PocketTTS) and the docker-socket-proxy Stats panel. Both degrade
-# gracefully — TTS falls back to the bundled Piper voice, the Stats system panel
-# simply hides. Piper + Kokoro are included, so the DJ has a natural voice.
-#
-# Bundled by default: the lean acoustic analyzer (librosa — bpm/key/intro/
-# loudness). In the split stack it's a separate `analyzer` sidecar; the AIO is
-# one container with no sidecars, so it bakes the venv in and runs it via the
-# controller's in-process local backend (ANALYZE_PYTHON). The heavy CLAP
-# "sounds-like" + Demucs vocal stack is OFF here (kept lean/small); CI publishes
-# a `subwave-aio-heavy` tag (WITH_CLAP=1 WITH_DEMUCS=1) for operators who want it,
-# and a `subwave-aio-cuda` tag (+ WITH_CUDA=1) that runs that same heavy stack on
-# an NVIDIA GPU — see the analyzer block below and docs/unraid.md.
+# NOT bundled (kept lean): tts-heavy engines and the docker-socket-proxy Stats
+# panel — both degrade gracefully. Bundled: Piper + Kokoro TTS and the lean
+# acoustic analyzer as an in-process venv (ANALYZE_PYTHON; no sidecars here).
+# CI also publishes `subwave-aio-heavy` (WITH_CLAP=1 WITH_DEMUCS=1) and
+# `subwave-aio-cuda` (+ WITH_CUDA=1) — see docs/unraid.md.
 
 # ---- web build: Next.js standalone (mirrors web/Dockerfile) ----------------
 FROM node:22-bookworm-slim AS webbuild
@@ -34,15 +18,10 @@ COPY web/package.json web/package-lock.json ./
 RUN npm ci
 COPY web/ ./
 ENV NEXT_TELEMETRY_DISABLED=1
-# The routes that emit absolute URLs (robots, sitemap, canonicals, OG cards)
-# all render per-request and read the RUNTIME SITE_URL env (inherited by the
-# web server via the supervisor), so a generic image works for any domain.
-# This build arg is belt-and-suspenders for source builds only.
+# Source builds only — absolute URLs render per-request off the RUNTIME env.
 ARG SITE_URL
 ENV SITE_URL=${SITE_URL}
-# Admin-console footer version, inlined into the web bundle at build time. See
-# web/next.config.js. Set from `git describe` by the publish-images CI; unset →
-# falls back to web/package.json.
+# Admin footer version, inlined at build time (web/next.config.js).
 ARG SUBWAVE_BUILD_VERSION
 ENV SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION}
 RUN npm run build
@@ -53,24 +32,17 @@ FROM caddy:2 AS caddybin
 # ---- node binary: lift Node 22 from the official image ----------------------
 FROM node:22-bookworm-slim AS nodebin
 
-# ---- final: everything under the liquidsoap (Debian bookworm) base ----------
-# v2.4.5 minimum — same reason as Dockerfile.broadcast: 2.4.4's O(n) clock
-# scan made the per-transition DJ effect chains stall the stream clock.
+# ---- final: everything under the liquidsoap (Debian) base -------------------
+# v2.4.5 minimum — same reason as Dockerfile.broadcast (2.4.4's O(n) clock scan
+# stalled the stream at every DJ-effect crossfade).
 FROM savonet/liquidsoap:v2.4.5
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive
 
-# System packages:
-#  - icecast2: the broadcast server (apt also creates the icecast2 user)
-#  - sudo: lets the supervisor drop privileges to icecast2 / liquidsoap
-#  - openssl: first-boot icecast secret generation
-#  - curl/ca-certificates: liquidsoap's HTTPS Subsonic fetch + health probes
-#  - iputils-ping: `ping` for in-container network debugging (self-host request)
-#  - espeak-ng/libsndfile1: Kokoro phonemisation + audio I/O
-#  - ffmpeg: jingle/SFX transcode on import (audio/audio-import.ts)
-#  - python3/python3-venv: the Kokoro worker venv
-#  - wget/tar/xz-utils: Piper + Kokoro model/binary pulls
+# icecast2 + sudo/openssl/curl: broadcast pair. espeak-ng/libsndfile1: Kokoro.
+# ffmpeg: jingle/SFX import transcode. python3/venv + wget/tar/xz-utils: the
+# TTS/analyzer venvs and model pulls. iputils-ping: in-container debugging.
 RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
         icecast2 sudo openssl curl ca-certificates \
@@ -80,10 +52,9 @@ RUN apt-get update -qq \
         wget tar xz-utils \
  && rm -rf /var/lib/apt/lists/*
 
-# Node.js 22 — runs both the controller (tsx) and the web server. Lifted from
-# the official image (same bookworm libc as this base) rather than installed
-# from NodeSource's apt repo: deb.nodesource.com serves per-IP 403s from its
-# CDN (nodesource/distributions#1844) and took out the v1.1.0 publish run.
+# Node.js 22 — lifted from the official image (same bookworm libc) rather than
+# NodeSource's apt repo, whose CDN serves per-IP 403s
+# (nodesource/distributions#1844) and took out the v1.1.0 publish run.
 COPY --from=nodebin /usr/local/bin/node /usr/local/bin/node
 COPY --from=nodebin /usr/local/lib/node_modules /usr/local/lib/node_modules
 COPY --from=nodebin /usr/local/include/node /usr/local/include/node
@@ -96,7 +67,7 @@ COPY --from=caddybin /usr/bin/caddy /usr/local/bin/caddy
 ARG WGET_RETRY="--tries=5 --retry-connrefused --waitretry=10 --timeout=60 --retry-on-http-error=429,500,502,503,504"
 
 # --- Piper (default TTS, ~30ms/word) ---------------------------------------
-# TARGETARCH is set by buildx; empty on a plain `docker build` → treat as amd64.
+# TARGETARCH comes from buildx; empty on plain `docker build` → amd64.
 ARG PIPER_VERSION=2023.11.14-2
 ARG TARGETARCH
 RUN cd /tmp && \
@@ -116,15 +87,11 @@ RUN mkdir -p /opt/piper/voices && \
       https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx.json
 
 # --- Kokoro (optional second TTS, more natural) ----------------------------
-# kokoro_worker.py imports misaki unconditionally, and kokoro-onnx 0.5.0 pairs
-# with misaki 0.9.4 (the controller image's validated combo). But misaki 0.9.4
-# requires Python <3.13, while this base (liquidsoap/Debian trixie) ships 3.13 —
-# so, unlike the controller (bookworm/py3.11), the system python3 can't build
-# the kokoro venv (misaki 0.9.4 has no 3.13 wheel and pip resolves nothing).
-# Provision a standalone CPython 3.12 via uv for THIS venv only; the analyzer
-# venv below stays on the system python3. The final import mirrors the worker's
-# import block, so a broken combo fails the build instead of silently falling
-# back to Piper at runtime.
+# misaki 0.9.4 (kokoro-onnx 0.5.0's validated pair) requires Python <3.13, but
+# this base (Debian trixie) ships 3.13 — so provision a standalone CPython 3.12
+# via uv for THIS venv only (the analyzer venv stays on system python3). The
+# import check mirrors the worker's import block so a broken combo fails the
+# build instead of silently falling back to Piper at runtime.
 COPY --from=ghcr.io/astral-sh/uv:0.11.27 /uv /usr/local/bin/uv
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 RUN uv venv --python 3.12 /opt/kokoro/venv && \
@@ -141,46 +108,21 @@ ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \
     KOKORO_PYTHON=/opt/kokoro/venv/bin/python
 
 # --- Acoustic analyzer (librosa + optional CLAP + Demucs) -------------------
-# The controller's analyze pass (bpm/key/intro/loudness, "sounds-like" CLAP
-# embeddings, Demucs vocal ranges) runs librosa, which isn't in the base
-# controller image — the split stack ships it as the separate `analyzer`
-# sidecar. The AIO has no sidecars, so we bake the same venv in and point the
-# controller at it via ANALYZE_PYTHON (music/analyzer.ts's local backend). The
-# analyze_worker.py copied with controller/scripts below is the single source of
-# truth; ffmpeg + libsndfile1 (installed above) give librosa codec coverage.
+# The split stack's `analyzer` sidecar, baked in as a venv and run via the
+# controller's local backend (ANALYZE_PYTHON). analyze_worker.py (copied with
+# controller/scripts below) is the single source of truth.
 #
-# CLAP ("sounds-like") + Demucs (vocal ranges) are the heavy tier — they add a
-# shared CPU-torch stack (~900MB on top of the lean venv) and are **OFF by
-# default**, so the default `subwave-aio` image stays lean (bpm/key/intro/
-# loudness only). CI also publishes a `subwave-aio-heavy`
-# tag built with WITH_CLAP=1 WITH_DEMUCS=1 — Unraid one-click users who want the
-# extra dimensions repoint their container at that tag. When on, both lazy-load
-# their weights the first time the admin toggles them during a rescan (into
-# HF_HOME, under the persisted state dir).
+# CLAP + Demucs are OFF by default (lean image); `subwave-aio-heavy` bakes
+# them, and `subwave-aio-cuda` (#1186) adds cu124 torch — WITH_CUDA implies the
+# heavy tier (CUDA torch alone would be dead weight), and the worker still
+# picks the device itself (ANALYZE_DEVICE=auto), so it degrades to CPU on a
+# driverless host. Host needs only the NVIDIA driver + container runtime; on
+# Unraid see docs/unraid.md.
 #
-# Version pins mirror the analyzer venv in docker/Dockerfile.analyzer — keep the
-# two in lockstep (same wheels, reproducible rebuilds). torch/torchaudio are held
-# at 2.6.0 repo-wide; WITH_CUDA only switches which 2.6.0 BUILD is installed —
-# the cpu wheel index (default) or cu124.
-#
-# WITH_CUDA=1 is the `subwave-aio-cuda` flavour (#1186): heavy + NVIDIA GPU, for
-# operators who run the one-click container on a box with a card and want CLAP +
-# Demucs off the CPU. It implies the heavy tier (CUDA torch with no CLAP/Demucs
-# would be several GB of dead weight), so CI builds it WITH_CLAP=1 WITH_DEMUCS=1.
-# The cu124 wheels vendor the CUDA runtime as nvidia-*-cu12 pip deps, so the base
-# image stays as-is and the host needs only the NVIDIA driver + container runtime
-# (on Unraid: the Nvidia Driver plugin, plus `--runtime=nvidia` and
-# NVIDIA_VISIBLE_DEVICES in the container's extra parameters — see docs/unraid.md).
-# Nothing else changes: analyze_worker.py picks the device itself (ANALYZE_DEVICE
-# defaults to auto — cuda when torch sees a GPU, else cpu with a logged warning),
-# so this image degrades to CPU on a driverless host rather than failing. It is
-# several GB larger than -heavy; the split stack's equivalent is the
-# subwave-analyzer-cuda image via the docker-compose.analyzer-gpu.yml overlay.
-#
-# NOTE: the analyzer venv runs on this base's system python3 (liquidsoap/Debian
-# trixie → 3.13, unlike Dockerfile.analyzer's python:3.11-slim). torch 2.6.0
-# publishes cp313 wheels on both the cpu and cu124 indexes, so the shared pin
-# holds on either side of the switch.
+# Pins mirror docker/Dockerfile.analyzer — keep the two in lockstep. This venv
+# runs on the system python3 (trixie → 3.13, unlike the analyzer image's 3.11);
+# torch 2.6.0 publishes cp313 wheels on both the cpu and cu124 indexes, so the
+# shared pin holds.
 ARG WITH_CLAP=0
 ARG WITH_DEMUCS=0
 ARG WITH_CUDA=0
@@ -190,10 +132,8 @@ RUN TORCH_INDEX="https://download.pytorch.org/whl/cpu" && \
     /opt/analyzer/venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/analyzer/venv/bin/pip install --no-cache-dir librosa==0.11.0 soundfile==0.14.0 pyloudnorm==0.2.0 && \
     if [ "$WITH_CLAP" = "1" ]; then \
-      # onnxruntime stays the CPU build even under WITH_CUDA: the ONNX path is
-      # the optional CLAP_MODEL_PATH custom-export route, and onnxruntime-gpu
-      # drags in a fragile CUDA/cuDNN version matrix. The default transformers
-      # path is what runs on the GPU.
+      # onnxruntime stays the CPU build even under WITH_CUDA — see
+      # docker/Dockerfile.analyzer.
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url "$TORCH_INDEX" \
         --extra-index-url https://pypi.org/simple \
@@ -201,12 +141,9 @@ RUN TORCH_INDEX="https://download.pytorch.org/whl/cpu" && \
       /opt/analyzer/venv/bin/python -c "import torch, transformers, onnxruntime" ; \
     fi && \
     if [ "$WITH_DEMUCS" = "1" ]; then \
-      # diffq: decompressor for demucs' quantized checkpoints (mdx_q, …). Tiny,
-      # but without it a DEMUCS_MODEL=*_q override makes demucs fatal() at load.
-      # It ships sdist-only (Cython ext), so lend it gcc + Python headers for the
-      # install and purge in the SAME layer — the lean image never pays for any
-      # of this. Unlike the analyzer image (python:3.11-slim ships headers), this
-      # base's apt python3 has none, so python3-dev is required for Python.h.
+      # diffq (quantized-checkpoint decompressor) ships sdist-only: lend it a
+      # toolchain and purge in the SAME layer. Unlike the analyzer image, this
+      # base's apt python3 has no headers — python3-dev supplies Python.h.
       apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev python3-dev && \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url "$TORCH_INDEX" \
@@ -216,22 +153,17 @@ RUN TORCH_INDEX="https://download.pytorch.org/whl/cpu" && \
       apt-get purge -y gcc libc6-dev python3-dev && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* ; \
     fi && \
     find /opt/analyzer/venv -depth -type d -name __pycache__ -exec rm -rf {} +
-# ANALYZE_PYTHON flips on the controller's local analyze backend; HF_HOME points
-# CLAP/Demucs weight downloads at the persisted state dir so they survive
-# recreates. ANALYZE_WORKER defaults to /app/scripts/analyze_worker.py (copied
-# below), so it needs no override here.
+# ANALYZE_PYTHON flips on the controller's local analyze backend; HF_HOME puts
+# CLAP/Demucs weights under the persisted state dir so they survive recreates.
+# ANALYZE_WORKER defaults to /app/scripts/analyze_worker.py (copied below).
 ENV ANALYZE_PYTHON=/opt/analyzer/venv/bin/python \
     HF_HOME=/var/sub-wave/hf-cache
 
 # --- Controller app ---------------------------------------------------------
 WORKDIR /app
 # .npmrc carries `legacy-peer-deps=true` (OpenRouter provider still declares a
-# stale `peer ai@^6` after the AI SDK v7 upgrade); it must land before install
-# or npm hits ERESOLVE.
+# stale `peer ai@^6`); it must land before install or npm hits ERESOLVE.
 COPY controller/package*.json controller/.npmrc ./
-# npm ci (not install): controller ships a package-lock.json, so ci gives a
-# reproducible, lockfile-exact install. The package*.json glob above already
-# brings the lockfile in before this runs.
 RUN npm ci --omit=dev
 COPY controller/src ./src
 COPY controller/scripts ./scripts
@@ -241,8 +173,8 @@ COPY controller/scripts ./scripts
 COPY --from=webbuild /web/.next/standalone /web
 COPY --from=webbuild /web/.next/static /web/.next/static
 COPY --from=webbuild /web/public /web/public
-# The /news routes (and the sitemap) render per-request, so the dispatch
-# markdown is read at runtime — the standalone trace doesn't include it.
+# /news + sitemap read the dispatch markdown at runtime — the standalone trace
+# doesn't include it.
 COPY --from=webbuild /web/content /web/content
 
 # --- Broadcast + edge config + bundled audio --------------------------------
@@ -257,16 +189,15 @@ RUN chmod +x /usr/local/bin/subwave-supervisor
 RUN mkdir -p /var/sub-wave && chmod 777 /var/sub-wave
 
 # Re-declared for the final stage (ARGs don't cross stage boundaries) so the
-# controller process reports the same version (backup manifest) as the web
-# build above. Same source as the webbuild-stage arg.
+# controller reports the same version as the web build above.
 ARG SUBWAVE_BUILD_VERSION
 ENV NODE_ENV=production \
     STATE_DIR=/var/sub-wave \
     SOUNDS_DIR=/sounds \
     SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION}
 
-# Single public port: Caddy on :80. Health = the controller's liveness via the
-# edge, which only answers once web + controller are both up.
+# Single public port: Caddy on :80. Health = controller liveness via the edge,
+# which only answers once web + controller are both up.
 EXPOSE 80
 HEALTHCHECK --interval=15s --timeout=5s --start-period=40s --retries=6 \
     CMD curl -fsS http://localhost:80/api/health > /dev/null || exit 1

--- a/docker/Dockerfile.analyzer
+++ b/docker/Dockerfile.analyzer
@@ -1,78 +1,38 @@
-# subwave-analyzer — optional acoustic-analysis sidecar.
+# subwave-analyzer — acoustic-analysis sidecar (bpm/key/intro/loudness, plus
+# optional CLAP "sounds-like" embeddings and Demucs vocal-activity ranges).
+# Default-on service in every compose file; the controller POSTs to it via
+# ANALYZE_URL. A thin FastAPI front (docker/analyzer/server.py) supervises the
+# SAME stdio worker the controller uses (controller/scripts/analyze_worker.py).
 #
-# Background: acoustic analysis (bpm / key / intro / loudness, plus optional
-# CLAP "sounds-like" embeddings and Demucs vocal-activity ranges) runs librosa
-# + a CPU-torch stack that deliberately does NOT live in the controller image
-# (controller/src/music/analyzer.ts). It used to ride inside the heavy-TTS
-# sidecar (docker/Dockerfile.tts-heavy), which meant an operator who wanted
-# analysis had to pull the full ~6GB Chatterbox + PocketTTS image even though
-# analysis has nothing to do with speech synthesis.
-#
-# This image is the analyzer on its own. It's a default-on service in every
-# compose file; the controller picks it up via ANALYZE_URL and POSTs analysis
-# requests to it. The analyze worker also ships in the tts-heavy image, so the
-# controller's URL resolution (ANALYZE_URL first, then TTS_HEAVY_URL) means a
-# tts-heavy-only install still gets analysis — see analyzer.ts.
-#
-# Architecture: a single librosa venv driven by the SAME stdio worker script
-# the controller + tts-heavy use (controller/scripts/analyze_worker.py), fronted
-# by a tiny FastAPI server (docker/analyzer/server.py) that supervises it as a
-# long-lived subprocess. Wire contract (/health + /analyze) is identical to
-# tts-heavy's, so the controller treats the two interchangeably.
-#
-# Three published flavours (see .github/workflows/publish-images.yml):
-#   * subwave-analyzer        — LEAN (default), ~1.1GB, MULTI-ARCH (amd64+arm64).
-#       librosa + ffmpeg, no torch: bpm/key/intro/loudness. WITH_CLAP=0 WITH_DEMUCS=0.
-#   * subwave-analyzer-heavy  — CLAP + Demucs baked (~1.9GB), amd64-only.
-#       "sounds-like" embeddings + vocal ranges. WITH_CLAP=1 WITH_DEMUCS=1.
-#       CPU-only torch wheels.
-#   * subwave-analyzer-cuda   — heavy + NVIDIA CUDA torch (cu124), amd64-only.
-#       Same features as -heavy with CLAP/Demucs on the GPU. WITH_CUDA=1 flips
-#       the torch wheel index; the host needs only the NVIDIA driver +
-#       nvidia-container-toolkit (cu124 wheels vendor the CUDA runtime). Run it
-#       via the docker-compose.analyzer-gpu.yml overlay, which also adds the
-#       GPU device reservation. Several GB larger than -heavy (nvidia-*-cu12).
-# Operators switch to the heavy image with `ANALYZER_HEAVY=1` in .env (the
-# compose `analyzer` service pulls `subwave-analyzer${ANALYZER_HEAVY:+-heavy}`);
-# the cuda image is selected by the analyzer-gpu overlay instead (a device
-# reservation can't be toggled from .env). Models are NOT baked: the heavy worker
-# downloads CLAP/Demucs weights into the HF cache (HF_HOME) the first time the
-# analyze pass needs them; the compose files mount a named volume over that
-# cache so the download survives container recreates.
+# Three published flavours (.github/workflows/publish-images.yml):
+#   * subwave-analyzer        — LEAN (default), ~1.1GB, multi-arch, no torch.
+#   * subwave-analyzer-heavy  — CLAP + Demucs baked (~1.9GB), amd64-only,
+#       CPU torch. Selected by ANALYZER_HEAVY=1 in .env.
+#   * subwave-analyzer-cuda   — heavy + cu124 torch, amd64-only. Selected by
+#       the docker-compose.analyzer-gpu.yml overlay (a device reservation
+#       can't be toggled from .env).
+# Models are NOT baked — the heavy worker downloads weights into HF_HOME on
+# first use; compose mounts a named volume over that cache.
 
 FROM python:3.11-slim-bookworm
 
-# ffmpeg + libsndfile1 give librosa broad codec coverage for the Navidrome
-# stream formats (opus/m4a/mp3). curl is for the operator's own healthchecks;
-# uvicorn handles its own internally.
+# ffmpeg + libsndfile1: librosa codec coverage for the Navidrome stream
+# formats. curl: operator healthchecks.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates ffmpeg libsndfile1 \
     && rm -rf /var/lib/apt/lists/*
 
-# --- Analyzer venv (librosa — bpm/key/intro/loudness; optional CLAP + Demucs) -
-# librosa/numba ship as wheels (no g++ needed). The base trio is always present.
+# --- Analyzer venv ----------------------------------------------------------
+# CLAP + Demucs are the heavy tier (~1.5GB each, CPU torch) — OFF by default so
+# the lean image stays small and multi-arch. At runtime each still needs its
+# own flag (ANALYZE_AUDIO_EMBEDDING / ANALYZE_VOCAL_ACTIVITY or the admin
+# toggle); with the stack absent those are clean no-ops.
 #
-# CLAP audio embeddings ("sounds-like" similarity) and Demucs vocal-activity
-# ranges are the heavy tier — CPU torch + transformers/torchaudio (~1.5GB each).
-# They are **OFF by default** so the published `subwave-analyzer` image stays
-# lean (~1.1GB, no torch) and multi-arch. Opt IN with `--build-arg WITH_CLAP=1` /
-# `WITH_DEMUCS=1`; the CI publishes that heavy build as the separate
-# `subwave-analyzer-heavy` image (see .github/workflows/publish-images.yml), and
-# operators switch to it with `ANALYZER_HEAVY=1` in their `.env` (the compose
-# `analyzer` service resolves `subwave-analyzer${ANALYZER_HEAVY:+-heavy}`). At
-# runtime each still needs its own flag (ANALYZE_AUDIO_EMBEDDING /
-# ANALYZE_VOCAL_ACTIVITY, or the admin toggle); with the stack absent those are
-# clean no-ops (bpm/key/loudness only).
-#
-# Version pins: every install is pinned to an exact stable so a rebuild months
-# from now resolves the SAME wheels (reproducible, no surprise major bumps).
-# These pins are the single source of truth for the analyzer venv — keep them in
-# lockstep with the mirrored analyzer block in docker/Dockerfile.aio. torch/
-# torchaudio are held at 2.6.0 (the version chatterbox pins in
-# docker/Dockerfile.tts-heavy; keeps one torch VERSION repo-wide). WITH_CUDA
-# only switches which 2.6.0 build is installed: the cpu wheel index (default)
-# or cu124 (the subwave-analyzer-cuda flavour — cu124 builds of 2.6.0 vendor
-# the CUDA runtime as nvidia-*-cu12 pip deps, so the base image stays slim).
+# All pins exact for reproducible rebuilds — keep in lockstep with the mirrored
+# analyzer block in docker/Dockerfile.aio. torch/torchaudio held at 2.6.0
+# (chatterbox's pin — one torch version repo-wide); WITH_CUDA only switches
+# which 2.6.0 build is installed (cpu wheel index vs cu124, whose wheels vendor
+# the CUDA runtime as nvidia-*-cu12 deps).
 ARG WITH_CLAP=0
 ARG WITH_DEMUCS=0
 ARG WITH_CUDA=0
@@ -84,9 +44,8 @@ RUN TORCH_INDEX="https://download.pytorch.org/whl/cpu" && \
     /opt/analyzer/venv/bin/pip install --no-cache-dir librosa==0.11.0 soundfile==0.14.0 pyloudnorm==0.2.0 && \
     if [ "$WITH_CLAP" = "1" ]; then \
       # onnxruntime stays the CPU build even under WITH_CUDA: the ONNX path is
-      # the optional CLAP_MODEL_PATH custom-export route, and onnxruntime-gpu
-      # drags in a fragile CUDA/cuDNN version matrix. The default transformers
-      # path is what runs on the GPU.
+      # only the CLAP_MODEL_PATH custom-export route, and onnxruntime-gpu drags
+      # in a fragile CUDA/cuDNN matrix. The transformers path runs on the GPU.
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url "$TORCH_INDEX" \
         --extra-index-url https://pypi.org/simple \
@@ -94,10 +53,9 @@ RUN TORCH_INDEX="https://download.pytorch.org/whl/cpu" && \
       /opt/analyzer/venv/bin/python -c "import torch, transformers, onnxruntime" ; \
     fi && \
     if [ "$WITH_DEMUCS" = "1" ]; then \
-      # diffq: decompressor for demucs' quantized checkpoints (mdx_q, …). Tiny,
-      # but without it a DEMUCS_MODEL=*_q override makes demucs fatal() at load.
-      # It ships sdist-only (Cython ext), so lend it gcc for the install and
-      # purge in the SAME layer — the lean image never pays for any of this.
+      # diffq decompresses demucs' quantized checkpoints — without it a
+      # DEMUCS_MODEL=*_q override makes demucs fatal() at load. It ships
+      # sdist-only (Cython ext): lend it gcc and purge in the SAME layer.
       apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev && \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url "$TORCH_INDEX" \
@@ -108,9 +66,7 @@ RUN TORCH_INDEX="https://download.pytorch.org/whl/cpu" && \
     fi && \
     find /opt/analyzer/venv -depth -type d -name __pycache__ -exec rm -rf {} +
 
-# --- Server venv (FastAPI only — no PyTorch needed) ------------------------
-# The HTTP front is thin: it spawns the stdio analyze worker and shuttles JSON
-# between it and the HTTP client. No model loading happens here.
+# --- Server venv (FastAPI only — spawns the stdio worker, no model loading) --
 RUN python3 -m venv /opt/server/venv && \
     /opt/server/venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/server/venv/bin/pip install --no-cache-dir \
@@ -122,28 +78,18 @@ ENV PATH=/opt/server/venv/bin:$PATH \
 
 WORKDIR /app
 COPY docker/analyzer/server.py /app/server.py
-# Reuse the SAME worker script the controller + tts-heavy use — single source of
-# truth for analysis logic. The script speaks JSON over stdio; server.py wraps
-# that with an HTTP surface.
+# The SAME worker the controller runs in-process — single source of truth.
 COPY controller/scripts/analyze_worker.py /app/workers/analyze_worker.py
 
-# Shared state mount with the controller — the controller may pre-fetch a track
-# into /var/sub-wave/analyze-tmp and pass the local path, which the worker reads
-# off this volume. Created by the controller image (chmod 777 there); we mkdir
-# here too so the image is self-contained when run standalone.
+# Shared state mount — the controller pre-fetches tracks into
+# /var/sub-wave/analyze-tmp. mkdir'd here so the image runs standalone too.
 RUN mkdir -p /var/sub-wave && chmod 777 /var/sub-wave
 
-# --- Drop root: run uvicorn (and the analyze worker) as an unprivileged user --
-# The server never needs root at runtime — it only writes to (a) the shared
-# /var/sub-wave mount (the entrypoints chmod it 777) and (b) the caches below:
-# the HF weights cache (ANALYZER_HF_HOME, only touched when CLAP is enabled) and
-# librosa/numba's JIT cache. It reads no root-only paths (no icecast secrets, no
-# venv writes), so a fixed non-root uid/gid (10001) is safe and keeps any
-# container breakout unprivileged. HOME + the XDG/NUMBA cache dirs are pointed at
-# a user-owned tree so numba's cache=True JIT files land somewhere writable
-# instead of the root-owned site-packages (which would just warn + skip caching).
-# /opt/analyzer/hf-cache is chowned so the compose named volume mounted over it
-# inherits the ownership on first create.
+# --- Drop root --------------------------------------------------------------
+# The server only writes the shared mount, the HF cache, and librosa/numba's
+# JIT cache. HOME/XDG/NUMBA point at a user-owned tree so numba's cache=True
+# JIT files land somewhere writable; the hf-cache chown makes the compose named
+# volume inherit ownership on first create.
 ENV HOME=/home/subwave \
     XDG_CACHE_HOME=/home/subwave/.cache \
     NUMBA_CACHE_DIR=/home/subwave/.cache/numba

--- a/docker/Dockerfile.broadcast
+++ b/docker/Dockerfile.broadcast
@@ -1,34 +1,20 @@
 # SUB/WAVE broadcast image — Icecast2 + Liquidsoap in one container.
+# icecast2 serves listeners on :7702; liquidsoap connects over loopback and
+# exposes telnet on :1234 (internal). broadcast-entrypoint.sh resolves the
+# shared passwords, renders icecast.xml, launches both, and exits if either
+# dies so the restart policy bounces them together.
 #
-# Replaces the previous split (subwave-icecast + subwave-liquidsoap). The two
-# processes are always launched together, share the same `state/` mount, and
-# already coordinate through the icecast-secrets handshake — collapsing them
-# removes the inter-container healthcheck race and the moul/icecast amd64-only
-# constraint at the same time.
-#
-# Layout inside the container:
-#   - icecast2 runs as the icecast2 user on :7702 (HTTP) — listener-facing.
-#   - liquidsoap runs as the liquidsoap user (uid 10000), connects to icecast
-#     over 127.0.0.1, and exposes its telnet control port on :1234 (internal).
-#   - A tiny shell supervisor (broadcast-entrypoint.sh) resolves the shared
-#     password, renders icecast.xml, launches both, and exits if either dies
-#     so the container's restart policy bounces them together.
-# v2.4.5 minimum: 2.4.4's clock scanned every source in the graph per pull,
-# and pass-through layers (smooth_add/compress) pull more than once per frame —
-# together the per-transition DJ effect chains (sweep/washout/dissolve, ~30
-# operators) pegged a core and stalled the stream clock at every crossfade
-# ("Latency is too high" → dead-air source resets). 2.4.5 makes clock
-# sync-source propagation push-based/O(1), which removes the stall entirely
-# (verified against the dissolve worst case in an isolated sandbox).
+# v2.4.5 minimum: 2.4.4's per-pull clock scan let the per-transition DJ effect
+# chains (~30 operators) peg a core and stall the stream clock at every
+# crossfade ("Latency is too high" → dead-air source resets). 2.4.5 makes
+# clock propagation push-based/O(1).
 FROM savonet/liquidsoap:v2.4.5
 
 USER root
 
-# - icecast2: the broadcast server (apt also creates the icecast2 user).
-# - sudo: lets the supervisor drop privileges to icecast2 / liquidsoap.
-# - openssl: random hex generation for first-boot secrets.
-# - curl: liquidsoap's protocol.external HTTPS fetch (Subsonic stream URLs)
-#   and the supervisor's "icecast accepting connections yet" probe.
+# sudo: drop privileges to icecast2/liquidsoap. openssl: first-boot secret
+# generation. curl: liquidsoap's HTTPS Subsonic fetch + the entrypoint's
+# "icecast up yet" probe.
 RUN apt-get update -qq \
  && apt-get install -y --no-install-recommends \
         icecast2 \
@@ -38,24 +24,19 @@ RUN apt-get update -qq \
         ca-certificates \
  && rm -rf /var/lib/apt/lists/*
 
-# Bake the icecast config template (with ${ICECAST_*_PASSWORD} placeholders)
-# and the mixer script + repo-bundled audio (emergency loop + studio bed).
-# Prod no longer bind-mounts these from the repo — operators install via the
-# image-only path. Dev compose can still bind-mount over the top for hot reload.
+# Baked config + repo-bundled audio (prod is image-only; dev compose can still
+# bind-mount over the top).
 COPY docker/icecast.xml.template /etc/icecast2/icecast.xml.template
 COPY liquidsoap/radio.liq /etc/liquidsoap/radio.liq
 COPY sounds /sounds
 
-# Bake the supervisor entrypoint.
 COPY docker/broadcast-entrypoint.sh /usr/local/bin/broadcast-entrypoint
 RUN chmod +x /usr/local/bin/broadcast-entrypoint
 
-# Healthcheck: icecast HTTP is reachable. Start period covers cold-boot
-# (apt'd icecast2 takes a couple of seconds to bind the socket).
 HEALTHCHECK --interval=10s --timeout=3s --start-period=15s --retries=6 \
     CMD curl -fsS http://localhost:7702/status-json.xsl > /dev/null || exit 1
 
-# Supervisor runs as root so it can resolve secrets, render icecast.xml, and
-# sudo into the dedicated user accounts for each process.
+# Entrypoint runs as root so it can resolve secrets, render icecast.xml, and
+# sudo into the per-process users.
 USER root
 ENTRYPOINT ["/usr/local/bin/broadcast-entrypoint"]

--- a/docker/Dockerfile.caddy
+++ b/docker/Dockerfile.caddy
@@ -1,6 +1,5 @@
 FROM caddy:2-alpine
 
-# Bake the Caddyfile in so prod compose doesn't need a bind mount and operators
-# don't need to clone the repo. To customise the edge config, rebuild the image
-# from a fork or override the file at /etc/caddy/Caddyfile with your own mount.
+# Baked in so prod compose needs no bind mount or clone. To customise, rebuild
+# from a fork or mount your own file over /etc/caddy/Caddyfile.
 COPY docker/Caddyfile /etc/caddy/Caddyfile

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -1,26 +1,20 @@
 FROM node:22-bookworm-slim
 
-# Shared build deps + espeak-ng for Kokoro phonemization (British English).
-# ffmpeg transcodes + level-matches operator-imported jingles/SFX (see
-# audio/audio-import.ts); without it the import path stores raw uploads as-is.
-# iputils-ping supplies `ping` for network debugging when you exec into the container.
+# espeak-ng: Kokoro phonemization. ffmpeg: transcode + level-match imported
+# jingles/SFX (audio/audio-import.ts). iputils-ping: in-container debugging.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates wget tar iputils-ping \
     python3 python3-venv \
     espeak-ng libsndfile1 ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
-# Common wget retry policy for the model/binary pulls below. GitHub releases and
-# HuggingFace's xet bridge intermittently return 429/5xx in CI; without retries
-# a single transient blip fails the whole release build (wget exit code 8).
-# --retry-on-http-error needs GNU wget >= 1.20 (bookworm ships 1.21).
-# ARG (not ENV) so it stays a build-time detail and isn't baked into the image.
+# Retry policy for the model/binary pulls below — GitHub releases and HF's xet
+# bridge intermittently 429/5xx in CI, and one blip fails the release build.
+# ARG (not ENV) so it stays build-time only.
 ARG WGET_RETRY="--tries=5 --retry-connrefused --waitretry=10 --timeout=60 --retry-on-http-error=429,500,502,503,504"
 
-# --- Piper -----------------------------------------------------------------
-# CPU-only, ~30ms/word. Default engine; remains the fast path even after Kokoro.
-# TARGETARCH is provided automatically by buildx (amd64 / arm64); map it to the
-# Piper release's asset naming so the multi-arch build pulls the right binary.
+# --- Piper (default TTS, CPU-only, ~30ms/word) ------------------------------
+# TARGETARCH comes from buildx (empty on plain `docker build` → amd64).
 ARG PIPER_VERSION=2023.11.14-2
 ARG TARGETARCH
 RUN cd /tmp && \
@@ -34,18 +28,16 @@ RUN cd /tmp && \
     ln -s /opt/piper/piper /usr/local/bin/piper && \
     rm piper_linux_${piper_arch}.tar.gz
 
-# British English voice — lift the same one you use in Kaze
+# British English voice
 RUN mkdir -p /opt/piper/voices && \
     wget -q ${WGET_RETRY} -O /opt/piper/voices/en_GB-alan-medium.onnx \
       https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx && \
     wget -q ${WGET_RETRY} -O /opt/piper/voices/en_GB-alan-medium.onnx.json \
       https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx.json
 
-# --- Kokoro ---------------------------------------------------------------
-# Optional second engine. Slower than Piper (~300-800ms/line on CPU) but a lot
-# more natural. Lives in an isolated venv so its Python deps don't tangle with
-# anything else in the image. Worker loads the model once on first use and
-# stays resident (see controller/scripts/kokoro_worker.py).
+# --- Kokoro (optional second TTS — slower, more natural) --------------------
+# Isolated venv; the worker loads the model once and stays resident
+# (controller/scripts/kokoro_worker.py).
 RUN python3 -m venv /opt/kokoro/venv && \
     /opt/kokoro/venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/kokoro/venv/bin/pip install --no-cache-dir \
@@ -61,40 +53,27 @@ ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \
     KOKORO_VOICES=/opt/kokoro/models/voices-v1.0.bin \
     KOKORO_PYTHON=/opt/kokoro/venv/bin/python
 
-# --- Chatterbox (opt-in) --------------------------------------------------
-# Fourth TTS engine — Resemble AI's Chatterbox Turbo: zero-shot voice cloning
-# plus native paralinguistic tags ([laugh], [sigh], …). Uses the official
-# `chatterbox-tts` PyPI package (PyTorch — there is no turn-key ONNX runtime).
-# The runtime + weights add ~2-3GB, and CPU inference is slow, so this is
-# deliberately NOT in the default image. Build with
-# `--build-arg WITH_CHATTERBOX=1` to bundle it into an isolated venv (same
-# pattern as Kokoro above). The final `from_pretrained` doubles as a build-time
-# smoke test (it fails the build if the install is broken) and pre-warms the
-# Hugging Face cache so the first DJ line doesn't trigger a multi-GB download.
-# When the venv is absent, chatterbox.isAvailable() (an existsSync on the venv
-# interpreter) reports false and the dispatcher falls back to Piper.
-# CHATTERBOX_PIP_PKG is overridable in case the package is renamed upstream.
+# --- Chatterbox (opt-in, --build-arg WITH_CHATTERBOX=1) ---------------------
+# Resemble AI's Chatterbox Turbo: zero-shot voice cloning + paralinguistic tags.
+# PyTorch-only (~2-3GB + slow CPU inference), so deliberately NOT in the default
+# image. The from_pretrained call doubles as a build-time smoke test and
+# pre-warms the HF cache. With the venv absent, chatterbox.isAvailable() reports
+# false and the dispatcher falls back to Piper.
 ENV HF_HOME=/opt/chatterbox/hf-cache
 ARG WITH_CHATTERBOX=0
 ARG CHATTERBOX_PIP_PKG=chatterbox-tts
-# GPU opt-in, mirroring docker/Dockerfile.tts-heavy. Defaults keep the CPU-only
-# build. Point CHATTERBOX_TORCH_INDEX_URL at a cuXXX wheel index, and for
-# RTX 50-series (Blackwell) also set CHATTERBOX_TORCH_SPEC to a newer torch
-# (e.g. "torch==2.9.1 torchaudio==2.9.1") to override chatterbox's ==2.6.0 pin.
-# The in-process route still needs a GPU device reservation on the controller
-# service itself — see docs/gpu-tts.md.
+# GPU opt-in (mirrors docker/Dockerfile.tts-heavy): point the index at a cuXXX
+# wheel; RTX 50-series also needs CHATTERBOX_TORCH_SPEC to override the ==2.6.0
+# pin. The in-process route still needs a GPU reservation on the controller
+# service — see docs/gpu-tts.md.
 ARG CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
 ARG CHATTERBOX_TORCH_SPEC=
-# Image size: the default PyPI `torch` wheel is the CUDA build, which drags in
-# ~3.6GB of NVIDIA libraries (nvidia-*, triton, cusparselt) that are dead weight
-# on a CPU-only station. torch + torchaudio + chatterbox-tts are therefore all
-# installed in ONE resolve with PyTorch's CPU wheel index as the primary index
-# and PyPI as the extra (for the non-torch deps). The CPU wheels carry a `+cpu`
-# local version tag, which sorts ABOVE the plain PyPI version, so pip prefers
-# them — and the CPU torch wheel simply doesn't declare the nvidia-* deps, so
-# they're never pulled. Installing in two separate commands does NOT work: the
-# second resolve sees only PyPI and re-pulls the CUDA torch. The final cleanup
-# strips compiled bytecode and torch's C++ headers/test suite (unused at runtime).
+# The default PyPI torch wheel is the CUDA build (~3.6GB of nvidia-* deps that
+# are dead weight on CPU). torch + torchaudio + chatterbox must be installed in
+# ONE resolve with the CPU wheel index primary: the `+cpu` local version tag
+# sorts above PyPI's, so pip prefers it, and the CPU wheel declares no nvidia-*
+# deps. Two separate installs do NOT work — the second resolve re-pulls CUDA
+# torch from PyPI.
 RUN if [ "$WITH_CHATTERBOX" = "1" ]; then \
       echo "Bundling Chatterbox Turbo (PyTorch) — adds ~3-4GB to the image" && \
       python3 -m venv /opt/chatterbox/venv && \
@@ -119,23 +98,16 @@ RUN if [ "$WITH_CHATTERBOX" = "1" ]; then \
       echo "Chatterbox not bundled — build with --build-arg WITH_CHATTERBOX=1 to include it" ; \
     fi
 
-# --- PocketTTS (opt-in) ---------------------------------------------------
-# Fifth TTS engine — kyutai-labs' PocketTTS: a 100M-param CPU-only model
-# (~6× real-time on a modern CPU, ~200ms time-to-first-chunk) covering EN/FR/
-# DE/IT/ES/PT built-in voices, MIT-licensed. Sits between Piper (fast, robotic)
-# and Chatterbox (heavy, expressive) in the local-engine ladder. The runtime
-# still drags PyTorch in, so this is deliberately NOT in the default image —
-# build with `--build-arg WITH_POCKETTTS=1` to bundle the venv. Same isolation
-# pattern as Chatterbox (its own venv at /opt/pocket-tts/venv, CPU torch wheels
-# only, model preload doubling as a build-time smoke test). When the venv is
-# absent, pocketTts.isAvailable() reports false and the dispatcher falls back
-# to Piper, so settings can safely reference the engine regardless.
-# HF_TOKEN (optional) unlocks PocketTTS voice cloning (issue #238): the cloning
-# weights (kyutai/pocket-tts) are GATED on Hugging Face. Without it the pre-warm
-# loads the open "without-voice-cloning" weights and cloned .wav voices revert
-# to a built-in. Setting HF_TOKEN at RUNTIME also works (lazy download on first
-# load); the build-arg only bakes the gated weights in. A build-arg token lands
-# in image history, so prefer the runtime env unless you control the image.
+# --- PocketTTS (opt-in, --build-arg WITH_POCKETTTS=1) -----------------------
+# kyutai-labs' PocketTTS: 100M-param CPU model between Piper (fast, robotic)
+# and Chatterbox (heavy, expressive). Still drags PyTorch in, so NOT in the
+# default image; same venv-isolation pattern as Chatterbox, model preload as
+# build-time smoke test. With the venv absent, pocketTts.isAvailable() reports
+# false and the dispatcher falls back to Piper.
+# HF_TOKEN (optional) unlocks voice cloning (#238) — the cloning weights are
+# gated; without it the pre-warm loads the open weights and cloned .wav voices
+# revert to a built-in. Runtime env also works (lazy download); a build-arg
+# token lands in image history, so prefer runtime unless you control the image.
 ARG WITH_POCKETTTS=0
 ARG HF_TOKEN=""
 RUN if [ "$WITH_POCKETTTS" = "1" ]; then \
@@ -161,31 +133,25 @@ ENV POCKET_TTS_PYTHON=/opt/pocket-tts/venv/bin/python \
 # --- Controller app -------------------------------------------------------
 WORKDIR /app
 # .npmrc carries `legacy-peer-deps=true` (OpenRouter provider still declares a
-# stale `peer ai@^6` after the AI SDK v7 upgrade); it must land before install
-# or npm hits ERESOLVE.
+# stale `peer ai@^6`); it must land before install or npm hits ERESOLVE.
 COPY controller/package*.json controller/.npmrc ./
-# npm ci (not install): controller ships a package-lock.json, so ci gives a
-# reproducible, lockfile-exact install and is faster in CI. The package*.json
-# glob above already brings the lockfile in before this runs.
 RUN npm ci --omit=dev
 COPY controller/src ./src
 COPY controller/scripts ./scripts
 
-# Version reported by the controller (e.g. the backup manifest). Set from `git
-# describe` by scripts/update.sh and the publish-images CI; unset → falls back
-# to controller/package.json (see routes/backup.ts).
+# Version reported by the controller (backup manifest). Set from `git describe`
+# by scripts/update.sh + CI; unset → controller/package.json (routes/backup.ts).
 ARG SUBWAVE_BUILD_VERSION
 ENV SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION}
 
-# Bake repo-bundled audio (emergency loop + studio bed + sfx). Prod no longer
-# bind-mounts ../sounds — operators install via the image-only path. Dev
-# compose can still bind-mount over the top for hot reload of new SFX.
+# Repo-bundled audio (emergency loop + studio bed + sfx). Prod is image-only;
+# dev compose can bind-mount over the top.
 COPY sounds /sounds
 
 # State dir shared with Liquidsoap
 RUN mkdir -p /var/sub-wave/voice && chmod 777 /var/sub-wave
 
 EXPOSE 7701
-# `tsx` is in `dependencies` (not devDeps) so it survives `npm install --omit=dev`
-# above; we run .ts directly — no separate build step. See controller/tsconfig.json.
+# tsx is in `dependencies` (not devDeps) so it survives --omit=dev; we run .ts
+# directly — no build step.
 CMD ["node_modules/.bin/tsx", "src/server.ts"]

--- a/docker/Dockerfile.tts-heavy
+++ b/docker/Dockerfile.tts-heavy
@@ -1,54 +1,27 @@
-# subwave-tts-heavy — optional sidecar for Chatterbox + PocketTTS.
+# subwave-tts-heavy — optional sidecar for Chatterbox + PocketTTS (#103: the
+# runtime opt-in for operators on pre-built images; the WITH_* build-arg path
+# in Dockerfile.controller still covers the in-process variant). Enabled with
+# `docker compose --profile tts-heavy up -d`; the controller POSTs speech
+# requests via TTS_HEAVY_URL.
 #
-# Background: the controller's default image is pure Node (Piper + Kokoro
-# in-process). The two heavy PyTorch engines (Chatterbox Turbo, PocketTTS) used
-# to live behind --build-arg WITH_CHATTERBOX=1 / WITH_POCKETTTS=1 inside
-# docker/Dockerfile.controller, which meant operators on the pre-built
-# ghcr.io/perminder-klair/subwave-controller image had no path to them
-# (issue #103 — they'd have to fork, rebuild, and publish their own image).
+# TWO isolated venvs, one per engine, driven by the existing stdio workers
+# (controller/scripts/{chatterbox,pocket_tts}_worker.py) behind a thin FastAPI
+# front (docker/tts-heavy/server.py). Two venvs because the engines need
+# incompatible pip resolutions — one venv forces chatterbox down to 0.1.3,
+# which lacks ChatterboxTurboTTS.
 #
-# This image is the runtime opt-in. Operators enable it with
-# `docker compose --profile tts-heavy up -d`; the controller picks the
-# sidecar up via TTS_HEAVY_URL (see docker-compose*.yml) and POSTs speech
-# requests to it. The build-arg path in Dockerfile.controller still works
-# for the in-process variant.
-#
-# Architecture: TWO isolated venvs (one per engine), driven by the existing
-# stdio worker scripts (controller/scripts/{chatterbox,pocket_tts}_worker.py)
-# and fronted by a tiny FastAPI server (docker/tts-heavy/server.py) that
-# supervises them as long-lived subprocesses. The two engines need
-# incompatible pip resolutions — chatterbox-tts ≥ 0.1.5 (which has the
-# tts_turbo import we use) pulls a different transformers/torch set than
-# pocket-tts wants, so combining them in one venv forces chatterbox down to
-# 0.1.3 which lacks ChatterboxTurboTTS. Two venvs side-step the resolver.
-# This also mirrors the pattern Dockerfile.controller already uses for the
-# legacy in-process WITH_* build args.
-#
-# Image size: ~5-6GB. CPU-only torch wheels (mirror of the index-url trick in
-# docker/Dockerfile.controller:72-87) to avoid the 3.6GB CUDA build. Models are
-# NOT baked at build time — each worker downloads its weights into the HF cache
-# (HF_HOME, set per-engine by server.py) the first time it boots, before it
-# reports ready (server.py's lifespan starts the workers at container start, so
-# the fetch happens on container boot, not on the first /speak). We used to
-# pre-warm them here with a from_pretrained() smoke test, but that pulled
-# several GB from the Hugging Face Hub *inside CI* over an unauthenticated,
-# heavily rate-limited connection, making the image build slow (20+ min) and
-# flaky (HF 429s / timeouts). The build now only does an import-only smoke test
-# (no network); the multi-GB fetch moves to runtime.
-#
-# The compose files mount a named volume over each HF cache dir
-# (tts-heavy-{chatterbox,pocket}-cache → /opt/{chatterbox,pocket-tts}/hf-cache)
-# so that boot-time download survives container recreates — otherwise it would
-# repeat on every `up -d --build` / image pull / update.
+# Models are NOT baked: each worker downloads its weights into the HF cache at
+# container boot, before reporting ready. A build-time from_pretrained pre-warm
+# used to pull several GB inside CI over an unauthenticated rate-limited
+# connection (20+ min, flaky 429s) — the build now does an import-only smoke
+# test. Compose mounts named volumes over the cache dirs so the boot-time
+# download survives recreates.
 
 FROM python:3.11-slim-bookworm
 
-# build-essential is needed because chatterbox-tts pulls pkuseg, which has no
-# wheel for Python ≥ 3.9 on Linux and so source-builds a Cython extension that
-# needs g++. We purge it after both venvs are built (see the apt purge step
-# below) to keep the runtime image lean.
-# libsndfile is what soundfile/torchaudio shell out to for WAV write. curl is
-# for the operator's own healthchecks; uvicorn handles its own internally.
+# build-essential: chatterbox-tts pulls pkuseg, which has no py≥3.9 wheel and
+# source-builds a Cython extension. Purged after both venvs are built.
+# libsndfile1: soundfile/torchaudio WAV write. curl: operator healthchecks.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates \
     libsndfile1 \
@@ -56,48 +29,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # --- Chatterbox venv -------------------------------------------------------
-# Mirrors the WITH_CHATTERBOX block in docker/Dockerfile.controller — same
-# CPU-only torch trick. numpy + Cython are pre-installed so pkuseg's source
-# build (no wheel for py3.11) can find them; --no-build-isolation makes them
-# visible to setup.py. The model weights are downloaded lazily at runtime (see
-# the header note) — the build only imports the package to validate the venv.
+# Same CPU-torch index trick as Dockerfile.controller. numpy + Cython are
+# pre-installed (+ --no-build-isolation) so pkuseg's source build can see them.
 #
-# onnxruntime is a hidden hard requirement of chatterbox-tts >= 0.1.7 — the
-# perth watermarker uses ONNX models.
+# onnxruntime is a hidden hard requirement of chatterbox-tts >= 0.1.7 (the
+# perth watermarker uses ONNX models).
 #
-# setuptools is pinned to <81 because v81 removed `pkg_resources`, and
-# perth.perth_net.__init__ still does `from pkg_resources import resource_filename`.
-# Without the pin, ChatterboxTurboTTS.from_pretrained() crashes at __init__
-# time when it instantiates perth.PerthImplicitWatermarker (which perth has
-# silently set to None because its module-level import failed). When pkg_resources
-# is gone, none of that is visible until you actually call the constructor.
+# setuptools <81 pin: v81 removed pkg_resources, which perth still imports at
+# module level — perth then silently sets its watermarker to None and
+# from_pretrained() crashes only at constructor time.
+#
+# Pins exact for reproducible rebuilds: chatterbox-tts 0.1.7 itself pins
+# torch/torchaudio==2.6.0 and numpy<2 (held at 1.26.4 for the pkuseg build);
+# transformers stays transitive.
 ENV CHATTERBOX_HF_HOME=/opt/chatterbox/hf-cache
-# GPU opt-in. The default is CPU-only torch wheels; point this at a CUDA wheel
-# index (e.g. https://download.pytorch.org/whl/cu124, matching the host driver)
-# to build a GPU-capable Chatterbox. Pair it with TTS_HEAVY_DEVICE=cuda + a GPU
-# device reservation — docker-compose.tts-heavy-gpu.yml wires both. Scoped to
-# the Chatterbox venv on purpose: PocketTTS (fast on CPU) doesn't benefit and
-# CUDA torch would add several GB to it. See docs/gpu-tts.md.
+# GPU opt-in: point at a cuXXX wheel index matching the host driver, pair with
+# TTS_HEAVY_DEVICE=cuda + a device reservation (docker-compose.tts-heavy-gpu.yml
+# wires both). Scoped to this venv — PocketTTS is fast on CPU and CUDA torch
+# would add several GB. See docs/gpu-tts.md.
 ARG CHATTERBOX_TORCH_INDEX_URL=https://download.pytorch.org/whl/cpu
-# Override the torch/torchaudio that chatterbox-tts pins (==2.6.0). Leave empty
-# to honour the pin — correct for CPU and for CUDA cards up to sm_90 (RTX 40xx
-# and older). RTX 50-series (Blackwell, sm_120) needs newer kernels than 2.6.0
-# ships, so its inference dies with "no kernel image is available"; and pip
-# cannot bump torch past chatterbox's exact pin in one resolve, even with a cu128
-# index. Set this to a Blackwell-capable spec (e.g. "torch==2.9.1
-# torchaudio==2.9.1") together with a cu128 CHATTERBOX_TORCH_INDEX_URL. It is
-# reinstalled OVER chatterbox's deps (which stay intact) WITH deps, so the
-# matching nvidia-* runtime libs come along — avoiding a --no-deps hand-install
-# of the whole tree. The worker carries the torch-2.9 float32 shim. See
-# docs/gpu-tts.md.
+# RTX 50-series (Blackwell, sm_120) only: torch 2.6.0 has no sm_120 kernels and
+# pip can't bump past chatterbox's exact pin in one resolve — set a newer spec
+# (e.g. "torch==2.9.1 torchaudio==2.9.1") with a cu128 index above. Reinstalled
+# OVER chatterbox's deps WITH deps, so the matching nvidia-* libs come along.
 ARG CHATTERBOX_TORCH_SPEC=
-# Version pins (exact, for reproducible rebuilds). chatterbox-tts 0.1.7 pins
-# torch==2.6.0 / torchaudio==2.6.0 / transformers==5.2.0 and numpy<2.0.0 (on
-# py3.11) itself, so we match torch/torchaudio to its pin, hold numpy at the last
-# 1.x (1.26.4) for the pkuseg build scaffolding, and let chatterbox-tts resolve
-# its own transitive transformers. setuptools is held at the last <81 release
-# (80.10.2) — v81 dropped pkg_resources, which perth still imports (see note
-# above). onnxruntime is chatterbox's watermarker dep.
 RUN python3 -m venv /opt/chatterbox/venv && \
     /opt/chatterbox/venv/bin/pip install --no-cache-dir --upgrade pip "setuptools==80.10.2" wheel==0.47.0 && \
     /opt/chatterbox/venv/bin/pip install --no-cache-dir numpy==1.26.4 Cython==3.2.8 && \
@@ -119,23 +74,12 @@ RUN python3 -m venv /opt/chatterbox/venv && \
     rm -rf "$SP/torch/include" "$SP/torch/test"
 
 # --- PocketTTS venv --------------------------------------------------------
-# Mirrors the WITH_POCKETTTS block. Smaller model (~100M params) but still
-# needs torch — separate venv so its pip resolution doesn't fight with
-# chatterbox-tts above.
+# Separate venv so its resolution doesn't fight chatterbox's. pocket-tts 2.1.0
+# needs torch>=2.5 / numpy>=2; torch held at the same 2.6.0 CPU wheel.
 #
-# HF_TOKEN (optional) unlocks PocketTTS voice cloning (issue #238). The cloning
-# weights (kyutai/pocket-tts) are GATED on Hugging Face; without a token the
-# worker loads the open "without-voice-cloning" weights and cloned .wav voices
-# silently revert to a built-in. It is a pure RUNTIME concern now — set HF_TOKEN
-# in the compose `environment` (the worker downloads the gated weights lazily
-# into the HF cache on first /speak, after you accept the model terms on
-# huggingface.co/kyutai/pocket-tts). The build no longer bakes weights (see the
-# header note on why the build-time pre-warm was removed), so there is no
-# `ARG HF_TOKEN` here — a build-arg token would do nothing.
-#
-# Version pins (exact, for reproducible rebuilds). pocket-tts 2.1.0 needs
-# torch>=2.5.0 / scipy>=1.5.0 / numpy>=2; torch is held at 2.6.0 (same CPU wheel
-# as the chatterbox venv), and numpy is left transitive (pip pulls a 2.x).
+# Voice cloning (#238) is a pure RUNTIME concern: the gated kyutai/pocket-tts
+# weights download lazily on first /speak once HF_TOKEN is set in the compose
+# env (no ARG here — the build bakes no weights).
 ENV POCKET_HF_HOME=/opt/pocket-tts/hf-cache
 RUN python3 -m venv /opt/pocket-tts/venv && \
     /opt/pocket-tts/venv/bin/pip install --no-cache-dir --upgrade pip && \
@@ -149,22 +93,16 @@ RUN python3 -m venv /opt/pocket-tts/venv && \
     SP=/opt/pocket-tts/venv/lib/python3.11/site-packages && \
     rm -rf "$SP/torch/include" "$SP/torch/test"
 
-# --- Server venv (FastAPI only — no PyTorch needed) ------------------------
-# The HTTP front is thin: it spawns one stdio worker per engine and shuttles
-# JSON between them and the HTTP client. No model loading happens here.
+# --- Server venv (FastAPI only — spawns the stdio workers, no model loading) -
 RUN python3 -m venv /opt/server/venv && \
     /opt/server/venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/server/venv/bin/pip install --no-cache-dir \
       fastapi==0.139.0 "uvicorn[standard]==0.49.0" pydantic==2.13.4
 
-# NOTE: acoustic analysis (librosa bpm/key + CLAP/Demucs) was removed from this
-# image — it now lives solely in the standalone `subwave-analyzer` sidecar
-# (`subwave-analyzer-heavy` for CLAP/Demucs, opt-in via ANALYZER_HEAVY=1). This
-# image is TTS-only (Chatterbox + PocketTTS). See docker/Dockerfile.analyzer.
+# This image is TTS-only — acoustic analysis lives in the standalone
+# subwave-analyzer sidecar (docker/Dockerfile.analyzer).
 
-# Strip the build toolchain now that pkuseg + any other source dists have
-# compiled. The runtime never needs g++/make again — torch + torchaudio +
-# pocket-tts all ship as wheels. Saves ~500MB off the final image.
+# Strip the build toolchain now that pkuseg has compiled (~500MB).
 RUN apt-get update && apt-get purge -y --auto-remove build-essential && \
     rm -rf /var/lib/apt/lists/*
 
@@ -176,29 +114,19 @@ ENV PATH=/opt/server/venv/bin:$PATH \
 
 WORKDIR /app
 COPY docker/tts-heavy/server.py /app/server.py
-# Reuse the SAME worker scripts the controller uses for its in-process path —
-# single source of truth for inference logic, including the PocketTTS RMS
-# normalisation. The scripts speak JSON over stdio; server.py wraps that with
-# an HTTP surface.
+# The SAME workers the controller runs in-process — single source of truth,
+# including the PocketTTS RMS normalisation.
 COPY controller/scripts/chatterbox_worker.py /app/workers/chatterbox_worker.py
 COPY controller/scripts/pocket_tts_worker.py /app/workers/pocket_tts_worker.py
 
-# Shared state mount with the controller — the sidecar writes WAVs into
-# /var/sub-wave/voice/* and the controller hands the same path to Liquidsoap
-# via next.txt / say.txt / intro.txt. The directory is created by the
-# controller image (chmod 777 there); the sidecar just writes into it. We
-# mkdir here too so the image is self-contained when run standalone.
+# Shared state mount — WAVs land in /var/sub-wave/voice/* and the controller
+# hands the paths to Liquidsoap. mkdir'd here so the image runs standalone too.
 RUN mkdir -p /var/sub-wave/voice && chmod 777 /var/sub-wave
 
-# --- Drop root: run uvicorn (and both TTS workers) as an unprivileged user ----
-# The server never needs root at runtime — it only writes to (a) the shared
-# /var/sub-wave mount (the entrypoints chmod it 777, and /speak's out paths live
-# there) and (b) the two per-engine HF weight caches below, plus torch's hub
-# cache. It reads no root-only paths (no icecast secrets, no venv writes), so a
-# fixed non-root uid/gid (10001) is safe and keeps any container breakout
-# unprivileged. HOME + the XDG/TORCH cache dirs are pointed at a user-owned tree;
-# /opt/{chatterbox,pocket-tts}/hf-cache are chowned so the compose named volumes
-# mounted over them inherit the ownership on first create.
+# --- Drop root --------------------------------------------------------------
+# The server only writes the shared mount and the caches. HOME/XDG/TORCH point
+# at a user-owned tree; the hf-cache chowns make the compose named volumes
+# inherit ownership on first create.
 ENV HOME=/home/subwave \
     XDG_CACHE_HOME=/home/subwave/.cache \
     TORCH_HOME=/home/subwave/.cache/torch

--- a/docker/aio/Caddyfile
+++ b/docker/aio/Caddyfile
@@ -1,22 +1,15 @@
-# Caddy edge router for the SUB/WAVE all-in-one image (docker/Dockerfile.aio).
-#
-# Unlike the split-stack docker/Caddyfile, every backend lives in THIS SAME
-# container, so the upstreams are loopback addresses rather than compose service
-# names. The route table is otherwise identical: one origin on :80, split by URL
-# prefix. The single host port the Unraid template maps points here.
-#
-# No Cloudflare trusted_proxies block — the AIO is aimed at LAN / self-hosted
-# use behind whatever reverse proxy the operator already runs (or none at all).
+# Caddy edge for the all-in-one image (docker/Dockerfile.aio). Same route
+# table as the split-stack docker/Caddyfile, but every backend is loopback in
+# this same container. No Cloudflare trusted_proxies block — the AIO is aimed
+# at LAN / behind whatever proxy the operator already runs.
 {
 	auto_https off
 }
 
 :80 {
-	# /stream.mp3 + /stream.opus + /stream.flac + /stream.aac — Icecast (served by
-	# liquidsoap → icecast on 7702). Opus/FLAC/AAC are opt-in and off by default,
-	# but they must still be listed here or they fall through to the Next.js
-	# catch-all below and 404. flush_interval -1 keeps the never-ending audio
-	# body live.
+	# Icecast mounts. Opus/FLAC/AAC are off by default but must be listed or
+	# they fall through to the catch-all and 404. flush_interval -1 keeps the
+	# never-ending audio body live.
 	@streams path /stream.mp3 /stream.opus /stream.flac /stream.aac
 	handle @streams {
 		reverse_proxy 127.0.0.1:7702 {
@@ -29,25 +22,20 @@
 		}
 	}
 
-	# /api/listener-auth — NOT reachable from the internet. Icecast is in this
-	# same container and calls the controller directly on localhost:7701 (see
-	# supervisor.sh render_icecast), so the edge never needs to carry it.
-	# Through /api/* it was an unthrottled oracle for the shared
-	# privacy.password that /api/station-auth rate-limits. Kept in lockstep
-	# with docker/Caddyfile.
+	# Icecast's URL-auth callback — NOT reachable from the internet (password
+	# oracle otherwise; icecast calls the controller on loopback directly).
+	# Kept in lockstep with docker/Caddyfile.
 	handle /api/listener-auth {
 		respond 404
 	}
 
-	# /api/* — controller REST API (prefix stripped so its routes stay at root).
+	# Controller REST API (prefix stripped so its routes stay at root).
 	handle_path /api/* {
 		reverse_proxy 127.0.0.1:7701
 	}
 
-	# /listen.pls + /listen.m3u — one-paste tune-in files (VLC, Sonos, hardware).
-	# Served by the controller at its root (NOT under /api), so use a plain handle
-	# with no path stripping. Without this they fall through to the catch-all
-	# below and 404.
+	# One-paste tune-in files — served by the controller at its root (NOT under
+	# /api), so plain handle, no path stripping.
 	@listen path /listen.pls /listen.m3u
 	handle @listen {
 		reverse_proxy 127.0.0.1:7701

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -1,34 +1,25 @@
 #!/usr/bin/env bash
-# SUB/WAVE all-in-one supervisor.
-#
-# Runs the whole stack — icecast2 + liquidsoap (the broadcast pair), the
-# controller, the Next.js web UI, and Caddy — inside ONE container for the
-# Unraid Community Applications one-click image (docker/Dockerfile.aio).
-#
-# The split-stack deployment runs these as five compose services wired over an
-# internal network; here they all share localhost and the /var/sub-wave volume,
-# so the file-based IPC (next.txt / say.txt / now-playing.json …) works exactly
-# as before with no code changes — only a handful of *_HOST/*_URL env overrides
-# repoint the controller at loopback.
+# SUB/WAVE all-in-one supervisor — runs icecast2 + liquidsoap (the broadcast
+# pair), the controller, the web UI, and Caddy in ONE container
+# (docker/Dockerfile.aio). Everything shares localhost + /var/sub-wave, so the
+# file-based IPC works unchanged; only *_HOST/*_URL overrides repoint loopback.
 #
 # Each service runs in its own restart loop, so a web or controller crash does
-# NOT take the station off the air. The icecast+liquidsoap pair is launched as a
-# unit (mirroring docker/broadcast-entrypoint.sh): if either dies the pair is
-# bounced together, because liquidsoap is useless without its icecast sink.
+# NOT take the station off the air. The broadcast pair is launched as a unit
+# (mirroring docker/broadcast-entrypoint.sh): if either dies both are bounced.
 #
-# Bash (not /bin/sh) for `wait -n`; the savonet/liquidsoap base ships bash.
+# Bash (not /bin/sh) for `wait -n`.
 set -u
 
 SECRETS=/var/sub-wave/icecast-secrets.env
 TEMPLATE=/etc/icecast2/icecast.xml.template
 RENDERED=/etc/icecast2/icecast.xml
 
-# Multi-station pointer (see docker/broadcast-entrypoint.sh — kept in lockstep).
+# Multi-station pointer (kept in lockstep with docker/broadcast-entrypoint.sh).
 # Called at the top of run_broadcast so every mixer relaunch re-resolves.
 #
 # Both paths are env-overridable so scripts/aio-log-link.test.ts can drive
-# link_liquidsoap_log() against a scratch dir. Neither var is set in the image,
-# so the container resolves the same literals it always did.
+# link_liquidsoap_log() against a scratch dir; neither var is set in the image.
 STATE_ROOT="${SUBWAVE_STATE_ROOT:-/var/sub-wave}"
 LIQ_LOG_DIR="${SUBWAVE_LIQ_LOG_DIR:-/var/log/liquidsoap}"
 STATE_DIR="$STATE_ROOT"
@@ -50,10 +41,8 @@ resolve_state_dir() {
 log() { echo "[subwave-aio] $*" >&2; }
 
 # ---------------------------------------------------------------------------
-# One-time state bootstrap — shared dirs, watch-mode m3u stubs, archive ignore.
-# Same responsibilities as docker/broadcast-entrypoint.sh, minus launching the
-# audio processes (the supervisor does that in a restart loop below). Mode 777
-# because the services run under different uids (icecast2 / liquidsoap / root).
+# One-time state bootstrap. Mode 777 because the services run under different
+# uids (icecast2 / liquidsoap / root).
 # ---------------------------------------------------------------------------
 init_state() {
 	mkdir -p /var/sub-wave \
@@ -77,21 +66,16 @@ init_state() {
 	touch /var/sub-wave/auto.m3u /var/sub-wave/jingles.m3u
 	chmod 666 /var/sub-wave/auto.m3u /var/sub-wave/jingles.m3u
 
-	# Keep a co-located Navidrome from scanning the station's own hourly
-	# archive mixdowns as junk "HH-00" tracks (issue #273).
+	# Keep a co-located Navidrome from scanning the hourly archive mixdowns
+	# in as junk "HH-00" tracks (issue #273).
 	touch /var/sub-wave/archive/.ndignore
 
 	link_liquidsoap_log
 
-	# Rotate radio.log on boot once it passes 50MB — same policy (and same
-	# container-side path) as docker/broadcast-entrypoint.sh. Now that the
-	# log persists in state, it would otherwise append forever; boot is the
-	# one safe moment to move it since liquidsoap isn't holding the fd yet.
-	# One .old generation caps disk at ~2x the threshold. Rotating via
-	# $LIQ_LOG_DIR (not $STATE_ROOT/logs) matters: after
-	# link_liquidsoap_log it resolves to wherever radio.log actually lands —
-	# state logs, an operator's own disk, a bind mount, or the local
-	# fallback — while the state path misses the last two branches.
+	# Rotate radio.log on boot once it passes 50MB (liquidsoap appends
+	# forever; boot is the one safe moment — fd not yet held). Rotating via
+	# $LIQ_LOG_DIR matters: after link_liquidsoap_log it resolves to wherever
+	# radio.log actually lands, which the state path can miss.
 	RADIO_LOG="$LIQ_LOG_DIR/radio.log"
 	if [ -f "$RADIO_LOG" ] && [ "$(stat -c %s "$RADIO_LOG" 2>/dev/null || echo 0)" -gt 52428800 ]; then
 		mv -f "$RADIO_LOG" "$RADIO_LOG.old"
@@ -100,55 +84,36 @@ init_state() {
 }
 
 # ---------------------------------------------------------------------------
-# Point /var/log/liquidsoap at the state ROOT's logs/, but never at the cost of
-# the station.
+# Point /var/log/liquidsoap at the state ROOT's logs/ (#1196: radio.log must
+# survive recreates; routes/debug.ts tails <stateRoot>/logs/radio.log) — but
+# never at the cost of the station: radio.liq opens the log path as its FIRST
+# lifecycle step, so an unopenable path is a fatal startup error, not a
+# degraded log. Every branch below must end in a path liquidsoap can open,
+# verified by probe.
 #
-# radio.liq opens settings.log.file.path during Dtools.Log.init — the FIRST
-# lifecycle step, before the mixer graph, before the telnet port, before the
-# Icecast connection. An unopenable log path is therefore not a degraded log,
-# it is a fatal startup error. That makes this the one bootstrap step that can
-# take the station off the air, so it fails soft: every branch below ends with
-# a path liquidsoap can actually open, verified by probe rather than assumed.
-#
-# The goal is still #1196's — radio.log has to survive container recreates and
-# routes/debug.ts tails <stateRoot>/logs/radio.log, the same install-level
-# location the compose stacks pin via their ${STATE_DIR}/logs bind mount.
-#
-# What #1196 got wrong: it created the symlink unconditionally and guarded
-# re-entry on `[ ! -L /var/log/liquidsoap ]`. If <state>/logs was itself a
-# symlink pointing back at /var/log/liquidsoap — the natural host-side
-# workaround for the pre-#1196 "AIO has no radio.log in the state dir" bug —
-# the two links closed a cycle and every start died with
-#
-#   Fatal error: exception Sys_error("/var/log/liquidsoap/radio.log: Too many
-#   levels of symbolic links")
-#
-# and because the guard only tested -L, it then SKIPPED (never repaired) the
-# bad link on every subsequent boot: an unbreakable 3s crash loop, both Doctor
-# broadcast checks red, and the "Restart mixer" fix button useless because it
-# speaks telnet to a port liquidsoap never got far enough to bind.
+# The original #1196 fix created the link unconditionally and guarded on -L
+# only. If <state>/logs was itself a symlink back at /var/log/liquidsoap (a
+# natural pre-#1196 host-side workaround), the two links closed an ELOOP cycle
+# ("Too many levels of symbolic links") that the guard then never repaired —
+# an unbreakable crash loop the "Restart mixer" button couldn't touch.
 # ---------------------------------------------------------------------------
 link_liquidsoap_log() {
 	local target="$STATE_ROOT/logs"
 
-	# 1. Heal a broken state-side logs link. `-d` is false for a dangling
-	#    symlink AND for a looping one (stat fails with ELOOP), which is
-	#    exactly the set worth replacing with a real directory. A symlink
-	#    that resolves to a real directory elsewhere is an operator parking
-	#    logs on another disk on purpose — left alone.
+	# 1. Heal a broken state-side logs link. `-d` is false for dangling AND
+	#    looping symlinks — exactly the set worth replacing. A link that
+	#    resolves elsewhere is an operator parking logs on another disk on
+	#    purpose — left alone.
 	if [ -L "$target" ] && [ ! -d "$target" ]; then
 		log "WARNING $target is a broken symlink (-> $(readlink "$target" 2>/dev/null || echo '?')) — replacing it with a real directory"
 		rm -f "$target" 2>/dev/null || true
 	fi
 
-	# 1b. A state-side link that RESOLVES INTO the container log path is the
-	#     #1196 cycle half wearing a disguise: it only looks healthy while
-	#     the fresh image's plain /var/log/liquidsoap still exists (the
-	#     exact shape the reported operator's install boots into after
-	#     pulling this fix). Linking $LIQ_LOG_DIR at a path that resolves to
-	#     $LIQ_LOG_DIR itself can only re-create the cycle, which the probe
-	#     below would then break — but at the price of dropping persistence.
-	#     Replacing the link with a real directory now keeps it.
+	# 1b. A state-side link that resolves INTO the container log path is the
+	#     #1196 cycle half in disguise — it only looks healthy while the fresh
+	#     image's plain /var/log/liquidsoap still exists. Linking $LIQ_LOG_DIR
+	#     at a path that resolves to itself can only re-create the cycle, so
+	#     replace the link with a real directory now (keeps persistence).
 	if [ -L "$target" ] && [ -d "$target" ] && command -v realpath >/dev/null 2>&1; then
 		local target_real liq_real
 		target_real=$(realpath -m -- "$target" 2>/dev/null || true)
@@ -163,31 +128,25 @@ link_liquidsoap_log() {
 	chmod 777 "$target" 2>/dev/null || true
 
 	# 2. Point the in-container path at it — unless something is mounted
-	#    there. An operator who bind-mounted a host dir onto
-	#    /var/log/liquidsoap (the split stack's compose mapping, copied into
-	#    an AIO `docker run`) already has a persistent log dir, so it is
-	#    used as-is. The mountpoint test must come BEFORE any `rm -rf`:
-	#    `rm -rf` on a mountpoint can't remove the mountpoint itself but
-	#    DOES delete everything inside it — which would wipe the very log
-	#    history the operator mounted the dir to keep, on every boot.
+	#    there (an operator's bind mount is already persistent; use as-is).
+	#    The mountpoint test must come BEFORE any `rm -rf`: rm on a
+	#    mountpoint can't remove the mountpoint but DOES delete everything
+	#    inside — wiping the log history the mount exists to keep.
 	if [ -d "$target" ]; then
 		if [ -e "$LIQ_LOG_DIR" ] && [ ! -L "$LIQ_LOG_DIR" ] && is_mountpoint "$LIQ_LOG_DIR"; then
 			log "$LIQ_LOG_DIR is a mountpoint — leaving it as-is; radio.log stays there"
 		else
-			# Anything unmounted at the container path — a plain dir
-			# from a pre-#1196 image, a stray file — is replaced by
-			# the link. `ln -s` onto a surviving directory would
-			# silently create the link INSIDE it
-			# (/var/log/liquidsoap/logs), hence the rm first.
+			# rm first: `ln -s` onto a surviving directory would
+			# silently create the link INSIDE it.
 			[ -L "$LIQ_LOG_DIR" ] || rm -rf "$LIQ_LOG_DIR" 2>/dev/null || true
 			if [ -e "$LIQ_LOG_DIR" ] && [ ! -L "$LIQ_LOG_DIR" ]; then
 				# Unremovable yet not detected as a mountpoint
 				# (exotic mount setups) — same outcome, use as-is.
 				log "$LIQ_LOG_DIR survived removal (bind mount?) — leaving it; radio.log stays there"
 			else
-				# -f replaces an existing link (including a looping one, which
-				# is removed rather than followed); -n keeps it from being
-				# planted inside a link-to-directory.
+				# -f replaces an existing link (including a looping
+				# one); -n keeps it from being planted inside a
+				# link-to-directory.
 				ln -sfn "$target" "$LIQ_LOG_DIR" 2>/dev/null || true
 			fi
 		fi
@@ -195,17 +154,15 @@ link_liquidsoap_log() {
 		log "WARNING $target is not a usable directory — not linking $LIQ_LOG_DIR at it"
 	fi
 
-	# 3. Prove liquidsoap can open a file there before handing over the path.
-	#    This is the backstop that turns the whole ELOOP class of bug into a
-	#    warning: any shape that fails the probe falls back to a plain
-	#    container-local directory, which costs the Debug tail its history
-	#    across recreates but keeps the station on the air.
+	# 3. Prove liquidsoap can open a file there before handing over the path
+	#    — the backstop that turns the whole ELOOP class into a warning. Any
+	#    failing shape falls back to a container-local dir: no persistence,
+	#    but the station stays on the air.
 	if ! probe_log_dir; then
 		log "WARNING $LIQ_LOG_DIR is unopenable — falling back to a container-local log dir; radio.log will NOT persist in the state dir"
-		# A mountpoint can be neither removed nor replaced, so rebuilding
-		# is pointless there — and `rm -rf` on a mount that somehow fails
-		# the probe would only strip the operator's files while leaving
-		# the path just as unopenable. Rebuild unmounted paths only.
+		# A mountpoint can be neither removed nor replaced — rebuild
+		# unmounted paths only (rm -rf on a failing mount would just strip
+		# the operator's files without fixing the path).
 		if ! is_mountpoint "$LIQ_LOG_DIR"; then
 			rm -rf "$LIQ_LOG_DIR" 2>/dev/null || true
 			mkdir -p "$LIQ_LOG_DIR" 2>/dev/null || true
@@ -213,21 +170,16 @@ link_liquidsoap_log() {
 		probe_log_dir || log "ERROR $LIQ_LOG_DIR is still unopenable — liquidsoap will fail to start"
 	fi
 
-	# Both follow the link to whatever directory we settled on. Deliberately
-	# NOT recursive: liquidsoap only needs to create/append radio.log in the
-	# directory itself, and an operator who pointed <state>/logs at their own
-	# disk shouldn't have its existing contents re-owned underneath them.
-	# The directory inode itself IS re-moded/re-owned even when it is the
-	# operator's own — that's the price of liquidsoap being able to create
-	# radio.log inside it; only the contents are left untouched.
+	# Deliberately NOT recursive: liquidsoap only needs to create/append
+	# radio.log in the directory itself, and an operator who pointed
+	# <state>/logs at their own disk shouldn't have its contents re-owned.
 	chmod 777 "$LIQ_LOG_DIR" 2>/dev/null || true
 	chown liquidsoap:liquidsoap "$LIQ_LOG_DIR" 2>/dev/null || true
 }
 
 # Can a file actually be created under $LIQ_LOG_DIR? Runs as root, so it proves
-# the PATH resolves (the ELOOP/dangling class) rather than that the liquidsoap
-# user has write permission — that part is the chmod/chown at the end of
-# link_liquidsoap_log.
+# the PATH resolves (the ELOOP/dangling class), not that the liquidsoap user
+# has write permission — that's the chmod/chown above.
 probe_log_dir() {
 	local probe="$LIQ_LOG_DIR/.write-probe"
 	: > "$probe" 2>/dev/null || return 1
@@ -235,12 +187,9 @@ probe_log_dir() {
 	return 0
 }
 
-# Is $1 a mountpoint? `mountpoint` ships with util-linux on the Debian base;
-# fall back to /proc/self/mountinfo (field 5 is the mount point) so the answer
-# never silently degrades to "not a mount" just because the binary is missing.
-# A symlink is never its own mountpoint, but `mountpoint` resolves it and
-# reports on the target — fine for both call sites, which only ask about
-# non-symlink shapes or paths about to be rebuilt anyway.
+# Is $1 a mountpoint? Falls back to /proc/self/mountinfo (field 5 is the mount
+# point) so the answer never degrades to "not a mount" just because the
+# `mountpoint` binary is missing.
 is_mountpoint() {
 	if command -v mountpoint >/dev/null 2>&1; then
 		mountpoint -q "$1" 2>/dev/null
@@ -250,14 +199,10 @@ is_mountpoint() {
 }
 
 # ---------------------------------------------------------------------------
-# Warn loudly if the state dir isn't a mounted volume. With no host path (or
-# volume) mapped to /var/sub-wave, everything the station writes — settings,
-# library.db with the acoustic analysis, hourly archives, the model cache —
-# lives in the container's throwaway writable layer, and the next image update
-# (which recreates the container) silently wipes it. The Unraid CA template maps
-# this as a required Appdata path; a bare `docker run` that forgets `-v` is the
-# footgun this catches (issue #902). A real bind/volume mount gets its own entry
-# in /proc/mounts at the target path; an un-mapped dir on the overlay fs doesn't.
+# Warn loudly if /var/sub-wave isn't a mounted volume: everything the station
+# writes would live in the container's writable layer and be wiped by the next
+# image update. A bare `docker run` that forgets `-v` is the footgun (#902); a
+# real mount gets its own /proc/mounts entry, an overlay dir doesn't.
 # ---------------------------------------------------------------------------
 warn_if_state_unmounted() {
 	if ! grep -q ' /var/sub-wave ' /proc/mounts 2>/dev/null; then
@@ -274,11 +219,9 @@ warn_if_state_unmounted() {
 }
 
 # ---------------------------------------------------------------------------
-# Resolve the three ICECAST_*_PASSWORD values and render icecast.xml.
-# Precedence (unchanged from broadcast-entrypoint): env override > persisted
-# state/icecast-secrets.env > freshly generated. Resolved values are exported
-# (liquidsoap reads ICECAST_SOURCE_PASSWORD from the environment) and written
-# back to the secrets file for operator visibility + the documented rotate path.
+# Resolve the ICECAST_*_PASSWORD values. Precedence: env override > persisted
+# secrets file > freshly generated. Written back for operator visibility + the
+# documented rotate path; exported for liquidsoap.
 # ---------------------------------------------------------------------------
 init_secrets() {
 	local ENV_SRC="${ICECAST_SOURCE_PASSWORD:-}"
@@ -303,22 +246,19 @@ init_secrets() {
 		ICECAST_ADMIN_PASSWORD=$ICECAST_ADMIN_PASSWORD
 		ICECAST_RELAY_PASSWORD=$ICECAST_RELAY_PASSWORD
 	EOF
-	# 0600: holds the Icecast passwords, read only by root (this supervisor
-	# sources it, and the in-process controller reads it off the state dir —
-	# all root in the AIO's single container). Keep it owner-only.
+	# 0600 — passwords, read only by root (all in-container readers are root).
 	chmod 600 "$SECRETS"
 
 	export ICECAST_SOURCE_PASSWORD ICECAST_ADMIN_PASSWORD ICECAST_RELAY_PASSWORD
-	# Liquidsoap connects to icecast over loopback inside this container;
-	# radio.liq reads ICECAST_HOST (default "icecast").
+	# Liquidsoap connects over loopback; radio.liq reads ICECAST_HOST.
 	export ICECAST_HOST=localhost
 }
 
 # ---------------------------------------------------------------------------
-# Render icecast.xml from the template + resolved secrets. Called on EVERY
-# broadcast pair (re)launch — not just boot — so a restart-mixer picks up a
-# flipped listener-auth flag (or a changed buffer/bitrate setting) the same
-# way the split stack's container restart re-runs its entrypoint.
+# Render icecast.xml. Called on EVERY broadcast pair (re)launch — not just boot
+# — so a restart-mixer picks up a flipped listener-auth flag or a changed
+# buffer/bitrate setting, the same way the split stack's container restart
+# re-runs its entrypoint.
 # ---------------------------------------------------------------------------
 read_state_num() {
 	# $1 = filename under $STATE_DIR, $2 = fallback. Non-numeric/missing → fallback.
@@ -331,9 +271,8 @@ read_state_num() {
 }
 
 render_icecast() {
-	# Concurrent-listener ceiling (<limits><clients>). Empty/unset → the stock 100.
-	# A non-numeric value would render invalid XML and fail icecast at boot,
-	# so fall back to the default with a warning instead.
+	# Non-numeric would render invalid XML and fail icecast at boot — fall
+	# back to 100 with a warning instead.
 	ICECAST_MAX_CLIENTS="${ICECAST_MAX_CLIENTS:-100}"
 	case "$ICECAST_MAX_CLIENTS" in
 		*[!0-9]*|'')
@@ -343,9 +282,8 @@ render_icecast() {
 	esac
 
 	# Listener buffer depth — same contract as docker/broadcast-entrypoint.sh
-	# (#1114): burst-size is a byte count, so it's derived from
-	# settings.stream.bufferSeconds x each mount's bitrate. Re-read on every
-	# pair launch so a settings change lands after a restart-mixer.
+	# (#1114): burst-size is a byte count, derived from
+	# settings.stream.bufferSeconds x each mount's bitrate.
 	local STREAM_BITRATE BUFFER_SECONDS OPUS_BITRATE AAC_BITRATE FLAC_BITRATE_EST
 	STREAM_BITRATE="${ICECAST_STREAM_BITRATE:-$(read_state_num liquidsoap_stream_bitrate.txt 192)}"
 	BUFFER_SECONDS="${ICECAST_BUFFER_SECONDS:-$(read_state_num liquidsoap_stream_buffer_seconds.txt 22)}"
@@ -367,8 +305,7 @@ render_icecast() {
 	log "listener buffer ${BUFFER_SECONDS}s @ mp3 ${STREAM_BITRATE}kbps / opus ${OPUS_BITRATE}kbps / aac ${AAC_BITRATE}kbps / flac ~${FLAC_BITRATE_EST}kbps"
 
 	# Listener auth (#478) — same contract as docker/broadcast-entrypoint.sh:
-	# only a literal 'true' in the controller-written flag file enables, and
-	# each stream mount then gets an <authentication type="url"> block. The
+	# only a literal 'true' in the controller-written flag enables. The
 	# controller runs in-process here, so the callback goes over loopback.
 	local FLAG=$STATE_DIR/icecast_listener_auth.txt
 	local AUTH_URL="${LISTENER_AUTH_URL:-http://localhost:7701/listener-auth}"
@@ -380,7 +317,7 @@ render_icecast() {
 
 	# One <mount> block per stream mount, ALWAYS rendered: each carries its
 	# own burst/queue sized for its own bitrate (the global <limits> value
-	# only fits the MP3 mount), plus the auth block when the toggle is on.
+	# only fits MP3), plus the auth block when the toggle is on.
 	local MOUNTS_XML=/etc/icecast2/stream-mounts.xml
 	: > "$MOUNTS_XML"
 	emit_mount() {
@@ -408,14 +345,11 @@ render_icecast() {
 	emit_mount /stream.flac "$FLAC_BITRATE_EST"
 	emit_mount /stream.aac  "$AAC_BITRATE"
 
-	# Trusted reverse proxies — same contract as docker/broadcast-entrypoint.sh
-	# (real listener IPs in admin → Listeners instead of the edge's address).
-	# The AIO has it easy: Caddy is in THIS container, so the peer is always
-	# loopback and the address is known without any DNS or ordering dance that
-	# the split stack has to negotiate. icecast-KH wants an exact IP, and both
-	# loopback forms are emitted because which one icecast sees depends on how
-	# Caddy resolved its upstream. ICECAST_TRUSTED_PROXY_IPS still overrides,
-	# for an AIO sitting behind a further reverse proxy that rewrites the chain.
+	# Trusted reverse proxies — same contract as docker/broadcast-entrypoint.sh.
+	# Caddy is in THIS container, so the peer is always loopback; both forms
+	# are emitted because which one icecast sees depends on how Caddy resolved
+	# its upstream (icecast-KH wants an exact IP). ICECAST_TRUSTED_PROXY_IPS
+	# still overrides, for an AIO behind a further proxy.
 	local TRUSTED_XML=/etc/icecast2/trusted-proxies.xml
 	local TRUSTED_LIST _ip
 	: > "$TRUSTED_XML"
@@ -450,18 +384,14 @@ render_icecast() {
 # loop can restart it. Do NOT `exec` — that would replace the loop.
 # ---------------------------------------------------------------------------
 
-# icecast2 + liquidsoap as a unit. Returns when either dies (the loop bounces
-# the pair). icecast runs as the icecast2 user; liquidsoap as the liquidsoap
-# user (uid 10000). `sudo -E` preserves the resolved ICECAST_* env.
+# icecast2 + liquidsoap as a unit; returns when either dies.
 run_broadcast() {
 	# Re-resolve the active station on every pair launch — this is how a
-	# station switch takes effect in the AIO without a container bounce (the
-	# supervise loop re-runs run_broadcast after every mixer restart).
+	# station switch takes effect in the AIO without a container bounce.
 	resolve_state_dir
 
-	# Bootstrap the resolved station dir's subdirs (mirrors init_state, but
-	# scoped to $STATE_DIR — the root case is already covered by init_state at
-	# boot, and a non-root station dir needs its own subdirs created here).
+	# Bootstrap the resolved station dir's subdirs (the root case is covered
+	# by init_state at boot; a non-root station dir needs its own here).
 	mkdir -p "$STATE_DIR" \
 	         "$STATE_DIR/voice" \
 	         "$STATE_DIR/voices" \
@@ -501,12 +431,10 @@ run_broadcast() {
 	done
 
 	log "starting liquidsoap"
-	# TEMPORARY (re-harden later): run liquidsoap as root instead of dropping to
-	# the `liquidsoap` user — same reason as docker/broadcast-entrypoint.sh. The
-	# savonet base bump 2.2.5 -> 2.4.4 changed that user's uid (10000 -> 100), so
-	# state files persisted under /var/sub-wave by the old image became unwritable
-	# to uid 100 and every on_meta write EACCES'd. Root ignores those perms.
-	# Restore the privilege drop once the state files are chowned to the new uid
+	# TEMPORARY (re-harden later): run liquidsoap as root — same reason as
+	# docker/broadcast-entrypoint.sh (savonet base bump changed the liquidsoap
+	# uid 10000 → 100, making persisted state files unwritable). Restore the
+	# privilege drop once state files are chowned to the new uid
 	# (radio.liq's settings.init.allow_root is set for the same reason).
 	liquidsoap /etc/liquidsoap/radio.liq &
 	local lq=$!
@@ -519,12 +447,10 @@ run_broadcast() {
 	return "$code"
 }
 
-# Controller — the AI DJ brain. The *_HOST/*_URL overrides repoint it from the
-# compose service names (broadcast:7702 / 1234) at loopback. DOCKER_HOST and
-# TTS_HEAVY_URL are intentionally unset: the Stats system panel degrades
-# gracefully and TTS falls back to the bundled Piper voice. All other config
-# (Navidrome, LLM, ADMIN_*, SITE_URL, TZ) is inherited from the container env
-# and the first-run wizard's settings.json.
+# Controller. The *_HOST/*_URL overrides repoint the compose service names at
+# loopback. DOCKER_HOST and TTS_HEAVY_URL are intentionally unset — the Stats
+# panel hides and TTS falls back to Piper. Everything else is inherited from
+# the container env + settings.json.
 run_controller() {
 	cd /app || return 1
 	export NODE_ENV=production \
@@ -567,12 +493,9 @@ supervise() {
 }
 
 # ---------------------------------------------------------------------------
-# Boot.
-#
-# Sourcing this file with SUBWAVE_SUPERVISOR_LIB=1 defines the functions
-# WITHOUT booting anything — the seam scripts/aio-log-link.test.ts drives to
-# exercise link_liquidsoap_log() against a scratch dir. The image never sets
-# it, so PID 1 always falls through to the real boot below.
+# Boot. Sourcing with SUBWAVE_SUPERVISOR_LIB=1 defines the functions WITHOUT
+# booting — the seam scripts/aio-log-link.test.ts uses. The image never sets
+# it, so PID 1 always falls through to the real boot.
 # ---------------------------------------------------------------------------
 if [ "${SUBWAVE_SUPERVISOR_LIB:-}" = "1" ]; then
 	return 0 2>/dev/null || exit 0
@@ -583,14 +506,12 @@ init_state
 init_secrets
 
 # On stop, signal the whole process group once, then give the children time to
-# shut down before exiting (reset the trap first so the kill doesn't re-enter
-# this handler). The grace period matters: this script is PID 1, and the
-# instant it exits the container namespace is torn down and everything left
-# gets SIGKILLed — which robbed the controller of its SIGTERM handler and left
-# library.db's WAL sidecar un-checkpointed on every stop (#786). `wait` covers
-# the supervise loops; the sleep covers their children (node etc.), which get
-# reparented to us when the loops die and which bash's wait can't see. Docker's
-# stop timeout (default 10s) still hard-caps the whole thing.
+# shut down (reset the trap first so the kill doesn't re-enter). The grace
+# period matters: this is PID 1, and the instant it exits everything left gets
+# SIGKILLed — which robbed the controller of its SIGTERM handler and left
+# library.db's WAL un-checkpointed on every stop (#786). `wait` covers the
+# supervise loops; the sleep covers their reparented children, which bash's
+# wait can't see. Docker's stop timeout still hard-caps the whole thing.
 trap 'trap "" TERM INT; log "shutting down"; kill -TERM 0 2>/dev/null; wait; sleep 2; exit 0' TERM INT
 
 supervise broadcast  run_broadcast  &

--- a/docker/analyzer/server.py
+++ b/docker/analyzer/server.py
@@ -1,23 +1,13 @@
 """
-subwave-analyzer — optional acoustic-analysis sidecar for SUB/WAVE.
+subwave-analyzer — acoustic-analysis sidecar for SUB/WAVE.
 
-Split out of docker/tts-heavy/server.py so operators who only want acoustic
-analysis (bpm / key / intro / loudness, plus optional CLAP "sounds-like"
-embeddings and Demucs vocal-activity ranges) don't have to pull the ~6GB
-Chatterbox + PocketTTS image. The wire contract is identical to tts-heavy's
-/health + /analyze, so the controller's analyzer client
-(controller/src/music/analyzer.ts) treats the two interchangeably — it probes
-ANALYZE_URL first, then TTS_HEAVY_URL, and uses whichever reports the 'analyze'
-engine. No audio over the wire — only metadata; the worker reads tracks from a
-stream URL or a path on the shared /var/sub-wave volume.
-
-Architecture: a thin FastAPI shim over one long-lived Python subprocess — the
-SAME stdio worker the controller + tts-heavy use
-(controller/scripts/analyze_worker.py), running in the librosa venv at
-/opt/analyzer/venv. The worker speaks one JSON object per line over stdin/stdout
-(emits {"ready": true} once loaded, then one response per request line). run()
-supervises it: start → wait-for-exit → respawn, so a crash (OOM, fatal model
-error) recovers without bouncing the container.
+A thin FastAPI shim over one long-lived subprocess: the SAME stdio worker the
+controller runs in-process (controller/scripts/analyze_worker.py), speaking one
+JSON object per line ({"ready": true} once loaded, then one response per
+request). run() supervises it — start → wait-for-exit → respawn — so a crash
+(OOM, fatal model error) recovers without bouncing the container. No audio
+over the wire: the worker reads tracks from a stream URL or a path on the
+shared /var/sub-wave volume.
 
 Endpoints:
   GET  /health   → {ok, engines, analyze_loaded, analyze_audio_capable, analyze_vocal_capable}
@@ -35,33 +25,23 @@ from typing import Any
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
-# Acoustic analysis (bpm/key/intro) — its own librosa venv, driven by the same
-# stdio worker the offline CLI uses (controller/scripts/analyze_worker.py).
 ANALYZE_PYTHON = os.environ.get("ANALYZE_PYTHON", "/opt/analyzer/venv/bin/python")
 ANALYZE_WORKER = os.environ.get("ANALYZE_WORKER", "/app/workers/analyze_worker.py")
-# 40s is enough for stable BPM (beat_track) / key (chroma); intro detection only
-# needs the first ~20-30s. Env-overridable (empty = unset — compose forwards
-# this as ${ANALYZE_SECONDS:-}); Demucs cost scales linearly with the window.
-# Keep in sync with analyze_worker.py and controller config.ts.
+# 40s is enough for stable BPM/key; keep in sync with analyze_worker.py and
+# controller config.ts. Compose forwards ${ANALYZE_SECONDS:-} (empty = unset).
 ANALYZE_SECONDS = os.environ.get("ANALYZE_SECONDS", "").strip() or "40"
-# The analyzer only touches HF when CLAP embeddings are enabled
-# (ANALYZE_AUDIO_EMBEDDING=1 with a WITH_CLAP=1 image) and no local
-# CLAP_MODEL_PATH is given — transformers then pulls the CLAP weights here. The
-# compose files mount a named volume over it so the download survives recreates.
+# Only touched when CLAP is enabled without a local CLAP_MODEL_PATH; compose
+# mounts a named volume over it so the weight download survives recreates.
 ANALYZER_HF_HOME = os.environ.get("ANALYZER_HF_HOME", "/opt/analyzer/hf-cache")
 
-# Idle worker recycle (#1204 follow-up). The worker's own idle release
-# (ANALYZE_IDLE_UNLOAD_S, analyze_worker.py) drops the CLAP/Demucs singletons,
-# but ~1GB of librosa/numba/torch scratch stays resident in the process — heap
-# a release can't reach. Restarting the worker is the only full reclaim (on
-# cuda it also drops the few-hundred-MB CUDA context the docs lament), so after
-# this many seconds with no HEAVY use — same clock semantics as the worker's
-# release: lean bpm/key traffic doesn't count — the shim terminates the worker
-# and lets run()'s supervisor respawn it. The recycle holds the request lock,
-# so a request that lands mid-recycle queues behind the respawn instead of
-# 500ing; the cost is one re-paid boot (imports, a few seconds) on the next
-# request. Default sits above the worker's largest release window so the cheap
-# release always fires first; 0 disables.
+# Idle worker recycle (#1204 follow-up). The worker's own idle release drops
+# the CLAP/Demucs singletons, but ~1GB of librosa/numba/torch scratch stays
+# resident — restarting the worker is the only full reclaim. After this many
+# seconds with no HEAVY use (lean bpm/key traffic doesn't count, same clock as
+# the worker's release) the shim terminates the worker and run() respawns it.
+# The recycle holds the request lock, so a request landing mid-recycle queues
+# behind the respawn instead of 500ing. Default sits above the worker's
+# largest release window so the cheap release always fires first; 0 disables.
 _RECYCLE_ENV = os.environ.get("ANALYZE_RECYCLE_IDLE_S", "").strip()
 try:
     RECYCLE_IDLE_S = float(_RECYCLE_ENV) if _RECYCLE_ENV else 3600.0
@@ -71,9 +51,9 @@ except ValueError:
     )
     RECYCLE_IDLE_S = 3600.0
 
-# Mirror of the worker's env-default flags (same truthy set as
-# analyze_worker.py) — when either is on, the worker loads models even for
-# requests that don't ask, so every /analyze counts as heavy use.
+# Mirror of the worker's env-default flags (same truthy set) — with either on,
+# the worker loads models even for requests that don't ask, so every /analyze
+# counts as heavy use.
 def _env_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
 
@@ -81,10 +61,9 @@ def _env_flag(name: str) -> bool:
 EMBED_DEFAULT = _env_flag("ANALYZE_AUDIO_EMBEDDING")
 VOCAL_DEFAULT = _env_flag("ANALYZE_VOCAL_ACTIVITY")
 
-# Max bytes of one worker stdout line. asyncio's default StreamReader limit is
-# 64 KiB, which a batch /embed-text response blows straight past (17 mood
-# prompts x 512 floats is ~150 KB on one line) — readline() then raises
-# LimitOverrunError and the endpoint 500s (#996).
+# Max bytes of one worker stdout line. asyncio's default 64 KiB StreamReader
+# limit is blown by a batch /embed-text response (~150 KB on one line) —
+# readline() then raises LimitOverrunError and the endpoint 500s (#996).
 WORKER_STDOUT_LIMIT = 16 * 1024 * 1024
 
 logging.basicConfig(
@@ -97,15 +76,9 @@ log = logging.getLogger("analyzer")
 class StdioWorker:
     """Async wrapper around a long-lived stdio worker subprocess.
 
-    The worker speaks one JSON object per line over stdin/stdout — the same
-    protocol used by controller/src/music/analyzer.ts and docker/tts-heavy.
-    We don't multiplex: one request in flight, gated by a lock.
-
-    Lifecycle is supervised by run() — a long-running coroutine kicked off from
-    the FastAPI lifespan as a background task. run() loops on
-    start → wait-for-exit → respawn with a short backoff, so a worker that
-    crashes mid-session (OOM, fatal model error) comes back without anyone
-    bouncing the container.
+    One JSON object per line over stdin/stdout; no multiplexing — one request
+    in flight, gated by a lock. run() supervises the lifecycle from the
+    FastAPI lifespan: start → wait-for-exit → respawn with a short backoff.
     """
 
     START_BACKOFF_S = 5.0
@@ -119,16 +92,14 @@ class StdioWorker:
         self.proc: asyncio.subprocess.Process | None = None
         self.lock = asyncio.Lock()
         self.ready = False
-        # The worker's ready message, minus the `ready` flag — carries per-engine
-        # capability metadata (audio_embedding_capable / vocal_activity_capable).
-        # Cleared on every restart cycle.
+        # Ready message minus the `ready` flag — per-engine capability
+        # metadata. Cleared on every restart cycle.
         self.ready_meta: dict[str, Any] = {}
         # Heavy-use bookkeeping for /health residency + the idle recycle.
-        # `last_heavy` is monotonic time of the last completed request that
-        # actually exercised CLAP/Demucs (None = none since this spawn);
-        # `models_resident` is best-effort — set true when a heavy request
-        # completes, cleared when the worker's idle-release log line goes by
-        # (see _pump_stderr) or the worker restarts.
+        # last_heavy = monotonic time of the last completed model-using
+        # request (None = none since this spawn); models_resident is
+        # best-effort — set on a heavy completion, cleared when the worker's
+        # idle-release log line goes by (_pump_stderr) or the worker restarts.
         self.last_heavy: float | None = None
         self.models_resident = False
         self.recycles = 0
@@ -159,9 +130,8 @@ class StdioWorker:
         self.ready = False
         self.proc = None
         self.ready_meta = {}
-        # A fresh worker holds no models (env pre-warm is re-detected at ready);
-        # clearing last_heavy also stands the recycle loop down until the next
-        # heavy request against the new process.
+        # A fresh worker holds no models; clearing last_heavy also stands the
+        # recycle loop down until the next heavy request.
         self.last_heavy = None
         self.models_resident = False
 
@@ -184,15 +154,13 @@ class StdioWorker:
             env=env,
             limit=WORKER_STDOUT_LIMIT,
         )
-        # Pump stderr to our log so the operator sees model load progress / fatal
-        # errors in the container logs. The task exits when the worker closes
-        # stderr on death.
+        # Pump stderr to our log so model load progress / fatal errors land in
+        # the container logs. Exits when the worker closes stderr on death.
         asyncio.create_task(self._pump_stderr())
 
-        # Read until {"ready": true}. Loading CLAP/Demucs the first time can take
-        # a while (lazy weight download), so no timeout here — run()'s restart
-        # loop is the upstream safety net if a load hangs forever. Non-JSON noise
-        # on stdout from transitive deps is skipped (see _await_message).
+        # Read until {"ready": true}. A first-time CLAP/Demucs load (lazy
+        # weight download) can take a while, so no timeout — run()'s restart
+        # loop is the upstream safety net.
         try:
             msg = await self._await_message()
             if msg.get("fatal"):
@@ -205,7 +173,7 @@ class StdioWorker:
         self.ready_meta = {k: v for k, v in msg.items() if k != "ready"}
         log.info(f"[{self.name}] ready {self.ready_meta or ''}".rstrip())
         # With an env flag on, the worker pre-warms that model BEFORE ready —
-        # count it as resident (and as heavy use, so the recycle clock runs)
+        # count it as resident (and heavy use, so the recycle clock runs)
         # unless the capability probe says the load failed.
         if (EMBED_DEFAULT and self.ready_meta.get("audio_embedding_capable")) or (
             VOCAL_DEFAULT and self.ready_meta.get("vocal_activity_capable")
@@ -240,11 +208,10 @@ class StdioWorker:
                 break
             text = line.decode().rstrip()
             log.info(f"[{self.name}] {text}")
-            # The worker announces its idle release on stderr (the wording is
-            # pinned by a keep-in-sync note at the log call in
-            # analyze_worker._release_models). Unsolicited stdout would corrupt
-            # the one-request-in-flight protocol, so stderr is the only channel
-            # this fact can ride — best-effort by design.
+            # The worker announces its idle release on stderr (wording pinned
+            # by a keep-in-sync note at analyze_worker._release_models).
+            # Unsolicited stdout would corrupt the one-request-in-flight
+            # protocol, so stderr is the only channel — best-effort by design.
             if "released" in text and "reloads on next use" in text:
                 self.models_resident = False
 
@@ -265,10 +232,9 @@ class StdioWorker:
 
     async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
         async with self.lock:
-            # Fail fast if the worker isn't up — the /analyze handler turns this
-            # into an HTTP error and the controller's client falls through
-            # cleanly (analysis row stays NULL), preferable to blocking on an
-            # unhealthy worker.
+            # Fail fast when the worker is down — the controller's client
+            # falls through cleanly (analysis row stays NULL), preferable to
+            # blocking on an unhealthy worker.
             if not self.ready or not self.proc or self.proc.returncode is not None:
                 raise RuntimeError(f"[{self.name}] worker not ready")
             assert self.proc.stdin
@@ -276,7 +242,7 @@ class StdioWorker:
             self.proc.stdin.write((req + "\n").encode())
             await self.proc.stdin.drain()
             msg = await self._await_message()
-            # Stamp heavy use from what actually came back, not just what was
+            # Stamp heavy use from what actually came back, not what was
             # asked: an analyze whose CLAP load failed still answers ok=true
             # (graceful degrade) but carries no model-derived fields, and must
             # not read as "models resident".
@@ -289,11 +255,10 @@ class StdioWorker:
             return msg
 
     async def recycle_loop(self, idle_s: float) -> None:
-        """Terminate the worker after `idle_s` seconds with no heavy use so
-        run()'s supervisor respawns it fresh — the full-memory counterpart to
-        the worker's own model release (see ANALYZE_RECYCLE_IDLE_S above).
-        Holding the lock across the respawn means a request that races the
-        recycle queues and then runs against the new worker instead of 500ing."""
+        """Terminate the worker after `idle_s` seconds without heavy use so
+        run() respawns it fresh — the full-memory counterpart to the worker's
+        own model release. Holding the lock across the respawn means a racing
+        request queues and then runs against the new worker instead of 500ing."""
         while True:
             await asyncio.sleep(60)
             if not self.ready or self.last_heavy is None:
@@ -314,8 +279,8 @@ class StdioWorker:
                 self._terminate()
                 # Wait (bounded) for run() to respawn and re-ready before
                 # releasing the lock. On timeout, release anyway — queued
-                # requests then fail fast exactly as they do for a crashed
-                # worker, and run() keeps retrying the respawn upstream.
+                # requests then fail fast as for a crashed worker, and run()
+                # keeps retrying upstream.
                 deadline = time.monotonic() + 180.0
                 while time.monotonic() < deadline and not self.ready:
                     await asyncio.sleep(0.5)
@@ -333,9 +298,9 @@ analyzer_worker = StdioWorker(
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    # Kick the worker supervisor as a background task so uvicorn binds :8080
-    # immediately — otherwise a cold CLAP/Demucs load would block the port bind
-    # and the controller's probe would see "connection refused" during boot.
+    # Background task so uvicorn binds :8080 immediately — a cold CLAP/Demucs
+    # load would otherwise block the bind and the controller's probe would see
+    # "connection refused" during boot.
     tasks = [asyncio.create_task(analyzer_worker.run(), name="analyze-run")]
     if RECYCLE_IDLE_S > 0:
         tasks.append(
@@ -356,11 +321,10 @@ app = FastAPI(title="subwave-analyzer", lifespan=lifespan)
 
 @app.get("/health")
 async def health():
-    # `engines` is the list of engines *currently ready*, not the static set
-    # this sidecar supports — the controller's probe
-    # (analyzer.ts:sidecarReachable) uses `engines.includes("analyze")` as its
-    # readiness signal, so advertising it while the worker is still booting (or
-    # crashed) would cause failed /analyze calls instead of a clean fall-through.
+    # `engines` lists engines *currently ready*, not the static set — the
+    # controller's probe (analyzer.ts:sidecarReachable) keys readiness on
+    # `engines.includes("analyze")`, so advertising it while booting/crashed
+    # would cause failed /analyze calls instead of a clean fall-through.
     ready_engines: list[str] = []
     if analyzer_worker.ready:
         ready_engines.append("analyze")
@@ -368,71 +332,60 @@ async def health():
         "ok": True,
         "engines": ready_engines,
         "analyze_loaded": analyzer_worker.ready,
-        # Whether the worker can emit CLAP "sounds-like" audio embeddings — true
-        # only when built WITH_CLAP=1. The controller surfaces this so the admin
-        # UI warns to rebuild *before* a fruitless run. None until ready.
+        # CLAP "sounds-like" capability (WITH_CLAP=1 builds only) — the admin
+        # UI warns to rebuild before a fruitless run. None until ready.
         "analyze_audio_capable": (
             analyzer_worker.ready_meta.get("audio_embedding_capable") if analyzer_worker.ready else None
         ),
-        # Likewise for Demucs vocal-activity ranges — true only when built
-        # WITH_DEMUCS=1. None until ready.
+        # Demucs vocal-activity capability (WITH_DEMUCS=1). None until ready.
         "analyze_vocal_capable": (
             analyzer_worker.ready_meta.get("vocal_activity_capable") if analyzer_worker.ready else None
         ),
-        # Tail vocal ranges (outro.vocalRanges) — a worker-version signal as
-        # much as a capability: workers predating the feature never emit the
-        # key, so this stays None on stale images and the controller's
-        # backfill widening (which requires === true) can't churn against
-        # them. None until ready.
+        # Tail vocal ranges — a worker-version signal as much as a capability:
+        # workers predating the feature never emit the key, so this stays None
+        # on stale images and the controller's backfill widening (which
+        # requires === true) can't churn against them.
         "analyze_tail_vocal_capable": (
             analyzer_worker.ready_meta.get("tail_vocal_capable") if analyzer_worker.ready else None
         ),
-        # Whether the worker can embed TEXT through the CLAP text tower (same
-        # 512-d space as the audio vectors) — powers "sounds like ..." search
-        # and zero-shot mood scoring. Needs torch, so lean images report false.
+        # CLAP text tower (same 512-d space as the audio vectors) — powers
+        # "sounds like ..." search and zero-shot moods. Needs torch, so lean
+        # images report false.
         "analyze_text_capable": (
             analyzer_worker.ready_meta.get("text_embedding_capable") if analyzer_worker.ready else None
         ),
-        # Best-effort residency (#1204 follow-up): whether CLAP/Demucs are
-        # believed loaded in the worker right now — true after a heavy request
-        # completes, false once the worker's idle release fires or the worker
-        # restarts. Lets an operator confirm the release without grepping logs.
-        # None while the worker is down.
+        # Best-effort residency (#1204): whether CLAP/Demucs are believed
+        # loaded right now — lets an operator confirm the idle release
+        # without grepping logs. None while the worker is down.
         "analyze_models_resident": analyzer_worker.models_resident if analyzer_worker.ready else None,
-        # Seconds since the last completed heavy (model-using) request against
-        # THIS worker process; null when none has run since it spawned.
+        # Seconds since the last completed heavy request against THIS worker
+        # process; null when none has run since it spawned.
         "analyze_heavy_idle_s": (
             round(time.monotonic() - analyzer_worker.last_heavy, 1)
             if analyzer_worker.ready and analyzer_worker.last_heavy is not None
             else None
         ),
-        # How many times the idle recycle (ANALYZE_RECYCLE_IDLE_S) has bounced
-        # the worker for a full memory reclaim since the container started.
         "analyze_worker_recycles": analyzer_worker.recycles,
     }
 
 
 class AnalyzeRequest(BaseModel):
-    # Either a remote stream url (the worker downloads it) or a local path on the
-    # shared /var/sub-wave volume the controller pre-fetched into. The
-    # controller's prefetch pipeline sends `path` to overlap network I/O with the
-    # sidecar's single-threaded compute; `url` stays as the fallback.
+    # Remote stream url, or a local path on the shared volume the controller
+    # pre-fetched into (overlaps network I/O with the sidecar's compute).
     url: str | None = None
     path: str | None = None
-    # Per-request CLAP opt-in (the controller's admin toggle). True makes the
-    # worker lazy-load CLAP even without ANALYZE_AUDIO_EMBEDDING in its env; None
-    # keeps the worker's env-driven default.
+    # Per-request CLAP opt-in (the admin toggle); None keeps the worker's
+    # env-driven default.
     embed: bool | None = None
-    # Same, for Demucs vocal-activity ranges (ANALYZE_VOCAL_ACTIVITY default).
+    # Same, for Demucs vocal-activity ranges.
     vocal: bool | None = None
-    # Whether `path` holds the COMPLETE file (the controller's capped prefetch
-    # knows). False vetoes outro analysis — a truncated file's "tail" is
-    # mid-song audio. None = unknown; the worker's decode-length check guards.
+    # Whether `path` holds the COMPLETE file. False vetoes outro analysis (a
+    # truncated file's "tail" is mid-song audio); None = unknown, the worker's
+    # decode-length check guards.
     complete: bool | None = None
-    # Stem-cache target dir on the shared volume (feature: stem-blend
-    # transitions). When set, the worker persists the Demucs stems it already
-    # computes (head + tail windows) as FLAC into this dir. Implies the
-    # separation pass even when `vocal` wasn't requested.
+    # Stem-cache target dir (stem-blend transitions). When set, the worker
+    # persists the Demucs stems it already computes as FLAC into this dir —
+    # implies the separation pass even when `vocal` wasn't requested.
     stems_dir: str | None = None
 
 
@@ -462,26 +415,23 @@ async def analyze(req: AnalyzeRequest):
         "intro_ms": msg.get("intro_ms"),
         "confidence": msg.get("confidence"),
     }
-    # Optional perceptual loudness + structural fields — present only when the
-    # worker computed them. Pass through; omitted otherwise so the client maps
-    # them to null.
+    # Optional fields — passed through only when the worker computed them, so
+    # the client maps omissions to null.
     for k in (
         "loudness_lufs", "peak_db", "sections", "vocal_ranges",
         "pace_curve", "beats", "bars", "key_ranges", "outro", "stems_cached",
     ):
         if k in msg:
             out[k] = msg[k]
-    # Optional CLAP audio embedding — present only when the worker has the model
-    # loaded (ANALYZE_AUDIO_EMBEDDING + CLAP weights). Omitted otherwise.
     if "audio_embedding" in msg:
         out["audio_embedding"] = msg["audio_embedding"]
     return out
 
 
 class RenderTransitionRequest(BaseModel):
-    # Stem-blend transition render (feature: stem-blend transitions). The
-    # controller supplies per-track alignment data straight from library.db —
-    # the worker never re-detects. Cache-hit-only: missing stems → ok=false.
+    # Stem-blend transition render. The controller supplies per-track
+    # alignment data straight from library.db — the worker never re-detects.
+    # Cache-hit-only: missing stems → ok=false.
     out: dict[str, Any]
     in_: dict[str, Any] = Field(alias="in")
     out_dir: str
@@ -495,8 +445,8 @@ class RenderTransitionRequest(BaseModel):
 async def render_transition(req: RenderTransitionRequest):
     """Mix a pre-rendered transition WAV from two tracks' cached stems onto
     the shared volume. Fast (a mix, not a separation) but still serialized
-    behind the single worker lock — the controller's own render deadline
-    handles a render stuck behind a bulk analyze item."""
+    behind the single worker lock — the controller's render deadline handles
+    a render stuck behind a bulk analyze item."""
     payload: dict[str, Any] = {
         "id": "1",
         "op": "render_transition",
@@ -525,18 +475,16 @@ async def render_transition(req: RenderTransitionRequest):
 
 class EmbedTextRequest(BaseModel):
     # 1-64 non-empty strings (the worker enforces the same envelope). One
-    # request = one worker round-trip, so mood-vocabulary batches go in a
-    # single call.
+    # request = one worker round-trip, so mood-vocabulary batches go in one call.
     texts: list[str]
 
 
 @app.post("/embed-text")
 async def embed_text(req: EmbedTextRequest):
     """CLAP text-tower embeddings — 512-d vectors in the SAME space as the
-    audio vectors, so the controller can cosine them against stored track
-    embeddings (natural-language "sounds like ..." search, zero-shot mood
-    scoring). 500s cleanly on a lean build (no torch); the controller's client
-    treats any failure as "text embedding unavailable"."""
+    audio vectors ("sounds like ..." search, zero-shot mood scoring). 500s
+    cleanly on a lean build (no torch); the controller treats any failure as
+    "text embedding unavailable"."""
     if not req.texts:
         raise HTTPException(400, "missing 'texts'")
     msg = await analyzer_worker.request({"id": "1", "texts": req.texts})

--- a/docker/broadcast-entrypoint.sh
+++ b/docker/broadcast-entrypoint.sh
@@ -1,41 +1,18 @@
 #!/usr/bin/env bash
-# SUB/WAVE broadcast supervisor.
+# SUB/WAVE broadcast supervisor: resolves the icecast secrets, renders
+# icecast.xml, launches icecast2 + liquidsoap, and exits as soon as either dies
+# so the container's restart policy bounces the pair together.
 #
-# Bash (not /bin/sh) because we need `wait -n` to react to whichever child
-# exits first. The savonet/liquidsoap base image's /bin/sh is dash, which
-# lacks `wait -n`; bash is in the same image (debian) so this is free.
-#
-# Launches icecast2 and liquidsoap in one container and exits as soon as
-# either dies, so the container's restart policy bounces the pair together.
-# This replaces the earlier two-container split (subwave-icecast +
-# subwave-liquidsoap) and the icecast-secrets handshake that bridged them.
-#
-# Boot sequence:
-#   1. Pre-create the shared /var/sub-wave subdirs with mode 777 so the
-#      controller (running as a different uid) can write into them. Same role
-#      the old subwave-icecast entrypoint played for the wider stack — it just
-#      happens to also be where this container's own state lives now.
-#   2. Resolve the three ICECAST_*_PASSWORD values. Precedence (unchanged):
-#        env override > persisted state/icecast-secrets.env > freshly generated.
-#      The resolved values are still written back to state/icecast-secrets.env
-#      for operator visibility and to keep the documented "delete the file +
-#      restart to rotate" path working.
-#   3. Render icecast.xml from the baked-in template.
-#   4. Launch icecast2 (as icecast2 user) in the background.
-#   5. Wait for icecast to accept HTTP connections (so liquidsoap doesn't
-#      immediately fail its source connect).
-#   6. Launch liquidsoap (as liquidsoap user) in the background with the
-#      resolved ICECAST_SOURCE_PASSWORD + ICECAST_HOST=localhost in its env.
-#   7. `wait -n` for whichever exits first; tear the other down; exit.
+# Bash (not /bin/sh) because we need `wait -n`; the base image's /bin/sh is
+# dash, which lacks it.
 
 set -eu
 
 # ---- Multi-station pointer resolution ---------------------------------------
-# state/stations/active.json (controller-written, {"activeId":"<slug>"}) picks
-# which station dir this boot serves. Everything below reads from $STATE_DIR;
-# only install-level files (icecast secrets) stay at $STATE_ROOT. No jq in
-# this image — the sed matches the controller's canonical output and the slug
-# charset [a-z0-9-], so a hand-mangled file falls back to the root.
+# state/stations/active.json ({"activeId":"<slug>"}) picks the station dir this
+# boot serves; install-level files (icecast secrets) stay at $STATE_ROOT. No jq
+# in this image — the sed matches the controller's canonical output and the
+# slug charset [a-z0-9-]; a hand-mangled file falls back to the root.
 STATE_ROOT=/var/sub-wave
 STATE_DIR="$STATE_ROOT"
 ACTIVE_FILE="$STATE_ROOT/stations/active.json"
@@ -55,9 +32,8 @@ TEMPLATE=/etc/icecast2/icecast.xml.template
 RENDERED=/etc/icecast2/icecast.xml
 
 # ---- Bootstrap shared state dirs --------------------------------------------
-# The controller container (different uid) also writes here. Mode 777 keeps
-# this hands-off — operators don't have to chown bind-mount sources before
-# the first boot succeeds.
+# Mode 777 because the controller container writes here as a different uid —
+# operators shouldn't have to chown bind-mount sources before first boot.
 
 mkdir -p "$STATE_ROOT" \
          "$STATE_DIR" \
@@ -77,25 +53,21 @@ chmod 777 "$STATE_ROOT" \
           "$STATE_DIR/logs" \
           "$STATE_DIR/sessions" \
           "$STATE_DIR/sfx"
-# Bootstrap empty m3u files Liquidsoap's reload_mode="watch" needs to see.
+# Liquidsoap's reload_mode="watch" playlists need the files to exist.
 touch "$STATE_DIR/auto.m3u" "$STATE_DIR/jingles.m3u"
 chmod 666 "$STATE_DIR/auto.m3u" "$STATE_DIR/jingles.m3u"
-# Tell a co-located Navidrome to skip the archive dir — its hourly mixdowns are
-# the station's own recordings, not library tracks, and otherwise get scanned in
-# as junk "HH-00" entries that confuse the DJ (issue #273). Harmless when
-# Navidrome lives elsewhere / doesn't overlap this path.
+# Keep a co-located Navidrome from scanning the hourly archive mixdowns in as
+# junk "HH-00" tracks (issue #273). Harmless when paths don't overlap.
 touch "$STATE_DIR/archive/.ndignore"
 
-# Liquidsoap writes radio.log to /var/log/liquidsoap as uid 10000. Compose
-# usually bind-mounts ${STATE_DIR}/logs over this path; that bind mount lands
-# owned by root on first boot, so chown it to the liquidsoap user.
+# The compose logs bind mount lands owned by root on first boot; liquidsoap
+# (uid 10000) writes radio.log there.
 mkdir -p /var/log/liquidsoap
 chown -R liquidsoap:liquidsoap /var/log/liquidsoap 2>/dev/null || true
 
-# Rotate radio.log on boot once it passes 50MB. Liquidsoap has no size-based
-# rotation of its own and appends forever (200MB+ after a couple of months);
-# boot is the one safe moment to move it since liquidsoap isn't holding the
-# fd yet. One .old generation caps disk at ~2x the threshold.
+# Rotate radio.log on boot once it passes 50MB — liquidsoap has no size-based
+# rotation and appends forever; boot is the one safe moment (fd not yet held).
+# One .old generation caps disk at ~2x the threshold.
 RADIO_LOG=/var/log/liquidsoap/radio.log
 if [ -f "$RADIO_LOG" ] && [ "$(stat -c %s "$RADIO_LOG" 2>/dev/null || echo 0)" -gt 52428800 ]; then
     mv -f "$RADIO_LOG" "$RADIO_LOG.old"
@@ -103,6 +75,7 @@ if [ -f "$RADIO_LOG" ] && [ "$(stat -c %s "$RADIO_LOG" 2>/dev/null || echo 0)" -
 fi
 
 # ---- Resolve passwords ------------------------------------------------------
+# Precedence: env override > persisted secrets file > freshly generated.
 # Capture env values FIRST so sourcing the secrets file can't clobber them.
 
 ENV_SRC="${ICECAST_SOURCE_PASSWORD:-}"
@@ -114,42 +87,36 @@ if [ -f "$SECRETS" ]; then
     . "$SECRETS"
 fi
 
-# Env values win when present (operator override via root .env).
 [ -n "$ENV_SRC" ] && ICECAST_SOURCE_PASSWORD="$ENV_SRC"
 [ -n "$ENV_ADM" ] && ICECAST_ADMIN_PASSWORD="$ENV_ADM"
 [ -n "$ENV_REL" ] && ICECAST_RELAY_PASSWORD="$ENV_REL"
 
-# Anything still empty gets a fresh random value.
 [ -z "${ICECAST_SOURCE_PASSWORD:-}" ] && ICECAST_SOURCE_PASSWORD="$(openssl rand -hex 16)"
 [ -z "${ICECAST_ADMIN_PASSWORD:-}"  ] && ICECAST_ADMIN_PASSWORD="$(openssl rand -hex 16)"
 [ -z "${ICECAST_RELAY_PASSWORD:-}"  ] && ICECAST_RELAY_PASSWORD="$(openssl rand -hex 16)"
 
+# Written back for operator visibility + the documented "delete + restart to
+# rotate" path.
 cat > "$SECRETS" <<EOF
 ICECAST_SOURCE_PASSWORD=$ICECAST_SOURCE_PASSWORD
 ICECAST_ADMIN_PASSWORD=$ICECAST_ADMIN_PASSWORD
 ICECAST_RELAY_PASSWORD=$ICECAST_RELAY_PASSWORD
 EOF
-# 0600: the file holds the Icecast passwords. Only root reads it — this
-# entrypoint sources it (as root, before dropping to the icecast2/liquidsoap
-# users via sudo -E), and the controller container (also root) reads it off the
-# shared /var/sub-wave mount in broadcast/listeners.ts. No non-root reader
-# needs it, so keep it owner-only.
+# 0600 — only root reads it (this entrypoint, and the controller container off
+# the shared mount in broadcast/listeners.ts).
 chmod 600 "$SECRETS"
 
 export ICECAST_SOURCE_PASSWORD ICECAST_ADMIN_PASSWORD ICECAST_RELAY_PASSWORD
-# Liquidsoap connects to icecast over loopback inside this container.
-# radio.liq reads ICECAST_HOST (default "icecast"); override here so the
-# stock script keeps working without a code edit.
+# Liquidsoap connects over loopback inside this container; radio.liq reads
+# ICECAST_HOST (default "icecast").
 export ICECAST_HOST=localhost
 
 # ---- Render icecast.xml -----------------------------------------------------
-# Plain sed is enough for four placeholders; the secrets are hex and the
-# listener cap numeric, so there's no escaping risk. Using `|` as the sed
-# delimiter keeps slashes safe.
+# Plain sed with `|` delimiters — the secrets are hex and the caps numeric, so
+# there's no escaping risk.
 
-# Concurrent-listener ceiling (<limits><clients>). Empty/unset → the stock 100.
-# A non-numeric value would render invalid XML and fail icecast at boot, so
-# fall back to the default with a warning instead of taking the stream down.
+# Concurrent-listener ceiling. A non-numeric value would render invalid XML and
+# fail icecast at boot, so fall back to 100 with a warning instead.
 ICECAST_MAX_CLIENTS="${ICECAST_MAX_CLIENTS:-100}"
 case "$ICECAST_MAX_CLIENTS" in
     *[!0-9]*|'')
@@ -158,19 +125,11 @@ case "$ICECAST_MAX_CLIENTS" in
         ;;
 esac
 
-# Listener buffer depth (<burst-size>) — audio bursted to a client on connect
-# so a coverage gap drains the buffer instead of stalling (issue #993).
-#
-# Sized in SECONDS and converted to bytes here, because burst-size is a byte
-# count and a fixed one means wildly different depths per bitrate: the old
-# hardcoded 512 KB was ~22s at 192k but ~66s at 64k, so the stations least able
-# to afford lag got the most of it (issue #1114). Deriving from the live
-# bitrate keeps the depth an operator picks the depth they actually get.
-#
-# Sources, in precedence order: env override > settings (written by the
-# controller on save) > default. Read from the shared state dir rather than
-# passed in, so a settings change applies on the next broadcast bounce with no
-# compose edit.
+# Listener buffer depth (<burst-size>, #993/#1114). Sized in SECONDS and
+# converted per bitrate here, because burst-size is a byte count — a fixed one
+# means wildly different depths per mount (512 KB was ~22s at 192k but ~66s at
+# 64k). Sources: env override > settings files (written by the controller) >
+# default; read from state so a settings change applies on the next bounce.
 read_state_num() {
     # $1 = filename, $2 = fallback. Non-numeric or missing → fallback.
     _v=$(cat "$STATE_DIR/$1" 2>/dev/null || true)
@@ -186,10 +145,8 @@ case "$STREAM_BITRATE" in *[!0-9]*|'') STREAM_BITRATE=192 ;; esac
 case "$BUFFER_SECONDS" in *[!0-9]*|'') BUFFER_SECONDS=22 ;; esac
 [ "$BUFFER_SECONDS" -gt 60 ] && BUFFER_SECONDS=60
 
-# Per-mount bitrates for the optional encoders, same sources as above. FLAC is
-# VBR with no bitrate setting — 900 kbps is a typical average for 44.1/16
-# stereo at default compression, close enough for a buffer depth (the players
-# align their displays to MEASURED lag, not this figure).
+# FLAC is VBR with no bitrate setting — ~900 kbps is a typical average for
+# 44.1/16 stereo, close enough for a buffer depth.
 OPUS_BITRATE="${ICECAST_OPUS_BITRATE:-$(read_state_num liquidsoap_opus_bitrate.txt 96)}"
 AAC_BITRATE="${ICECAST_AAC_BITRATE:-$(read_state_num liquidsoap_aac_bitrate.txt 192)}"
 case "$OPUS_BITRATE" in *[!0-9]*|'') OPUS_BITRATE=96 ;; esac
@@ -201,24 +158,19 @@ ICECAST_BURST_SIZE=$(( BUFFER_SECONDS * STREAM_BITRATE * 125 ))
 
 # queue-size is the per-client backlog before Icecast drops a lagging listener.
 # It must comfortably exceed burst-size or a client is evicted the moment it
-# falls behind its own primed buffer. 4x the burst (floored at the historical
-# 2 MB) preserves the ~minute of rope issue #993 wanted at the default depth
-# while still scaling with a deeper buffer.
+# falls behind its own primed buffer; 4x (floored at the historical 2 MB)
+# preserves #993's ~minute of rope while scaling with a deeper buffer.
 ICECAST_QUEUE_SIZE=$(( ICECAST_BURST_SIZE * 4 ))
 [ "$ICECAST_QUEUE_SIZE" -lt 2097152 ] && ICECAST_QUEUE_SIZE=2097152
 
 echo "broadcast: listener buffer ${BUFFER_SECONDS}s @ mp3 ${STREAM_BITRATE}kbps" \
      "/ opus ${OPUS_BITRATE}kbps / aac ${AAC_BITRATE}kbps / flac ~${FLAC_BITRATE_EST}kbps" >&2
 
-# Listener auth (#478). The controller writes state/icecast_listener_auth.txt
-# ('true'/'false') from settings.privacy.listenerAuth; only the literal value
-# "true" enables (mirroring the archive_enabled pattern — missing/garbled file
-# means public). When enabled, every stream mount gets an
-# <authentication type="url"> block: icecast POSTs each listener connect to
-# the controller, which admits it with an `icecast-auth-user: 1` header. The
-# password itself lives ONLY in the controller's settings.json — password
-# changes apply live, and this render only matters when the toggle flips
-# (which the admin UI routes through the existing restart-mixer flow).
+# Listener auth (#478): only a literal 'true' in the controller-written flag
+# enables (missing/garbled → public). Each stream mount then gets an
+# <authentication type="url"> block; icecast POSTs listener connects to the
+# controller. The password lives ONLY in settings.json — changes apply live;
+# this render only matters when the toggle flips (which rides restart-mixer).
 LISTENER_AUTH_FLAG=$STATE_DIR/icecast_listener_auth.txt
 LISTENER_AUTH_URL="${LISTENER_AUTH_URL:-http://controller:7701/listener-auth}"
 LISTENER_AUTH=false
@@ -227,14 +179,10 @@ if [ "$(cat "$LISTENER_AUTH_FLAG" 2>/dev/null | tr -d '[:space:]')" = "true" ]; 
     echo "broadcast: listener auth ON — mounts require credentials via $LISTENER_AUTH_URL" >&2
 fi
 
-# One <mount> block per stream mount, ALWAYS rendered (not just under listener
-# auth): burst-size is a BYTE count, so the global <limits> value — sized for
-# the MP3 bitrate — lands wildly wrong on the other mounts (the same 528 KB
-# that means 22s at mp3-192k is ~43s at opus-96k and ~6s of FLAC), and the
-# whole point of sizing in seconds (#1114) is that the operator's chosen depth
-# is the depth every listener gets. queue-size scales with each mount's burst
-# for the same reason it does globally: a client must never be evicted for
-# falling behind its own primed buffer.
+# One <mount> block per stream mount, ALWAYS rendered (not just under auth):
+# burst-size is a byte count, so the global <limits> value — sized for MP3 —
+# lands wildly wrong on the other mounts (22s of mp3-192k is ~43s of opus-96k
+# and ~6s of FLAC). Per-mount queue-size scales for the same reason.
 MOUNTS_XML=/etc/icecast2/stream-mounts.xml
 : > "$MOUNTS_XML"
 emit_mount() {
@@ -262,29 +210,17 @@ emit_mount /stream.opus "$OPUS_BITRATE"
 emit_mount /stream.flac "$FLAC_BITRATE_EST"
 emit_mount /stream.aac  "$AAC_BITRATE"
 
-# Trusted reverse proxies — what makes admin → Listeners show real listener
-# IPs instead of the edge's container address. Icecast's only peer is Caddy,
-# so unless an <x-forwarded-for> element names Caddy's address, every row
-# reads 172.x. icecast-KH matches on an EXACT IP (a CIDR is accepted and then
-# silently never matches), so the address has to be resolved, not described.
+# Trusted reverse proxies — real listener IPs in admin → Listeners instead of
+# the edge's container address. icecast-KH matches an EXACT IP only (a CIDR is
+# accepted and then silently never matches), so the address must be resolved.
+# Precedence: ICECAST_TRUSTED_PROXY_IPS (explicit, wins) > DNS for
+# ICECAST_TRUSTED_PROXY_HOSTS (default 'caddy', the bundled edge).
 #
-# Precedence:
-#   ICECAST_TRUSTED_PROXY_IPS   — explicit addresses (space/comma separated).
-#     The deterministic option: set it when the edge is pinned to a static IP,
-#     lives outside this compose network (byo compose, host-network nginx), or
-#     isn't resolvable by name from here.
-#   ICECAST_TRUSTED_PROXY_HOSTS — names to resolve at render time, default
-#     'caddy' (the bundled edge).
-#
-# The DNS path is deliberately best-effort. On a COLD `compose up` it misses:
-# caddy depends_on this container being healthy, and healthy means icecast is
-# already serving, so the name cannot resolve before this render — measured at
-# ~6s of "unresolved". Every subsequent restart (including the telnet
-# restart-mixer, which bounces this container) lands with caddy up and picks
-# the address up on its own. A miss degrades to today's behaviour — the proxy's
-# IP in the table — never to a wrong listener IP, so nothing downstream has to
-# handle a half-applied state. Operators who want it right from first boot pin
-# the edge and set ICECAST_TRUSTED_PROXY_IPS (see docs/deployment.md).
+# The DNS path is deliberately best-effort: on a COLD `compose up` caddy can't
+# be running yet (it depends_on this container being healthy), so the name
+# doesn't resolve — every later restart picks it up. A miss degrades to the old
+# behaviour (proxy IP shown), never to a wrong IP. Operators who want first-boot
+# accuracy pin the edge and set ICECAST_TRUSTED_PROXY_IPS (docs/deployment.md).
 TRUSTED_XML=/etc/icecast2/trusted-proxies.xml
 : > "$TRUSTED_XML"
 TRUSTED_LIST=""
@@ -292,17 +228,17 @@ if [ -n "${ICECAST_TRUSTED_PROXY_IPS:-}" ]; then
     TRUSTED_LIST=$(echo "$ICECAST_TRUSTED_PROXY_IPS" | tr ',' ' ')
 else
     for _host in $(echo "${ICECAST_TRUSTED_PROXY_HOSTS:-caddy}" | tr ',' ' '); do
-        # ahosts, not hosts: `getent hosts` returns ONE address family, so on
-        # a dual-stack network it can hand back only the IPv6 while Caddy
-        # dials icecast over IPv4 — and an exact-IP match then never fires.
+        # ahosts, not hosts: `getent hosts` returns ONE address family, so on a
+        # dual-stack network it can hand back only the IPv6 while Caddy dials
+        # icecast over IPv4 — and the exact-IP match then never fires.
         _found=$(getent ahosts "$_host" 2>/dev/null | awk '{print $1}' | sort -u || true)
         [ -n "$_found" ] && TRUSTED_LIST="$TRUSTED_LIST $_found"
     done
 fi
 
 # Only hex/dot/colon runs are addresses. A malformed entry is dropped rather
-# than interpolated — it would otherwise render XML icecast refuses to parse,
-# turning a cosmetic setting into a station that won't boot.
+# than interpolated — invalid XML here would turn a cosmetic setting into a
+# station that won't boot.
 TRUSTED_COUNT=0
 for _ip in $TRUSTED_LIST; do
     case "$_ip" in
@@ -320,9 +256,8 @@ else
     echo "broadcast: no trusted proxy resolved — listener IPs will show the connecting peer" >&2
 fi
 
-# `r` splices the generated mount blocks (empty file = nothing) where the
-# marker sits, then the marker line itself is deleted. Same for the trusted
-# proxy elements.
+# `r` splices the generated blocks (empty file = nothing) where each marker
+# sits, then the marker line itself is deleted.
 sed \
     -e "s|\${ICECAST_SOURCE_PASSWORD}|$ICECAST_SOURCE_PASSWORD|g" \
     -e "s|\${ICECAST_ADMIN_PASSWORD}|$ICECAST_ADMIN_PASSWORD|g" \
@@ -343,9 +278,8 @@ echo "broadcast: starting icecast2" >&2
 sudo -E -u icecast2 icecast2 -n -c "$RENDERED" &
 ICECAST_PID=$!
 
-# Wait up to ~10s for icecast to accept HTTP. Without this, liquidsoap can
-# beat icecast to the punch and bail with "Cannot connect to remote host" on
-# its very first source connect.
+# Wait up to ~10s for icecast to accept HTTP, or liquidsoap can beat it and
+# bail with "Cannot connect to remote host" on its first source connect.
 for i in 1 2 3 4 5 6 7 8 9 10; do
     if curl -fsS http://localhost:7702/ > /dev/null 2>&1; then
         echo "broadcast: icecast accepting connections after ${i}s" >&2
@@ -358,20 +292,15 @@ done
 
 echo "broadcast: starting liquidsoap" >&2
 # TEMPORARY (re-harden later): run liquidsoap as root instead of dropping to
-# the `liquidsoap` user. The savonet base image bump 2.2.5 -> 2.4.4 changed the
-# `liquidsoap` user's uid (10000 -> 100), so the persisted state files under the
-# bind-mounted /var/sub-wave (e.g. now-playing.json, owned 10000:10001 mode 644
-# by the old image) became unwritable to uid 100 — every on_meta write EACCES'd
-# and the UI froze one song behind. Root ignores those perms. Restore the
-# privilege drop once the state files are chowned to the new liquidsoap uid
+# the `liquidsoap` user. The savonet base bump 2.2.5 → 2.4.4 changed that
+# user's uid (10000 → 100), making state files persisted by the old image
+# unwritable — every on_meta write EACCES'd and the UI froze one song behind.
+# Restore the privilege drop once the state files are chowned to the new uid
 # (needs settings.init.allow_root reverted in radio.liq too).
 liquidsoap /etc/liquidsoap/radio.liq &
 LIQ_PID=$!
 
 # ---- Wait for either to die, then exit -------------------------------------
-# `wait -n` is a bash builtin (and not yet in dash, which is /bin/sh on the
-# savonet image — hence the bash shebang at the top). If either child exits,
-# kill the other and propagate the exit code so docker restarts the container.
 
 trap 'kill -TERM "$ICECAST_PID" "$LIQ_PID" 2>/dev/null || true' INT TERM
 

--- a/docker/icecast.xml.template
+++ b/docker/icecast.xml.template
@@ -7,40 +7,26 @@
         <sources>4</sources>
         <!-- queue-size: per-client backlog before Icecast drops a lagging
              listener. Computed by broadcast-entrypoint.sh as 4x burst-size
-             (floored at the historical 2 MB) — it must comfortably exceed the
-             burst or a client is evicted the moment it falls behind its own
-             primed buffer, and it gives jittery mobile and Cloudflare-proxied
-             clients a good minute of rope to ride out a coverage gap without
-             being kicked (issue #993). -->
+             (floored at 2 MB) — it must comfortably exceed the burst or a
+             client is evicted the moment it falls behind its own primed
+             buffer (issue #993). -->
         <queue-size>${ICECAST_QUEUE_SIZE}</queue-size>
         <client-timeout>30</client-timeout>
         <header-timeout>15</header-timeout>
         <source-timeout>10</source-timeout>
         <burst-on-connect>1</burst-on-connect>
-        <!-- burst-size: audio bursted to a client on connect to prime its
-             buffer, deep enough that a real cellular dead zone drains the
-             buffer instead of stalling (issue #993). Delivered at line speed,
-             so tune-in stays instant — the cost is listening that far behind
-             the live edge. Every player-watchdog reconnect carries a ?t=
-             cache-buster, so each reconnect primes a fresh burst.
+        <!-- burst-size: audio bursted on connect to prime the client's buffer
+             (issue #993). Delivered at line speed, so tune-in stays instant;
+             the cost is listening that far behind the live edge, which is why
+             /now-playing publishes stream.bufferSeconds and players shift
+             their displays by it (issue #1114).
 
              Computed by broadcast-entrypoint.sh from settings.stream.
-             bufferSeconds x the live bitrate, NOT hardcoded: this is a byte
-             count, so a fixed value drifts badly across bitrates (the old flat
-             512 KB was ~22s at 192k but ~66s at 64k). Deriving it keeps the
-             depth the operator picked the depth every bitrate gets.
-
-             This is also roughly how far behind the live edge a listener
-             sits, so /now-playing publishes stream.bufferSeconds and players
-             use it to align the now-playing title and elapsed clock with the
-             audio actually in someone's ears (issue #1114) — the web player
-             prefers its own measured lag (buffered.end − currentTime) and
-             falls back to the advertised figure when it isn't the thing
-             playing the audio.
+             bufferSeconds x the live bitrate, NOT hardcoded — it's a byte
+             count, so a fixed value drifts badly across bitrates.
 
              These <limits> values are sized for the MP3 mount and act as the
-             default; every stream mount below carries its own burst/queue
-             sized for its own bitrate. -->
+             default; every stream mount below carries its own burst/queue. -->
         <burst-size>${ICECAST_BURST_SIZE}</burst-size>
     </limits>
 
@@ -59,14 +45,11 @@
 
     <fileserve>1</fileserve>
 
-    <!-- Stream mounts: the entrypoint replaces the marker below with one
-         <mount> block per stream mount, always rendered. Each carries its own
-         <burst-size>/<queue-size> sized from settings.stream.bufferSeconds x
-         THAT mount's bitrate — the global <limits> values above are sized for
-         the MP3 mount only, and a byte count that means 22s of MP3 is ~43s of
-         Opus or ~6s of FLAC. When state/icecast_listener_auth.txt is 'true'
-         (#478), each block additionally carries <authentication type="url">
-         pointing at the controller's POST /listener-auth. -->
+    <!-- The entrypoint replaces the marker with one <mount> block per stream
+         mount, each with its own burst/queue sized from bufferSeconds x THAT
+         mount's bitrate (the global <limits> above only fit MP3). Under
+         listener auth (#478) each block also carries <authentication
+         type="url"> pointing at the controller's POST /listener-auth. -->
     <!--@STREAM_MOUNTS@-->
 
 
@@ -78,22 +61,13 @@
         <pidfile>/var/run/icecast2/icecast.pid</pidfile>
         <alias source="/" destination="/status.xsl"/>
 
-        <!-- Trusted reverse proxies: the entrypoint replaces the marker below
-             with one <x-forwarded-for> element per proxy IP. Without at least
-             one, icecast attributes EVERY listener to the proxy's container IP
-             (the 172.x rows in admin → Listeners), because the only peer it
-             ever sees is Caddy.
-
-             Two icecast-KH quirks drive the shape of this (both verified
-             against 2.4.0-kh22, the build in this image):
-               - the value must be an EXACT IP. A CIDR (172.16.0.0/12) is
-                 accepted without complaint and then silently never matches,
-                 so a subnet can't stand in for the proxy's address.
-               - the LEFT-MOST entry of the X-Forwarded-For chain wins, which
-                 is the original client — correct even though Caddy appends
-                 its own peer to the chain on the way through.
-             Multiple elements are allowed, which is how a multi-hop or
-             multi-proxy front end is covered. -->
+        <!-- The entrypoint replaces the marker with one <x-forwarded-for>
+             element per trusted proxy IP; without one, every listener shows as
+             the proxy's container IP. Two icecast-KH quirks (verified on
+             2.4.0-kh22): the value must be an EXACT IP — a CIDR is accepted
+             and then silently never matches — and the LEFT-MOST entry of the
+             X-Forwarded-For chain wins (the original client, correct even
+             though Caddy appends its own peer). -->
         <!--@TRUSTED_PROXIES@-->
     </paths>
 

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -1,20 +1,14 @@
 """
 subwave-tts-heavy — optional Chatterbox + PocketTTS sidecar for SUB/WAVE.
 
-The controller (controller/src/audio/chatterbox.ts, audio/pocketTts.ts) talks
-to this service over HTTP when TTS_HEAVY_URL is set in its environment. The
-shared /var/sub-wave volume is mounted in both containers, so the sidecar
-writes the WAV to the absolute `out` path the controller asks for, and the
-controller hands the same path to Liquidsoap via next.txt / say.txt /
-intro.txt. No audio over the wire — only metadata.
-
-Architecture: this is a thin FastAPI shim. The real inference happens in two
-long-lived Python subprocesses — the SAME stdio worker scripts the controller
-uses for its in-process build (controller/scripts/{chatterbox,pocket_tts}_
-worker.py). Each runs in its own venv (/opt/chatterbox/venv,
-/opt/pocket-tts/venv) because chatterbox-tts and pocket-tts have incompatible
-pip resolutions in a single env. asyncio.Lock per worker serialises requests
-so two simultaneous DJ lines don't interleave.
+The controller (audio/chatterbox.ts, audio/pocketTts.ts) talks to this over
+HTTP when TTS_HEAVY_URL is set. A thin FastAPI shim over two long-lived
+subprocesses — the SAME stdio workers the controller runs in-process
+(controller/scripts/{chatterbox,pocket_tts}_worker.py), one venv each because
+the two packages have incompatible pip resolutions. One JSON object per line
+over stdin/stdout; an asyncio.Lock per worker serialises requests. No audio
+over the wire — the sidecar writes the WAV to the absolute `out` path on the
+shared /var/sub-wave volume and the controller hands that path to Liquidsoap.
 
 Endpoints:
   GET  /health   → {ok, engines, chatterbox_loaded, pocket_loaded}
@@ -41,26 +35,21 @@ POCKET_TTS_WORKER = os.environ.get("POCKET_TTS_WORKER", "/app/workers/pocket_tts
 DEVICE = os.environ.get("TTS_HEAVY_DEVICE", "cpu").lower()
 POCKET_TTS_DEFAULT_VOICE = os.environ.get("POCKET_TTS_VOICE", "alba")
 
-# Per-worker HF cache homes so the two engines don't fight over the same
-# directory. Each is a named volume in the compose files, so the weights a
-# worker downloads on its first boot survive container recreates. The env vars
-# below tell huggingface_hub where to look at runtime (and are passed into each
-# worker's env via env_extra below).
+# Per-worker HF cache homes so the engines don't fight over one directory;
+# each is a named volume in compose, so first-boot weight downloads survive
+# recreates. Passed into each worker's env via env_extra.
 CHATTERBOX_HF_HOME = os.environ.get("CHATTERBOX_HF_HOME", "/opt/chatterbox/hf-cache")
 POCKET_HF_HOME = os.environ.get("POCKET_HF_HOME", "/opt/pocket-tts/hf-cache")
 
-# Max bytes of one worker stdout line. asyncio's default StreamReader limit is
-# 64 KiB; TTS responses are small (a WAV path) but keep this in step with the
-# analyzer sidecar so a future payload can't hit LimitOverrunError (#996).
+# Max bytes of one worker stdout line. TTS responses are small, but keep in
+# step with the analyzer sidecar so a future payload can't hit asyncio's
+# 64 KiB default and LimitOverrunError (#996).
 WORKER_STDOUT_LIMIT = 16 * 1024 * 1024
 
-# Which engines this sidecar should actually load. BOTH are baked into the
-# image, but loading a PyTorch model costs RAM + a multi-GB first-boot weight
-# download + 30-60s of startup — so an operator who only uses one engine can
-# skip the other entirely by narrowing this list. Comma-separated; defaults to
-# both for back-compat. e.g. TTS_HEAVY_ENGINES=pocket-tts runs PocketTTS only
-# (no Chatterbox). Unknown/empty entries are ignored; an empty result falls
-# back to loading both so a typo never silently disables all TTS.
+# Which engines to load. BOTH are baked into the image, but each costs RAM +
+# a multi-GB first-boot download + 30-60s startup, so operators can narrow the
+# comma-separated list. Unknown/empty entries are ignored; an empty result
+# falls back to both so a typo never silently disables all TTS.
 _ALL_ENGINES = ("chatterbox", "pocket-tts")
 ENABLED_ENGINES = [
     e
@@ -83,22 +72,15 @@ log = logging.getLogger("tts-heavy")
 class TtsWorker:
     """Async wrapper around a long-lived stdio TTS worker subprocess.
 
-    The worker scripts speak one JSON object per line over stdin/stdout —
-    same protocol used by controller/src/audio/{chatterbox,pocketTts}.ts.
-    We don't multiplex: one request in flight per worker, gated by a lock.
-
-    Lifecycle is supervised by run() — a long-running coroutine kicked off
-    from the FastAPI lifespan as a background task. run() loops on
-    start → wait-for-exit → respawn with a short backoff, mirroring the
-    auto-restart behaviour in the controller-side TS workers. This is what
-    lets a worker that crashes mid-session (OOM, fatal model error) come
-    back without anyone bouncing the container.
+    One JSON object per line over stdin/stdout (the same protocol as the
+    controller's in-process TS clients); no multiplexing — one request in
+    flight per worker, gated by a lock. run() supervises the lifecycle:
+    start → wait-for-exit → respawn with a short backoff, so a crash (OOM,
+    fatal model error) recovers without bouncing the container.
     """
 
-    # Backoff between restart cycles. Short — we'd rather see the worker try
-    # again quickly than babysit a long retry window. start_backoff applies
-    # when start() itself fails (model load error, missing venv); run_backoff
-    # applies when start() succeeded but the worker exited later.
+    # START_BACKOFF applies when start() itself fails (model load error,
+    # missing venv); RUN_BACKOFF when the worker exited after a clean start.
     START_BACKOFF_S = 5.0
     RUN_BACKOFF_S = 2.0
 
@@ -110,17 +92,13 @@ class TtsWorker:
         self.proc: asyncio.subprocess.Process | None = None
         self.lock = asyncio.Lock()
         self.ready = False
-        # The worker's ready message, minus the `ready` flag — carries
-        # per-engine capability metadata (e.g. pocket-tts' voice_cloning,
-        # issue #238). Cleared on every restart cycle.
+        # Ready message minus the `ready` flag — per-engine capability
+        # metadata (e.g. pocket-tts' voice_cloning, #238). Cleared on restart.
         self.ready_meta: dict[str, Any] = {}
 
     async def run(self) -> None:
-        """Keep the worker alive forever (or until cancelled).
-
-        Cancellation comes from the lifespan teardown. We catch it once to
-        terminate the running subprocess cleanly before bubbling up.
-        """
+        """Keep the worker alive forever; on cancellation (lifespan teardown)
+        terminate the running subprocess before bubbling up."""
         try:
             while True:
                 try:
@@ -130,7 +108,6 @@ class TtsWorker:
                     self._reset()
                     await asyncio.sleep(self.START_BACKOFF_S)
                     continue
-                # Worker is ready. Block until it exits, then respawn.
                 assert self.proc is not None
                 code = await self.proc.wait()
                 log.warning(
@@ -143,13 +120,11 @@ class TtsWorker:
             raise
 
     def _reset(self) -> None:
-        """Clear ready/proc between restart cycles."""
         self.ready = False
         self.proc = None
         self.ready_meta = {}
 
     def _terminate(self) -> None:
-        """Best-effort kill the current subprocess (used on shutdown)."""
         if self.proc and self.proc.returncode is None:
             try:
                 self.proc.terminate()
@@ -168,21 +143,14 @@ class TtsWorker:
             env=env,
             limit=WORKER_STDOUT_LIMIT,
         )
-        # Pump stderr to our log so the operator sees the worker's startup
-        # output (model load progress, fatal errors, etc.) in tts-heavy's
-        # docker logs. The task exits naturally when the worker closes stderr
-        # on death, so there's one pump task per active subprocess.
+        # Pump stderr to our log so model load progress / fatal errors land in
+        # the container logs. Exits when the worker closes stderr on death.
         asyncio.create_task(self._pump_stderr())
 
-        # Read until we see {"ready": true}. Workers emit some non-JSON noise
-        # on stdout during model load — perth (chatterbox's watermarker) prints
-        # "loaded PerthNet (Implicit) at step 250,000" via a bare print().
-        # Mirror the controller's TS code (controller/src/audio/chatterbox.ts
-        # handleMessage) and silently skip anything that doesn't parse — the
-        # workers themselves only emit JSON for protocol messages. Chatterbox
-        # can take 30+ seconds to instantiate ChatterboxTurboTTS even from a
-        # warm cache, so no timeout here — run()'s restart loop is the
-        # upstream safety net if a load hangs forever.
+        # Read until {"ready": true}, skipping non-JSON stdout noise (perth —
+        # chatterbox's watermarker — bare-print()s a load message). Chatterbox
+        # can take 30+ seconds even from a warm cache, so no timeout — run()'s
+        # restart loop is the upstream safety net.
         try:
             msg = await self._await_message()
             if msg.get("fatal"):
@@ -190,8 +158,8 @@ class TtsWorker:
             if not msg.get("ready"):
                 raise RuntimeError(f"[{self.name}] expected ready, got: {msg}")
         except Exception:
-            # Failed to reach ready — terminate the half-booted process so
-            # run() doesn't pile orphans up across retry cycles.
+            # Terminate the half-booted process so run() doesn't pile orphans
+            # up across retry cycles.
             self._terminate()
             raise
         self.ready_meta = {k: v for k, v in msg.items() if k != "ready"}
@@ -211,9 +179,8 @@ class TtsWorker:
             try:
                 msg = json.loads(text)
             except json.JSONDecodeError:
-                # Almost certainly noise from a transitive dep (perth's
-                # PerthNet load message, etc.). Log at info so it's visible
-                # but don't fail the protocol.
+                # Noise from a transitive dep — visible but not a protocol
+                # failure.
                 log.info(f"[{self.name}] non-JSON on stdout: {text!r}")
                 continue
             return msg
@@ -229,19 +196,17 @@ class TtsWorker:
 
     async def request(self, payload: dict[str, Any]) -> dict[str, Any]:
         async with self.lock:
-            # Fail fast if the worker isn't currently up. The /speak handler
-            # turns this into an HTTP error and the controller's dispatcher
-            # falls back to Piper — preferable to blocking the HTTP request
-            # while we wait for an unhealthy worker to come back.
+            # Fail fast when the worker is down — the controller's dispatcher
+            # falls back to Piper, preferable to blocking the HTTP request on
+            # an unhealthy worker.
             if not self.ready or not self.proc or self.proc.returncode is not None:
                 raise RuntimeError(f"[{self.name}] worker not ready")
             assert self.proc.stdin
             req = json.dumps(payload, ensure_ascii=False)
             self.proc.stdin.write((req + "\n").encode())
             await self.proc.stdin.drain()
-            # _await_message skips non-JSON stdout chatter — same fix as in
-            # start(). Without it, any post-ready print() from the workers
-            # would crash the next /speak call.
+            # _await_message skips post-ready print() noise too — without
+            # that, any stray stdout would crash the next /speak call.
             return await self._await_message()
 
 
@@ -269,11 +234,9 @@ pocket_worker = TtsWorker(
 
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
-    # Kick the worker supervisors as background tasks so uvicorn binds :8080
-    # immediately. Without this, chatterbox's 30-60s cold load would block
-    # the port bind and the controller's probe would see "connection refused"
-    # for the entire boot — leading operators to think the sidecar is broken
-    # when it's just still loading.
+    # Background tasks so uvicorn binds :8080 immediately — chatterbox's
+    # 30-60s cold load would otherwise block the bind and the controller's
+    # probe would see "connection refused" for the entire boot.
     log.info(f"enabled engines: {', '.join(ENABLED_ENGINES)}")
     tasks = []
     if "chatterbox" in ENABLED_ENGINES:
@@ -285,9 +248,8 @@ async def lifespan(_app: FastAPI):
     finally:
         for t in tasks:
             t.cancel()
-        # Give the supervisors a moment to terminate their subprocesses
-        # cleanly before uvicorn exits. SIGKILL from the container stop is
-        # the upstream fallback if any of this hangs.
+        # Let the supervisors terminate their subprocesses before uvicorn
+        # exits; the container-stop SIGKILL is the fallback if this hangs.
         await asyncio.gather(*tasks, return_exceptions=True)
 
 
@@ -304,13 +266,11 @@ class SpeakRequest(BaseModel):
 
 @app.get("/health")
 async def health():
-    # `engines` is the list of engines that are *currently ready*, not the
-    # static set this sidecar supports. The controller's probe loop in
-    # controller/src/audio/ttsHeavyClient.ts uses `engines.includes(<name>)`
-    # as its readiness signal, so reporting an engine here while its worker
-    # is still booting (or has crashed mid-session) would cause failed
-    # /speak calls instead of clean fall-throughs to Piper. The boolean
-    # *_loaded fields are kept for operator diagnostics.
+    # `engines` lists engines *currently ready*, not the static set — the
+    # controller's probe (audio/ttsHeavyClient.ts) keys readiness on
+    # `engines.includes(<name>)`, so advertising a still-booting or crashed
+    # engine would cause failed /speak calls instead of clean fall-throughs
+    # to Piper. The *_loaded booleans are operator diagnostics.
     ready_engines: list[str] = []
     if chatterbox_worker.ready:
         ready_engines.append("chatterbox")
@@ -319,17 +279,13 @@ async def health():
     return {
         "ok": True,
         "engines": ready_engines,
-        # The engines this sidecar was configured to load (TTS_HEAVY_ENGINES),
-        # regardless of whether they've finished loading yet — for operator
-        # diagnostics. `engines` above is the subset currently *ready*.
+        # What TTS_HEAVY_ENGINES asked for, regardless of load state.
         "enabled": ENABLED_ENGINES,
         "chatterbox_loaded": chatterbox_worker.ready,
         "pocket_loaded": pocket_worker.ready,
-        # Whether PocketTTS can do zero-shot voice cloning. False when the
-        # gated kyutai/pocket-tts weights weren't available at load (no
-        # HF_TOKEN) — the controller surfaces this so cloned .wav voices don't
-        # silently revert to a built-in (issue #238). None until the worker is
-        # ready and has reported its capability.
+        # PocketTTS zero-shot cloning capability — false when the gated
+        # weights weren't available at load (no HF_TOKEN), so cloned .wav
+        # voices don't silently revert to a built-in (#238). None until ready.
         "pocket_voice_cloning": (
             pocket_worker.ready_meta.get("voice_cloning") if pocket_worker.ready else None
         ),
@@ -345,9 +301,9 @@ async def speak(req: SpeakRequest):
         raise HTTPException(400, "missing 'out' path")
     Path(req.out).parent.mkdir(parents=True, exist_ok=True)
 
-    # A known engine that this sidecar was told not to load: fail clearly so
-    # the controller's dispatcher falls back to Piper instead of blocking on a
-    # worker that will never become ready.
+    # A known engine this sidecar was told not to load: fail clearly so the
+    # dispatcher falls back to Piper instead of blocking on a worker that
+    # will never become ready.
     if req.engine in _ALL_ENGINES and req.engine not in ENABLED_ENGINES:
         raise HTTPException(
             503,
@@ -367,9 +323,8 @@ async def speak(req: SpeakRequest):
             "id": "1",
             "text": text,
             "voice": req.voice or POCKET_TTS_DEFAULT_VOICE,
-            # Issue #213 — forward the reference WAV path for zero-shot
-            # cloning. Mirrors the chatterbox branch above; the worker treats
-            # an empty value as "use the built-in voice".
+            # Reference WAV for zero-shot cloning (#213); the worker treats an
+            # empty value as "use the built-in voice".
             "reference_wav": req.reference_wav or "",
             "out": req.out,
         })
@@ -382,14 +337,10 @@ async def speak(req: SpeakRequest):
         "ok": True,
         "path": msg["path"],
         "duration_s": msg.get("duration_s", 0),
-        # Surface PocketTTS' per-call voice substitution (issue #238) so the
-        # controller can log when the requested voice/clone wasn't honoured.
-        # Absent for engines that don't report it (chatterbox).
+        # PocketTTS' per-call voice substitution (#238) so the controller can
+        # log when the requested voice/clone wasn't honoured. Absent for
+        # engines that don't report it.
         "voice_used": msg.get("voice_used"),
         "fell_back": msg.get("fell_back", False),
         "fell_back_reason": msg.get("fell_back_reason"),
     }
-
-
-# NOTE: acoustic analysis (/analyze) was removed from this sidecar — it lives in
-# the standalone `subwave-analyzer` image now. This server is TTS-only.

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -19,29 +19,17 @@ settings.server.telnet.port := 1234
 # SUBWAVE_STATE_DIR. Single-station installs and dev runs get the default.
 state_dir = environment.get(default="/var/sub-wave", "SUBWAVE_STATE_DIR")
 
-# Scratch dirs for the atomic marker writes below (#1240). `file.write` with
-# `atomic=true` writes to a temp file and renames it into place; with no
-# `temp_dir` it picks one under $TMPDIR (the container's overlay fs), and a
-# rename from there onto the state mount is cross-device — so EVERY write took
-# the stdlib's `error.file.cross_device` fallback: a warning per write and a
-# NON-atomic copy, which is exactly the half-written-JSON race atomic=true was
-# added to prevent. Handing each writer a temp dir on the state fs makes the
-# rename a real rename.
-#
-# ONE DIR PER WRITER, deliberately: the stdlib names the temp file `atomic.write`
-# inside whatever dir it is given, so a shared dir would let two concurrent
-# writes (the jingle marker is `synchronous=false`) interleave into one file
-# and rename each other's bytes into place.
-#
-# Created here rather than in the entrypoint so the broadcast container and the
-# AIO supervisor can't drift out of lockstep over it.
-#
-# Probe-checked, and null on any failure: `file.mkdir` does NOT raise when it
-# can't create the dir, so an unwritable state mount would leave `temp_dir`
-# pointing at nothing and every marker write would then raise ENOENT from
-# inside `on_metadata` — worse than the cross-device warning this replaces.
-# A null temp_dir is exactly today's behaviour, so the degraded path is the
-# one we already ship.
+# Scratch dirs for the atomic marker writes below (#1240). Without a temp_dir
+# on the state fs, file.write(atomic=true) stages under $TMPDIR (the container
+# overlay) and the rename is cross-device — the stdlib silently degrades to a
+# NON-atomic copy, the exact half-written-JSON race atomic=true exists to
+# prevent. ONE DIR PER WRITER: the stdlib always names its temp file
+# `atomic.write` inside the dir it is given, and the jingle write is
+# synchronous=false — a shared dir would let concurrent writes interleave.
+# Created here (not the entrypoints) so broadcast and the AIO can't drift.
+# Probe-checked and null on failure: file.mkdir does NOT raise, and a bad
+# temp_dir would ENOENT inside on_metadata — null falls back to $TMPDIR,
+# i.e. exactly the old behaviour.
 def ensure_tmp_dir(p) =
   file.mkdir(parents=true, p)
   probe = path.concat(p, "probe")
@@ -80,34 +68,26 @@ stream_bitrate = ref(192)
 ogg_icy_metadata = ref(true)
 station_name = ref("SUB/WAVE")
 
-# DJ transition effects (filter sweep + echo washout + reverb dissolve + beat
-# chop + exit loop) — see dj_transition
-# below. The effects are built PER-BRANCH inside the transition callback, on
-# the OUTGOING track's source only: idle playout never passes through an
-# effect operator at all, and the incoming track always lands clean and dry —
-# the way a DJ's filter/echo ride the channel that's leaving. The envelopes
-# are pure functions of source.elapsed() on the transition branch (closures,
-# no threads, no shared state): sample-accurate in AUDIO time, so they hold
-# under any clock — the offline render harness (sync="none") exposed that
-# wall-clock thread envelopes and audio time drift apart.
-# Verified on liquidsoap v2.2.5, v2.4.4 AND v2.4.5 (scripts/fx-render-test.sh
-# probe). NB: v2.4.5 is the MINIMUM runtime for these effects — on 2.4.4 the
-# clock's O(n) source scan × multi-pull pass-through layers made every effect
+# DJ transition effects (sweep / washout / dissolve / chop / exit loop) — see
+# dj_transition below. Effects are built PER-BRANCH inside the transition
+# callback, on the OUTGOING track's source only: idle playout passes through
+# no effect operator, and the incoming track always lands clean and dry. The
+# envelopes are pure functions of source.elapsed() on the branch (closures —
+# no threads, no shared state), so they hold in AUDIO time under any clock
+# (wall-clock thread envelopes drift; exposed by the offline render harness).
+# Verified on v2.2.5/v2.4.4/v2.4.5 (scripts/fx-render-test.sh probe). NB:
+# v2.4.5 is the MINIMUM runtime — 2.4.4's O(n) clock scan made every effect
 # transition peg a core and stall the stream (see Dockerfile.broadcast).
-# filter.rc and comb instantiate cleanly INSIDE the cross callback on a
-# request.queue-backed source — the "Early computation of source content-type"
-# crash is specific to iir_filter/HPF — and audibly alter the render.
-# WHY comb, NOT echo: liquidsoap's native `echo` (incl. its ping_pong flag) is a
-# verified NO-OP in BOTH the v2.2.5 and v2.4.4 savonet builds — it type-checks
-# but passes audio through bit-for-bit unchanged (confirmed by render:
-# identical md5 dry vs wet, re-confirmed on 2.4.4 with the dB-form feedback
-# the 2.4 API demands). `comb` (a feedback delay line) is the working PCM primitive
-# with a getter-controlled `feedback`. The tail is therefore centred, not a true
-# L/R ping-pong; real stereo bounce would need the heavier ffmpeg.filter.aecho
-# send path. Do NOT "simplify" this back to `echo`.
-# NB: the SVF `filter` operator goes unstable near sr/4 (~11 kHz @ 44.1 k) and
-# collapses the signal to near-silence — hence filter.rc with the "open" cutoff
-# capped at 9 kHz (near-transparent on music).
+# filter.rc and comb instantiate cleanly INSIDE the cross callback; the
+# "Early computation of source content-type" crash is specific to
+# iir_filter/HPF.
+# WHY comb, NOT echo: native `echo` (incl. ping_pong) is a verified NO-OP on
+# BOTH the v2.2.5 and v2.4.4 builds — type-checks, passes audio through
+# bit-for-bit (identical md5 dry vs wet; re-confirmed on 2.4.4 with dB-form
+# feedback). `comb` is the working PCM primitive with getter feedback; the
+# tail is centred, not true L/R ping-pong. Do NOT "simplify" back to `echo`.
+# NB: the SVF `filter` operator goes unstable near sr/4 and collapses to
+# near-silence — hence filter.rc with the "open" cutoff capped at 9 kHz.
 
 if file.exists("#{state_dir}/liquidsoap_jingle_ratio.txt") then
   raw = string.trim(file.contents("#{state_dir}/liquidsoap_jingle_ratio.txt"))
@@ -140,11 +120,9 @@ if file.exists("#{state_dir}/liquidsoap_stream_bitrate.txt") then
   if v > 0 then stream_bitrate := v end
 end
 
-# Opt IN to the Ogg-Opus mount, which adds a continuous encoder (+ its
-# 44.1->48k resample). Only Blink (Chrome/Edge) clients ever select Opus — see
-# web/hooks/usePlayer.ts, which keeps Safari/iOS/Firefox on the MP3 mount — so
-# it's off by default and operators who want the extra mount turn it on. The
-# mandatory /stream.mp3 mount always serves everyone.
+# Opt IN to the Ogg-Opus mount (a continuous encoder + 44.1->48k resample).
+# Only Blink clients ever select Opus (web/hooks/usePlayer.ts); the mandatory
+# /stream.mp3 mount always serves everyone.
 if file.exists("#{state_dir}/liquidsoap_opus_enabled.txt") then
   raw = string.trim(file.contents("#{state_dir}/liquidsoap_opus_enabled.txt"))
   opus_enabled := (raw == "true")
@@ -156,10 +134,8 @@ if file.exists("#{state_dir}/liquidsoap_opus_bitrate.txt") then
   if v > 0 then opus_bitrate := v end
 end
 
-# Opt IN to the AAC-LC mount (raw ADTS, served as audio/aac). AAC's role here is
-# device compatibility — players/hardware that decode AAC but not Opus — so it's
-# off by default and aimed at external players, not the web/native UI (which
-# never auto-select it). Stays at the source 44.1 kHz (no resample).
+# Opt IN to the AAC-LC mount (raw ADTS, audio/aac) — device compatibility for
+# players that decode AAC but not Opus. External players only; no resample.
 if file.exists("#{state_dir}/liquidsoap_aac_enabled.txt") then
   raw = string.trim(file.contents("#{state_dir}/liquidsoap_aac_enabled.txt"))
   aac_enabled := (raw == "true")
@@ -171,22 +147,18 @@ if file.exists("#{state_dir}/liquidsoap_aac_bitrate.txt") then
   if v > 0 then aac_bitrate := v end
 end
 
-# Opt IN to the Ogg-FLAC mount — a lossless capture of the processed broadcast
-# bus (no resample; stays at the source 44.1 kHz). Runs a third continuous
-# encoder at ~800-900 kbps, so it's off by default. It's a true lossless tier
-# only when the source files are themselves lossless; for lossy-source libraries
-# it faithfully carries lossy audio at 4x the MP3 bandwidth. Intended for
-# external players (VLC / foobar / network streamers) — the web player does not
-# auto-select it. The mandatory /stream.mp3 mount always serves everyone.
+# Opt IN to the Ogg-FLAC mount — a lossless capture of the processed bus at
+# the source 44.1 kHz (~800-900 kbps encoder, hence off by default; only a
+# true lossless tier when the source files are lossless). External players
+# only — the web player never auto-selects it.
 if file.exists("#{state_dir}/liquidsoap_flac_enabled.txt") then
   raw = string.trim(file.contents("#{state_dir}/liquidsoap_flac_enabled.txt"))
   flac_enabled := (raw == "true")
 end
 
-# ICY (out-of-band) per-track titles on BOTH Ogg mounts (/stream.opus +
-# /stream.flac). ON by default — only an explicit "false" disables it, the
-# mirror image of the opt-in mount toggles above. See make_stream_outputs()
-# for the client trade-off this switches between (issue #1052 vs foobar2000).
+# ICY (out-of-band) per-track titles on BOTH Ogg mounts. ON by default — only
+# an explicit "false" disables. See make_stream_outputs() for the client
+# trade-off (#1052 vs foobar2000).
 if file.exists("#{state_dir}/liquidsoap_ogg_icy_metadata.txt") then
   raw = string.trim(file.contents("#{state_dir}/liquidsoap_ogg_icy_metadata.txt"))
   ogg_icy_metadata := (raw != "false")
@@ -200,14 +172,10 @@ end
 log("settings loaded: jingle_ratio=#{jingle_ratio()} crossfade_duration=#{crossfade_duration()} archive_enabled=#{archive_enabled()} archive_bitrate=#{archive_bitrate()} stream_bitrate=#{stream_bitrate()} opus_enabled=#{opus_enabled()} opus_bitrate=#{opus_bitrate()} flac_enabled=#{flac_enabled()} aac_enabled=#{aac_enabled()} aac_bitrate=#{aac_bitrate()} ogg_icy_metadata=#{ogg_icy_metadata()} station_name=#{station_name()}")
 
 # ---------------------------------------------------------------------------
-# HTTP(S) FETCH OVERRIDE — Liquidsoap's built-in http.get.stream returns
-# spurious 522s when fetching from Cloudflare-fronted origins. Shelling out
-# to curl (installed via Dockerfile.liquidsoap) is reliable.
+# subhttp:<full-url> — strips the prefix and shells out to curl. Liquidsoap's
+# built-in http.get.stream returns spurious 522s on the Cloudflare-fronted
+# Navidrome origin.
 # ---------------------------------------------------------------------------
-
-# subhttp:<full-url> — strips the prefix and shells to curl. Used because
-# Liquidsoap's built-in http.get.stream returns spurious 522s when talking
-# to the Cloudflare-fronted Navidrome origin.
 def proto_subhttp(~rlog, ~maxtime, arg) =
   ignore(rlog)
   uri = arg
@@ -233,15 +201,12 @@ end
 protocol.add(temporary=true, syntax="subhttp:<full url>", doc="Navidrome stream via curl", "subhttp", proto_subhttp)
 
 # ---------------------------------------------------------------------------
-# QUEUE — read tracks from the controller
+# QUEUE — the controller writes one annotated track URI to next.txt; polled
+# every 1s into request.queue so new tracks land without a restart.
 # ---------------------------------------------------------------------------
-# The controller writes track URIs to /var/sub-wave/queue.txt, one per line.
-# request.queue lets us push tracks programmatically; we use a polling
-# wrapper so the controller can drop new tracks in without a restart.
 
 dj_queue = request.queue(id="dj_queue")
 
-# Periodically drain the queue file into request.queue
 def poll_queue() =
   if file.exists("#{state_dir}/next.txt") then
     contents = string.trim(file.contents("#{state_dir}/next.txt"))
@@ -255,10 +220,9 @@ end
 thread.run(every=1.0, poll_queue)
 
 # ---------------------------------------------------------------------------
-# AUTONOMOUS FALLBACK — when queue is empty
+# AUTONOMOUS FALLBACK — the controller maintains auto.m3u with mood-
+# appropriate tracks; reload_mode="watch" picks up its rewrites.
 # ---------------------------------------------------------------------------
-# The controller maintains /var/sub-wave/auto.m3u with mood-appropriate
-# tracks for the current context. Refreshed every 10 minutes.
 
 auto_playlist = playlist(
   id="auto",
@@ -278,68 +242,39 @@ music = fallback(
 )
 
 # ---------------------------------------------------------------------------
-# HARD TRACK-LENGTH CAP — enforce max-track-length as a real ceiling (#447)
+# HARD TRACK-LENGTH CAP (#447) — the controller stamps liq_cue_out on
+# autonomous picks and auto.m3u entries when a max-track-length is set;
+# cue_cut stops the track there, so an over-length track NEVER airs in full
+# (even ones that slipped selection with unknown duration). Listener requests
+# are deliberately UN-stamped — an explicit ask for a long mix isn't cut; a
+# cue_out past a shorter track's end is a no-op. Placed BEFORE the music_meta
+# capture (one clean on_metadata event per cut track) and before `cross` (the
+# cut end drives a normal crossfade out).
 # ---------------------------------------------------------------------------
-# The controller stamps `liq_cue_out="<seconds>"` (annotate:, via
-# subsonic.getAnnotatedUri) on autonomous picks and auto.m3u fallback entries
-# when a station/show max-track-length is set. `cue_cut` honours it and stops
-# the track at that offset, so an over-length track NEVER airs in full — even
-# the ones that slip past the controller's selection filter (unknown duration)
-# or that were already on the way when the limit changed. This is the safety
-# net that makes the admin setting a ceiling, not just a selection bias.
-#
-# Listener requests are deliberately left UN-stamped by the controller, so they
-# carry no cue_out and play in full — an explicit ask for a long mix isn't cut.
-# A cue_out past a shorter track's end is a no-op, so sub-cap tracks are
-# untouched. Default out-metadata label is `liq_cue_out`. Placed BEFORE the
-# music_meta capture so on_metadata still sees one clean event per cut track,
-# and before `cross` so the cut track-end drives a normal crossfade out.
 music = cue_cut(music)
 
 # ---------------------------------------------------------------------------
 # CROSSFADE TRANSITION — equal-amplitude blend across the full cross window
 # ---------------------------------------------------------------------------
-# fade.out/fade.in span the ENTIRE cross() buffer so the two tracks curve
-# past each other at ~-6 dB midpoint and sum to ~unity throughout. If the
-# fade is shorter than the buffer, the outgoing track plays at full volume
-# while the incoming is ramping in (and vice versa at the tail), summing
-# to +6 dB and producing an audible "slap-back echo / doubling" feel on
-# every transition. Earlier per-transition energy scaling (fade_d = d * 0.5
-# for loud incoming, etc.) caused exactly that — see git log for context.
+# INVARIANT: fade.out/fade.in span the ENTIRE cross() buffer so the tracks
+# curve past each other at ~-6 dB midpoint and sum to ~unity. A fade shorter
+# than the buffer leaves the outgoing at full level while the incoming ramps
+# — +6 dB and an audible doubling/slap-back on every transition (earlier
+# per-transition energy scaling did exactly that). For loudness-aware
+# behaviour, vary the cross BUFFER length, never the fade inside it.
 #
-# If we ever want loudness-aware behaviour back, vary the cross BUFFER
-# length (e.g. via `override_duration`) rather than shrinking the fade
-# inside a fixed-width buffer.
+# Low-level `cross`, NOT the `crossfade` wrapper: crossfade(smart=false)
+# silently routes through its internal simple_transition and ignores a custom
+# callback. `a`/`b` are records with .source/.metadata/.db_level.
 #
-# IMPORTANT: We use the low-level `cross` operator here, NOT the high-level
-# `crossfade` wrapper. `crossfade(default=…)` with `smart=false` silently
-# routes through an internal `simple_transition` and ignores the custom
-# callback entirely. `cross` takes a positional transition function and
-# always calls it.
-#
-# The function receives records `a` and `b` with fields `.source`,
-# `.metadata`, `.db_level`. Reach into `.source` for the audio.
-#
-# DJ TRANSITION EFFECTS live INSIDE this callback, per-branch on the outgoing
-# source (see the state block near the top of this file). Instantiating
-# operators here is safe for filter.rc and comb specifically — proven against
-# the real v2.2.5 and v2.4.4 images by scripts/fx-render-test.sh probe. The historical
-# `Early computation of source content-type detected for source iir_filter!`
-# crash is specific to IIR filters (iir_filter/HPF) on a not-yet-typed
-# `request.queue`-backed source; re-test with the probe before adding any OTHER
-# operator class inside this callback.
-# DJ-mode adaptive blend: the controller may stamp `liq_cross_duration` on a
-# track (annotate:, via subsonic.getAnnotatedUri) to size its transition from
-# tempo/harmonic compatibility. CRITICAL: `cross` reads `liq_cross_duration` to
-# size its buffer from the OUTGOING track's metadata — the value registered when
-# that track started controls the crossfade at its END (see liquidsoap docs).
-# So the buffer for THIS transition equals `a`'s override (the outgoing track),
-# NOT `b`'s. The fade therefore must read `a.metadata` too, or fade != buffer:
-# a fade longer than the buffer gets truncated → the outgoing track is cut
-# mid-fade and the incoming jumps to full (audible gaps / "no crossfade"); a
-# fade shorter than the buffer sums to +6 dB (doubling). Reading `a` keeps
-# fade == buffer — the invariant the whole section depends on.
-# Absent / unparseable → crossfade_duration(), i.e. the global startup default.
+# Adaptive blends: the controller stamps `liq_cross_duration` per track.
+# CRITICAL: `cross` sizes this transition's buffer from the OUTGOING track's
+# stamp (registered at its start, controls its END — see liquidsoap docs), so
+# the fade must read `a.metadata` too or fade != buffer (a longer fade gets
+# truncated → audible gap; a shorter one sums to +6 dB). Absent/unparseable →
+# crossfade_duration(). Effect operators are instantiated inside the callback
+# — proven safe for filter.rc/comb specifically; re-run
+# scripts/fx-render-test.sh before adding any OTHER operator class here.
 def dj_transition(a, b) =
   d = float_of_string(default=crossfade_duration(), a.metadata["liq_cross_duration"])
   # Washout rides the ENDING track's own annotation — `a` IS the flagged track,
@@ -353,34 +288,23 @@ def dj_transition(a, b) =
   # (it may carry the length-cap auto-arm; the queue avoids stacking them,
   # this is belt-and-braces).
   looping = a.metadata["liq_loop"] == "true" and not washing
-  # Sweep rides the INCOMING pick's annotation ("sweep into my pick") but the
-  # filter is applied to the OUTGOING branch: the track we're leaving sinks
-  # under a closing lowpass while the pick rises clean underneath.
-  # All three entry-side effects (sweep/dissolve/chop, flagged on the incoming
-  # pick) yield to a loop already riding the outgoing track's exit: the loop
-  # IS the transition, and garnishing it (filtering/washing/gating a loop)
-  # chokes the gesture. The queue strips these upstream; enforced here too.
+  # Sweep rides the INCOMING pick's annotation but the filter is applied to
+  # the OUTGOING branch: the leaving track sinks under a closing lowpass.
+  # All three entry-side effects (sweep/dissolve/chop) yield to a loop riding
+  # the outgoing exit — the loop IS the transition, and garnishing it chokes
+  # the gesture. The queue strips these upstream; enforced here too.
   sweeping = b.metadata["liq_sweep"] == "true" and not looping
-  # Dissolve (reverb wash) rides the INCOMING pick like the sweep — "dissolve
-  # the current track under my pick" — and is likewise applied to the OUTGOING
-  # branch: the track we're leaving loses its transients and pulse to a
-  # diffuse comb-cluster wash while the pick rises clean through it. The
-  # SMOOTH way across a clash (the sweep is the dramatic way); the controller
-  # only arms it between CLASHING tracks (mix.effectAllowedFor).
-  # Precedence: a washout on the outgoing track's own annotation also shapes
-  # this exit (echo tail vs ambient wash are mutually exclusive gestures) —
-  # the washout wins because it may carry the length-cap auto-arm.
+  # Dissolve (reverb wash) rides the INCOMING pick, applied to the OUTGOING
+  # branch: the leaving track dissolves into a diffuse comb-cluster wash. The
+  # SMOOTH clash option (sweep = dramatic); armed only between CLASHING
+  # tracks (mix.effectAllowedFor). The washout wins when both ride — it may
+  # carry the length-cap auto-arm.
   dissolving = b.metadata["liq_dissolve"] == "true" and not washing and not looping
-  # Chop (crossfader cut) rides the INCOMING pick like the sweep/dissolve —
-  # "cut the current track out on the beat under my pick" — and is likewise
-  # applied to the OUTGOING branch: the track we're leaving is gated
-  # rhythmically at full level, stabs thinning and sparsening while the pick
-  # rises clean through the gaps. The PERCUSSIVE way across a clash (sweep =
-  # dramatic, dissolve = smooth); the controller only arms it between CLASHING
-  # tracks (mix.effectAllowedFor) and stamps liq_chop_period (one beat of the
-  # OUTGOING track's BPM) alongside the flag. Same washout precedence as the
-  # dissolve: an echo tail and a beat gate fight over the same exit, and the
-  # washout may carry the length-cap auto-arm.
+  # Chop (crossfader cut) rides the INCOMING pick, applied to the OUTGOING
+  # branch: rhythmic gating at full level. The PERCUSSIVE clash option; armed
+  # only between CLASHING tracks (mix.effectAllowedFor), with liq_chop_period
+  # stamped as one beat of the OUTGOING track's BPM. Same washout precedence
+  # as the dissolve.
   chopping = b.metadata["liq_chop"] == "true" and not washing and not looping
   # Washout drops the dry signal early (exp fade) so the tail reads as a
   # dissolve. An early drop sums BELOW unity mid-cross — a dip, which is the
@@ -715,36 +639,23 @@ def dj_transition(a, b) =
     else
       a_source
     end
-  # CHOP ENVELOPE — the crossfader cut: rhythmic amplitude gating of the
-  # outgoing track, opening AT each beat start (the downbeat transient
-  # survives) and closing for the rest of the beat. Pure `amplify` driven by a
-  # pure function of the branch's own source.elapsed() — the same proven
-  # closure pattern as sweep_gain/wash_gain, no new operator class, so no
-  # fx-render-test re-probe needed. The gesture runs on its own compressed
-  # clock dd = min(d, 10 s): a cut is a cut — stretched over a long operator
-  # crossfade it read as slow pumping (heard on-air, #861), so the envelope
-  # finishes in ≤10 s and leaves the rest of the buffer to the incoming ramp.
-  # Four envelopes compose per frame:
-  #   rate    — the gate ACCELERATES like a DJ transform cut: one cut per beat
-  #             through 40% of dd, eighths to 72%, sixteenth stutter into the
-  #             throw. p/2 and p/4 divide p, so every original beat start is
-  #             still a gate-open and the downbeat transient survives; a zone
-  #             switch mid-gate costs one irregular gap, inaudible at speed.
-  #   duty    — how much of each gate stays open: 1.0 (transparent engage) →
-  #             0.55 by 15% of dd → 0.30 by 72% (stabs tighten).
-  #   floor   — gain UNDER the closed gate: 0.45 → 0 over the first 25% of dd:
-  #             the first holes read as beat-synced pumping just long enough
-  #             to establish the move, then harden into true cuts (full
-  #             silence between the very first stabs read as dropouts).
-  #   (the old every-other-beat sparsen is gone — the stutter accelerando IS
-  #   the exit now; isolated late stabs read as slowing down, the wrong
-  #   direction for a cut.)
-  # Gate edges are ~12 ms smoothsteps (square edges click); a wet ramp over
-  # the first 8% of dd makes the engage bit-transparent (at e=0 gain is
-  # exactly 1 — any instant dip against the pre-cross signal is a step); a
-  # master release kills the stutter by 0.92·dd so the branch is silent long
-  # before the transition source truncates at d (amplify vanishes at the
-  # boundary like every branch operator).
+  # CHOP ENVELOPE — the crossfader cut: rhythmic gating of the outgoing
+  # track, opening AT each beat start so the downbeat transient survives.
+  # Pure `amplify` over source.elapsed() — the proven closure pattern, no new
+  # operator class (no fx-render-test re-probe needed). Runs on its own
+  # compressed clock dd = min(d, 10 s): stretched over a long crossfade the
+  # cut read as slow pumping (heard on-air, #861). Per frame: the gate RATE
+  # accelerates like a transform cut (quarters → eighths at 40% → sixteenth
+  # stutter at 72%; p/2 and p/4 divide p, so every beat start stays a
+  # gate-open); DUTY tightens 1.0 → 0.55 → 0.30; the FLOOR under the closed
+  # gate drops 0.45 → 0 over the first 25% (the first holes read as
+  # beat-synced pumping, then harden — full silence between the very first
+  # stabs read as dropouts). The stutter accelerando IS the exit — isolated
+  # late stabs read as slowing down, the wrong direction for a cut. Gate
+  # edges are ~12 ms smoothsteps (square edges click); a wet ramp over the
+  # first 8% keeps the engage bit-transparent (gain exactly 1 at e=0); a
+  # master release silences the branch by 0.92·dd, well before the transition
+  # source truncates at d.
   a_source =
     if chopping then
       p = float_of_string(default=0.5, b.metadata["liq_chop_period"])
@@ -818,33 +729,26 @@ def dj_transition(a, b) =
     else
       a_source
     end
-  # LOOP ENVELOPE — the exit loop ("loop out"): the last bar of the OUTGOING
-  # track is caught in a loop as the dry is hard-cut, riding in tempo under
-  # the incoming pick, then filtered down and released.
+  # LOOP ENVELOPE — exit loop: the last bar of the OUTGOING track is caught
+  # in a loop as the dry is hard-cut, rides in tempo under the pick, then
+  # filters down and releases.
   #
-  # HOW THE LOOP IS BUILT — measured comb facts first (burst-probed on the
-  # real v2.4.5 image; see the combprobe history in PR #863): this build's
-  # `comb` is a ONE-SHOT feed-forward echo, NOT a recirculating feedback
-  # comb — a single burst in yields exactly one delayed copy, then silence,
-  # whatever the feedback value (getter or constant). So no single comb can
-  # loop. Instead: a CASCADE OF DOUBLING DELAYS. K combs at bar, 2·bar,
-  # 4·bar, 8·bar convolve to taps at EVERY multiple 0..(2^K−1) of bar (the
-  # binary counter), so a one-bar capture tiles gaplessly — each bar-slot
-  # holds exactly one copy, no overlap, no pileup, and the repetition
-  # terminates by construction (nothing recirculates, so it cannot ring past
-  # its last tap or run away). At feedback=0.0 the tap set measures FLAT at
-  # a fixed −6 dB regardless of stage count (probed at 2, 3 and 4 stages) —
-  # one constant ×2 makeup restores unity. Stages 4·bar / 8·bar are built
-  # only when their delay < d: a tap at ≥ d is never heard, and 2^K·bar ≥ d
-  # then guarantees repeats reach the end of every canvas.
+  # Measured comb facts (burst-probed on the real v2.4.5 image, PR #863):
+  # this build's `comb` is a ONE-SHOT feed-forward echo, NOT recirculating —
+  # one burst in yields exactly one delayed copy whatever the feedback value,
+  # so no single comb can loop. Hence a CASCADE OF DOUBLING DELAYS: K combs
+  # at bar/2·bar/4·bar/8·bar convolve to taps at every multiple 0..(2^K−1) of
+  # bar, so a one-bar capture tiles gaplessly (no overlap, no pileup) and
+  # terminates by construction. At feedback=0.0 the tap set measures FLAT at
+  # a fixed −6 dB regardless of stage count — one constant ×2 makeup restores
+  # unity. The 4·bar/8·bar stages are built only when their delay < d (a tap
+  # at ≥ d is never heard; 2^K·bar ≥ d guarantees repeats fill the canvas).
   #
-  # The gesture: unity through the CAPTURE PASS (the first bar), then a hard
-  # 12 ms gate cut — the CUT is what reads as "caught in a loop" (the
-  # washout's exp fade is what reads as echo). Known compromise, accepted:
-  # the analyzer gives tempo, not beat PHASE — the loop starts where the
-  # cross fires, not on a downbeat, so it lands as a tape-loop, not a
-  # gridded serato loop, and the splice may tick once per pass. The tick
-  # repeats in tempo (reads as vinyl) and the ride-out lowpass softens it.
+  # Unity through the CAPTURE PASS (first bar), then a hard 12 ms cut — the
+  # CUT is what reads as "caught in a loop". Known compromise: the analyzer
+  # gives tempo, not beat PHASE, so this lands as a tape-loop, not a gridded
+  # serato loop; the splice tick repeats in tempo (reads as vinyl) and the
+  # ride-out lowpass softens it.
   a_source =
     if looping then
       bar = float_of_string(default=2.0, a.metadata["liq_loop_bar"])
@@ -1007,35 +911,26 @@ end
 # one song behind until the next crossfade.
 music_meta = music
 
-# BEDS ↔ JINGLES — true from a bed's first metadata until the next real song's
-# (both set in on_meta, defined further down). The jingle rotate below counts
-# every music-chain track and a bed IS a track, so without a gate the rotate
-# can insert a stinger BETWEEN the bed and the song it ramps into — the bed's
-# exit cross then lands on a jingle, right after the DJ's closing words. While
-# this flag is up the jingles source reads as unavailable, so the rotate skips
-# it (exactly as it does for an empty jingles.m3u) and the jingle defers to
-# the next real track boundary.
+# BEDS ↔ JINGLES — true from a bed's first metadata until the next real
+# song's (both set in on_meta below). The jingle rotate counts every
+# music-chain track and a bed IS a track, so without this gate a stinger can
+# land BETWEEN the bed and the song it ramps into. While up, the jingles
+# source reads as unavailable and the rotate defers to the next real boundary.
 bed_on_air = ref(false)
 
 # JINGLES & STATION ID — rotate a jingle in every N tracks.
 #
 # CRITICAL: this rotate MUST sit here, on the raw pre-cross / pre-duck music
-# source, NOT at the top of the chain. `rotate` defaults to track_sensitive=true
-# so it only advances to the next source at a *track boundary* of the source it
-# is currently playing. Both `cross` (below) and the `smooth_add` ducking layers
-# present their output as ONE continuous, never-ending track — they do not
-# propagate the underlying per-track boundaries upward (the same reason
-# on_metadata hooks `music_meta` here and not the post-cross source). If the
-# rotate is placed above them it plays exactly one jingle at startup, switches to
-# the music side, never sees a track end again, and is stuck on music forever —
-# jingles "stop triggering" (issue: jingles only fire once per restart). Placing
-# it on the raw playlist sources keeps the boundaries clean so it rotates
-# indefinitely. An empty jingles.m3u is fine: rotate skips the unavailable
-# source and plays music. music_meta is captured ABOVE this, so jingles never
+# source. `rotate` is track_sensitive and only advances at a track boundary
+# of the source it is playing — `cross` and the `smooth_add` layers present
+# their output as ONE never-ending track, so a rotate above them plays one
+# jingle at startup and is then stuck on music forever ("jingles only fire
+# once per restart"). An empty jingles.m3u is fine (rotate skips the
+# unavailable source). music_meta is captured ABOVE this, so jingles never
 # show up in now-playing.
-# jingle_ratio 0 = jingles OFF (issue #997): the rotate isn't built at all, so
-# the chain is byte-identical to a station with no jingles. Applied at startup
-# like every other liquidsoap_*.txt setting — changing it needs a mixer restart.
+# jingle_ratio 0 = jingles OFF (#997): the rotate isn't built at all. Applied
+# at startup like every liquidsoap_*.txt setting — changes need a mixer
+# restart.
 music =
   if jingle_ratio() > 0 then
     jingles = playlist(
@@ -1073,20 +968,13 @@ music =
     music
   end
 
-# Per-track loudness normalisation. The controller stamps `liq_amplify` (in the
-# "<n> dB" form, via subsonic.getAnnotatedUri) on any track with a measured LUFS;
-# `amplify` reads it per track — exactly the ReplayGain mechanism. Base factor
-# 1.0 = unity, so a track without the metadata (un-analysed library, or no
-# pyloudnorm) plays untouched. Applied BEFORE the cross so each track carries its
-# own gain into the crossfade, and AFTER the music_meta capture so the
-# on_metadata hook still sees clean pre-cross metadata. No master-bus normaliser
-# is involved — the broadcast bus stays the brick-wall limiter only.
+# Per-track loudness normalisation: the controller stamps `liq_amplify`
+# ("<n> dB" form) on any track with a measured LUFS; `amplify` reads it per
+# track — the ReplayGain mechanism. Base 1.0 = unity for un-analysed tracks.
+# BEFORE the cross (each track carries its own gain into the crossfade),
+# AFTER the music_meta capture. The bus itself stays limiter-only.
 music = amplify(override="liq_amplify", 1., music)
 
-# NB: no effect operators on the bus here — the DJ transition effects (sweep /
-# washout) are built per-transition on the outgoing branch inside dj_transition,
-# so idle playout has no effect operators in its path at all, and jingles can
-# never be caught inside a ramp.
 # persist_override=true (2.4): with the new default (false) the
 # liq_cross_duration override is reset before it ever sizes the stamped
 # track's own end-of-track buffer (verified by scripts/fx-render-test.sh
@@ -1104,16 +992,11 @@ music = cross(
 )
 
 # ---------------------------------------------------------------------------
-# DJ VOICE — TTS intros that duck the music
+# DJ VOICE — TTS clips dropped as paths into say.txt / intro.txt.
+# voice_queue = solo voice (heavy duck: station IDs, hourly, request
+# back-announce); intro_queue = talk-over links (light duck, the song stays
+# audible underneath).
 # ---------------------------------------------------------------------------
-# Piper writes WAVs to /var/sub-wave/voice/, controller drops the path
-# into /var/sub-wave/say.txt to trigger playback.
-
-# Two voice channels:
-#   voice_queue — solo voice (station ID, hourly time, weather, listener-
-#                 request back-announce). Heavy duck so music drops out.
-#   intro_queue — talk-over voice (auto DJ links between tracks). Light duck
-#                 so the song you just queued stays audibly underneath.
 voice_queue = request.queue(id="voice_queue")
 intro_queue = request.queue(id="intro_queue")
 
@@ -1123,12 +1006,10 @@ intro_queue = request.queue(id="intro_queue")
 # already produced — and mixed in below (its own light `smooth_add` layer).
 sfx_queue = request.queue(id="sfx_queue")
 
-# Silent lead-in clip. Pushed into a voice channel immediately before the
-# actual speech file so smooth_add starts ducking the music while this silence
-# plays — the dip completes BEFORE the DJ's first word, then ramps back up
-# once the speech finishes. request.queue plays the two pushes back to back
-# with no gap, so the duck holds continuously across the join. Engine-agnostic:
-# the speech file itself may be a WAV (Piper/Kokoro) or an mp3 (ElevenLabs).
+# Silent lead-in clip, pushed immediately before each speech file: smooth_add
+# ducks over the silence so the dip completes BEFORE the DJ's first word.
+# request.queue plays the two pushes gaplessly, so the duck holds across the
+# join. The speech file may be WAV (Piper/Kokoro) or mp3 (ElevenLabs).
 leadin_path = "/sounds/leadin.wav"
 has_leadin = file.exists(leadin_path)
 if has_leadin then
@@ -1182,24 +1063,13 @@ end
 thread.run(every=0.5, poll_sfx)
 
 # ---------------------------------------------------------------------------
-# MIC CHAIN — make Piper TTS sound like it's in a broadcast studio
+# MIC CHAIN — broadcast-style processing on both voice channels (numbers
+# tuned for an en_GB-alan-medium-ish voice).
 # ---------------------------------------------------------------------------
-# Piper outputs flat, dry speech. Real radio voices go through a hardware mic
-# chain: highpass → compressor → presence EQ → makeup gain. This mirrors that
-# in Liquidsoap (HPF/EQ skipped, see note below) so the DJ stops sounding like
-# a TTS robot.
-#
-# All numbers are tuned for an en_GB-alan-medium-ish voice; tweak in place
-# and `docker compose up -d --build liquidsoap` to audition changes.
-
-# Mic chain applied identically to both voice channels. Defining this as a
-# function (rather than reusing a chain variable) avoids Liquidsoap's
-# "Early computation of source content-type" error — each call instantiates
-# fresh operator nodes for its argument.
-#
-# Skipped (this Liquidsoap build doesn't cooperate with them on a request.queue
-# source — "Early computation" error): HPF at 80 Hz and a parallel 3 kHz
-# presence shelf. Revisit when we upgrade Liquidsoap or wire in LADSPA.
+# A FUNCTION (not a shared chain variable) so each call instantiates fresh
+# operator nodes — reuse hits "Early computation of source content-type".
+# Skipped for the same error on request.queue sources: 80 Hz HPF + 3 kHz
+# presence shelf. Revisit on an engine upgrade or LADSPA.
 def mic_chain(s) =
   # Broadcast-style compression — fast attack, gentle ratio. Tames Piper's
   # peaks and brings the body of the voice forward without pumping.
@@ -1222,26 +1092,19 @@ def mic_chain(s) =
   s
 end
 
-# Per-segment voice level trim. The controller stamps `liq_amplify` (in the
-# "<n> dB" form) onto the say.txt/intro.txt URI per spoken clip — a per-engine +
-# per-persona gain that levels the loudness gap between TTS engines (see
-# settings.tts.gainDb + audio/tts.ts:voiceGainDb). `amplify` reads it per
-# request — the same ReplayGain mechanism the music bus uses (line 214). Applied
-# BEFORE mic_chain so the fixed-threshold compressor sees a levelled input. The
-# un-annotated silent lead-in carries no `liq_amplify`, so it plays at the base
-# factor 1. (unity). Un-trimmed clips (gainDb 0) write a bare path → also unity.
-# Micro edge fade-IN on each spoken clip. Some TTS engines cut the WAV hard at
-# the file boundary; once the mic-chain compressor's makeup gain lifts the
-# clip, that hard edge lands as an audible click/tick. 40 ms is short enough
-# not to soften the first word (speech onsets are slower than that) but long
-# enough to zero out the boundary discontinuity. Applied per track, so the
-# silent lead-in clip is faded too (harmless — it's silence). Placed BEFORE
-# amplify/mic_chain so the compressor never sees the raw edge.
-# fade.in ONLY — no fade.out. On a request.queue source this Liquidsoap build
-# doesn't know the track's remaining time, so fade.out treats the whole clip
-# as inside the fade zone and multiplies it to silence (every voice segment
-# aired as dead air under the duck). Verified empirically against the
-# broadcast image. Tail clicks must be faded at WAV-render time instead.
+# Per-segment voice trim: the controller stamps `liq_amplify` ("<n> dB") per
+# spoken clip (settings.tts.gainDb + audio/tts.ts:voiceGainDb) — the same
+# ReplayGain mechanism as the music bus. BEFORE mic_chain so the
+# fixed-threshold compressor sees a levelled input; the un-annotated lead-in
+# plays at unity.
+# 40 ms edge fade-IN per clip: some engines cut the WAV hard at the boundary
+# and the compressor's makeup gain turns that edge into an audible tick;
+# 40 ms zeroes it without softening the first word. BEFORE amplify/mic_chain
+# so the compressor never sees the raw edge.
+# fade.in ONLY — on a request.queue source this build doesn't know remaining
+# time, so fade.out treats the WHOLE clip as inside the fade zone and
+# multiplies it to silence (verified: every segment aired as dead air). Tail
+# clicks must be faded at WAV-render time.
 def edge_fade(s) =
   fade.in(duration=0.04, s)
 end
@@ -1250,14 +1113,9 @@ voice = mic_chain(amplify(override="liq_amplify", 1., edge_fade(voice_queue)))
 intro = mic_chain(amplify(override="liq_amplify", 1., edge_fade(intro_queue)))
 
 # ---------------------------------------------------------------------------
-# STUDIO BED — continuous low-level ambient room tone (Phase 2)
+# STUDIO BED — low-level room tone, mixed in BEFORE voice ducking so
+# smooth_add ducks it with the music (otherwise it competes with the voice).
 # ---------------------------------------------------------------------------
-# Mixed into the music bus BEFORE voice ducking so that smooth_add ducks the
-# bed along with the music when the DJ talks — otherwise the bed stays loud
-# under the voice and competes with it. Tweak the bed weight if it's too
-# present (lower) or inaudible under music (higher).
-# Replace sounds/bed.mp3 with any ambient loop — the repo ships one, and
-# scripts/setup.sh renders a warm pink-noise fallback if it's ever missing.
 
 bed_path = "/sounds/bed.mp3"
 
@@ -1283,28 +1141,15 @@ music_bus =
 # DUCKING — gated talkbax, like a broadcast desk
 # ---------------------------------------------------------------------------
 # `smooth_add` drops the music to a fixed ratio whenever a voice source has
-# audio to play, then ramps back to unity when it doesn't. Two layers stacked
-# because we have two voice channels with different duck depths:
+# signal; two stacked layers because the two channels duck to different
+# depths (voice_queue heavy ~22%, intro_queue light ~30%).
 #
-#   voice_queue (say.txt)  → HEAVY duck. Request intros, station IDs, hourly
-#                            time checks, weather. The voice is the focus;
-#                            music drops well underneath to ~22%.
-#   intro_queue (intro.txt) → LIGHT duck. Between-track auto-DJ links. The
-#                            song that just started should still be audible
-#                            under the voice, so we only dip to ~40%.
-#
-# Why gated and not RMS-keyed: an earlier RMS sidechain follower drove the
-# music bus to -91 dB even with voice_queue empty (see git log f38a9af).
-# `smooth_add` is what real radio talkbax buttons emulate — it doesn't care
-# how loud the voice is, it cares whether the mic channel has signal. The
-# only downside is that quiet TTS phrases get the same duck as loud ones,
-# which on a single-tenant station is fine.
-#
-# Tuning: delay controls how long the duck "holds" between words so brief
-# pauses don't make the music pump. p is the ratio while voice is active.
+# Gated, NOT RMS-keyed: an earlier RMS sidechain follower drove the music bus
+# to -91 dB even with voice_queue empty (git f38a9af). smooth_add cares only
+# whether the channel has signal — the talkbax model; quiet phrases get the
+# same duck as loud ones, fine on a single-tenant station.
 
-# Heavy duck for request intros / station IDs / hourly / weather.
-# duration = fade time into/out of the duck. p is a getter (curly braces).
+# Heavy duck. duration = fade into/out of the duck; p is a getter.
 ducked = smooth_add(
   duration=0.8,     # gentle fade; each voice channel gets a silent lead-in
                     # clip pushed ahead of the speech (see poll_voice /
@@ -1337,11 +1182,8 @@ radio = smooth_add(
   special=sfx_bed
 )
 
-# NOTE: jingles are NOT rotated in here. The rotate lives up on the raw pre-cross
-# music source (see the "JINGLES & STATION ID" block above music_meta) because a
-# track_sensitive rotate placed above `cross` + `smooth_add` only ever fires one
-# jingle at startup and then stalls — those operators hide the per-track
-# boundaries it needs to switch on.
+# NOTE: the jingle rotate lives up on the raw pre-cross music source — see
+# the JINGLES block above music_meta for why it cannot sit here.
 
 # ---------------------------------------------------------------------------
 # SAFETY — fallback to the emergency loop when the source dies
@@ -1356,19 +1198,14 @@ radio = fallback(track_sensitive=false, [radio, emergency])
 # ---------------------------------------------------------------------------
 # IDLE GATE — silence the programme while nobody is listening
 # ---------------------------------------------------------------------------
-# When the controller has seen zero Icecast listeners for a while it flips
-# idle_mode on (telnet idle_on / idle_off, registered below): the switch
-# selects blank() and the whole chain above — dj_queue, the auto playlist,
-# the cross buffer, the subhttp downloads from Navidrome — stops being
-# pulled, frozen mid-track. The Icecast mounts STAY UP serving silence, so
-# any client (VLC, Sonos, a browser) connects normally; the controller sees
-# the new listener on its next poll, flips idle_mode off, and playback
-# resumes exactly where it froze. Contrast stream_off (further down), which
-# tears the mounts down and 404s new listeners.
-# A plain blank() branch is safe here — the #660 CPU spin was specific to
-# the blank.skip operator, not a blank source.
-# Not persisted: a mixer restart always comes back live (mirrors stream_on);
-# the controller re-asserts idle over telnet if the room is still empty.
+# The controller flips idle_mode over telnet (idle_on/idle_off): the switch
+# selects blank() and the whole chain above stops being pulled, frozen
+# mid-track. Mounts STAY UP serving silence, so clients connect normally; the
+# controller sees a listener on its next poll and playback resumes exactly
+# where it froze. Contrast stream_off, which tears the mounts down. A plain
+# blank() is safe — the #660 CPU spin was specific to blank.skip. Not
+# persisted: a mixer restart always comes back live; the controller
+# re-asserts idle if the room is still empty.
 idle_mode = ref(false)
 radio = switch(
   id="idle_gate",
@@ -1376,33 +1213,21 @@ radio = switch(
   [({idle_mode()}, blank(id="idle_silence")), ({true}, radio)]
 )
 
-# NOTE: a `blank.skip(max_blank=5.0, radio)` used to sit here to skip >5s of
-# digital silence. It was REMOVED (#660). With no music in the chain — a fresh
-# install pre-onboarding, Navidrome down, or the auto playlist exhausted —
-# blank.skip busy-loops at ~100% CPU: it pegs a core and stops feeding Icecast,
-# so /stream.mp3 starts returning 404. The spin happens in ANY position (before
-# OR after this fallback — both were measured at ~100% CPU on an empty-library
-# broadcast; removing the operator drops it to ~5%), so reordering does not help.
-# The emergency single above already covers the only case blank.skip protected
-# against in practice (a dead source), so the silence-skip is not worth a
-# fresh-install-breaking CPU spin.
+# NOTE: blank.skip was REMOVED here (#660). With no music in the chain (fresh
+# install, Navidrome down, playlist exhausted) it busy-loops at ~100% CPU and
+# starves Icecast (/stream.mp3 404s) — measured in ANY position, so
+# reordering doesn't help. The emergency single already covers a dead source;
+# don't reintroduce it.
 
 # ---------------------------------------------------------------------------
-# BROADCAST BUS — masters preserved, brick-wall as the only safety
+# BROADCAST BUS — masters preserved; the brick-wall limiter is the ONLY
+# processing. A -14 LUFS normaliser, stereo widener and bus compressor were
+# all removed — each audibly reshaped the masters. The limiter stays because
+# MP3 encoding generates inter-sample peaks ~0.5-1 dB over the source, so
+# modern masters (~-0.3 dBFS TP) would clip listeners' decoders without a
+# -1 dBFS ceiling. Typically 0 dB of reduction — a safety net, not a tone
+# tool.
 # ---------------------------------------------------------------------------
-# Goal: deliver the original masters as untouched as a streaming pipeline
-# allows. Earlier revisions had a -14 LUFS normaliser, a stereo widener, and
-# a bus compressor stacked here. All three reshaped the audio — the
-# normaliser pumped on dynamic material, the widener altered the stereo
-# image the engineers chose, and the bus comp was tickling dynamics on every
-# loud section. They're gone.
-#
-# The brick-wall limiter stays. MP3 encoding generates inter-sample peaks
-# that can exceed the source's peak by ~0.5–1 dB in the decoded waveform,
-# so without a -1 dBFS ceiling, modern masters (which peak at ~-0.3 dBFS TP)
-# can cause audible clipping in listeners' decoders. The limiter typically
-# does 0 dB of gain reduction on catalogue audio — it's a safety net, not a
-# tone tool.
 
 radio = compress(
   attack=1.0,
@@ -1415,24 +1240,16 @@ radio = compress(
 )
 
 # ---------------------------------------------------------------------------
-# METADATA — write current track info for the web UI
+# METADATA — ICY title driven explicitly from the pre-cross on_meta hook so
+# it matches now-playing.json. BOTH operators are load-bearing:
+#  1. metadata.map strip — kills ALL metadata still flowing through the
+#     chain. dj_transition's fades pass initial_metadata=, so ~crossfade
+#     seconds after on_meta fires the cross re-emits the OUTGOING track's
+#     metadata, which would reach output.icecast and clobber the title back
+#     (Icecast frozen one track behind).
+#  2. insert_metadata — after the strip, the ONLY source of stream metadata,
+#     pushed from on_meta.
 # ---------------------------------------------------------------------------
-
-# Drive the Icecast stream title explicitly from the pre-cross on_metadata
-# hook (on_meta, below) so it matches now-playing.json and the web UI.
-#
-# Two operators, and BOTH are load-bearing:
-#
-#  1. metadata.map(...strip...) — kill ALL metadata still flowing through the
-#     broadcast chain. dj_transition's fade.out passes initial_metadata=a.metadata,
-#     so ~crossfade_duration seconds after on_meta fires for a new track, the
-#     cross transition re-emits the OUTGOING track's metadata downstream. That
-#     packet would reach output.icecast and clobber the title back to the
-#     previous track (the symptom: Icecast frozen one track behind). Stripping
-#     here means nothing from the cross can overwrite what we inject.
-#  2. insert_metadata — gives us a handle to push the correct title in from
-#     on_meta. After the strip above, this is the ONLY source of stream
-#     metadata, so the ICY title can no longer lag.
 radio = metadata.map(update=false, strip=true, fun(_) -> [], radio)
 radio = insert_metadata(radio)
 
@@ -1442,17 +1259,13 @@ def on_meta(m) =
   album = m["album"]
   filename = m["filename"]
   subsonic_id = m["subsonic_id"]
-  # BEDS — an instrumental bed the controller pushed into dj_queue for the DJ to
-  # talk over between two songs (broadcast/beds.ts). It rides the music chain
-  # like any other request, but it is NOT a song: it must never reach
-  # now-playing.json (the UI would announce it) and must never push an ICY title
-  # (hardware radios would show it). It carries no title/artist, so the gate
-  # below would drop it silently anyway — and that silence is the problem, since
-  # the controller learns "the bed is on air, air the link now" only from this
-  # marker. So branch BEFORE the gate and announce it on its own channel.
-  #
-  # Same shape and rationale as jingle-playing.json (#997): liquidsoap telling
-  # the controller that a non-track thing started.
+  # BEDS — an instrumental the controller pushed into dj_queue for the DJ to
+  # talk over BETWEEN songs (broadcast/beds.ts). It rides the music chain but
+  # is NOT a song: never reaches now-playing.json, never pushes an ICY title.
+  # It carries no title/artist so the gate below would drop it silently — and
+  # that silence is the problem: the controller learns "bed on air, air the
+  # link now" only from this marker. So branch BEFORE the gate. Same shape
+  # and rationale as jingle-playing.json (#997).
   if m["subwave_kind"] == "bed" then
     log("on_meta: bed started (#{filename})")
     bed_on_air := true
@@ -1517,30 +1330,18 @@ music_meta.on_metadata(synchronous=false, on_meta)
 # OUTPUT — broadcast to Icecast
 # ---------------------------------------------------------------------------
 
-# Stream on/off control. An Icecast output can't be paused, but it can be
-# shut down and recreated on demand (Liquidsoap's dynamic-sources pattern).
-# `stream_off` shuts all mounts down — /stream.mp3, /stream.opus (and any
-# optional mounts) disconnect and the station goes genuinely off air, and the
-# hourly archive output (also built here) stops recording with them; `stream_on`
-# recreates them. force_start lets the recreated outputs start after init.
-# The on/off state lives in refs and is read back over telnet by the
-# controller. It is NOT persisted: a mixer restart always comes back on air.
+# Stream on/off control. Icecast outputs can't pause, but they can be shut
+# down and recreated (the dynamic-sources pattern): stream_off disconnects
+# every mount (and stops the hourly archive, built in make_stream_outputs);
+# stream_on recreates them. force_start lets recreated outputs start after
+# init. State lives in refs, read back over telnet; NOT persisted — a mixer
+# restart always comes back on air.
 #
-# Two mounts in parallel:
-#   /stream.mp3  — MP3, the universal compatibility floor
-#                  (Sonos, hardware radios, car receivers, pre-iOS-17 Safari).
-#                  Bitrate is operator-configurable (admin → Settings → Stream
-#                  MP3 bitrate); 192 is the default. The default sits at 192,
-#                  not 128, because dense, brick-walled masters (e.g. hot
-#                  Punjabi/hip-hop catalogue pinned at 0 dBFS) produced audible
-#                  encode grain ("swishy static") at 128 with no headroom — the
-#                  extra ~50% bandwidth buys a clean re-encode of busy material.
-#                  Dropping below 192 reintroduces that grain on hot masters.
-#   /stream.opus — Ogg-Opus 96 kbps, ~equal-or-better quality at half the
-#                  bandwidth for modern browsers (the web player auto-prefers
-#                  it via canPlayType). Browsers / VLC / cliamp on a recent
-#                  build all decode it; older clients keep using MP3.
-# Per-listener bandwidth is per-mount, so the unused side costs nothing.
+# /stream.mp3 is the universal floor and always serves. Its default bitrate
+# is 192, not 128: dense brick-walled masters produced audible encode grain
+# ("swishy static") at 128 — dropping below 192 reintroduces it. The other
+# mounts are opt-in (see the toggles at the top); per-listener bandwidth is
+# per-mount, so an unused mount costs nothing.
 settings.init.force_start := true
 
 # TEMPORARY (re-harden later): allow running as root. The broadcast entrypoint
@@ -1618,16 +1419,13 @@ def make_stream_outputs() =
         opus_enc,
         id="stream_opus",
         fallible=true,
-        # ICY metadata is an operator toggle (default ON). output.icecast leaves
-        # send_icy_metadata null by default, which GUESSES it off for any
-        # Ogg-container format and relies on in-band Ogg header re-emission (a new
-        # chained logical stream per track) instead. Many radio clients — Ferrosonic,
-        # Google Cast receivers, Symfonium — read the Ogg Vorbis comment only once at
-        # connect and never re-parse on a chained boundary, so without ICY they
-        # freeze on the first track's title (issue #1052). foobar2000 is the
-        # opposite: it parses the in-band chained-Ogg tags correctly and the ICY
-        # channel on top breaks its Ogg-FLAC metadata — no single value suits both
-        # client camps, hence the toggle instead of a hardcoded true.
+        # ICY metadata toggle (default ON). output.icecast's null default
+        # guesses ICY off for Ogg containers and relies on in-band chained-Ogg
+        # re-emission — but many radio clients (Ferrosonic, Cast, Symfonium)
+        # read the Ogg comment once at connect and freeze on the first title
+        # (#1052), while foobar2000 parses the in-band tags correctly and the
+        # ICY channel breaks its Ogg-FLAC metadata. No single value suits both
+        # camps, hence the toggle.
         send_icy_metadata=ogg_icy_metadata(),
         host=environment.get(default="icecast", "ICECAST_HOST"),
         port=7702,
@@ -1661,10 +1459,7 @@ def make_stream_outputs() =
         ),
         id="stream_flac",
         fallible=true,
-        # ICY metadata operator toggle — see the /stream.opus note above. Default ON
-        # so Ogg-FLAC internet-radio clients (Ferrosonic etc.) get per-track titles
-        # (#1052); off for stations with foobar2000 listeners, where the ICY channel
-        # breaks fb2k's in-band Ogg-FLAC metadata.
+        # ICY toggle — see the /stream.opus note above (#1052 vs foobar2000).
         send_icy_metadata=ogg_icy_metadata(),
         host=environment.get(default="icecast", "ICECAST_HOST"),
         port=7702,
@@ -1800,12 +1595,8 @@ server.register(
   end
 )
 
-# Take the station off air / back on air on demand. stream_off shuts the
-# Icecast outputs down so /stream.mp3 and /stream.opus disconnect together (and
-# stops the hourly archive recording); stream_on recreates them all.
-# stream_status reports the current state for the
-# admin UI and the listener-facing player. Operator-only — listeners can't
-# reach this.
+# Off air / back on air on demand (stream_up/stream_down above);
+# stream_status reports the current state. Operator-only.
 server.register(
   "stream_off",
   description="Take the station off air (disconnect the Icecast mount)",
@@ -1835,12 +1626,9 @@ server.register(
   fun(_) -> if stream_on() then "on" else "off" end
 )
 
-# Pause / resume the programme while keeping the mounts up (the idle gate
-# above). idle_on swaps the broadcast to silence without disconnecting
-# anyone; idle_off resumes mid-track. Driven by the controller's stream-idle
-# monitor when "pause the programme when nobody is listening" is enabled.
-# Both are idempotent and only log on an actual state change, so the
-# controller can re-assert the desired state cheaply after a mixer restart.
+# Pause / resume while keeping the mounts up (the idle gate above). Driven
+# by the controller's stream-idle monitor. Idempotent, logging only on a
+# state change, so the controller can re-assert cheaply after a restart.
 server.register(
   "idle_on",
   description="Silence the programme while nobody listens (mounts stay up)",
@@ -1874,11 +1662,9 @@ server.register(
   fun(_) -> if idle_mode() then "on" else "off" end
 )
 
-# Skip the currently playing track. `radio` is the final broadcast source;
-# .skip() propagates down through compress → fallback → rotate →
-# smooth_add → cross → music, force-ending the current track. `cross` then
-# runs the normal dj_transition crossfade into the next track (next dj_queue
-# item, else auto_playlist). Operator-only — listeners can't reach this.
+# Skip the current track: .skip() on the final source propagates down the
+# chain, force-ending the track; cross then runs the normal dj_transition
+# into the next (dj_queue item, else auto). Operator-only.
 server.register(
   "skip",
   description="Skip the currently playing track",
@@ -1890,13 +1676,10 @@ server.register(
   end
 )
 
-# Remove a PENDING request from dj_queue by request id (RID). Whatever is on
-# air — or already pulled out of the queue as the next source — is no longer
-# in .queue(), so it reports NOT_FOUND instead of half-removing; the caller
-# treats that as "too late to cancel". Used by the controller's queue-cancel
-# endpoint (DELETE /dj/queue/:trackId), which resolves the RID via
-# dj_queue.queue + request.metadata first. Operator-only — listeners can't
-# reach this.
+# Remove a PENDING request from dj_queue by RID. Anything on air or already
+# pulled as the next source is no longer in .queue() → NOT_FOUND, which the
+# caller treats as "too late to cancel". Used by DELETE /dj/queue/:trackId.
+# Operator-only.
 server.register(
   "dj_queue_remove",
   description="Remove a pending request from dj_queue by request id",
@@ -1908,18 +1691,14 @@ server.register(
     if list.length(matches) == 0 then
       "NOT_FOUND"
     else
-      # Removal goes through the stdlib's remove(), which filters the pending
-      # list in place and only rebuilds the inner (prefetched) queue when the
-      # target actually sits there. The previous filter + set_queue(kept)
-      # rebuild looked equivalent but set_queue() FLUSHES request.dynamic's
-      # inner queue wholesale (s.set_queue([]) in stdlib request.liq) — and a
-      # request the source has already popped for prefetch at a track
-      # boundary is in NEITHER visible list while its download runs, so the
-      # flush orphaned it: cancelling rids 32+33 silently killed resolving
-      # rid 31 and the source fell to auto at the boundary (observed live,
-      # twice). That mid-prefetch request is equally invisible to queue()
-      # here, so it reads as NOT_FOUND — which the controller already treats
-      # as "too late to cancel", exactly right for a track about to air.
+      # Removal MUST go through the stdlib's remove(). The old filter +
+      # set_queue(kept) rebuild looked equivalent, but set_queue() FLUSHES
+      # request.dynamic's inner queue wholesale — and a request already
+      # popped for prefetch at a track boundary is in NEITHER visible list
+      # while its download runs, so the flush orphaned it (cancelling rids
+      # 32+33 silently killed resolving rid 31; observed live, twice). That
+      # mid-prefetch request is equally invisible to queue() here, so it
+      # reads as NOT_FOUND — "too late to cancel", exactly right.
       list.iter(fun(r) -> dj_queue.remove(r), matches)
       # Destroy the dropped request so its file/URI is released now instead of
       # lingering until Liquidsoap flags it as leaked.


### PR DESCRIPTION
## Summary

Leans the AI-slop comment mass out of the Docker/infra layer and the mixer script — **+1146 / −2208 lines across 19 files, zero functional change**:

- **Compose files** (`docker-compose*.yml`, both GPU overlays): duplicated paragraphs collapsed (the OOM-containment essay appeared 4×, the analyzer env explanations 3×), each env var down to a 1–2 line note.
- **Dockerfiles** (broadcast, controller, analyzer, tts-heavy, aio, caddy): history lessons and next-line narration dropped; the real gotchas kept short — the pip single-resolve CPU-wheel trick, the setuptools<81 `pkg_resources` pin, the NodeSource 403 workaround, the misaki/py3.13 uv venv, pins-in-lockstep notes.
- **Entrypoints** (`broadcast-entrypoint.sh`, `aio/supervisor.sh`): boot-sequence prose that mirrored the code removed; the #1196 ELOOP repair logic, per-mount burst sizing (#1114), trusted-proxy DNS caveats and the #786 shutdown grace period all survive as terse notes.
- **Caddyfiles / icecast template**: tightened; the listener-auth password-oracle warning and the icecast-KH exact-IP / left-most-XFF quirks stay.
- **Sidecar servers** (`docker/analyzer/server.py`, `docker/tts-heavy/server.py`): docstrings compressed to protocol contracts; #996 stdout limit, perth noise-skipping, ready-engines health semantics and recycle-lock behaviour kept.
- **`radio.liq`**: lighter touch by design — the measured tuning log (echo no-op, broken `filter.rc mode="high"`, one-shot comb probes, fade==buffer invariant, `set_queue()` prefetch orphaning) is all preserved; only duplication and narration went.

### Stale claims fixed along the way
- Icecast template + entrypoint still said the web player "prefers its own measured lag" — removed by #1114.
- Analyzer image/server still claimed a `TTS_HEAVY_URL` analysis fallback that no longer exists.
- `radio.liq` referenced `queue.txt` (it's `next.txt`) and "refreshed every 10 minutes" for the auto playlist (it's `AUTO_QUEUE_REFRESH_MINUTES`, default 60).

## Verification

- Comment-stripped functional lines are **byte-identical to the previous revision** in every file (scripted check)
- All 3 compose files + both GPU overlays pass `docker compose config`
- `bash -n` on both shell scripts; `scripts/aio-log-link.test.ts` passes
- Both `server.py` ASTs unchanged (docstrings ignored); `py_compile` clean
- `radio.liq` parses + type-checks under the real liquidsoap binary (`liquidsoap --check` in the broadcast container)
- Icecast template stays well-formed XML with both sed markers intact

https://claude.ai/code/session_01SPkrXjTWvxCbTBV36YC2qW