### PR TITLE
fix(broadcast): stop spoken clocks running ahead of air time (#1282)

### DIFF
--- a/controller/scripts/clock-phrase.test.ts
+++ b/controller/scripts/clock-phrase.test.ts
@@ -4,7 +4,7 @@
 // Run: `npm test -- clock-phrase` (tsx scripts/clock-phrase.test.ts).
 
 import assert from 'node:assert/strict';
-import { clockDisplay, spokenHourPhrase } from '../src/time.js';
+import { clockDisplay, spokenHourPhrase, spokenTimePhrase } from '../src/time.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -74,6 +74,30 @@ async function main() {
   await test('out-of-range hours normalise instead of crashing', () => {
     assert.equal(spokenHourPhrase(24), 'midnight');
     assert.equal(spokenHourPhrase(-1), 'eleven at night');
+  });
+
+  console.log('spokenTimePhrase (#1282 — minute-aware, coarse radio buckets):');
+  await test('top of the hour is still "just gone"', () => {
+    assert.equal(spokenTimePhrase(18, 0), 'just gone six in the evening');
+    assert.equal(spokenTimePhrase(18, 4), 'just gone six in the evening');
+  });
+  await test('the reported case — 18:31 is no longer "just gone six"', () => {
+    assert.equal(spokenTimePhrase(18, 31), 'half past six in the evening');
+  });
+  await test('early minutes are "just after"', () => {
+    assert.equal(spokenTimePhrase(9, 8), 'just after nine in the morning');
+  });
+  await test('quarter past around :15-:24', () => {
+    assert.equal(spokenTimePhrase(14, 17), 'quarter past two in the afternoon');
+  });
+  await test('past :40 leans on the next hour', () => {
+    assert.equal(spokenTimePhrase(18, 45), 'quarter to seven in the evening');
+    assert.equal(spokenTimePhrase(18, 55), 'coming up on seven in the evening');
+  });
+  await test('day edges — next-hour phrases normalise across midnight/noon', () => {
+    assert.equal(spokenTimePhrase(23, 50), 'coming up on midnight');
+    assert.equal(spokenTimePhrase(11, 45), 'quarter to noon');
+    assert.equal(spokenTimePhrase(0, 20), 'quarter past midnight');
   });
 
   if (failures) {

--- a/controller/scripts/handoff-boundary.test.ts
+++ b/controller/scripts/handoff-boundary.test.ts
@@ -34,7 +34,7 @@
 
 import assert from 'node:assert/strict';
 import { contextDate, handoffIsStale, rollIsBackward } from '../src/broadcast/session.js';
-import { PICK_SHOW_LOOKAHEAD_SEC, pickLeadSec } from '../src/broadcast/queue/pure.js';
+import { PICK_SHOW_LOOKAHEAD_SEC, linkAirDate, pickLeadSec } from '../src/broadcast/queue/pure.js';
 
 const MAX_AGE = 20 * 60_000;   // mirrors HANDOFF_MAX_AGE_MS in dj-agent.ts
 
@@ -194,6 +194,18 @@ function main() {
 
   test('at a track start remaining ≈ duration → byte-for-byte the old lead', () => {
     assert.equal(pickLeadSec(420), 420);
+  });
+
+  test('#1282 — linkAirDate inverts the showAt padding back to air time', () => {
+    // Reported case: logged 08:48:01, the on-air track has 2 min left, so the
+    // link airs at 08:50 — but showAt (air + the attribution padding) says
+    // 08:52 and the link announced "eight fifty-two"-adjacent times on air.
+    // The spoken clock must come from linkAirDate(showAt) = now + leadSec
+    // exactly, whatever the padding constant is set to.
+    const now = Date.parse('2026-08-03T08:48:01.000Z');
+    const lead = pickLeadSec(119) as number;
+    const showAt = new Date(now + (lead + PICK_SHOW_LOOKAHEAD_SEC) * 1000);
+    assert.equal(linkAirDate(showAt).getTime(), now + lead * 1000);
   });
 
   test('held predecessor (deadline path) → remaining + the held track', () => {

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -29,7 +29,8 @@ import { resolveShowPlaylistPool, resolveExcludedPlaylistIds } from '../music/sh
 import * as library from '../music/library.js';
 import * as subsonic from '../music/subsonic.js';
 import * as dj from '../llm/dj.js';
-import { energyForDaypart } from '../context.js';
+import { energyForDaypart, getClockContext, getDateContext, getTimeContext } from '../context.js';
+import { linkAirDate } from './queue/pure.js';
 import { djObject, nearestId, modelTolerant } from '../llm/sdk.js';
 import * as budget from './dj-budget.js';
 import { withTrace, logEvent } from '../observability/events.js';
@@ -449,6 +450,24 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
   return true;
 }
 
+// The link's context, with the clock stepped back from `showAt` to the moment
+// the link actually AIRS (showAt minus the show-attribution padding — see
+// linkAirDate). ctx resolved at showAt is right for show identity but its
+// clock runs PICK_SHOW_LOOKAHEAD_SEC fast, and every pick-attached link spoke
+// that padded time on air — "Local time eight fifty" logged at 08:48 (#1282).
+// The same identity/clock split runPickCycle's handoff already makes with its
+// live-clock override: show/mood/festival stay on showAt, only the
+// clock-derived fields (at/date/clock/time) move to air time. `isDark` rides
+// over from ctx — it comes from the weather fetch, not the clock, and a
+// two-minute shift can't flip it.
+function linkAirContext(ctx: any, showAt: Date | null) {
+  if (!showAt || !ctx) return ctx;
+  const airAt = linkAirDate(showAt);
+  const clock: any = getClockContext(airAt);
+  if (typeof ctx.clock?.isDark === 'boolean') clock.isDark = ctx.clock.isDark;
+  return { ...ctx, at: airAt.toISOString(), date: getDateContext(airAt), clock, time: getTimeContext(airAt) };
+}
+
 // Returns 'queued' when a pick was actually enqueued, 'empty' when the pool
 // produced none, 'collision' when its pick deduped against something already
 // queued. The final fallback ignores the answer (nothing is left to try), but
@@ -474,10 +493,12 @@ async function pickViaPool(queue, ctx, { wantLink, current, showAt = null }: { w
   if (wantLink && current) {
     try {
       link = await dj.generateLink({
-        previous: current, current: result.song, context: ctx,
-        // ctx is the queue watcher's look-ahead snapshot exactly when showAt is
-        // set, so its clock is the link's air time — the only case the link may
-        // speak it (issue #864: generation-time clocks aired a track late).
+        // ctx with the clock stepped back to the link's air moment — showAt's
+        // own clock carries the show-attribution padding and ran two minutes
+        // fast on air (#1282). Only with the look-ahead resolved may the link
+        // speak the clock at all (issue #864: generation-time clocks aired a
+        // track late).
+        previous: current, current: result.song, context: linkAirContext(ctx, showAt),
         clockIsAirTime: !!showAt,
         // Name the speaker explicitly. Left unset, scripts.generateLink falls
         // back to getEffectivePersona() on the wall clock, which disagrees with
@@ -619,12 +640,16 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     // clock at all — the model extrapolates one from stale stamped lines in
     // its session window, then the link airs a further full track after it's
     // written, so spoken times ran 10-20 minutes behind. When the queue
-    // watcher resolved the look-ahead (showAt), ctx's clock IS the link's air
-    // time — hand it over as the only time the link may speak; without the
-    // look-ahead (unknown duration), ban the clock outright.
+    // watcher resolved the look-ahead (showAt), the link's air moment is
+    // knowable — but showAt's own clock carries the show-attribution padding
+    // and ran two minutes FAST on air (#1282), so step it back to air time
+    // (linkAirDate) before handing it over as the only time the link may
+    // speak; without the look-ahead (unknown duration), ban the clock
+    // outright.
+    const airClock = showAt && ctx?.clock?.hhmm ? getClockContext(linkAirDate(showAt)) : null;
     const clockClause = wantLink
-      ? (showAt && ctx?.clock?.hhmm
-          ? ` The link airs at about ${ctx.clock.display || ctx.clock.hhmm} — if you mention the clock, that is the time to use, never an earlier one.`
+      ? (airClock
+          ? ` The link airs at about ${airClock.display || airClock.hhmm} — if you mention the clock, that is the time to use, never an earlier one.`
           : ` Never state the clock time in the link — you can't know exactly when it airs.`)
       : '';
     const varietyClause = wantLink

--- a/controller/src/broadcast/queue/pure.ts
+++ b/controller/src/broadcast/queue/pure.ts
@@ -48,6 +48,18 @@ export const BACKFILL_DEDUP_MAX_GAP_MS = 15 * 60_000;
 // two early — is how real radio tees up a changeover anyway.
 export const PICK_SHOW_LOOKAHEAD_SEC = 120;
 
+// The moment the pick — and its attached link — actually starts AIRING:
+// `showAt` minus the attribution padding above. `showAt` deliberately probes
+// past the start so show identity resolves right (#1205), but a link's spoken
+// clock must not inherit that padding: ctx resolved at `showAt` put "Local
+// time" exactly two minutes ahead of air on every pick-attached link (#1282,
+// a regression from #864's own fix). Exact inverse of runPickCycle's
+// `showAt = now + leadSec + PICK_SHOW_LOOKAHEAD_SEC`, kept here beside the
+// constant so the two can't drift apart.
+export function linkAirDate(showAt: Date): Date {
+  return new Date(showAt.getTime() - PICK_SHOW_LOOKAHEAD_SEC * 1000);
+}
+
 // Seconds from NOW until the pick being made will start airing — the lead the
 // show look-ahead adds to the wall clock (see runPickCycle).
 //

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -6,7 +6,7 @@ import { fetchWithTimeout } from './util/fetch-timeout.js';
 import { resolveActiveShow, resolveOnAirLocation, get as getSettings, moodScheduleFor, weatherMoodFor } from './settings.js';
 import * as session from './broadcast/session.js';
 import { getListenerCount } from './broadcast/listeners.js';
-import { zonedParts, zonedISODate, clockDisplay, spokenHourPhrase } from './time.js';
+import { zonedParts, zonedISODate, clockDisplay, spokenHourPhrase, spokenTimePhrase } from './time.js';
 
 // The day-period → {vibe, show} table stays in code (these feed spoken-segment
 // prompts and show resolution). Each period's MOOD is operator-editable
@@ -240,6 +240,10 @@ export function getClockContext(date = new Date()) {
     // in the morning") — computed here so the model never converts 24-hour
     // digits itself (it says "one in the morning" at 00:03).
     spokenHour: spokenHourPhrase(h),
+    // Minute-aware variant for the hourly time check — "just gone six" only
+    // near :00, "half past six" mid-hour (#1282: a manual trigger at 18:31
+    // still announced "just gone six in the evening").
+    spokenTime: spokenTimePhrase(h, m),
     isWeekend: dow === 0 || dow === 6,
     isLateNight: h < 5,
     isCommute: (minutesOfDay >= 450 && minutesOfDay < 570) ||  // 07:30-09:30

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -231,14 +231,21 @@ export async function generateLink({ previous, current, context, clockIsAirTime 
 
 export async function generateHourlyTime({ recap = null, context = null, recentOpeners = null, persona = null }: any = {}) {
   const ctxLines = buildContextLines(context, { contextFields: SCRIPT_CONTEXT_FIELDS });
-  // The hour is converted to words in code (context.clock.spokenHour) rather
+  // The time is converted to words in code (context.clock.spokenTime) rather
   // than asking the model to read the clock line itself — small models get
   // the 24-hour conversion wrong at the edges ("00:03" announced as "one in
-  // the morning"). The fallback keeps the old behaviour for a bare context.
+  // the morning"). The minute-aware phrase replaces the old hour-only one,
+  // which hardcoded "just gone X" whatever the minute — right on the :00 cron
+  // this normally rides, but a manual trigger at 18:31 still said "just gone
+  // six in the evening" (#1282). The fallbacks keep the old behaviour for
+  // contexts that predate spokenTime, then for a bare context.
+  const spokenTime = context?.clock?.spokenTime;
   const spoken = context?.clock?.spokenHour;
-  const timeClause = spoken
-    ? `The hour to announce is ${spoken} — say exactly that hour, in natural spoken words ("just gone ${spoken}", or similar) — never digits or 24-hour form, never a different hour.`
-    : `Say the time in natural spoken words ("two in the afternoon", "just gone eight") — never digits or 24-hour form.`;
+  const timeClause = spokenTime
+    ? `The time to announce is "${spokenTime}" — say exactly that time, in natural spoken words — never digits or 24-hour form, never a different time.`
+    : spoken
+      ? `The hour to announce is ${spoken} — say exactly that hour, in natural spoken words ("just gone ${spoken}", or similar) — never digits or 24-hour form, never a different hour.`
+      : `Say the time in natural spoken words ("two in the afternoon", "just gone eight") — never digits or 24-hour form.`;
   ctxLines.push(`Task: a brief top-of-the-hour time check, in character. ${lengthPhrase('hourly', persona || undefined)}. ${timeClause}`);
   return djText({
     system: djSystem(persona || undefined),

--- a/controller/src/time.ts
+++ b/controller/src/time.ts
@@ -118,3 +118,21 @@ export function spokenHourPhrase(hour: number) {
   if (h < 22) return `${word} in the evening`;
   return `${word} at night`;
 }
+
+// The time as a radio DJ would round it — minute-aware, deliberately coarse
+// (radio rounds, it doesn't read a watch). The hourly check normally rides the
+// :00 cron where "just gone six" is honest, but manual /dj/segment triggers
+// and voice-queue holds can land it anywhere in the hour, and the hour-only
+// phrase said "just gone six" at 6:31 (#1282). Past :40 the phrase leans on
+// the NEXT hour ("quarter to seven") — spokenHourPhrase normalises h+1 at the
+// day edge, so 23:50 reads "coming up on midnight".
+export function spokenTimePhrase(hour: number, minute: number) {
+  const h = ((hour % 24) + 24) % 24;
+  const m = ((Math.trunc(minute) % 60) + 60) % 60;
+  if (m <= 4) return `just gone ${spokenHourPhrase(h)}`;
+  if (m <= 14) return `just after ${spokenHourPhrase(h)}`;
+  if (m <= 24) return `quarter past ${spokenHourPhrase(h)}`;
+  if (m <= 39) return `half past ${spokenHourPhrase(h)}`;
+  if (m <= 49) return `quarter to ${spokenHourPhrase(h + 1)}`;
+  return `coming up on ${spokenHourPhrase(h + 1)}`;
+}


### PR DESCRIPTION
Fixes #1282 — both bugs from the report.

## Bug 1: pick-attached links spoke a clock ~2 min ahead

The single `showAt` date in `runPickCycle` deliberately probes `PICK_SHOW_LOOKAHEAD_SEC` (120s) past the pick's start for show-boundary attribution, and drives the whole boundary sequence off one date by design (#1205). But the context resolved at `showAt` also fed both link paths with `clockIsAirTime`, so every link's "Local time" ran exactly 120s fast — matching the report's 08:48→"eight fifty" example. Regression introduced by #864's own fix.

Fix keeps `showAt` untouched (identity still looks ahead) and steps only the clock back to the air moment — the same identity/clock split the handoff path already makes with its live-clock override:

- `queue/pure.ts`: new `linkAirDate(showAt)` = showAt − padding, kept beside the constant so they can't drift.
- `dj-agent.ts`: `linkAirContext()` overrides `at`/`date`/`clock`/`time` at air time for the pool path's `generateLink` context (`isDark` rides over — it's weather-derived, a 2-min shift can't flip it); the agent path's clock clause uses `getClockContext(linkAirDate(showAt))`.

## Bug 2: hourly check said "just gone X" whatever the minute

`spokenHourPhrase` takes only the hour and `generateHourlyTime` hardcoded the "just gone" exemplar — honest on the `0 * * * *` cron it normally rides, wrong on manual `/dj/segment` triggers (18:31 → "just gone six in the evening").

Fix: minute-aware `spokenTimePhrase(hour, minute)` in `time.ts` with deliberately coarse radio buckets (just gone ≤:04 / just after ≤:14 / quarter past ≤:24 / half past ≤:39 / quarter to ≤:49 / coming up on :50+, next-hour phrases normalising across midnight/noon), exposed as `clock.spokenTime` and preferred by `generateHourlyTime`; the hour-only clause stays as fallback for bare contexts.

## Tests

- `clock-phrase.test.ts`: bucket pins including the reported 18:31 case and the midnight/noon edges.
- `handoff-boundary.test.ts`: `linkAirDate` inverts the `showAt` formula exactly (the 08:48 reported case).
- Full controller suite (75 files) + lint pass.