### PR TITLE
refactor(web): two-column Appearance modal, drop the light/dark pin

### DIFF
--- a/web/components/ThemeProvider.tsx
+++ b/web/components/ThemeProvider.tsx
@@ -14,12 +14,8 @@ import {
   cacheAppearance,
   loadThemeOverride,
   saveThemeOverride,
-  loadModeOverride,
-  saveModeOverride,
   resolveAppearance,
-  systemMode,
   type Theme,
-  type ThemeMode,
 } from '@/lib/theme';
 // Install-level concern: the theme registry belongs to *this* deployment, so
 // this always goes through the same-origin default client — never a showcase
@@ -34,26 +30,10 @@ interface ThemeContextValue {
   /** Per-browser override id, or null when none is set. */
   overrideId: string | null;
   /** Effective theme *selection* (override if set + still in registry, else
-   *  station). This is what the picker highlights and what `t` cycles from —
-   *  it stays the listener's choice even while a pinned mode pauses it. */
+   *  station). This is what the picker highlights and what `t` cycles from. */
   effectiveId: string | null;
-  /** The palette actually on screen, or null when a pinned light/dark mode has
-   *  paused it in favour of the built-in base. Differs from `effectiveId` only
-   *  in that paused case. */
-  paintedId: string | null;
   /** Save or clear the override and re-apply immediately. null clears it. */
   setOverride: (id: string | null) => void;
-  /** The listener's pinned light/dark mode, or null when following the active
-   *  palette / system preference ("auto"). */
-  mode: ThemeMode | null;
-  /** What the document is rendering right now, whatever got it there. */
-  renderedMode: ThemeMode;
-  /** Pin a mode, or hand back to auto with null. */
-  setMode: (mode: ThemeMode | null) => void;
-  /** Flip the rendered mode — the `d` hotkey and the switcher row. Lands back
-   *  on auto whenever auto would render the mode being asked for, so the
-   *  listener is never permanently pinned by a single keypress. */
-  cycleMode: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
@@ -62,22 +42,6 @@ const ThemeContext = createContext<ThemeContextValue | null>(null);
  *  and before the provider is mounted. */
 export function useThemeSwitcher(): ThemeContextValue | null {
   return useContext(ThemeContext);
-}
-
-// Bare-letter shortcuts must never fire while the listener is entering text.
-// Beyond the obvious form controls that means the popup widgets that implement
-// their own first-letter typeahead — Radix's Select/DropdownMenu content is a
-// div with a listbox/menu role, not a <select>, so a `d` inside one belongs to
-// the widget, not to us.
-const TYPEAHEAD_CONTAINERS =
-  '[role="listbox"],[role="menu"],[role="menubar"],[role="tree"],[role="grid"],[role="combobox"]';
-
-function isTypingTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) return false;
-  const tag = target.tagName;
-  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
-  if (target.isContentEditable) return true;
-  return !!target.closest(TYPEAHEAD_CONTAINERS);
 }
 
 // Single, app-wide theme syncer + provider. Mounted from the root layout so
@@ -91,8 +55,10 @@ function isTypingTarget(target: EventTarget | null): boolean {
 //   3. A listener override beats the station — apply it whenever it exists in
 //      the live registry. Stale ids (theme deleted under our feet) silently
 //      fall back to the station active.
-//   4. A listener pinned light/dark — see resolveAppearance for how that
-//      interacts with the palette.
+//
+// Light vs dark is a property of the palette, not a separate listener control:
+// each theme declares its own mode and a listener who wants dark picks a dark
+// theme. There is no per-browser mode pin and no `d` hotkey.
 //
 // 30 s poll cadence is the upper bound on how long a listener sees the old
 // theme after an operator switch. Cheap call (returns a tiny JSON blob);
@@ -101,51 +67,28 @@ export default function ThemeProvider({ children }: { children?: ReactNode }) {
   const [themes, setThemes] = useState<Theme[]>([]);
   const [stationActiveId, setStationActiveId] = useState<string | null>(null);
   const [overrideId, setOverrideIdState] = useState<string | null>(null);
-  const [mode, setModeState] = useState<ThemeMode | null>(null);
-  const [paintedId, setPaintedId] = useState<string | null>(null);
-  const [systemDark, setSystemDark] = useState(false);
 
-  // Read the overrides on mount so SSR can render through cleanly — localStorage
+  // Read the override on mount so SSR can render through cleanly — localStorage
   // is only safe to touch in an effect. The pre-paint <script> already painted
-  // the right tokens + mode, so a one-tick lag in state is invisible.
+  // the right tokens, so a one-tick lag in state is invisible.
   useEffect(() => {
     setOverrideIdState(loadThemeOverride());
-    setModeState(loadModeOverride());
   }, []);
 
-  // Track `prefers-color-scheme` so `renderedMode` stays honest while the
-  // listener is on auto with no palette. The CSS repaints itself off the media
-  // query; this is only so the UI can *say* which way it went.
-  useEffect(() => {
-    const media = window.matchMedia('(prefers-color-scheme: dark)');
-    const onChange = () => setSystemDark(media.matches);
-    onChange();
-    media.addEventListener('change', onChange);
-    return () => media.removeEventListener('change', onChange);
-  }, []);
-
-  // Hold the latest themes + overrides in refs so the polling loop can resolve
+  // Hold the latest themes + override in refs so the polling loop can resolve
   // the effective appearance without re-creating itself on every state change.
   const themesRef = useRef<Theme[]>(themes);
   const overrideRef = useRef<string | null>(overrideId);
-  const modeRef = useRef<ThemeMode | null>(mode);
   themesRef.current = themes;
   overrideRef.current = overrideId;
-  modeRef.current = mode;
 
-  // Resolve + paint + cache from the latest registry and both overrides. The
+  // Resolve + paint + cache from the latest registry and the override. The
   // single place appearance reaches the DOM.
   const applyEffective = useCallback(
-    (
-      registry: Theme[],
-      stationId: string | null,
-      override: string | null,
-      modeOverride: ThemeMode | null,
-    ) => {
-      const resolved = resolveAppearance(registry, stationId, override, modeOverride);
+    (registry: Theme[], stationId: string | null, override: string | null) => {
+      const resolved = resolveAppearance(registry, stationId, override);
       applyAppearance(resolved);
       cacheAppearance(resolved);
-      setPaintedId(resolved.theme?.id ?? null);
     },
     [],
   );
@@ -162,7 +105,7 @@ export default function ThemeProvider({ children }: { children?: ReactNode }) {
         if (cancelled) return;
         setThemes(j.themes);
         setStationActiveId(j.active);
-        applyEffective(j.themes, j.active, overrideRef.current, modeRef.current);
+        applyEffective(j.themes, j.active, overrideRef.current);
       } catch {
         // Network blip — keep the existing CSS variables. The next poll will
         // sort it out, and the pre-paint cache covers the meantime.
@@ -184,76 +127,16 @@ export default function ThemeProvider({ children }: { children?: ReactNode }) {
       saveThemeOverride(id);
       overrideRef.current = id;
       setOverrideIdState(id);
-      applyEffective(themesRef.current, stationActiveId, id, modeRef.current);
+      applyEffective(themesRef.current, stationActiveId, id);
     },
     [applyEffective, stationActiveId],
   );
-
-  // Pin (or, with null, release) the explicit light/dark mode. Applies
-  // immediately; releasing re-applies the active palette's own mode.
-  const setMode = useCallback(
-    (next: ThemeMode | null) => {
-      saveModeOverride(next);
-      // Keep the ref in lock-step so the resolve below sees the new value on
-      // this same tick (releasing must not re-apply the old mode).
-      modeRef.current = next;
-      setModeState(next);
-      applyEffective(themesRef.current, stationActiveId, overrideRef.current, next);
-    },
-    [applyEffective, stationActiveId],
-  );
-
-  // Auto is a real, reachable state, not just the initial one: flipping *back*
-  // releases the pin rather than pinning the opposite mode. Without this a
-  // single stray `d` would detach the listener from the operator's palette
-  // forever, since a two-state toggle can only ever move between light and
-  // dark.
-  const cycleMode = useCallback(() => {
-    const auto = resolveAppearance(themesRef.current, stationActiveId, overrideRef.current, null);
-    const autoMode = auto.mode ?? systemMode();
-    const rendered = modeRef.current ?? autoMode;
-    const next: ThemeMode = rendered === 'dark' ? 'light' : 'dark';
-    setMode(autoMode === next ? null : next);
-  }, [setMode, stationActiveId]);
-
-  // Global dark-mode shortcut: bare `d`, ignoring auto-repeat, modifier combos,
-  // and anything aimed at a text field or a typeahead popup.
-  const cycleModeRef = useRef(cycleMode);
-  cycleModeRef.current = cycleMode;
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.repeat || e.defaultPrevented) return;
-      if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
-      if (e.key.toLowerCase() !== 'd') return;
-      if (isTypingTarget(e.target)) return;
-      // Stand down while focus is inside an open modal, matching the player
-      // shell's s/t cycling — a keypress aimed at a dialog shouldn't restyle
-      // the app behind it.
-      if (e.target instanceof HTMLElement && e.target.closest('[role="dialog"]')) return;
-      // Deliberately neither preventDefault nor act inline. Several listeners
-      // share this keypress — each skin's shortcut map, and the "press any key"
-      // tune-in gate that doubles as the browser's audio-unblock gesture — and
-      // which one is registered first is mount-order dependent (skins are lazy
-      // chunks, so they can register *after* this root-level provider). Handing
-      // the press back and settling on the next task lets every other listener
-      // run first; if any of them claimed it, `defaultPrevented` is now true
-      // and we stand down. Tuning in always beats changing the theme.
-      setTimeout(() => {
-        if (e.defaultPrevented) return;
-        cycleModeRef.current();
-      }, 0);
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, []);
 
   // The resolved effective id — what the picker highlights as "active".
   // Mirrors resolveAppearance's palette precedence so context consumers don't
   // need to re-implement it.
   const effectiveId =
     (overrideId && themes.some(t => t.id === overrideId) ? overrideId : stationActiveId) ?? null;
-  const renderedMode: ThemeMode =
-    mode ?? themes.find(t => t.id === effectiveId)?.mode ?? (systemDark ? 'dark' : 'light');
 
   return (
     <ThemeContext.Provider
@@ -262,12 +145,7 @@ export default function ThemeProvider({ children }: { children?: ReactNode }) {
         stationActiveId,
         overrideId,
         effectiveId,
-        paintedId,
         setOverride,
-        mode,
-        renderedMode,
-        setMode,
-        cycleMode,
       }}
     >
       {children}

--- a/web/components/ThemeSwitcher.tsx
+++ b/web/components/ThemeSwitcher.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useRef, useState, type ReactNode } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { LayoutTemplate, Moon, Palette, Sun, Zap } from 'lucide-react';
+import { LayoutTemplate, Palette, Zap } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { useDynamicStyle } from '../hooks/useDynamicStyle';
 import { useLiteMode } from '../hooks/useLiteMode';
@@ -24,9 +24,16 @@ function Swatch({ color }: SwatchProps) {
   return <span ref={ref} className="h-4 w-4 sm:h-5 sm:w-5" aria-hidden="true" />;
 }
 
+// Spans the full grid so a section heading always sits above its whole row of
+// cards, never beside the first one.
 function SectionLabel({ children, className }: { children: ReactNode; className?: string }) {
   return (
-    <span className={cn('v3-eyebrow border-b border-soft-border px-1 pb-1 text-[10px] tracking-[0.3em]', className)}>
+    <span
+      className={cn(
+        'v3-eyebrow col-span-full border-b border-soft-border px-1 pb-1 text-[10px] tracking-[0.3em]',
+        className,
+      )}
+    >
       {children}
     </span>
   );
@@ -70,13 +77,7 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
   // nothing useful to open.
   if (!ctx || ctx.themes.length === 0) return null;
 
-  const { themes, stationActiveId, overrideId, effectiveId, paintedId, mode, renderedMode, cycleMode } =
-    ctx;
-  const isDark = renderedMode === 'dark';
-  // A pinned mode the active palette wasn't authored for pauses that palette in
-  // favour of the built-in base (see resolveAppearance) — say so rather than
-  // leaving the picker highlighting a row that isn't on screen.
-  const palettePaused = mode !== null && paintedId === null;
+  const { themes, stationActiveId, overrideId, effectiveId } = ctx;
 
   return (
     <Dialog.Root open={open} onOpenChange={setOpen}>
@@ -106,7 +107,10 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
           className={cn(
             'v3-modal-pop fixed top-1/2 left-1/2 z-50 flex flex-col border border-ink bg-bg text-ink shadow-drawer outline-none',
             '-translate-x-1/2 -translate-y-1/2',
-            'max-h-[calc(100vh-3rem)] w-[min(360px,calc(100vw-2rem))]',
+            // Two columns of cards need roughly twice the old 360px; the modal
+            // still clamps to the viewport so a phone gets the single-column
+            // stack the grid falls back to below `sm`.
+            'max-h-[calc(100vh-3rem)] w-[min(620px,calc(100vw-2rem))]',
           )}
         >
           <div className="flex items-baseline justify-between gap-3 border-b border-ink px-5 py-3.5">
@@ -121,7 +125,7 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
             </Dialog.Close>
           </div>
 
-          <div className="v3-scroll grid flex-1 gap-1 overflow-auto px-3 py-3">
+          <div className="v3-scroll grid flex-1 grid-cols-1 gap-1 overflow-auto px-3 py-3 sm:grid-cols-2">
             <SectionLabel>Theme</SectionLabel>
             {themes.map(t => {
               const isActive = t.id === effectiveId;
@@ -162,7 +166,7 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
               onClick={() => onPickTheme(null)}
               disabled={!overrideId}
               className={cn(
-                'mt-1 w-full border-0 bg-transparent px-2 py-1 text-left text-[10px] tracking-[0.2em] text-muted uppercase',
+                'col-span-full mt-1 w-full border-0 bg-transparent px-2 py-1 text-left text-[10px] tracking-[0.2em] text-muted uppercase',
                 overrideId ? 'v3-focus cursor-pointer hover:text-ink' : 'cursor-default opacity-60',
               )}
             >
@@ -172,47 +176,6 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
                   ({themes.find(t => t.id === stationActiveId)?.name ?? stationActiveId})
                 </span>
               )}
-            </button>
-
-            {/* Light/dark control — independent of which palette is active, and
-                the on-screen twin of the `d` keyboard shortcut. Three states,
-                not two: AUTO follows the palette (and the system preference
-                when there is no palette), LIGHT/DARK pin it per-browser.
-                Flipping back off a pin returns to AUTO rather than pinning the
-                opposite, so a stray press can't detach the listener from the
-                operator's palette for good. Stays open so the flip is visible. */}
-            <button
-              type="button"
-              onClick={() => cycleMode()}
-              aria-label={`Appearance: ${mode ? `${mode} (pinned)` : `auto, currently ${renderedMode}`}. Activate to switch to ${isDark ? 'light' : 'dark'}.`}
-              className="v3-focus mt-2 flex w-full cursor-pointer items-center gap-2 border border-soft-border bg-bg px-2 py-1.5 text-left hover:bg-[var(--overlay)]"
-            >
-              {isDark ? (
-                <Moon className="h-4 w-4 shrink-0" aria-hidden="true" />
-              ) : (
-                <Sun className="h-4 w-4 shrink-0" aria-hidden="true" />
-              )}
-              <span className="grid min-w-0 flex-1 gap-0.5">
-                <span className="truncate text-[11px] font-bold tracking-[0.12em] uppercase">
-                  Light / dark
-                </span>
-                <span className="truncate text-[10px] leading-[1.3] text-muted">
-                  {palettePaused
-                    ? 'Palette paused while pinned — shortcut: D'
-                    : mode
-                      ? 'Pinned — press again for auto · shortcut: D'
-                      : 'Following the palette — shortcut: D'}
-                </span>
-              </span>
-              <span
-                className={cn(
-                  'shrink-0 text-[10px] font-bold tracking-[0.2em] uppercase',
-                  mode ? 'text-vermilion' : 'text-muted',
-                )}
-                aria-hidden="true"
-              >
-                {mode ?? 'Auto'}
-              </span>
             </button>
 
             {/* Player-skin picker — a different face for the whole player, not
@@ -259,7 +222,7 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
                   }}
                   disabled={!skinCtx.overrideId}
                   className={cn(
-                    'mt-1 w-full border-0 bg-transparent px-2 py-1 text-left text-[10px] tracking-[0.2em] text-muted uppercase',
+                    'col-span-full mt-1 w-full border-0 bg-transparent px-2 py-1 text-left text-[10px] tracking-[0.2em] text-muted uppercase',
                     skinCtx.overrideId ? 'v3-focus cursor-pointer hover:text-ink' : 'cursor-default opacity-60',
                   )}
                 >
@@ -280,7 +243,7 @@ export default function ThemeSwitcher({ variant = 'player' }: ThemeSwitcherProps
               aria-pressed={lite}
               onClick={() => setLite(!lite)}
               className={cn(
-                'v3-focus mt-2 flex w-full cursor-pointer items-center gap-2 border px-2 py-1.5 text-left',
+                'v3-focus col-span-full mt-2 flex w-full cursor-pointer items-center gap-2 border px-2 py-1.5 text-left',
                 lite
                   ? 'border-vermilion bg-[var(--ink-softer)]'
                   : 'border-soft-border bg-bg hover:bg-[var(--overlay)]',

--- a/web/lib/theme.ts
+++ b/web/lib/theme.ts
@@ -13,9 +13,6 @@ import { THEME_TOKEN_KEYS, type DisplayFontId, type MonoFontId } from './theme-t
 const TOKEN_KEY_SET = new Set<string>(THEME_TOKEN_KEYS);
 const TOKEN_CACHE_KEY = 'subwave-theme-tokens';
 const OVERRIDE_KEY = 'subwave-theme-override';
-// A listener's explicit light/dark choice, independent of which palette is
-// active. When set it steers which palette is picked — see resolveAppearance.
-const MODE_KEY = 'subwave-mode-override';
 
 // A theme stores --display-font / --mono-font as a curated id; resolve it to a
 // real family stack here (the stacks reference next/font variables set in
@@ -92,79 +89,44 @@ function syncDarkClass(mode: ThemeMode): void {
 
 /** Drop every palette token from the document root so the built-in light/dark
  *  base in globals.css (`:root` / `:root[data-theme="dark"]`) paints instead.
- *
- *  This is the load-bearing half of the mode override. `applyTheme` writes the
- *  palette as *inline* styles on <html>, and an inline `--bg` beats the
- *  `:root[data-theme="dark"]` rule — so flipping the attribute alone leaves the
- *  surfaces at the palette's own mode while `dark:` utilities and the
- *  `[data-theme="dark"]` grain/frame rules flip underneath them. Half-dark.
- *  Clearing the tokens first is what makes the flip whole. */
+ *  Only reachable when the registry is empty — the palette's tokens are written
+ *  as *inline* styles on <html> and would otherwise beat the base rules. */
 function clearThemeTokens(): void {
   if (typeof document === 'undefined') return;
   const html = document.documentElement;
   for (const key of THEME_TOKEN_KEYS) html.style.removeProperty(key);
 }
 
-/** Force the document into an explicit light/dark mode: sets `data-theme`
- *  (which drives the built-in token blocks, the Tailwind `dark:` variant, and
- *  the grain/frame rules) and mirrors the `.dark` class. Only meaningful once
- *  the palette's inline tokens are out of the way — see `clearThemeTokens`. */
-function applyMode(mode: ThemeMode): void {
-  if (typeof document === 'undefined') return;
-  document.documentElement.setAttribute('data-theme', mode);
-  syncDarkClass(mode);
-}
-
-/** Hand the document back to `prefers-color-scheme`: drop the explicit
- *  `data-theme` so the media-query block in globals.css applies. */
-function clearMode(): void {
-  if (typeof document === 'undefined') return;
-  document.documentElement.removeAttribute('data-theme');
-  syncDarkClass(systemMode());
-}
-
 /** What `prefers-color-scheme` currently reports. */
-export function systemMode(): ThemeMode {
+function systemMode(): ThemeMode {
   if (typeof window === 'undefined') return 'light';
   return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
 /** What the document should end up rendering, given the registry and the
- *  listener's two independent overrides. */
+ *  listener's palette override. */
 export interface ResolvedAppearance {
   /** The palette to paint, or null to fall back to the built-in base — which
-   *  happens when a mode is pinned and no registry palette renders in it. */
+   *  only happens when the registry is empty. */
   theme: Theme | null;
-  /** The mode to pin, or null to follow `prefers-color-scheme`. */
-  mode: ThemeMode | null;
 }
 
-/** Resolve palette + mode together. Pure — `applyAppearance` does the DOM work.
+/** Resolve which palette paints. Pure — `applyAppearance` does the DOM work.
  *
- *  Palette precedence is unchanged: the listener's override beats the station's
- *  active palette beats the first registry entry. A pinned light/dark mode then
- *  decides whether that palette survives — it does if it was authored for that
- *  mode, and is otherwise *paused* in favour of the built-in base, which ships
- *  a complete and coherent light/dark pair.
+ *  Precedence: the listener's override beats the station's active palette beats
+ *  the first registry entry.
  *
- *  Pausing rather than recolouring is deliberate: a palette is a hand-picked
- *  set of surfaces, ink, and accents that only holds together in the mode it
- *  was written for. Repainting one into the other mode produces mud, and
- *  silently swapping in a *different* palette would leave the picker
- *  highlighting a row that isn't on screen. A listener who wants a dark palette
- *  picks one — the picker is in the same menu as this toggle. */
+ *  Light vs dark is not a separate axis. Every theme declares the mode it was
+ *  authored for, and a palette is a hand-picked set of surfaces, ink, and
+ *  accents that only holds together in that mode — repainting one into the
+ *  other produces mud. A listener who wants dark picks a dark theme. */
 export function resolveAppearance(
   registry: Theme[],
   stationId: string | null,
   override: string | null,
-  modeOverride: ThemeMode | null,
 ): ResolvedAppearance {
   const byId = (id: string | null) => (id ? registry.find(t => t.id === id) : undefined);
-  const base = byId(override) ?? byId(stationId) ?? registry[0] ?? null;
-
-  if (!modeOverride) return { theme: base, mode: base ? base.mode : null };
-  if (base && base.mode === modeOverride) return { theme: base, mode: modeOverride };
-  return { theme: null, mode: modeOverride };
+  return { theme: byId(override) ?? byId(stationId) ?? registry[0] ?? null };
 }
 
 /** Paint a resolved appearance onto the document root. */
@@ -174,31 +136,10 @@ export function applyAppearance(resolved: ResolvedAppearance): void {
     applyTheme(resolved.theme);
     return;
   }
+  // No palette to paint — hand the document back to `prefers-color-scheme`.
   clearThemeTokens();
-  if (resolved.mode) applyMode(resolved.mode);
-  else clearMode();
-}
-
-/** Read the listener's explicit light/dark override, or null when unset. */
-export function loadModeOverride(): ThemeMode | null {
-  if (typeof window === 'undefined') return null;
-  try {
-    const raw = window.localStorage.getItem(MODE_KEY);
-    return raw === 'light' || raw === 'dark' ? raw : null;
-  } catch {
-    return null;
-  }
-}
-
-/** Save (or, with null, clear) the listener's explicit light/dark override. */
-export function saveModeOverride(mode: ThemeMode | null): void {
-  if (typeof window === 'undefined') return;
-  try {
-    if (mode) window.localStorage.setItem(MODE_KEY, mode);
-    else window.localStorage.removeItem(MODE_KEY);
-  } catch {
-    /* private mode / quota — non-fatal */
-  }
+  document.documentElement.removeAttribute('data-theme');
+  syncDarkClass(systemMode());
 }
 
 /** Cache the theme so the next page load can apply it pre-paint via
@@ -211,8 +152,8 @@ export function cacheTheme(theme: Theme): void {
 }
 
 /** Cache whatever was actually painted, so the pre-paint script reproduces it
- *  exactly. A resolution that lands on the built-in base drops the cache
- *  entirely rather than leaving a stale palette for the script to apply. */
+ *  exactly. A resolution that lands on the built-in base (empty registry) drops
+ *  the cache rather than leaving a stale palette for the script to apply. */
 export function cacheAppearance(resolved: ResolvedAppearance): void {
   if (typeof window === 'undefined') return;
   if (resolved.theme) {
@@ -261,15 +202,9 @@ export function saveThemeOverride(id: string | null): void {
 export const THEME_INIT_SCRIPT = `
   try {
     var html = document.documentElement;
-    var mode = localStorage.getItem('${MODE_KEY}');
-    if (mode !== 'light' && mode !== 'dark') mode = null;
     var raw = localStorage.getItem('${TOKEN_CACHE_KEY}');
     var t = raw ? JSON.parse(raw) : null;
-    // Mirror resolveAppearance's rule: a pinned mode only keeps the cached
-    // palette if that palette was authored for it. Otherwise skip the tokens
-    // entirely and let the built-in base paint — applying them and then
-    // flipping data-theme would leave inline light surfaces under dark rules.
-    var usePalette = t && t.tokens && (!mode || t.mode === mode);
+    var usePalette = !!(t && t.tokens);
     if (usePalette) {
       var keys = ${JSON.stringify([...THEME_TOKEN_KEYS])};
       var fonts = ${JSON.stringify(FONT_STACKS)};
@@ -282,7 +217,7 @@ export const THEME_INIT_SCRIPT = `
         }
       }
     }
-    var resolved = mode || (usePalette && (t.mode === 'light' || t.mode === 'dark') ? t.mode : null);
+    var resolved = usePalette && (t.mode === 'light' || t.mode === 'dark') ? t.mode : null;
     if (resolved) html.setAttribute('data-theme', resolved);
     else html.removeAttribute('data-theme');
     html.classList.toggle(


### PR DESCRIPTION
The palette menu (`ThemeSwitcher`) listed themes and skins one per row in a 360px column, so even a modest registry needed scrolling before you could see the skins.

## What changed

**Two columns.** Cards sit two-up at `sm` and wider in a 620px modal, single column below it. Section labels and the reset / lite-mode rows span the full width. With the stock registry the whole menu now fits without scrolling on desktop.

**The light/dark control is gone**, along with the `d` hotkey and the per-browser mode pin behind them. Mode is a property of the palette — every theme declares the one it was authored for, and a listener who wants dark picks a dark theme. The pin only ever *paused* a palette it disagreed with in favour of the built-in base, i.e. a second control that could take the operator's chosen look off screen.

That let a fair amount of machinery go: `resolveAppearance` drops its `modeOverride` argument and now only answers which palette paints, and `applyAppearance`'s mode branches, `loadModeOverride`/`saveModeOverride`, the `subwave-mode-override` key, the `d` keydown listener with its typeahead guards, and the pre-paint script's mode read all go with it. `ThemeContext` sheds `mode`, `renderedMode`, `setMode`, `cycleMode`, and `paintedId` — no consumer used them outside the switcher (`PlayerShell`'s `t` theme cycling only reads `themes`/`effectiveId`/`setOverride`).

A stale pin left in localStorage from before this change is ignored; the palette's own mode wins on the next load.

## Verified

`npm run lint` clean in `web/` (3 pre-existing `no-explicit-any` warnings in `playlist-builder/generate.ts`, untouched). Against a live controller with Playwright:

- Desktop 1280x900 — two columns, no scroll; mobile 420px — single column stack.
- Three presses of `d` outside a dialog leave `data-theme`, `.dark`, `--bg` and localStorage byte-identical.
- Picking Vinyl (light) over a dark station default flips `data-theme` and repaints, and a reload reproduces it exactly through the pre-paint script.
- A stale `subwave-mode-override: dark` alongside a light palette override renders light — the pin is ignored, not honoured.