### PR TITLE
feat(admin): clearer Cloud TTS provider picker on Settings and Personas

### DIFF
--- a/web/components/admin/personas/helpers.ts
+++ b/web/components/admin/personas/helpers.ts
@@ -5,6 +5,7 @@ import {
   PROMPT_NAME_MAX, PROMPT_MIN, PROMPT_MAX,
   KOKORO_RE, CHATTERBOX_VOICE_RE, POCKET_TTS_VOICE_RE,
 } from './constants';
+import { CLOUD_PROVIDER_ENV_KEY, cloudProviderLabel } from '../tts/cloudProviderMeta';
 
 // Client-minted opaque id ('p_' personas, 'dp_' prompt presets). The server
 // re-mints anything that fails its ID_RE, so these only need to be unique
@@ -207,36 +208,32 @@ export function voiceForSave(engine: string, voice: string): string {
   return voice; // piper ignores voice; cloud carries its own
 }
 
-// Prefers the controller's provider-aware readiness contract (it covers both
-// credentials and the station-wide Cloud switch); env presence is the fallback for
-// an older controller without that contract.
+// Why this persona's cloud voice won't play, or null when it will.
+//
+// The controller's readiness flag (`cloudByProvider`) folds TWO causes into one
+// boolean: no credentials, and the station-wide `tts.cloud.enabled` switch being
+// off. Reporting them with one sentence sent operators to hunt for a key they
+// had already set — visibly so next to the provider picker's own KEY SET badge,
+// which reads env presence directly. So credentials are checked first and the
+// readiness flag only speaks for what's left: the station switch.
 export function cloudIssue(persona: Persona | undefined, data: SettingsResponse | null): string | null {
   if (persona?.tts?.engine !== 'cloud') return null;
   const provider = persona.tts.cloudProvider;
-  const readiness = data?.tts?.available?.cloudByProvider;
-  if (readiness && provider in readiness) {
-    if (readiness[provider] === false) {
-      const label = provider === 'fish-audio'
-        ? 'Fish Audio'
-        : provider === 'elevenlabs'
-          ? 'ElevenLabs'
-          : provider === 'openai'
-            ? 'OpenAI'
-            : provider;
-      return `${label} is unavailable. Enable Cloud TTS and configure its credentials in Settings.`;
-    }
-    return null;
-  }
   // openai-compatible has no env-key convention — its URL, model, and optional
   // bearer live in tts.cloud settings rather than state/secrets.env.
   if (provider === 'openai-compatible') return null;
-  const envKey = provider === 'elevenlabs'
-    ? 'ELEVENLABS_API_KEY'
-    : provider === 'fish-audio'
-      ? 'FISH_API_KEY'
-      : 'OPENAI_API_KEY';
-  if (data?.env && !data.env[envKey]) {
+  const readiness = data?.tts?.available?.cloudByProvider;
+  const ready = readiness && provider in readiness ? readiness[provider] : undefined;
+  if (ready === true) return null;
+
+  const envKey = CLOUD_PROVIDER_ENV_KEY[provider];
+  // `data.env` absent means the settings payload hasn't landed; stay quiet
+  // rather than accusing a key of being missing before we can see it.
+  if (envKey && data?.env && !data.env[envKey]) {
     return `${envKey} is not configured in Settings.`;
+  }
+  if (ready === false) {
+    return `${cloudProviderLabel(provider)} has a key on file, but Cloud TTS is switched off for the station. Turn it on under Settings → Voice.`;
   }
   return null;
 }

--- a/web/components/admin/settings/TtsSection.tsx
+++ b/web/components/admin/settings/TtsSection.tsx
@@ -17,6 +17,8 @@ import {
 } from '../../ui/select';
 import { Card, Btn, Pill, Seg } from '../ui';
 import { EngineSelector } from '../tts/EngineSelector';
+import { CloudProviderSelector } from '../tts/CloudProviderSelector';
+import { cloudProviderLabel, resolveKeyPresence } from '../tts/cloudProviderMeta';
 import { EngineVoiceFields, ENGINE_UNAVAILABLE } from '../tts/EngineVoiceFields';
 import { VoicePreviewButton } from '../tts/VoicePreviewButton';
 import { VoicePicker } from '../tts/VoicePicker';
@@ -53,11 +55,17 @@ function envKeyForCloudProvider(provider: string): 'OPENAI_API_KEY' | 'ELEVENLAB
   return 'OPENAI_API_KEY';
 }
 
-function cloudProviderLabel(provider: string): string {
-  if (provider === 'openai') return 'OpenAI';
-  if (provider === 'elevenlabs') return 'ElevenLabs';
-  if (provider === 'fish-audio') return 'Fish Audio';
-  return 'OpenAI-compatible';
+// Small labelled rule that splits the Cloud panel into its three steps. Same
+// type treatment as the other in-card headings (HeavyEngineSetupGuide's).
+function GroupHead({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <span className="flex-none text-[10px] font-bold tracking-[0.16em] text-ink uppercase">
+        {children}
+      </span>
+      <span className="h-px min-w-0 flex-1 bg-[var(--separator-strong)]" />
+    </div>
+  );
 }
 
 // Engine ids match the server contract exactly — note the hyphen in `pocket-tts`.
@@ -741,6 +749,9 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
               value={form.tts.defaultEngine}
               engineIds={engines}
               available={selectorAvailable}
+              // This IS Settings → Voice, so the default "go to Settings →
+              // Voice" wording would send the operator in a circle.
+              statusOpts={{ cloudKeyAction: 'pick a provider below and add its key' }}
               onChange={selectEngine}
             />
             <div className="field-hint">
@@ -954,246 +965,273 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
         )}
 
         {form.tts.defaultEngine === 'cloud' && (() => {
+          const providerIds = data.tts?.cloudProviders
+            || ['openai', 'elevenlabs', 'fish-audio', 'openai-compatible'];
           return (
-          <div className="mt-4">
+          // Three ordered steps — provider, then credentials, then what to
+          // render with. Model and voice discovery both depend on the
+          // credentials, so those have to come first; they used to sit below,
+          // under hints telling the operator to look "above" for them.
+          <div className="mt-4 grid gap-[26px]">
             <div className="field">
               <Label>Provider</Label>
-              <Seg
-                accent
+              <CloudProviderSelector
                 value={form.tts.cloud.provider}
-                options={(data.tts?.cloudProviders || ['openai', 'elevenlabs', 'fish-audio', 'openai-compatible']).map(p => ({ id: p, label: cloudProviderLabel(p) }))}
+                providerIds={providerIds}
+                availability={{
+                  cloudByProvider: resolveKeyPresence(providerIds, available.cloudByProvider, data.env),
+                  compatBaseUrlSet: !!form.tts.cloud.baseUrl.trim(),
+                }}
                 onChange={v => setForm(f => selectCloudProvider(f, v))}
+                // Connection is the very next block, and it carries its own
+                // KeyStatus — a "next step" note here would just bounce the eye.
+                enableHint={false}
+                gridClassName="md:grid-cols-4"
+                hint={<>
+                  Which service renders Cloud speech. Each provider keeps its own
+                  key, model and voice, so switching here doesn’t carry the last
+                  one’s settings across.
+                </>}
               />
             </div>
-            {isCompat && (
-              <div className="field mt-3.5">
-                <Label>Server base URL</Label>
-                <Input
-                  value={form.tts.cloud.baseUrl}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                    setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, baseUrl: e.target.value } } }))
-                  }
-                  placeholder="http://192.168.1.101:5000/v1"
-                  className="max-w-[360px]"
-                />
-                <div className="field-hint">
-                  Any OpenAI-compatible TTS server (Chatterbox, Qwen3 TTS,
-                  VibeVoice, …) that exposes <code>/v1/audio/speech</code>,
-                  including the <code>/v1</code> suffix. Must be reachable from the
-                  controller container. Use the host’s LAN or Tailscale IP, not
-                  <code>127.0.0.1</code>.
+
+            <div className="grid gap-3.5">
+              <GroupHead>Connection</GroupHead>
+              {isCompat && (
+                <div className="field">
+                  <Label>Server base URL</Label>
+                  <Input
+                    value={form.tts.cloud.baseUrl}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                      setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, baseUrl: e.target.value } } }))
+                    }
+                    placeholder="http://192.168.1.101:5000/v1"
+                    className="max-w-[360px]"
+                  />
+                  <div className="field-hint">
+                    Any OpenAI-compatible TTS server (Chatterbox, Qwen3 TTS,
+                    VibeVoice, …) that exposes <code>/v1/audio/speech</code>,
+                    including the <code>/v1</code> suffix. Must be reachable from the
+                    controller container. Use the host’s LAN or Tailscale IP, not
+                    <code>127.0.0.1</code>.
+                  </div>
                 </div>
-              </div>
-            )}
-            <div className="mt-3.5 grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-[18px]">
-              <div className="field">
-                <Label>Model</Label>
-                <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
-                  {isFish ? (
-                    <>
-                      <Input
-                        list="fish-audio-models"
+              )}
+              {!isCompat && (() => {
+                const cloudKeyVar = envKeyForCloudProvider(form.tts.cloud.provider);
+                return (
+                  <>
+                    <div className="field">
+                      <Label>{cloudProviderLabel(form.tts.cloud.provider)} API key</Label>
+                      <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
+                        <Input
+                          type="password"
+                          autoComplete="off"
+                          value={cloudKeyInput}
+                          placeholder={data.env?.[cloudKeyVar] ? '•••••• (on file)' : (KEY_HINTS[cloudKeyVar] ?? '')}
+                          onChange={(e: ChangeEvent<HTMLInputElement>) => setCloudKeyInput(e.target.value)}
+                          className="max-w-[360px]"
+                        />
+                        <Btn
+                          onClick={testCloudKey}
+                          disabled={cloudKeyTesting || (!cloudKeyInput.trim() && !data.env?.[cloudKeyVar])}
+                        >
+                          {cloudKeyTesting ? 'Testing…' : 'Test key'}
+                        </Btn>
+                      </div>
+                      <div className="field-hint">
+                        Stored in <code>state/secrets.env</code>, takes effect immediately. Leave blank to keep the existing key.
+                      </div>
+                      {cloudKeyVar === 'OPENAI_API_KEY' && (
+                        <div className="field-hint">
+                          This key is shared across LLM and Cloud TTS.
+                        </div>
+                      )}
+                    </div>
+                    {cloudKeyTest && <KeyTestResult result={cloudKeyTest} />}
+                    <KeyStatus envVar={cloudKeyVar} present={!!data.env?.[cloudKeyVar]} />
+                  </>
+                );
+              })()}
+              {isCompat && (
+                <div className="field">
+                  <Label>API key</Label>
+                  <Input
+                    type="password"
+                    autoComplete="off"
+                    value={compatKeyInput}
+                    placeholder={savedCloud.apiKey === 'set' ? '•••••• (on file)' : 'Optional'}
+                    onChange={(e: ChangeEvent<HTMLInputElement>) => setCompatKeyInput(e.target.value)}
+                    className="max-w-[360px]"
+                  />
+                  <div className="field-hint">
+                    Optional, only if your server requires one (e.g. SUB/WAVE DJ
+                    Brain); most self-hosted servers accept any non-empty key.
+                    Blank keeps the existing key. Saved with these settings, takes
+                    effect immediately.
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <div className="grid gap-3.5">
+              <GroupHead>Model &amp; voice</GroupHead>
+              <div className="grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-[18px]">
+                <div className="field">
+                  <Label>Model</Label>
+                  <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
+                    {isFish ? (
+                      <>
+                        <Input
+                          list="fish-audio-models"
+                          value={form.tts.cloud.model}
+                          maxLength={100}
+                          onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                            setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, model: e.target.value } } }))
+                          }
+                          placeholder="s2.1-pro"
+                          className="max-w-[360px]"
+                        />
+                        <datalist id="fish-audio-models">
+                          {CLOUD_MODELS['fish-audio'].map(model => <option key={model} value={model} />)}
+                        </datalist>
+                      </>
+                    ) : ttsDiscovery.models.length > 0 ? (
+                      <ModelCombobox
+                        models={ttsDiscovery.models}
                         value={form.tts.cloud.model}
-                        maxLength={100}
+                        onChange={v => setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, model: v } } }))}
+                        placeholder="Select a model"
+                      />
+                    ) : (
+                      <Input
+                        value={form.tts.cloud.model}
                         onChange={(e: ChangeEvent<HTMLInputElement>) =>
                           setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, model: e.target.value } } }))
                         }
-                        placeholder="s2.1-pro"
+                        placeholder={
+                          isCompat
+                            ? 'chatterbox'
+                            : (CLOUD_MODELS[form.tts.cloud.provider as keyof typeof CLOUD_MODELS]?.[0] || 'gpt-4o-mini-tts')
+                        }
                         className="max-w-[360px]"
                       />
-                      <datalist id="fish-audio-models">
-                        {CLOUD_MODELS['fish-audio'].map(model => <option key={model} value={model} />)}
-                      </datalist>
-                    </>
-                  ) : ttsDiscovery.models.length > 0 ? (
-                    <ModelCombobox
-                      models={ttsDiscovery.models}
-                      value={form.tts.cloud.model}
-                      onChange={v => setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, model: v } } }))}
-                      placeholder="Select a model"
-                    />
-                  ) : (
-                    <Input
-                      value={form.tts.cloud.model}
-                      onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                        setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, model: e.target.value } } }))
-                      }
-                      placeholder={
-                        isCompat
-                          ? 'chatterbox'
-                          : (CLOUD_MODELS[form.tts.cloud.provider as keyof typeof CLOUD_MODELS]?.[0] || 'gpt-4o-mini-tts')
-                      }
-                      className="max-w-[360px]"
-                    />
-                  )}
-                  {ttsDiscovery.loading
-                    ? <span className="animate-pulse text-[11px] whitespace-nowrap text-muted">discovering…</span>
-                    : ttsDiscoveryEnabled && (
-                      <Btn onClick={ttsDiscovery.refresh} title="Refresh model list">↻</Btn>
-                    )
+                    )}
+                    {ttsDiscovery.loading
+                      ? <span className="animate-pulse text-[11px] whitespace-nowrap text-muted">discovering…</span>
+                      : ttsDiscoveryEnabled && (
+                        <Btn onClick={ttsDiscovery.refresh} title="Refresh model list">↻</Btn>
+                      )
+                    }
+                  </div>
+                  <div className="field-hint">
+                    {isFish
+                      ? <>Use <code>s2.1-pro</code> for the full model or <code>s2.1-pro-free</code> for the free tier. You can also type a custom Fish model id.</>
+                      : ttsDiscovery.models.length > 0
+                        ? `${ttsDiscovery.models.length} model${ttsDiscovery.models.length !== 1 ? 's' : ''} discovered. Pick one from the list.`
+                      : !ttsDiscoveryEnabled
+                        ? (isCompat
+                            ? 'Set a base URL above to discover available models.'
+                            : 'Set an API key above to discover and select a model.')
+                        : ttsDiscovery.error
+                          ? `Discovery failed: ${ttsDiscovery.error}. Type a model ID manually.`
+                          : ttsDiscovery.loading
+                            ? 'Discovering models…'
+                            : (isCompat
+                                ? 'Model id exactly as the server reports it at /v1/models, required.'
+                                : 'e.g. "gpt-4o-mini-tts" (OpenAI) or "eleven_flash_v2_5" (ElevenLabs).')}
+                  </div>
+                </div>
+                {(() => {
+                  const provider = form.tts.cloud.provider;
+                  const voice = form.tts.cloud.voice.trim();
+                  const isPreset = isKnownCloudVoice(provider, discoveredVoices, voice);
+                  const setVoice = (v: string) =>
+                    setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: v } } }));
+                  // A compat server that advertised no voices leaves nothing to pick
+                  // from — keep the plain text box it had before discovery.
+                  const hasList = discoveredVoices.length > 0 || !isCompat;
+                  if (!hasList) {
+                    return (
+                      <div className="field">
+                        <Label>Default voice</Label>
+                        <Input
+                          value={form.tts.cloud.voice}
+                          maxLength={100}
+                          placeholder="Server-specific (cloning ref or speaker id)"
+                          onChange={(e: ChangeEvent<HTMLInputElement>) => setVoice(e.target.value)}
+                        />
+                        <div className="field-hint">
+                          {voiceDiscovery.loading
+                            ? 'Checking the server for a voice list…'
+                            : <>Server-specific: Chatterbox cloning ref name, Qwen3
+                                speaker id, etc. Leave blank to let the server pick its
+                                own default.</>}
+                        </div>
+                      </div>
+                    );
                   }
-                </div>
-                <div className="field-hint">
-                  {isFish
-                    ? <>Use <code>s2.1-pro</code> for the full model or <code>s2.1-pro-free</code> for the free tier. You can also type a custom Fish model id.</>
-                    : ttsDiscovery.models.length > 0
-                      ? `${ttsDiscovery.models.length} model${ttsDiscovery.models.length !== 1 ? 's' : ''} discovered. Pick one from the list.`
-                    : !ttsDiscoveryEnabled
-                      ? (isCompat
-                          ? 'Set a base URL above to discover available models.'
-                          : 'Set an API key above to discover and select a model.')
-                      : ttsDiscovery.error
-                        ? `Discovery failed: ${ttsDiscovery.error}. Type a model ID manually.`
-                        : ttsDiscovery.loading
-                          ? 'Discovering models…'
-                          : (isCompat
-                              ? 'Model id exactly as the server reports it at /v1/models, required.'
-                              : 'e.g. "gpt-4o-mini-tts" (OpenAI) or "eleven_flash_v2_5" (ElevenLabs).')}
-                </div>
-              </div>
-              {(() => {
-                const provider = form.tts.cloud.provider;
-                const voice = form.tts.cloud.voice.trim();
-                const isPreset = isKnownCloudVoice(provider, discoveredVoices, voice);
-                const setVoice = (v: string) =>
-                  setForm(f => ({ ...f, tts: { ...f.tts, cloud: { ...f.tts.cloud, voice: v } } }));
-                // A compat server that advertised no voices leaves nothing to pick
-                // from — keep the plain text box it had before discovery.
-                const hasList = discoveredVoices.length > 0 || !isCompat;
-                if (!hasList) {
                   return (
                     <div className="field">
                       <Label>Default voice</Label>
-                      <Input
-                        value={form.tts.cloud.voice}
-                        maxLength={100}
-                        placeholder="Server-specific (cloning ref or speaker id)"
-                        onChange={(e: ChangeEvent<HTMLInputElement>) => setVoice(e.target.value)}
+                      <VoicePicker
+                        value={isPreset ? voice : CUSTOM_VOICE_ID}
+                        onChange={val => {
+                          // Clearing the preset flips isPreset false, revealing the
+                          // free-text input below.
+                          setVoice(val === CUSTOM_VOICE_ID ? '' : val);
+                        }}
+                        groups={buildCloudVoiceGroups(provider, discoveredVoices)}
+                        title="Default cloud voice"
+                        preview={{
+                          engine: 'cloud',
+                          cloudProvider: provider,
+                          cloudModel: form.tts.cloud.model,
+                          fishSettings: provider === 'fish-audio'
+                            ? {
+                              temperature: form.tts.cloud.temperature,
+                              topP: form.tts.cloud.topP,
+                              latency: form.tts.cloud.latency,
+                            }
+                            : undefined,
+                          adminFetch,
+                        }}
                       />
+                      {!isPreset && (
+                        <Input
+                          // A blank compat voice is legitimate — the server picks
+                          // its own default — so don't flag it red.
+                          className={cn('mt-2', voice || isCompat ? 'border-ink' : 'border-[var(--danger)]')}
+                          value={form.tts.cloud.voice}
+                          maxLength={100}
+                          placeholder={isCompat ? 'Blank = server default' : 'Enter a custom voice id'}
+                          onChange={(e: ChangeEvent<HTMLInputElement>) => setVoice(e.target.value)}
+                        />
+                      )}
                       <div className="field-hint">
-                        {voiceDiscovery.loading
-                          ? 'Checking the server for a voice list…'
-                          : <>Server-specific: Chatterbox cloning ref name, Qwen3
-                              speaker id, etc. Leave blank to let the server pick its
-                              own default.</>}
+                        Used when a Cloud persona hasn’t set its own voice.{' '}
+                        {discoveredVoices.length > 0
+                          ? <>{discoveredVoices.length} voice{discoveredVoices.length === 1 ? '' : 's'} found
+                              on your {isCompat ? 'server' : 'account'}. Or choose <em>Custom voice id…</em> to
+                              enter one that isn’t listed.</>
+                          : <>Pick a default, or choose <em>Custom voice id…</em> for any other OpenAI voice
+                              name, ElevenLabs voice id, or Fish Audio reference id.</>}
                       </div>
                     </div>
                   );
-                }
-                return (
-                  <div className="field">
-                    <Label>Default voice</Label>
-                    <VoicePicker
-                      value={isPreset ? voice : CUSTOM_VOICE_ID}
-                      onChange={val => {
-                        // Clearing the preset flips isPreset false, revealing the
-                        // free-text input below.
-                        setVoice(val === CUSTOM_VOICE_ID ? '' : val);
-                      }}
-                      groups={buildCloudVoiceGroups(provider, discoveredVoices)}
-                      title="Default cloud voice"
-                      preview={{
-                        engine: 'cloud',
-                        cloudProvider: provider,
-                        cloudModel: form.tts.cloud.model,
-                        fishSettings: provider === 'fish-audio'
-                          ? {
-                            temperature: form.tts.cloud.temperature,
-                            topP: form.tts.cloud.topP,
-                            latency: form.tts.cloud.latency,
-                          }
-                          : undefined,
-                        adminFetch,
-                      }}
-                    />
-                    {!isPreset && (
-                      <Input
-                        // A blank compat voice is legitimate — the server picks
-                        // its own default — so don't flag it red.
-                        className={cn('mt-2', voice || isCompat ? 'border-ink' : 'border-[var(--danger)]')}
-                        value={form.tts.cloud.voice}
-                        maxLength={100}
-                        placeholder={isCompat ? 'Blank = server default' : 'Enter a custom voice id'}
-                        onChange={(e: ChangeEvent<HTMLInputElement>) => setVoice(e.target.value)}
-                      />
-                    )}
-                    <div className="field-hint">
-                      Used when a Cloud persona hasn’t set its own voice.{' '}
-                      {discoveredVoices.length > 0
-                        ? <>{discoveredVoices.length} voice{discoveredVoices.length === 1 ? '' : 's'} found
-                            on your {isCompat ? 'server' : 'account'}. Or choose <em>Custom voice id…</em> to
-                            enter one that isn’t listed.</>
-                        : <>Pick a default, or choose <em>Custom voice id…</em> for any other OpenAI voice
-                            name, ElevenLabs voice id, or Fish Audio reference id.</>}
-                    </div>
-                  </div>
-                );
-              })()}
-            </div>
-            {!isCompat && (() => {
-              const cloudKeyVar = envKeyForCloudProvider(form.tts.cloud.provider);
-              return (
-                <>
-                  <div className="field">
-                    <Label>{cloudProviderLabel(form.tts.cloud.provider)} API key</Label>
-                    <div className="flex flex-wrap items-stretch gap-2 sm:flex-nowrap">
-                      <Input
-                        type="password"
-                        autoComplete="off"
-                        value={cloudKeyInput}
-                        placeholder={data.env?.[cloudKeyVar] ? '•••••• (on file)' : (KEY_HINTS[cloudKeyVar] ?? '')}
-                        onChange={(e: ChangeEvent<HTMLInputElement>) => setCloudKeyInput(e.target.value)}
-                        className="max-w-[360px]"
-                      />
-                      <Btn
-                        onClick={testCloudKey}
-                        disabled={cloudKeyTesting || (!cloudKeyInput.trim() && !data.env?.[cloudKeyVar])}
-                      >
-                        {cloudKeyTesting ? 'Testing…' : 'Test key'}
-                      </Btn>
-                    </div>
-                    <div className="field-hint">
-                      Stored in <code>state/secrets.env</code>, takes effect immediately. Leave blank to keep the existing key.
-                    </div>
-                    {cloudKeyVar === 'OPENAI_API_KEY' && (
-                      <div className="field-hint">
-                        This key is shared across LLM and Cloud TTS.
-                      </div>
-                    )}
-                  </div>
-                  {cloudKeyTest && <KeyTestResult result={cloudKeyTest} />}
-                </>
-              );
-            })()}
-            {isCompat && (
-              <div className="field">
-                <Label>API key</Label>
-                <Input
-                  type="password"
-                  autoComplete="off"
-                  value={compatKeyInput}
-                  placeholder={savedCloud.apiKey === 'set' ? '•••••• (on file)' : 'Optional'}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => setCompatKeyInput(e.target.value)}
-                  className="max-w-[360px]"
-                />
-                <div className="field-hint">
-                  Optional, only if your server requires one (e.g. SUB/WAVE DJ
-                  Brain); most self-hosted servers accept any non-empty key.
-                  Blank keeps the existing key. Saved with these settings, takes
-                  effect immediately.
-                </div>
+                })()}
               </div>
-            )}
-            <TtsGainField engineId="cloud" form={form} setForm={setForm} />
-            <TtsSpeedField engineId="cloud" form={form} setForm={setForm} />
-            {form.tts.cloud.provider === 'elevenlabs' && (
-              <ElevenLabsVoiceSettingsField form={form} setForm={setForm} />
-            )}
-            {isFish && <FishAudioSettingsField form={form} setForm={setForm} />}
-            {!isCompat && (() => {
-              const kv = envKeyForCloudProvider(form.tts.cloud.provider);
-              return <KeyStatus envVar={kv} present={!!data.env?.[kv]} />;
-            })()}
+            </div>
+
+            <div className="grid">
+              <GroupHead>Voice tuning</GroupHead>
+              <TtsGainField engineId="cloud" form={form} setForm={setForm} />
+              <TtsSpeedField engineId="cloud" form={form} setForm={setForm} />
+              {form.tts.cloud.provider === 'elevenlabs' && (
+                <ElevenLabsVoiceSettingsField form={form} setForm={setForm} />
+              )}
+              {isFish && <FishAudioSettingsField form={form} setForm={setForm} />}
+            </div>
           </div>
           );
         })()}

--- a/web/components/admin/tts/CloudProviderSelector.tsx
+++ b/web/components/admin/tts/CloudProviderSelector.tsx
@@ -1,0 +1,126 @@
+'use client';
+// Radio-card grid for picking a Cloud TTS provider, shared by the Settings voice
+// tab and the per-persona voice slot. Deliberately the same affordance as
+// EngineSelector one level up — picking OpenAI vs ElevenLabs is the same kind of
+// decision as picking Cloud vs Piper, and it used to be a tab strip, which read
+// as page navigation rather than a form field. The badge makes "this one has no
+// key" visible before the click instead of after it.
+import type { ReactNode } from 'react';
+import { cn } from '../../../lib/cn';
+import {
+  CLOUD_PROVIDER_META, cloudProviderStatus,
+  type CloudProviderAvailability, type CloudProviderStatusOpts,
+} from './cloudProviderMeta';
+
+interface CloudProviderSelectorProps {
+  value: string;
+  // The controller's data.tts.cloudProviders — never hardcoded here, so a
+  // provider added server-side shows up without a UI change.
+  providerIds: string[];
+  availability?: CloudProviderAvailability;
+  statusOpts?: CloudProviderStatusOpts;
+  onChange: (id: string) => void;
+  // Shown under the grid whatever the selection, above the enable hint.
+  hint?: ReactNode;
+  // The "how to fix it" note for a provider that can't speak. Off where the fix
+  // is the very next field — the Settings panel would otherwise point down at a
+  // key input that already points back up at itself.
+  enableHint?: boolean;
+  className?: string;
+  gridClassName?: string;
+}
+
+export function CloudProviderSelector({
+  value, providerIds, availability, statusOpts, onChange, hint,
+  enableHint = true, className, gridClassName,
+}: CloudProviderSelectorProps) {
+  const selected = cloudProviderStatus(value, availability, statusOpts);
+  return (
+    <div className={cn('grid gap-2.5', className)}>
+      <div
+        role="radiogroup"
+        aria-label="Cloud TTS provider"
+        // Two-up by default: the persona voice card puts this in a half-width
+        // column, where four across would crush "OpenAI-compatible". Full-width
+        // callers widen it themselves.
+        className={cn('grid grid-cols-2 gap-2.5', gridClassName)}
+      >
+        {providerIds.map(id => {
+          const meta = CLOUD_PROVIDER_META[id];
+          const status = cloudProviderStatus(id, availability, statusOpts);
+          const active = value === id;
+          const muted = status.state === 'off';
+          return (
+            <button
+              key={id}
+              type="button"
+              role="radio"
+              aria-checked={active}
+              onClick={() => onChange(id)}
+              className={cn(
+                'grid cursor-pointer content-start gap-1.5 border p-3 text-left font-[inherit]',
+                muted && !active && 'opacity-60',
+                active
+                  ? 'border-[var(--accent)] bg-[var(--accent-soft)]'
+                  : 'border-ink bg-transparent hover:bg-[var(--ink-softer)]',
+              )}
+            >
+              <div className="flex items-center gap-1.5">
+                <span
+                  className={cn(
+                    'size-2 flex-none rounded-full border',
+                    active ? 'border-[var(--accent)] bg-[var(--accent)]' : 'border-ink bg-transparent',
+                  )}
+                />
+                <span
+                  className={cn(
+                    'min-w-0 text-[10px] font-bold tracking-[0.16em] break-words uppercase',
+                    active ? 'text-vermilion' : 'text-ink',
+                  )}
+                >
+                  {meta?.label || id}
+                </span>
+              </div>
+              <div className="flex items-end justify-between gap-2">
+                <span className="min-w-0 text-[9px] leading-[1.4] text-muted">{meta?.blurb}</span>
+                {status.label && (
+                  <span
+                    className={cn(
+                      'flex-none border px-1 py-[1px] text-[8px] font-bold tracking-[0.1em] uppercase',
+                      status.tone === 'warn'
+                        ? 'border-[var(--danger)] text-[var(--danger)]'
+                        : 'border-[color:var(--separator-strong)] text-muted',
+                    )}
+                  >
+                    {status.label}
+                  </span>
+                )}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+      {hint && <div className="field-hint max-w-[70ch]">{hint}</div>}
+      {/* Enable hint for the selected provider. The live region stays mounted
+          (content toggles) so screen readers reliably announce it — a region
+          inserted on demand can miss its first announcement. Same pattern as
+          EngineSelector. */}
+      {enableHint && (
+        <p
+          role="status"
+          className={cn(
+            'text-[11px] leading-[1.55] text-muted',
+            selected.hint && 'border border-[var(--separator-strong)] bg-[var(--ink-softer)] px-3 py-2',
+          )}
+        >
+          {selected.hint && (
+            <>
+              {selected.hint.reason}.
+              {selected.hint.action && <> Next step: <code>{selected.hint.action}</code>.</>}
+            </>
+          )}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/components/admin/tts/EngineSelector.tsx
+++ b/web/components/admin/tts/EngineSelector.tsx
@@ -3,7 +3,9 @@
 // the Settings voice tab. The status badge makes availability visible before a
 // selection. Tailwind-only, no inline styles (issue #50).
 import { cn } from '../../../lib/cn';
-import { ENGINE_META, engineStatus, type EngineAvailability } from './engineMeta';
+import {
+  ENGINE_META, engineStatus, type EngineAvailability, type EngineStatusOpts,
+} from './engineMeta';
 
 interface EngineSelectorProps {
   value: string;
@@ -11,12 +13,20 @@ interface EngineSelectorProps {
   engineIds: string[];
   // SettingsResponse.tts.available — drives the per-card status badge.
   available?: EngineAvailability;
+  // Call-site wording for the "how to fix it" note; see EngineStatusOpts.
+  statusOpts?: EngineStatusOpts;
+  // Off where the call site already shows a more specific notice for the same
+  // fault — the generic "no key for the selected provider" line otherwise
+  // stacks under a red alert that has just said it with the provider named.
+  showStatusHint?: boolean;
   onChange: (id: string) => void;
   className?: string;
 }
 
-export function EngineSelector({ value, engineIds, available, onChange, className }: EngineSelectorProps) {
-  const hint = engineStatus(value, available).hint;
+export function EngineSelector({
+  value, engineIds, available, statusOpts, showStatusHint = true, onChange, className,
+}: EngineSelectorProps) {
+  const hint = showStatusHint ? engineStatus(value, available, statusOpts).hint : null;
   return (
     <div className={cn('grid gap-2.5', className)}>
       <div

--- a/web/components/admin/tts/EngineVoiceFields.tsx
+++ b/web/components/admin/tts/EngineVoiceFields.tsx
@@ -15,8 +15,9 @@ import { useVoiceDiscovery } from '../../../hooks/useVoiceDiscovery';
 import {
   CB_DEFAULT_VOICE, KOKORO_RE, CHATTERBOX_VOICE_RE, POCKET_TTS_VOICE_RE,
 } from '../personas/constants';
-import { Seg } from '../ui';
 import { EngineSelector } from './EngineSelector';
+import { CloudProviderSelector } from './CloudProviderSelector';
+import { resolveKeyPresence } from './cloudProviderMeta';
 import { VoicePreviewButton } from './VoicePreviewButton';
 import { VoicePicker, type VoicePickerGroup } from './VoicePicker';
 import { ENGINES, type EngineAvailability } from './engineMeta';
@@ -67,6 +68,8 @@ export const ENGINE_UNAVAILABLE: Record<string, ReactNode> = {
 // The slice of GET /settings this component reads. Structural on purpose — the
 // Personas and Settings pages model the rest of that payload differently.
 export interface EngineVoiceData {
+  // Which provider keys the controller can see; feeds the Cloud provider badge.
+  env?: Record<string, unknown>;
   tts?: {
     kokoroVoices?: string[];
     kokoroVoiceLanguages?: Record<string, string>;
@@ -104,7 +107,10 @@ export function EngineVoiceFields({
   const kokoroVoices: string[] = data?.tts?.kokoroVoices || [];
   const kokoroLanguages = data?.tts?.kokoroVoiceLanguages || {};
   const pocketTtsVoices = data?.tts?.pocketTtsVoices || [];
-  const cloudProviders = data?.tts?.cloudProviders || ['openai', 'elevenlabs'];
+  // Mirrors the controller's TTS_CLOUD_PROVIDERS, so a payload that predates the
+  // field still offers every provider the server accepts.
+  const cloudProviders = data?.tts?.cloudProviders
+    || ['openai', 'elevenlabs', 'fish-audio', 'openai-compatible'];
 
   // Every slot uses the station-wide server, so sending no base URL is right —
   // the server falls back to the saved one. ElevenLabs and Fish are gated on a
@@ -161,6 +167,10 @@ export function EngineVoiceFields({
     }
   }
 
+  // The caller's cloud alert names the provider and says what speaks instead,
+  // so it stands in for both generic "not configured" hints below it.
+  const cloudAlerted = value.engine === 'cloud' && !!cloudIssue;
+
   const notice = (engine: string) => (
     <div className="mb-2.5 border border-[var(--danger)] px-3 py-2.5 text-[11px] leading-[1.6] text-[var(--danger)]">
       {unavailableNote(engine)}
@@ -175,6 +185,7 @@ export function EngineVoiceFields({
           value={value.engine}
           engineIds={ENGINE_IDS}
           available={selectorAvailable}
+          showStatusHint={!cloudAlerted}
           onChange={selectEngine}
         />
         {engineHint && <div className="field-hint max-w-[70ch]">{engineHint}</div>}
@@ -398,21 +409,20 @@ export function EngineVoiceFields({
                 {cloudIssue}
               </div>
             )}
-            <div className="stack-mobile grid grid-cols-[1fr_1fr] gap-4">
+            {/* Provider and voice each get their own row: the provider grid is
+                four cards wide, and a voice id picked before the provider is
+                settled is a voice id that gets thrown away. */}
+            <div className="grid gap-4">
               <div className="field">
                 <Label>Cloud provider</Label>
-                <Seg
+                <CloudProviderSelector
                   value={value.cloudProvider}
-                  options={cloudProviders.map(id => ({
-                    id,
-                    label: id === 'fish-audio'
-                      ? 'Fish Audio'
-                      : id === 'elevenlabs'
-                        ? 'ElevenLabs'
-                        : id === 'openai'
-                          ? 'OpenAI'
-                          : 'OpenAI-compatible',
-                  }))}
+                  providerIds={cloudProviders}
+                  availability={{
+                    cloudByProvider: resolveKeyPresence(
+                      cloudProviders, data?.tts?.available?.cloudByProvider, data?.env,
+                    ),
+                  }}
                   onChange={v => {
                     // Switching provider invalidates the old voice id.
                     // openai-compatible has no curated voices, so blank lets
@@ -420,14 +430,13 @@ export function EngineVoiceFields({
                     const next = CLOUD_VOICES[v as keyof typeof CLOUD_VOICES]?.[0]?.id || '';
                     onChange({ cloudProvider: v, voice: next });
                   }}
+                  enableHint={!cloudAlerted}
+                  hint={isCompat
+                    ? <>The base URL and model come from the station’s Cloud settings. Only the voice is set here.</>
+                    : <>The API key and model come from the station’s Cloud settings. Only the voice is set here.</>}
                 />
-                <div className="field-hint">
-                  {isCompat
-                    ? 'Uses the shared base URL + model from Settings.'
-                    : 'Uses the shared API key + model from Settings.'}
-                </div>
               </div>
-              <div className="field">
+              <div className="field max-w-[420px]">
                 <Label>Cloud voice</Label>
                 {!hasList ? (
                   <>

--- a/web/components/admin/tts/cloudProviderMeta.ts
+++ b/web/components/admin/tts/cloudProviderMeta.ts
@@ -1,0 +1,132 @@
+// Single source of truth for the Cloud TTS provider picker, shared by the
+// Settings voice tab and the per-persona voice slot. No React, no DOM — safe to
+// unit-import. Mirrors engineMeta.ts, one level down: Cloud is an engine, these
+// are the services it can speak through.
+
+export interface CloudProviderMeta {
+  id: string;
+  label: string;
+  // One-line descriptor under the name — what the operator is choosing.
+  blurb: string;
+}
+
+// Order mirrors the controller's cloudProviders list (audio/cloudTts.ts).
+export const CLOUD_PROVIDERS: CloudProviderMeta[] = [
+  { id: 'openai', label: 'OpenAI', blurb: 'Cheap · fast · stock voices' },
+  { id: 'elevenlabs', label: 'ElevenLabs', blurb: 'Most natural · your library' },
+  { id: 'fish-audio', label: 'Fish Audio', blurb: 'Expressive · performance cues' },
+  { id: 'openai-compatible', label: 'OpenAI-compatible', blurb: 'Your own server · no key' },
+];
+
+export const CLOUD_PROVIDER_META: Record<string, CloudProviderMeta> = Object.fromEntries(
+  CLOUD_PROVIDERS.map(p => [p.id, p]),
+);
+
+// Display label for a provider id, including ones not in the curated list (the
+// controller is free to report more).
+export function cloudProviderLabel(id: string): string {
+  return CLOUD_PROVIDER_META[id]?.label || id;
+}
+
+// The process env var each managed provider's key lives in. `openai-compatible`
+// has no managed-key convention and is absent on purpose.
+export const CLOUD_PROVIDER_ENV_KEY: Record<string, string> = {
+  openai: 'OPENAI_API_KEY',
+  elevenlabs: 'ELEVENLABS_API_KEY',
+  'fish-audio': 'FISH_API_KEY',
+};
+
+// Whether each provider has a key behind it, for the picker's badge.
+//
+// `available.cloudByProvider` alone answers a narrower question than the badge
+// asks: it also folds in the saved `tts.cloud.enabled` switch, so on a station
+// that has never saved a Cloud engine it reads false for EVERY provider — which
+// is precisely when this picker is on screen. The badge would then say "no key"
+// directly above a key-status panel saying the key is present. Env presence
+// (`GET /settings`'s `env` booleans, the same source that panel reads) is the
+// tiebreaker; either one being true means there is a key.
+export function resolveKeyPresence(
+  providerIds: string[],
+  cloudByProvider: Record<string, boolean> | undefined,
+  env: Record<string, unknown> | undefined,
+): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const id of providerIds) {
+    const envVar = CLOUD_PROVIDER_ENV_KEY[id];
+    if (!envVar) continue; // openai-compatible resolves off its base URL instead
+    const configured = cloudByProvider?.[id];
+    const envSet = !!env?.[envVar];
+    // An absent flag AND no env key means "not yet known" — leave the id out so
+    // cloudProviderStatus renders no badge rather than a wrong one.
+    if (configured === undefined && !envSet) continue;
+    out[id] = !!configured || envSet;
+  }
+  return out;
+}
+
+export type CloudProviderStatusTone = 'ok' | 'warn';
+// 'ready' = usable now; 'off' = will fall back until the operator acts;
+// 'unknown' = the caller can't tell (the persona slot doesn't see the base URL),
+// which renders no badge rather than a wrong one.
+export type CloudProviderStatusState = 'ready' | 'off' | 'unknown';
+
+export interface CloudProviderEnableHint {
+  reason: string;
+  action?: string;
+}
+
+export interface CloudProviderStatus {
+  label: string;
+  tone: CloudProviderStatusTone;
+  state: CloudProviderStatusState;
+  // Present whenever state === 'off'.
+  hint?: CloudProviderEnableHint;
+}
+
+export interface CloudProviderAvailability {
+  // SettingsResponse.tts.available.cloudByProvider — key-based providers only.
+  cloudByProvider?: Record<string, boolean>;
+  // Whether the shared openai-compatible base URL is set. `undefined` where the
+  // caller can't see it (the persona slot reads the station's saved value), and
+  // that gap is why the state has an explicit 'unknown'.
+  compatBaseUrlSet?: boolean;
+}
+
+export interface CloudProviderStatusOpts {
+  // Where the operator adds a missing key. The Settings voice tab carries the
+  // field itself, the persona slot has to point at it — same status, different
+  // next step, so the copy is the caller's to supply.
+  keyAction?: string;
+}
+
+// Badge + machine state + enable hint in one branch tree so the three can never
+// disagree — same contract as engineMeta.engineStatus. A missing flag means
+// "not yet known", so only a hard `=== false` is flagged.
+export function cloudProviderStatus(
+  id: string,
+  availability: CloudProviderAvailability | undefined,
+  opts: CloudProviderStatusOpts = {},
+): CloudProviderStatus {
+  const a = availability || {};
+  if (id === 'openai-compatible') {
+    // No key-based entry: this provider is trusted once it has somewhere to
+    // send the request.
+    if (a.compatBaseUrlSet === undefined) return { label: '', tone: 'ok', state: 'unknown' };
+    return a.compatBaseUrlSet
+      ? { label: 'server set', tone: 'ok', state: 'ready' }
+      : {
+          label: 'no server', tone: 'warn', state: 'off',
+          hint: { reason: 'No base URL is set for your OpenAI-compatible server', action: 'enter its /v1 URL below' },
+        };
+  }
+  const configured = a.cloudByProvider?.[id];
+  if (configured === undefined) return { label: '', tone: 'ok', state: 'unknown' };
+  if (configured) return { label: 'key set', tone: 'ok', state: 'ready' };
+  return {
+    label: 'no key', tone: 'warn', state: 'off',
+    hint: {
+      reason: `No API key is configured for ${cloudProviderLabel(id)}`,
+      action: opts.keyAction || 'add it in Settings → Voice',
+    },
+  };
+}

--- a/web/components/admin/tts/engineMeta.ts
+++ b/web/components/admin/tts/engineMeta.ts
@@ -51,12 +51,20 @@ export interface EngineAvailability {
   [engine: string]: boolean | string[] | null | Record<string, boolean> | undefined;
 }
 
+export interface EngineStatusOpts {
+  // What to do about an unconfigured Cloud engine. The default points at the
+  // Settings voice tab, which is wrong copy when you are already standing on
+  // it — that page passes its own.
+  cloudKeyAction?: string;
+}
+
 // Badge + machine state + enable hint in one branch tree, so the three can never
 // disagree. A missing flag means "not yet known / assumed up", so only a hard
 // `=== false` is flagged. `warn` is the recoverable-problem tone.
 export function engineStatus(
   id: string,
   available: EngineAvailability | undefined,
+  opts: EngineStatusOpts = {},
 ): EngineStatus {
   const a = available || {};
   switch (id) {
@@ -96,7 +104,10 @@ export function engineStatus(
       return a.cloud === false
         ? {
             label: 'no key', tone: 'warn', state: 'off',
-            hint: { reason: 'No API key is configured for the selected provider', action: 'add it in Settings → Voice' },
+            hint: {
+              reason: 'No API key is configured for the selected provider',
+              action: opts.cloudKeyAction || 'add it in Settings → Voice',
+            },
           }
         : { label: 'key set', tone: 'ok', state: 'ready' };
     case 'remote':


### PR DESCRIPTION
The Cloud provider choice was a tab strip — it read as page navigation rather than a form field, and said nothing about which providers were actually usable. It is now the same radio-card grid as the engine picker one level up, with a per-provider readiness badge, in a shared `CloudProviderSelector` both surfaces use.

## Settings → TTS voice

The Cloud panel is ordered into three labelled steps — **Provider**, **Connection**, **Model & voice** — plus **Voice tuning**.

Model and voice discovery both depend on the credentials, so those move above them. Previously the model hint read *"Set an API key above to discover and select a model"* while the key field sat below it.

## Personas → edit → Voice

The provider grid and **Cloud voice** each get their own row rather than sharing a two-column split.

## Three notices for the same fault, collapsed to one

The provider badge now reads key presence directly from `env` instead of `available.cloudByProvider`. That flag also folds in the saved `tts.cloud.enabled` switch, so on a station that had never saved a Cloud engine it reported "no key" for *every* provider — including ones whose key was plainly on file, directly above a panel saying so.

`cloudIssue()` splits the same two causes apart: a persona with credentials is now told the station-wide Cloud switch is off, rather than sent hunting for a key it already has. Where that specific alert shows, the two generic "not configured" hints above it stand down.

## Verified

Isolated controller + worktree dev server, driven in Chrome:

- Settings, all three provider shapes — OpenAI (no key), ElevenLabs (key set), OpenAI-compatible (base URL + optional key, no key-status panel). Switching providers relabels the key field, swaps model/voice defaults, and shows the ElevenLabs/Fish tuning sliders.
- Personas, Marlowe → Cloud — badges match the alert in both directions: with a key, "Cloud TTS is switched off for the station"; without, "OPENAI_API_KEY is not configured in Settings".

`npm run lint` in `web/` is clean (3 pre-existing warnings in `playlist-builder/generate.ts`, untouched).

No controller or contract changes — presentation, copy, and one client-side readiness derivation.