### PR TITLE
fix(admin): cap the dash Listeners table with a scrollbar and sticky header

### DIFF
--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -66,6 +66,16 @@ import {
   maskIp,
   sortConnections,
 } from './dash/types';
+
+// Header cells of the capped Listeners table. `sticky top-0` resolves against
+// the ScrollArea viewport (the nearest scrollport), and the opaque card-bg is
+// what stops rows showing through as they scroll under the header. The rule
+// under the header is an inset shadow rather than `border-b`: the table is
+// border-collapse (Tailwind preflight), and a collapsed border belongs to the
+// table rather than the cell, so it stays behind while the cell scrolls away.
+const STICKY_TH =
+  'sticky top-0 z-[1] bg-[var(--card-bg)] shadow-[inset_0_-1px_0_var(--separator-strong)]';
+
 export default function DashPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
   const [status, setStatus] = useState<DashStatus | null>(null);
@@ -732,11 +742,23 @@ export default function DashPanel() {
         ) : conns.connections.length === 0 ? (
           <div className="text-muted italic">nobody listening right now</div>
         ) : (
-          <ScrollArea>
+          /* Capped like the other admin lists (requests, stats breakdowns) so a
+             busy station's connection list scrolls inside the card instead of
+             stretching the dash down the page. */
+          <ScrollArea className="max-h-[360px]">
             <table className="w-full text-[12px]">
               <thead>
                 <tr className="text-left text-[9px] tracking-[0.2em] text-muted uppercase">
-                  <SortableTh label="IP" col="ip" sort={sort} onSort={setSort} className="pr-3" />
+                  {/* Sticky against the ScrollArea viewport so the sort controls
+                      stay reachable once the list scrolls; card-bg masks the rows
+                      passing underneath. */}
+                  <SortableTh
+                    label="IP"
+                    col="ip"
+                    sort={sort}
+                    onSort={setSort}
+                    className={STICKY_TH + ' pr-3'}
+                  />
                   {/* Mount is the least useful of the four on a phone — the
                       remaining three fit 390px without a sideways scroll. */}
                   <SortableTh
@@ -744,23 +766,31 @@ export default function DashPanel() {
                     col="mount"
                     sort={sort}
                     onSort={setSort}
-                    className="hidden pr-3 sm:table-cell"
+                    className={STICKY_TH + ' hidden pr-3 sm:table-cell'}
                   />
                   <SortableTh
                     label="Connected"
                     col="connectedSeconds"
                     sort={sort}
                     onSort={setSort}
-                    className="pr-3"
+                    className={STICKY_TH + ' pr-3'}
                   />
-                  <SortableTh label="Client" col="client" sort={sort} onSort={setSort} />
+                  <SortableTh
+                    label="Client"
+                    col="client"
+                    sort={sort}
+                    onSort={setSort}
+                    className={STICKY_TH}
+                  />
                 </tr>
               </thead>
               <tbody>
                 {sortConnections(conns.connections, sort).map((c, i) => (
                   <tr
                     key={`${c.ip}:${c.mount}:${i}`}
-                    className="border-t border-dashed border-separator-strong"
+                    // first:border-t-0 — the sticky header already draws a solid
+                    // rule, so the top row's dashed border would double it.
+                    className="border-t border-dashed border-separator-strong first:border-t-0"
                   >
                     <td className="py-1.5 pr-3 font-mono whitespace-nowrap" title={c.ip}>
                       {revealIps ? c.ip || '—' : maskIp(c.ip)}


### PR DESCRIPTION
The Listeners card's `ScrollArea` had no height cap, so a busy station stretched the connection list down the dash instead of scrolling inside the card the way every other admin list does (requests, stats breakdowns, LLM/Subsonic calls).

- Caps the scrollport at `max-h-[360px]` so the shadcn vertical scrollbar takes over — same pattern as `RequestsCard` (520), `LlmCalls` (600), `StatsPanel`'s `ScrollBox` (260). Short lists are untouched; the bar only appears once the content exceeds the cap. The existing horizontal `ScrollBar` is unchanged.
- Pins the sortable `<thead>` against the ScrollArea viewport so the sort controls stay reachable once the list scrolls, matching the sticky header in `StatsPanel`'s `Table`.
- The rule under the header is an **inset shadow, not `border-b`**: the table is `border-collapse` (Tailwind preflight), and a collapsed border belongs to the table rather than the cell, so a `border-b` stays behind while the sticky cell scrolls away (verified — it rendered nothing under the pinned header). The top row drops its dashed `border-t` so the two don't double up at rest.

## Verification

Isolated worktree Next dev server against a fake controller serving 30 listener connections (the real station was never touched). Measured on the ScrollArea viewport:

- `clientHeight: 360`, `scrollHeight: 956`, 30 rows → scrollable.
- After `scrollTop = 150`, the header's top edge still equals the viewport's top edge → sticky resolves against the viewport, not the page.
- Screenshotted at rest and mid-scroll (1280px) and at 390px, where the table still fits three columns with no sideways overflow (`scrollWidth === clientWidth`).

`npm run lint` in `web/` passes (0 errors; the 3 `no-explicit-any` warnings are pre-existing in `playlist-builder/generate.ts`).