### PR TITLE
feat(seo): point self-hosted installs' shared-page canonicals at getsubwave.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ SITE_URL=
 
 # Web
 # SUBWAVE_HOMEPAGE=player          # or 'landing' for the marketing host
+# SUBWAVE_INDEX_ALL=1              # index the shared docs/news/catalog pages on
+#                                  # THIS domain too; default points their
+#                                  # canonicals at getsubwave.com so search
+#                                  # engines credit one copy
 # NEXT_PUBLIC_GA_ID=               # Google Analytics ID. Applied at RUNTIME
 #                                  # (recreate `web`, no rebuild) as well as at
 #                                  # build time. Unset → no analytics.

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -195,6 +195,10 @@ services:
       # RUNTIME source of truth for absolute URLs (canonicals, og:url,
       # robots.txt, sitemap.xml) — the generic image serves any domain.
       - SITE_URL=\${SITE_URL:-}
+      # Set to 1 to keep the shared product pages (landing, docs, news,
+      # catalogs) self-canonical + in this install's sitemap instead of
+      # crediting getsubwave.com (web/lib/site.ts IS_OFFICIAL_SITE).
+      - SUBWAVE_INDEX_ALL=\${SUBWAVE_INDEX_ALL:-}
       # GA Measurement ID at RUNTIME (web/lib/ga.ts) — analytics turn on with a
       # \`web\` recreate, no rebuild. The build-arg above still bakes it.
       - GA_ID=\${NEXT_PUBLIC_GA_ID:-}
@@ -479,6 +483,10 @@ services:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=\${SUBWAVE_HOMEPAGE:-player}
       - SITE_URL=\${SITE_URL:-}
+      # Set to 1 to keep the shared product pages (landing, docs, news,
+      # catalogs) self-canonical + in this install's sitemap instead of
+      # crediting getsubwave.com (web/lib/site.ts IS_OFFICIAL_SITE).
+      - SUBWAVE_INDEX_ALL=\${SUBWAVE_INDEX_ALL:-}
       # GA Measurement ID at RUNTIME (web/lib/ga.ts) — analytics turn on with a
       # \`web\` recreate, no rebuild.
       - GA_ID=\${NEXT_PUBLIC_GA_ID:-}
@@ -935,6 +943,10 @@ SITE_URL=
 
 # Web
 # SUBWAVE_HOMEPAGE=player          # or 'landing' for the marketing host
+# SUBWAVE_INDEX_ALL=1              # index the shared docs/news/catalog pages on
+#                                  # THIS domain too; default points their
+#                                  # canonicals at getsubwave.com so search
+#                                  # engines credit one copy
 # NEXT_PUBLIC_GA_ID=               # Google Analytics ID. Applied at RUNTIME
 #                                  # (recreate \`web\`, no rebuild) as well as at
 #                                  # build time. Unset → no analytics.

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -163,6 +163,10 @@ services:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=${SUBWAVE_HOMEPAGE:-player}
       - SITE_URL=${SITE_URL:-}
+      # Set to 1 to keep the shared product pages (landing, docs, news,
+      # catalogs) self-canonical + in this install's sitemap instead of
+      # crediting getsubwave.com (web/lib/site.ts IS_OFFICIAL_SITE).
+      - SUBWAVE_INDEX_ALL=${SUBWAVE_INDEX_ALL:-}
       # GA Measurement ID at RUNTIME (web/lib/ga.ts) — analytics turn on with a
       # `web` recreate, no rebuild.
       - GA_ID=${NEXT_PUBLIC_GA_ID:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,6 +186,10 @@ services:
       # RUNTIME source of truth for absolute URLs (canonicals, og:url,
       # robots.txt, sitemap.xml) — the generic image serves any domain.
       - SITE_URL=${SITE_URL:-}
+      # Set to 1 to keep the shared product pages (landing, docs, news,
+      # catalogs) self-canonical + in this install's sitemap instead of
+      # crediting getsubwave.com (web/lib/site.ts IS_OFFICIAL_SITE).
+      - SUBWAVE_INDEX_ALL=${SUBWAVE_INDEX_ALL:-}
       # GA Measurement ID at RUNTIME (web/lib/ga.ts) — analytics turn on with a
       # `web` recreate, no rebuild. The build-arg above still bakes it.
       - GA_ID=${NEXT_PUBLIC_GA_ID:-}

--- a/web/app/listen/page.tsx
+++ b/web/app/listen/page.tsx
@@ -11,6 +11,8 @@ const GENERIC = pageMeta({
   description:
     'Tune in to the SUB/WAVE broadcast — one live stream, with an AI DJ picking tracks and talking between them. See what is on air right now.',
   path: '/listen',
+  // The player is this station's own page — self-canonical on every install.
+  scope: 'station',
 });
 
 // The other player route, so a branded station's link preview is not labelled
@@ -29,6 +31,7 @@ export async function generateMetadata(): Promise<Metadata> {
     description: meta.description,
     path: '/listen',
     siteName: meta.name,
+    scope: 'station',
   });
 }
 

--- a/web/app/news/[slug]/page.tsx
+++ b/web/app/news/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation';
 import { AnimatedLink } from '@/components/ui/animated-link';
 import { getAllNews, getNewsArticle, formatNewsDate } from '@/lib/news';
 import JsonLd from '@/components/JsonLd';
-import { absoluteUrl } from '@/lib/seo';
+import { absoluteUrl, canonicalUrl } from '@/lib/seo';
 
 // Render per-request like the rest of the news segment — generateStaticParams
 // would win over the layout's force-dynamic and prerender each article with
@@ -19,7 +19,9 @@ export async function generateMetadata({
   const { slug } = await params;
   const article = getNewsArticle(slug);
   if (!article) return { title: { absolute: 'SUB/WAVE — Dispatches' } };
-  const url = absoluteUrl(`/news/${article.slug}`);
+  // Dispatches are shared product content — on a non-official install the
+  // canonical/og:url point at getsubwave.com (see PageScope in lib/seo.ts).
+  const url = canonicalUrl(`/news/${article.slug}`);
   return {
     // `absolute` opts out of the root layout's `%s · SUB/WAVE` template —
     // the brand is already appended here.
@@ -76,7 +78,9 @@ export default async function NewsArticlePage({
       logo: { '@type': 'ImageObject', url: absoluteUrl('/icons/512') },
     },
     image: absoluteUrl('/og'),
-    mainEntityOfPage: absoluteUrl(`/news/${article.slug}`),
+    // Matches the <link rel="canonical"> above; the icon/og image URLs stay
+    // on this host because they are served from it.
+    mainEntityOfPage: canonicalUrl(`/news/${article.slug}`),
   };
 
   return (

--- a/web/app/privacy/page.tsx
+++ b/web/app/privacy/page.tsx
@@ -5,6 +5,9 @@ export const metadata = pageMeta({
   description:
     'How the SUB/WAVE player apps handle your data: no account, no analytics, no trackers. Stations are stored on your device; playback connects straight to the station you choose.',
   path: '/privacy',
+  // Legal pages bind this operator, so they stay self-canonical even though
+  // the text is identical everywhere — see PageScope in lib/seo.ts.
+  scope: 'station',
 });
 
 // Render per-request so the canonical/og:url pick up the runtime SITE_URL — a

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from 'next';
-import { SITE_URL } from '@/lib/site';
+import { SITE_URL, IS_OFFICIAL_SITE } from '@/lib/site';
 import { getAllNews } from '@/lib/news';
 
 // Served by Next at /sitemap.xml. Public, indexable routes only — the
@@ -41,6 +41,12 @@ const ROUTES = [
   '/terms',
 ];
 
+// The subset that is the operator's OWN surface (see PageScope in lib/seo.ts).
+// A non-official install's sitemap lists only these: every other route above
+// is the shared product site whose canonical points at getsubwave.com there,
+// and a sitemap must not advertise URLs that declare themselves non-canonical.
+const STATION_ROUTES = new Set(['/', '/listen', '/privacy', '/terms']);
+
 // Rendered per-request so SITE_URL (and the news list) come from the runtime
 // container env / filesystem rather than being baked at image-build time —
 // the published GHCR image can't know the operator's domain. See robots.ts.
@@ -48,9 +54,12 @@ export const dynamic = 'force-dynamic';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const now = new Date();
-  const news = getAllNews();
+  const routes = IS_OFFICIAL_SITE ? ROUTES : ROUTES.filter((r) => STATION_ROUTES.has(r));
+  // Dispatches are shared content — official sitemap only, same reasoning as
+  // STATION_ROUTES above.
+  const news = IS_OFFICIAL_SITE ? getAllNews() : [];
 
-  const staticEntries: MetadataRoute.Sitemap = ROUTES.map((route) => ({
+  const staticEntries: MetadataRoute.Sitemap = routes.map((route) => ({
     url: `${SITE_URL}${route}`,
     lastModified: now,
     changeFrequency: route === '/' || route === '/listen' ? 'daily' : 'monthly',

--- a/web/app/terms/page.tsx
+++ b/web/app/terms/page.tsx
@@ -5,6 +5,9 @@ export const metadata = pageMeta({
   description:
     'The plain terms for using the SUB/WAVE apps and the public station: the software is provided as is, and each station operator is responsible for the music they broadcast and any licences it needs.',
   path: '/terms',
+  // Legal pages bind this operator, so they stay self-canonical even though
+  // the text is identical everywhere — see PageScope in lib/seo.ts.
+  scope: 'station',
 });
 
 // Render per-request so the canonical/og:url pick up the runtime SITE_URL — a

--- a/web/lib/seo.ts
+++ b/web/lib/seo.ts
@@ -1,5 +1,10 @@
 import type { Metadata } from 'next';
-import { SITE_URL } from '@/lib/site';
+import { SITE_URL, OFFICIAL_SITE_URL, IS_OFFICIAL_SITE } from '@/lib/site';
+
+function urlOnBase(base: string, path = '/'): string {
+  if (!path || path === '/') return base;
+  return `${base}${path.startsWith('/') ? path : `/${path}`}`;
+}
 
 // Absolute URL for a path — used for canonical + Open Graph / Twitter URLs.
 // Always emit absolute strings: Next pins *relative* metadata URLs to
@@ -7,8 +12,33 @@ import { SITE_URL } from '@/lib/site';
 // so a relative canonical would resolve to a localhost origin. Absolute
 // strings are emitted verbatim and survive untouched.
 export function absoluteUrl(path = '/'): string {
-  if (!path || path === '/') return SITE_URL;
-  return `${SITE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+  return urlOnBase(SITE_URL, path);
+}
+
+// Which install a page's content belongs to:
+// - 'shared'  — the product site: landing, /setup, /manual, /news, and the
+//   community catalogs. Byte-identical on every install (one shared image),
+//   so on a non-official install its canonical points at getsubwave.com —
+//   otherwise every public self-hosted station self-asserts canonical over
+//   the same content and Google picks one winner per duplicate cluster,
+//   which may not be the official site (see IS_OFFICIAL_SITE in lib/site.ts).
+// - 'station' — the operator's own surface (/, /listen) plus /privacy and
+//   /terms, which stay self-canonical everywhere: the player is genuinely
+//   this station's page, and the legal pages bind this operator even though
+//   the text is identical (search engines expect duplicated boilerplate).
+//
+// 'shared' is the default on purpose: nearly every pageMeta consumer is the
+// product site, and a forgotten flag on a new docs page should donate to the
+// official site rather than assert a fresh duplicate.
+export type PageScope = 'shared' | 'station';
+
+// The URL a page declares as its canonical (and og:url — crawlers treat a
+// mismatched og:url as a competing canonical hint, so they must agree).
+export function canonicalUrl(path: string, scope: PageScope = 'shared'): string {
+  if (scope === 'shared' && !IS_OFFICIAL_SITE) {
+    return urlOnBase(OFFICIAL_SITE_URL, path);
+  }
+  return absoluteUrl(path);
 }
 
 // Per-page metadata with a self-referencing canonical and a matching OG url.
@@ -32,14 +62,16 @@ export function pageMeta({
   path,
   type = 'website',
   siteName = 'SUB/WAVE',
+  scope = 'shared',
 }: {
   title: string;
   description?: string;
   path: string;
   type?: 'website' | 'article';
   siteName?: string;
+  scope?: PageScope;
 }): Metadata {
-  const url = absoluteUrl(path);
+  const url = canonicalUrl(path, scope);
   return {
     title: { absolute: title },
     ...(description ? { description } : {}),

--- a/web/lib/site.ts
+++ b/web/lib/site.ts
@@ -17,3 +17,30 @@ export const SITE_URL = (
   process.env.NEXT_PUBLIC_SITE_URL ||
   'http://localhost:7700'
 ).replace(/\/$/, '');
+
+// The project's own public site. Non-official installs point the canonicals
+// of SHARED pages (landing, docs, news, community catalogs) here — see
+// lib/seo.ts canonicalUrl().
+export const OFFICIAL_SITE_URL = 'https://getsubwave.com';
+
+function isOfficialHost(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === 'getsubwave.com' || host === 'www.getsubwave.com';
+  } catch {
+    return false;
+  }
+}
+
+// True when this install IS the official site, or the operator explicitly
+// opted into indexing everything with SUBWAVE_INDEX_ALL=1.
+//
+// Every install serves the same marketing/docs/news pages as getsubwave.com
+// (one shared image), and each used to self-assert canonical over them — so
+// Google folds the duplicates into ONE winner per cluster, and a public
+// self-hosted station could win a dispatch or setup guide away from the
+// official site. Non-official installs therefore donate those canonicals
+// back (and drop the pages from their sitemap) while keeping the pages
+// themselves fully served — nothing changes for their visitors.
+export const IS_OFFICIAL_SITE =
+  process.env.SUBWAVE_INDEX_ALL === '1' || isOfficialHost(SITE_URL);


### PR DESCRIPTION
## Why

Self-hosted stations on public domains serve the exact same landing page, `/setup` + `/manual` docs, `/news` dispatches, and community-catalog pages as getsubwave.com — same GHCR image — and every install self-asserts `rel=canonical` over them and lists them in its sitemap. Google folds duplicate clusters into **one** winner each, and nothing guarantees that winner is getsubwave.com: a public self-hosted station can take a dispatch or setup guide's ranking away from the official site, splitting link signals across N copies in the process.

## What

**Non-official installs** (`SITE_URL` host ≠ getsubwave.com) now tell crawlers the shared pages belong to the official site, while serving them unchanged to visitors:

- `lib/site.ts`: `IS_OFFICIAL_SITE` — runtime host check (the public segments are already `force-dynamic`, so no build-time knowledge needed) with a `SUBWAVE_INDEX_ALL=1` escape hatch.
- `lib/seo.ts`: `pageMeta()` gains a `scope` param. `'shared'` (the default) canonicalises + `og:url`s to `https://getsubwave.com/<path>` on non-official installs; `'station'` stays self-canonical. Default is `'shared'` on purpose — a forgotten flag on a new docs page donates to the official site instead of minting a fresh duplicate.
- Station-scoped (self-canonical everywhere): `/listen` (both metadata paths), `/privacy`, `/terms` — the player is genuinely the operator's page, and legal pages bind the operator even with identical text (crawlers expect duplicated boilerplate). `/` never emitted a canonical and is untouched.
- `/news/[slug]`: hand-built metadata switched to the same `canonicalUrl()` helper (canonical, `og:url`, JSON-LD `mainEntityOfPage`).
- `sitemap.ts`: non-official installs list only `/`, `/listen`, `/privacy`, `/terms` and no dispatches — a sitemap must not advertise URLs whose canonical points off-site.
- Both prod composes plumb `SUBWAVE_INDEX_ALL` into the web container; `.env.example` documents it; CLI assets re-embedded.

Note: `/skills`, `/shows`, `/personas`, `/stations` are the **community catalogs** (identical on every install — they read the shared community repo, not the station's roster), so they're in the shared class.

## Verification

`web` lint (eslint + tsc) passes. Live smoke against a worktree dev server in all three configs:

| config | /manual canonical | /listen | /privacy | /news/\<slug\> | sitemap |
|---|---|---|---|---|---|
| `SITE_URL=https://radio.selfhoster.example` | getsubwave.com | self | self | getsubwave.com (+JSON-LD) | 4 station URLs only |
| `SITE_URL=https://getsubwave.com` | self | self | self | self | full 62 URLs |
| selfhoster + `SUBWAVE_INDEX_ALL=1` | self | self | self | self | full 62 URLs |

(`web/` has no test harness — lint is the merge gate per CLAUDE.md — so verification is the matrix above.)