### PR TITLE
Link news articles to manual pages and cross-references

### DIFF
--- a/web/content/news/2026-05-12-what-is-subwave.md
+++ b/web/content/news/2026-05-12-what-is-subwave.md
@@ -29,6 +29,6 @@ The DJ pulls from what you actually own, so the station sounds like your taste, 
 
 ## Tune in
 
-Open the player and hit play. If you're setting up your own, the [setup guide](/setup) gets you on air in about ten minutes. Everything past the first three settings is configured from the admin screen: the DJ's voice, its personality, how chatty it is, the look of the player.
+Open the player and hit play. The DJ [takes requests](/news/request-a-track), and the stream plays on [far more than a browser](/news/listen-anywhere). If you're setting up your own, the [setup guide](/setup) gets you on air in about ten minutes. Everything past the first three settings is configured from the [admin screen](/manual/admin): the DJ's [voice](/manual/voices), its personality, how chatty it is, the [look of the player](/manual/themes).
 
 It's your station. It just happens to run itself.

--- a/web/content/news/2026-05-18-bring-your-own-llm.md
+++ b/web/content/news/2026-05-18-bring-your-own-llm.md
@@ -14,13 +14,13 @@ Fresh installs talk to a local [Ollama](https://ollama.com) box. It needs no API
 
 ## How to switch
 
-Open admin, go to the LLM settings, and pick a provider:
+Open admin, go to the [LLM settings](/manual/llm), and pick a provider:
 
 - Ollama (local, the default)
 - Any OpenAI-compatible server (llama.cpp, vLLM, LM Studio) by pasting its base URL
 - OpenAI, Anthropic, Google, DeepSeek, OpenRouter, or the Vercel AI Gateway
 
-Drop in a model name and an API key if the provider needs one, then save. That's it. Every call the DJ makes reroutes to the new model immediately, whether that's picking the next track, writing an intro, or matching a request. No rebuild, no restart, no code change.
+Drop in a model name and an API key if the provider needs one, then save. That's it. (Running GGUF models through locca? It gets [first-class treatment of its own](/news/run-on-locca).) Every call the DJ makes reroutes to the new model immediately, whether that's picking the next track, writing an intro, or matching a request. No rebuild, no restart, no code change.
 
 ## Why it matters
 

--- a/web/content/news/2026-05-22-listen-anywhere.md
+++ b/web/content/news/2026-05-22-listen-anywhere.md
@@ -10,7 +10,7 @@ Under the hood SUB/WAVE broadcasts a normal Icecast stream. Nothing proprietary.
 
 ## The easy way
 
-Open the player in any browser and press play. On a phone you can install it as an app with "Add to Home Screen," and it behaves like a native player, with controls on your lock screen, your headphones, and CarPlay or Android Auto.
+Open the [player](/listen) in any browser and press play. On a phone you can install it as an app with "Add to Home Screen," and it behaves like a native player, with controls on your lock screen, your headphones, and CarPlay or Android Auto.
 
 ## Everywhere else
 
@@ -19,6 +19,8 @@ Want it on the good speakers? Point any of these at the stream URL:
 - Sonos and other networked speakers
 - A car receiver or an old hardware internet radio
 - VLC, or any desktop audio player that opens a URL
+
+The exact URLs, with per-device walkthroughs, are in the manual's [Listen With](/manual/clients) page. And the community has built players of its own, desktop apps, terminal clients, even a Raspberry Pi desk radio: browse them at [/apps](/apps).
 
 The station serves two versions of the same broadcast. Modern browsers and players get Opus, which sounds great at about half the bandwidth. Everything else gets MP3, the universal fallback that Sonos, car stereos, and older devices all understand. The web player sniffs your browser and picks the better one for you.
 

--- a/web/content/news/2026-05-25-request-a-track.md
+++ b/web/content/news/2026-05-25-request-a-track.md
@@ -17,7 +17,7 @@ Open the request panel in the player and type what you're after. You don't need 
 - "More of this, but older"
 - A specific song or artist by name
 
-Send it. The DJ reads what you meant (the artist, the mood, the intent), finds candidates in your library, and lines one up.
+Send it. The DJ reads what you meant (the artist, the mood, the intent), finds candidates in your library, and lines one up. More phrasing tricks live in the manual's [Making Requests](/manual/requests) page.
 
 <figure data-shot="phone">
   <img src="/screenshots/player-request-song.webp" alt="The request panel on a phone: a slip headed LINE OPEN with a handwritten-looking note and a signature underneath, four suggestion chips reading more like this, drive home vibes, overcast mood and surprise me, and a red SEND TO THE BOOTH button." />
@@ -25,7 +25,7 @@ Send it. The DJ reads what you meant (the artist, the mood, the intent), finds c
 
 ## What happens next
 
-Your pick joins the queue and plays for everyone, because there's only one stream. When it comes on, the DJ usually says a quick line introducing it, sometimes nodding to the request itself. It won't cut off the current song, because tracks always finish, so think of it as leaning over and asking the DJ, not grabbing the aux cord.
+Your pick joins the queue and plays for everyone, because there's [only one stream](/news/what-is-subwave). When it comes on, the DJ usually says a quick line introducing it, sometimes nodding to the request itself. It won't cut off the current song, because tracks always finish, so think of it as leaning over and asking the DJ, not grabbing the aux cord.
 
 ## Why it's good
 

--- a/web/content/news/2026-05-28-themes-and-playback.md
+++ b/web/content/news/2026-05-28-themes-and-playback.md
@@ -11,7 +11,7 @@ Two changes this week. One you'll see, one you'll hear.
 
 ## Pick your own light or dark
 
-The station palette is still yours to set in admin, and that's what shapes the overall look for everyone. But the day-to-day light-or-dark choice is now personal. There's a switcher in the player header and in the admin header.
+The [station palette](/manual/themes) is still yours to set in admin, and that's what shapes the overall look for everyone. But the day-to-day light-or-dark choice is now personal. There's a switcher in the player header and in the admin header.
 
 Tap it to cycle light, dark, or system. System follows your device, so the player goes dark at night with everything else. Your pick is remembered on your device and doesn't change anyone else's view.
 
@@ -19,7 +19,7 @@ Tap it to cycle light, dark, or system. System follows your device, so the playe
 
 Firefox had a rough edge with the Opus stream: on some track changes the audio would just go silent until you reloaded. We traced it to how Firefox handled the Opus mount mid-stream.
 
-The fix is simple. Firefox now stays on the MP3 mount, which it handles cleanly through track changes. Chrome, Safari, and the rest still get Opus at roughly half the bandwidth. Nothing for you to do; it's the default now.
+The fix is simple. Firefox now stays on the [MP3 mount](/news/listen-anywhere), the same universal one Sonos and car stereos use, which it handles cleanly through track changes. Chrome, Safari, and the rest still get Opus at roughly half the bandwidth. Nothing for you to do; it's the default now.
 
 ## Why it helps
 

--- a/web/content/news/2026-05-30-clone-a-voice.md
+++ b/web/content/news/2026-05-30-clone-a-voice.md
@@ -25,7 +25,7 @@ Find a clean clip of the voice you want. A few seconds of clear speech is plenty
 state/voices/morning-host.wav
 ```
 
-Then open a DJ persona in admin and set its voice to that filename. Save. The next time that persona is on the desk, it speaks in the cloned voice. If a clone ever fails to load, PocketTTS falls back to one of its built-in voices so the segment still airs.
+Then open a DJ persona in admin and set its voice to that filename. Save. The next time that persona is on the desk, it speaks in the cloned voice. If a clone ever fails to load, PocketTTS falls back to one of its built-in voices so the segment still airs. Haven't switched a heavy engine on yet? [The setup nudge](/news/heavy-tts-setup-guide) walks you through it, and the manual's [Voices & TTS](/manual/voices) page covers every engine.
 
 Already had clips in the old `chatterbox-voices/` folder? Leave them. SUB/WAVE still reads that folder, so nothing breaks on upgrade.
 

--- a/web/content/news/2026-05-31-custom-dj-skills.md
+++ b/web/content/news/2026-05-31-custom-dj-skills.md
@@ -15,7 +15,7 @@ A skill is one between-track line. The DJ glances at something, then either says
 
 ## How to use it
 
-Each skill is a folder with a `SKILL.md` inside. The frontmatter sets the name and how often it can fire; the markdown body is the brief the DJ actually follows: what to say, the tone, when to keep mum.
+Each skill is a folder with a `SKILL.md` inside. The frontmatter sets the name and how often it can fire; the markdown body is the brief the DJ actually follows: what to say, the tone, when to keep mum. The full frontmatter reference is in the manual's [Custom Skills](/manual/skills) page.
 
 ```
 state/skills/
@@ -36,4 +36,4 @@ The skills that come in the box are files now, same as your own. On first boot t
 
 ## Why it bothers
 
-Your station starts to sound like yours. The bits between tracks stop being generic and start being the things you actually care about, in the voice you picked.
+Your station starts to sound like yours. The bits between tracks stop being generic and start being the things you actually care about, in the voice you picked. And a brief that lands doesn't have to stay home: skills can [travel between stations](/news/pass-a-skill-along), and the public catalog at [/skills](/skills) shows what other operators run.

--- a/web/content/news/2026-05-31-heavy-tts-setup-guide.md
+++ b/web/content/news/2026-05-31-heavy-tts-setup-guide.md
@@ -23,6 +23,8 @@ docker compose --profile tts-heavy up -d
 
 That brings up a separate container holding both heavy engines. It shares the same volume as the controller, so once it's running your chosen voice just works, with no extra wiring. Until then the station keeps talking on Piper, so you never go off air while you sort it out.
 
+Once the sidecar is up, both engines can [clone a voice from a single WAV](/news/clone-a-voice), and Chatterbox can move onto [an NVIDIA card](/news/chatterbox-on-the-gpu) if you have one. The manual's [Voices & TTS](/manual/voices) page compares all five engines.
+
 ## Why it helps
 
 You stop guessing. The reason a voice didn't change is now on the screen, with the fix next to it, so getting the good voices going takes a minute instead of a debugging session.

--- a/web/content/news/2026-06-01-dj-mode-mixes.md
+++ b/web/content/news/2026-06-01-dj-mode-mixes.md
@@ -10,7 +10,7 @@ DJ mode used to change what the DJ said. It teased the next track and called bac
 
 ## What's new
 
-When a persona is in DJ mode, the crossfade stops being one fixed length. It shapes each join to the two tracks:
+When a persona is in [DJ mode](/manual/dj), the crossfade stops being one fixed length. It shapes each join to the two tracks:
 
 - Tracks that **share a tempo and key** lock into a short, tight blend.
 - A **clash** gets a longer wash that hides the seam.
@@ -20,7 +20,7 @@ It also times its between-track line to finish before the vocals come in, and it
 
 ## How to use it
 
-First, analyse your library so the station knows each track's tempo, key, and intro length:
+First, [analyse your library](/manual/analysis) so the station knows each track's tempo, key, and intro length:
 
 ```
 cd controller && npm run analyze
@@ -36,4 +36,4 @@ For the riser flourishes, open Settings, go to the Sound FX tab, and leave "Enab
 
 ## Why it helps
 
-A fixed ten second fade treats every pair of songs the same. This reads the tempo and key and shapes each join to fit. Compatible tracks slide together. A clash gets a longer wash, and the DJ talks over the intro instead of the vocals. The station starts to sound like a set instead of a shuffle.
+A fixed ten second fade treats every pair of songs the same. This reads the tempo and key and shapes each join to fit. Compatible tracks slide together. A clash gets a longer wash, and the DJ talks over the intro instead of the vocals. The station starts to sound like a set instead of a shuffle. The named transition moves the DJ picks between got [a dispatch of their own](/news/four-ways-to-leave-a-track).

--- a/web/content/news/2026-06-04-put-your-station-on-the-map.md
+++ b/web/content/news/2026-06-04-put-your-station-on-the-map.md
@@ -6,11 +6,11 @@ author: The SUB/WAVE desk
 excerpt: The new /stations page is a live directory of SUB/WAVE stations around the world. Add yours with a short form and it shows what it is playing the moment it merges.
 ---
 
-SUB/WAVE is self-hosted, so anyone can run their own station. Until now there was no way to find out who else did. The new /stations page is a directory of stations around the world, with a map and a grid that shows who is on the air right now.
+SUB/WAVE is self-hosted, so anyone can run their own station. Until now there was no way to find out who else did. The new [/stations](/stations) page is a directory of stations around the world, with a map and a grid that shows who is on the air right now.
 
 ## What's new
 
-Visit /stations and you get three things:
+Visit [/stations](/stations) and you get three things:
 
 - **A live grid of station cards**, each showing what it's playing this second.
 - **A world map** with every station plotted as a dot and labelled by city.
@@ -24,4 +24,4 @@ Adding your station takes a minute and needs no fork. On the page, click "Add yo
 
 ## Why it helps
 
-A self-hosted network is invisible by default. This gives it a home. You can see who else is running a station, hear what they are playing right now, and add your own to the map in a couple of minutes. One file per station keeps submissions easy to review and easy to revert, so the directory grows by contribution without getting messy.
+A self-hosted network is invisible by default. This gives it a home. You can see who else is running a station, hear what they are playing right now, and add your own to the map in a couple of minutes. (Not on air yet? The [setup guide](/setup) gets a station running first.) One file per station keeps submissions easy to review and easy to revert, so the directory grows by contribution without getting messy.

--- a/web/content/news/2026-06-06-your-dj-knows-your-library.md
+++ b/web/content/news/2026-06-06-your-dj-knows-your-library.md
@@ -12,7 +12,7 @@ Your DJ can only play a track once it knows that track's mood and energy. Workin
 
 ![The rebuilt Library page: a headline reading how much of the library the DJ knows, a mood-and-energy progress bar with the tagged count under it, a line of acoustic-analysis coverage, a Start tagging button, and a list of recently added tracks showing their mood tags](/screenshots/admin-library.webp)
 
-The old page had two control strips that both talked about tagging, and neither said why it mattered. Now there's one panel. It opens with a plain line, "Your DJ knows 92% of your library", and under that sits the count of tagged tracks, how many still need it, and one button to close the gap. Every row shows its moods and energy as small tags, so you can see what tagging actually produces. Browse filters by mood, energy, genre, and year.
+The old page had two control strips that both talked about tagging, and neither said why it mattered. Now there's one panel. It opens with a plain line, "Your DJ knows 92% of your library", and under that sits the count of tagged tracks, how many still need it, and one button to close the gap. Every row shows its moods and energy as small tags, so you can see what tagging actually produces. Browse filters by mood, energy, genre, and year. The [acoustic analysis](/manual/analysis) coverage sits on the same panel.
 
 ## How to use it
 
@@ -23,3 +23,5 @@ Changed your embedding model lately? Open "Maintenance and re-scan" in the same 
 ## Why it helps
 
 Tagging is what lets the DJ reach for the right track instead of playing at random. The state of it is now in front of you: what's done, what's left, and a button for the rest. And a model swap no longer paints you into a corner, since you re-embed from the same place.
+
+Two shortcuts worth knowing: already tagged your library in AudioMuse-AI? [The importer](/news/import-from-audiomuse) carries that work across. And once tagging is done, the [Library Observatory](/news/see-the-shape-of-your-library) turns the whole thing into one picture.

--- a/web/content/news/2026-06-13-see-the-shape-of-your-library.md
+++ b/web/content/news/2026-06-13-see-the-shape-of-your-library.md
@@ -10,7 +10,7 @@ The DJ holds a lot in its head: every track's mood, energy, tempo, key, and a pa
 
 ## What's new
 
-It's a full-screen map of every track you've tagged. Each one is a point, sitting near others in its genre, lit on an ink-to-vermilion ramp by how energetic it is. Faint lines wire close neighbours together. Pan around, scroll to zoom.
+It's a full-screen map of every track [you've tagged](/news/your-dj-knows-your-library). Each one is a point, sitting near others in its genre, lit on an ink-to-vermilion ramp by how energetic it is. Faint lines wire close neighbours together. Pan around, scroll to zoom.
 
 The panels down the right keep a running count:
 
@@ -23,11 +23,7 @@ The panels down the right keep a running count:
 
 ## How to use it
 
-Open admin and click Observatory in the nav, or go straight to:
-
-```
-/observatory
-```
+Open admin and click Observatory in the nav, or go straight to [/observatory](/observatory).
 
 Click any point to open its dossier: BPM, key, energy, loudness, its mood and last.fm tags, and the track's text and audio fingerprints. There's a song-shape timeline too, charting the track end to end: its pace curve, where the intro ends, the sections, the vocal passages, and how the key moves over time. Under that sits Mix Next, the closest tracks in vector space, with the links drawn back onto the map. Recolour the map by energy, confidence, tag source, analysis, loudness, pace, or voice from the left rail, and filter by scene, mood, or tag source.
 
@@ -35,7 +31,7 @@ Click any point to open its dossier: BPM, key, energy, loudness, its mood and la
   <img src="/screenshots/observatory-track.webp" alt="The top of a track dossier: title, artist and album, then BPM, key, energy and length, the mood tags and their energy and acoustic meters. Below the crop sit the text and audio embedding fingerprints and the nearest tracks in vector space." />
 </figure>
 
-Big library? Use the MAP SIZE control in the rail. It draws up to 25,000 tracks by default and goes to 100,000. Past that it shows an even sample across genres, so the shape stays honest.
+Big library? Use the MAP SIZE control in the rail. It draws up to 25,000 tracks by default and goes to 100,000. Past that it shows an even sample across genres, so the shape stays honest. Every rail control is documented in the manual's [Library Observatory](/manual/observatory) page.
 
 ## Why it helps
 

--- a/web/content/news/2026-06-17-run-on-locca.md
+++ b/web/content/news/2026-06-17-run-on-locca.md
@@ -6,7 +6,7 @@ author: The SUB/WAVE desk
 excerpt: locca is now a first-class LLM provider. Point SUB/WAVE at a local llama.cpp server for the DJ, and a locca embedding server for the library tagger. No API keys, no cloud.
 ---
 
-SUB/WAVE already ran on Ollama or any cloud model. Now it runs on locca too. locca is a small TUI around llama.cpp for local GGUF models, and SUB/WAVE treats it as a first-class provider for both the DJ and the library tagger. No hand-typed server URLs.
+SUB/WAVE already ran on [Ollama or any cloud model](/news/bring-your-own-llm). Now it runs on locca too. locca is a small TUI around llama.cpp for local GGUF models, and SUB/WAVE treats it as a first-class provider for both the DJ and the library tagger. No hand-typed server URLs.
 
 ## What's new
 
@@ -50,4 +50,4 @@ Click Test embeddings, then Start tagging.
 
 ## Why it helps
 
-The whole station runs on your own hardware. The DJ thinks on a local model and the tagger embeds your library locally, so nothing leaves the box. Switch providers later from admin with no redeploy.
+The whole station runs on your own hardware. The DJ thinks on a local model and the tagger embeds your library locally, so nothing leaves the box. Switch providers later from admin with no redeploy. Provider details and token budgets live in the manual's [Models & Tokens](/manual/llm) page.

--- a/web/content/news/2026-06-21-chatterbox-on-the-gpu.md
+++ b/web/content/news/2026-06-21-chatterbox-on-the-gpu.md
@@ -6,7 +6,7 @@ author: The SUB/WAVE desk
 excerpt: The tts-heavy sidecar ships CPU-only, but with a small rebuild you can move Chatterbox onto an nvidia card for faster voice synthesis. Here is the index swap, the compose change, and the one caveat.
 ---
 
-The heavy TTS sidecar ships CPU-only on purpose. The PyTorch wheels inside it are the CPU build, which keeps the image from ballooning by several gigabytes. That is the right default for most boxes. But if you just moved your Docker host to a machine with a real nvidia card, you can put Chatterbox on it and get faster voice synthesis. It takes a small rebuild.
+The [heavy TTS sidecar](/news/heavy-tts-setup-guide) ships CPU-only on purpose. The PyTorch wheels inside it are the CPU build, which keeps the image from ballooning by several gigabytes. That is the right default for most boxes. But if you just moved your Docker host to a machine with a real nvidia card, you can put Chatterbox on it and get faster voice synthesis. It takes a small rebuild.
 
 ## What you're changing
 
@@ -52,4 +52,6 @@ The worker logs which device it loaded on. Look for `loading ChatterboxTurboTTS 
 
 ## One caveat
 
-Only Chatterbox follows `TTS_HEAVY_DEVICE`. PocketTTS and the audio analyzer stay on the CPU no matter what. So this is worth doing if Chatterbox is your DJ voice, where it is the heaviest of the engines and the card buys you the most. On PocketTTS it changes nothing.
+Only Chatterbox follows `TTS_HEAVY_DEVICE`. PocketTTS and the audio analyzer stay on the CPU no matter what. So this is worth doing if Chatterbox is your [DJ voice](/manual/voices), where it is the heaviest of the engines and the card buys you the most. On PocketTTS it changes nothing.
+
+*Update: the analyzer has since grown [a CUDA image of its own](/news/analyzer-on-the-gpu), no Dockerfile edit required, so the acoustic side of the load can move to the card too.*

--- a/web/content/news/2026-06-22-one-click-on-unraid.md
+++ b/web/content/news/2026-06-22-one-click-on-unraid.md
@@ -24,7 +24,7 @@ Open the Apps tab, search for SUB/WAVE, and hit Install. Four fields to fill in:
 
 Apply, then open the WebUI and go to `/onboarding` to point it at your Navidrome server and pick a voice and an LLM. Keep Appdata on your array or pool, not the USB flash. The station's recordings and library cache grow over time, and the flash is the wrong place for that.
 
-No big GPU? That's most Unraid boxes. Install the official ollama container, run `ollama signin` in its console, and pick a cloud model. A small local model works too if you'd rather keep everything on the box.
+No big GPU? That's most Unraid boxes. Install the official ollama container, run `ollama signin` in its console, and [pick a cloud model](/news/bring-your-own-llm). A small local model works too if you'd rather keep everything on the box. And if there is an NVIDIA card in the machine, the all-in-one image now has [a CUDA flavour](/news/one-click-on-the-gpu) that puts it to work on library analysis.
 
 ## Why it helps
 

--- a/web/content/news/2026-06-23-meet-the-booth-buddy.md
+++ b/web/content/news/2026-06-23-meet-the-booth-buddy.md
@@ -10,7 +10,7 @@ The player has a new resident. It's a small pixel creature that sits at the head
 
 ## What's new
 
-The booth buddy is a tiny mascot drawn entirely in CSS, so it adds nothing to load and picks up your theme colours on its own. It has five moods:
+The booth buddy is a tiny mascot drawn entirely in CSS, so it adds nothing to load and picks up your [theme colours](/manual/themes) on its own. It has five moods:
 
 - **On air** — open mouth and a pulsing antenna while the DJ is talking.
 - **Curious** — a head tilt and wide eyes while the DJ picks the next track.

--- a/web/content/news/2026-06-29-your-own-tts-server.md
+++ b/web/content/news/2026-06-29-your-own-tts-server.md
@@ -11,7 +11,7 @@ There's a new voice engine called Remote. It points SUB/WAVE at a text-to-speech
 
 ## What's new
 
-Until now, self-hosting a TTS engine meant either baking it into the controller image or dressing it up as the tts-heavy sidecar. Remote is the clean way. It speaks a tiny HTTP contract, and you bring whatever model you like: Qwen3-TTS, F5-TTS, CosyVoice, your own.
+Until now, self-hosting a TTS engine meant either baking it into the controller image or dressing it up as the [tts-heavy sidecar](/news/heavy-tts-setup-guide). Remote is the clean way. It speaks a tiny HTTP contract, and you bring whatever model you like: Qwen3-TTS, F5-TTS, CosyVoice, your own.
 
 ## How to use it
 
@@ -32,4 +32,4 @@ A persona's Remote voice is free text, forwarded straight to your server: a voic
 
 ## Why it helps
 
-You can run a big, natural-sounding model on hardware that suits it and keep the controller lean. No image rebuild, no pretending to be another provider. Point it at the box, save, and your DJ speaks through your own server.
+You can run a big, natural-sounding model on hardware that suits it and keep the controller lean. No image rebuild, no pretending to be another provider. Point it at the box, save, and your DJ speaks through your own server. The wire contract sits alongside the other engines in the manual's [Voices & TTS](/manual/voices) page.

--- a/web/content/news/2026-07-03-four-ways-to-leave-a-track.md
+++ b/web/content/news/2026-07-03-four-ways-to-leave-a-track.md
@@ -7,7 +7,7 @@ author: The SUB/WAVE desk
 excerpt: DJ mode now has four named transition moves, blend, washout, sweep, and dissolve. The DJ picks the one that fits each pair of tracks, so no two joins sound the same.
 ---
 
-A crossfade used to be a crossfade, one fixed shape for every pair of songs. DJ mode now knows four different ways to leave one track and arrive at the next, and it chooses between them by how well the two tracks fit.
+A crossfade used to be a crossfade, one fixed shape for every pair of songs. [DJ mode](/manual/dj) now knows four different ways to leave one track and arrive at the next, and it chooses between them by how well the two tracks fit.
 
 ## The four moves
 
@@ -18,7 +18,7 @@ A crossfade used to be a crossfade, one fixed shape for every pair of songs. DJ 
 
 ## How to use it
 
-There's nothing new to switch on. The moves ride on DJ mode and an analysed library, the same two things that turn on mixing in the first place:
+There's nothing new to switch on. The moves ride on DJ mode and an [analysed library](/manual/analysis), the same two things that [turn on mixing in the first place](/news/dj-mode-mixes):
 
 ```
 cd controller && npm run analyze

--- a/web/content/news/2026-07-04-pass-a-skill-along.md
+++ b/web/content/news/2026-07-04-pass-a-skill-along.md
@@ -7,7 +7,7 @@ author: The SUB/WAVE desk
 excerpt: Skills can move between stations now. Browse the community catalog in admin, share your own with one button, or hand a zip straight to another operator.
 ---
 
-You spent three evenings getting a skill's brief just right, and now the DJ lands the line every time. Until now, the only way to give that to a friend's station was to paste the file into a chat and hope they dropped it in the right folder. Skills travel properly now, three ways.
+You spent three evenings getting a [skill's brief](/news/custom-dj-skills) just right, and now the DJ lands the line every time. Until now, the only way to give that to a friend's station was to paste the file into a chat and hope they dropped it in the right folder. Skills travel properly now, three ways.
 
 ## Take one from the catalog
 
@@ -25,4 +25,6 @@ For a direct handoff, hit Export on the edit sheet and you get a `.zip` of the w
 
 ## Why it bothers
 
-The bits between tracks are where a station gets its personality, and a good brief takes real fiddling to get right. Two community skills are in the catalog already: a two-line micro-poem sparked by the moment, and a warm aside about taping songs off the radio. There's room next to them.
+The bits between tracks are where a station gets its personality, and a good brief takes real fiddling to get right. Two community skills are in the catalog already: a two-line micro-poem sparked by the moment, and a warm aside about taping songs off the radio. There's room next to them, and the catalog has a public face at [/skills](/skills).
+
+*Update: the catalog no longer ships inside the controller image. Stations now [read it live](/news/install-from-the-community), so a newly merged skill is installable the same day, no software update needed.*

--- a/web/content/news/2026-07-06-agent-in-the-booth.md
+++ b/web/content/news/2026-07-06-agent-in-the-booth.md
@@ -21,8 +21,8 @@ claude mcp add --transport http subwave https://your-station/api/mcp \
   --header "Authorization: Basic $(printf '%s' "$ADMIN_USER:$ADMIN_PASS" | base64)"
 ```
 
-The admin **Connect → MCP** tab hands you that command with your station's URL already filled in. Claude Desktop and Claude Code both work, and there's still a local stdio server if you'd rather not expose the endpoint. For the alert trick, call `subwave_dj_announce` with `mode: raw` so nothing gets paraphrased, and `sfx: airhorn`.
+The admin **Connect → MCP** tab hands you that command with your station's URL already filled in. Claude Desktop and Claude Code both work, and there's still a local stdio server if you'd rather not expose the endpoint. Every tool is documented in the manual's [Agent Access](/manual/mcp) page. For the alert trick, call `subwave_dj_announce` with `mode: raw` so nothing gets paraphrased, and `sfx: airhorn`.
 
 ## Why it helps
 
-The station already runs itself; this gives your other automations a proper way in. A weather watcher, a calendar bot, a home server that wants to say the backup finished: anything that can speak MCP can now put a voice on your air, airhorn included, with the same guardrails the admin panel uses.
+The station already runs itself; this gives your other automations a proper way in. A weather watcher, a calendar bot, a home server that wants to say the backup finished: anything that can speak MCP can now put a voice on your air, airhorn included, with the same guardrails the admin panel uses. The community is building on the same API too; see what's already out there at [/apps](/apps).

--- a/web/content/news/2026-07-08-import-from-audiomuse.md
+++ b/web/content/news/2026-07-08-import-from-audiomuse.md
@@ -10,7 +10,7 @@ Plenty of you turned up already having tagged your whole library in AudioMuse-AI
 
 ## What's new
 
-A small standalone tool lives under `tools/audiomuse-import`. Point it at your AudioMuse instance and it reads the analysis you already have and writes it into SUB/WAVE's library. Both apps happen to key tracks by the same Navidrome song id, so the match is exact, no guessing by filename. It works even on a fresh SUB/WAVE with an empty library.
+A small standalone tool lives under `tools/audiomuse-import`. Point it at your AudioMuse instance and it reads the analysis you already have and writes it into SUB/WAVE's library. Watch the coverage climb on the [Library page](/news/your-dj-knows-your-library) as it lands. Both apps happen to key tracks by the same Navidrome song id, so the match is exact, no guessing by filename. It works even on a fresh SUB/WAVE with an empty library.
 
 ## How to use it
 
@@ -24,7 +24,7 @@ AUDIOMUSE_URL=http://your-audiomuse:8000 node import.mjs
 
 By default it only fills in blanks, so anything you've already tagged in SUB/WAVE stays put. Add `--dry-run` to see what it would do first, or `--overwrite` to let AudioMuse's data win everywhere.
 
-What comes across: moods, BPM, musical key (as Camelot), energy, and genre. What stays behind: the audio embeddings and the ending and structure data, because SUB/WAVE measures those with a different model than AudioMuse does. So run `npm run analyze` once afterwards to layer the transition and "sounds like" data on top.
+What comes across: moods, BPM, musical key (as Camelot), energy, and genre. What stays behind: the audio embeddings and the ending and structure data, because SUB/WAVE measures those with a different model than AudioMuse does. So run `npm run analyze` once afterwards to layer the transition and "sounds like" data on top ([Acoustic Analysis](/manual/analysis) in the manual explains what that pass measures, and it's what [DJ-mode mixing](/news/dj-mode-mixes) runs on).
 
 ## Why it helps
 

--- a/web/content/news/2026-07-13-give-your-player-a-new-face.md
+++ b/web/content/news/2026-07-13-give-your-player-a-new-face.md
@@ -20,12 +20,18 @@ A skin is a full-screen layout drawn on the same live data. The stream underneat
 
 ![The Classic skin: a masthead across the top carrying the show, mood and weather, cover art beside the track title and artist, a line from the booth underneath, the panel rail down the right, and a waveform above the transport bar](/screenshots/listen.webp)
 
+![The Subamp skin: three stacked windows on a flat blue field, a broadcast deck with a bar spectrum analyzer and transport buttons, a booth feed reading the DJ's last line, and a numbered station log with a request box at the bottom](/screenshots/gallery/subamp-blueprint.webp)
+
+![The TTY skin: the station as a terminal, the track title in giant cyan block capitals, an ASCII progress bar, panes for the booth tail, the queue and the recent-plays log, and a status line reading TUNED with the listener count](/screenshots/gallery/tty-cyberpunk.webp)
+
 ## How to use it
 
-You set the station default in admin. Open Settings, then Skin & Themes, and pick one under Player skin. It applies live on the next poll, no restart.
+You set the station default in admin. Open Settings, then [Skin & Themes](/manual/themes), and pick one under Player skin. It applies live on the next poll, no restart.
 
-Listeners get their own say. In the player, tap the Appearance icon (the palette near the top of the header) and choose a skin under Player skin. That pick rides in their browser only, and it beats your default until they hit Use station default.
+Listeners get their own say. In the player, tap the Appearance icon (the palette near the top of the header) and choose a skin under Player skin. That pick rides in their browser only, and it beats your default until they hit Use station default. The same menu holds the personal [light-or-dark switch](/news/themes-and-playback).
 
 ## Why it helps
 
 One station can read like a broadsheet on a desk monitor and a cassette deck on a phone, and the stream never changes underneath. Pick the face that fits your station, then let each listener bend it to how they actually listen.
+
+*Update: the shelf has grown since this went out. [Platter](/news/a-turntable-for-your-player), a working turntable, arrived the next day, and Spool has since retired in favour of the Unit SW-9 receiver that shipped with [1.0](/news/subwave-is-one-point-oh).*

--- a/web/content/news/2026-07-13-install-from-the-community.md
+++ b/web/content/news/2026-07-13-install-from-the-community.md
@@ -12,7 +12,7 @@ Community skills and personas used to be baked into each release, so you only sa
 
 The catalog is one shared place operators publish three kinds of thing:
 
-- Skills, the short between-track segments your DJ can run.
+- [Skills](/news/custom-dj-skills), the short between-track segments your DJ can run.
 - DJ personas, a full character with its own voice and temperament.
 - Shows, new here. A ready-made template: a standing brief plus the music filters that steer it.
 
@@ -26,7 +26,9 @@ Open admin and pick Skills, Personas, or Shows. Each panel has a Community butto
 - A persona joins your roster with a default voice, ready to edit.
 - A show installs unscheduled with your active DJ as host. Give it a persona and paint it into the weekly grid.
 
-To share your own, the public pages at `/skills`, `/personas`, and `/shows` each have a Share button. It opens a short form, a bot turns that into a pull request on the catalog, and once a maintainer merges it, every station can install it.
+![The admin Shows page: the on-air, up-next and after-that shows across the top, a brush row of show names, and the weekly grid below it, every hour of the week painted in each show's colour](/screenshots/admin-shows.webp)
+
+To share your own, the public pages at [/skills](/skills), [/personas](/personas), and [/shows](/shows) each have a Share button. It opens a short form, a bot turns that into a pull request on the catalog, and once a maintainer merges it, every station can install it.
 
 Running your own catalog, or a fork? Point your station at it and everything above reads from there instead:
 

--- a/web/content/news/2026-07-14-a-turntable-for-your-player.md
+++ b/web/content/news/2026-07-14-a-turntable-for-your-player.md
@@ -6,7 +6,7 @@ author: The SUB/WAVE desk
 excerpt: Platter is the sixth player skin, a working turntable where the record spins as a track plays and the tonearm tracks the groove. Set it station-wide or pick it just for yourself.
 ---
 
-The player shipped five skins last time. Here is a sixth, and it is the one we kept wanting to build. Platter, a reference turntable that becomes the whole interface. A record on the platter, a tonearm over it, the label spinning while the station plays.
+The player shipped [five skins last time](/news/give-your-player-a-new-face). Here is a sixth, and it is the one we kept wanting to build. Platter, a reference turntable that becomes the whole interface. A record on the platter, a tonearm over it, the label spinning while the station plays.
 
 ## What's new
 
@@ -14,9 +14,11 @@ Platter is a full-screen skin like the others, drawn on the same live stream. No
 
 It joins Classic, Spool, Drift, Subamp and TTY. Six faces now, one station.
 
+![The Platter skin: a black record on a cream deck, the tonearm resting in the groove and the label carrying the cover art, with the track title in serif italics, a Next on the Platter slip, the recently spun list and a Dear DJ request line down the right](/screenshots/gallery/platter-vinyl.webp)
+
 ## How to use it
 
-Set it as the station default in admin. Open Settings, then Skin & Themes, and pick Platter under Player skin. It applies on the next poll, no restart.
+Set it as the station default in admin. Open Settings, then [Skin & Themes](/manual/themes), and pick Platter under Player skin. It applies on the next poll, no restart.
 
 Listeners can choose it just for themselves. In the player, tap the Appearance icon (the palette near the top of the header) and pick Platter under Player skin. That choice stays in their browser and beats the station default until they hit Use station skin.
 

--- a/web/content/news/2026-07-21-analyzer-on-the-gpu.md
+++ b/web/content/news/2026-07-21-analyzer-on-the-gpu.md
@@ -6,7 +6,7 @@ author: The SUB/WAVE desk
 excerpt: A new CUDA analyzer image runs sounds-like and vocal analysis on an NVIDIA card, and a quiet-times switch pauses library scans while anyone is tuned in.
 ---
 
-This one came straight from a listener request. Deep analysis, the sounds-like fingerprint and the vocal detection, chews through a big library one track at a time on the CPU. If that CPU is also running your local LLM and your voices, the scan and the station end up fighting over the same cores. Two fixes shipped together.
+This one came straight from a listener request. [Deep analysis](/manual/analysis), the sounds-like fingerprint and the vocal detection, chews through a big library one track at a time on the CPU. If that CPU is also running your local LLM and your voices, the scan and the station end up fighting over the same cores. Two fixes shipped together.
 
 ## What's new
 
@@ -26,8 +26,10 @@ The overlay swaps the analyzer to the CUDA image and hands it the GPU. The host 
 
 ## Analyse at quiet times
 
-Open the Library page in admin. Next to the sounds-like and vocal controls there is a new row, Quiet times. Enable it and set the idle window, ten minutes by default. A running pass pauses between tracks the moment someone tunes in and shows "Waiting for quiet". Once the room has been empty long enough, it picks up where it left off. It applies to manual runs too, so turn it off if you want a scan right now regardless.
+Open the [Library page](/news/your-dj-knows-your-library) in admin. Next to the sounds-like and vocal controls there is a new row, Quiet times. Enable it and set the idle window, ten minutes by default. A running pass pauses between tracks the moment someone tunes in and shows "Waiting for quiet". Once the room has been empty long enough, it picks up where it left off. It applies to manual runs too, so turn it off if you want a scan right now regardless.
 
 ## Why it helps
 
-A big collection gets its fingerprints without a week of pegged cores, and the scan never steals cycles from the broadcast. Turn on quiet times, kick off a full rescan, and the station does the homework in its own gaps.
+A big collection gets its fingerprints without a week of pegged cores, and the scan never steals cycles from the broadcast. Turn on quiet times, kick off a full rescan, and the station does the homework in its own gaps. It is the same trade [Chatterbox made a month ago](/news/chatterbox-on-the-gpu), this time for the analysis side.
+
+*Update: running the all-in-one image instead of the compose stack? It got [the same CUDA path](/news/one-click-on-the-gpu) a few days later.*

--- a/web/content/news/2026-07-23-two-new-pages-in-the-console.md
+++ b/web/content/news/2026-07-23-two-new-pages-in-the-console.md
@@ -22,11 +22,11 @@ Make each one from the configured voice or a text-to-sound prompt, or import you
 
 Click Moods. Four tabs again.
 
-- Vocabulary is the list of moods every track gets tagged with, each with an optional sound description the analyzer can listen for.
+- Vocabulary is the list of moods every track gets tagged with, each with an optional sound description the analyzer can listen for. (Tagging itself still runs from the [Library page](/news/your-dj-knows-your-library).)
 - Moments sets which mood each part of the day, and each kind of weather, leans into.
 - Festivals is the calendar that colours the mood on the day.
 - Speech is the pronunciation fixes read before every spoken line.
 
 ## Why it helps
 
-The mood list used to live in the code. Changing it meant a rebuild. Now it is a text box, and every show, festival, and auto-pick draws from whatever words you put there. The jingles, stingers and beds moved for a plainer reason: they are audio you make and manage, not knobs you set once, so they belong together in one room instead of buried three sections deep in Settings.
+The mood list used to live in the code. Changing it meant a rebuild. Now it is a text box, and every show, festival, and auto-pick draws from whatever words you put there. The jingles, stingers and beds moved for a plainer reason: they are audio you make and manage, not knobs you set once, so they belong together in one room instead of buried three sections deep in Settings. The full map of the console lives in the manual's [Admin & Settings](/manual/admin) chapter.

--- a/web/content/news/2026-07-24-run-more-than-one-station.md
+++ b/web/content/news/2026-07-24-run-more-than-one-station.md
@@ -25,4 +25,4 @@ To put a different station on air, hit **Make live** (on its card, or straight f
 
 ## Why it helps
 
-The obvious use is a second identity, a weekend jazz channel or a festival pop-up, without renting a second server. The less obvious one is a scratch station: duplicate your real one, point the DJ at a strange prompt, and see what happens. Whatever you break stays inside that station's folder. The station people actually listen to never notices.
+The obvious use is a second identity, a weekend jazz channel or a festival pop-up, without renting a second server. Each one can take its own place [on the map](/news/put-your-station-on-the-map) too. The less obvious one is a scratch station: duplicate your real one, point the DJ at a strange prompt, and see what happens. Whatever you break stays inside that station's folder. The station people actually listen to never notices.

--- a/web/content/news/2026-07-26-one-click-on-the-gpu.md
+++ b/web/content/news/2026-07-26-one-click-on-the-gpu.md
@@ -6,7 +6,7 @@ author: The SUB/WAVE desk
 excerpt: A new subwave-aio-cuda image runs the sounds-like and vocal analysis on an NVIDIA card, so one-click installs get the fast path without splitting into a five-service stack.
 ---
 
-When the CUDA analyzer shipped last week, it only helped one kind of install. The overlay it rides on swaps a container inside the full compose stack, and the one-click image has none to swap. So an operator running the all-in-one asked the obvious question. What about the rest of us?
+When [the CUDA analyzer shipped last week](/news/analyzer-on-the-gpu), it only helped one kind of install. The overlay it rides on swaps a container inside the full compose stack, and the [one-click image](/news/one-click-on-unraid) has none to swap. So an operator running the all-in-one asked the obvious question. What about the rest of us?
 
 ## What's new
 
@@ -39,4 +39,4 @@ One trap to avoid. Do not point an all-in-one container at `subwave-analyzer-cud
 
 ## Why it helps
 
-A one-click install was always a trade, less to configure in exchange for less to tune. This takes one thing off that list. If there is a card in the box, the deep analysis can use it, no five-service stack required.
+A one-click install was always a trade, less to configure in exchange for less to tune. This takes one thing off that list. If there is a card in the box, the [deep analysis](/manual/analysis) can use it, no five-service stack required.

--- a/web/content/news/2026-07-27-subwave-is-one-point-oh.md
+++ b/web/content/news/2026-07-27-subwave-is-one-point-oh.md
@@ -11,9 +11,9 @@ The version counter finally rolled over. Three months and forty-eight releases a
 
 ## What's new
 
-The release itself is a normal drop wearing a big number. The player has a new face, Unit SW-9, which replaces the old Spool skin (find it in the palette menu).
+The release itself is a normal drop wearing a big number. The player has a new face, Unit SW-9, which replaces the old [Spool skin](/news/give-your-player-a-new-face) (find it in the palette menu).
 
-![The Unit SW-9 skin: a milled-aluminium panel of soft-touch keys and weighted knobs on the left, a dot-matrix grille showing the cover art, and a black window on the right reading the track title, artist, elapsed time and a level display](/screenshots/listen-unit.webp) The all-in-one image now runs acoustic analysis on your GPU, which got its own dispatch yesterday. And stem blends no longer demand a full re-analysis of your library. Turn the stem cache on and it backfills on its own, pass by pass, with a disk budget you can set under Settings → Transitions.
+![The Unit SW-9 skin: a milled-aluminium panel of soft-touch keys and weighted knobs on the left, a dot-matrix grille showing the cover art, and a black window on the right reading the track title, artist, elapsed time and a level display](/screenshots/listen-unit.webp) The all-in-one image now runs acoustic analysis on your GPU, which got [its own dispatch yesterday](/news/one-click-on-the-gpu). And stem blends no longer demand a full re-analysis of your library. Turn the stem cache on and it backfills on its own, pass by pass, with a disk budget you can set under Settings → Transitions.
 
 The bigger news is the number itself. From 1.0 on, the surfaces you build a station on are stable. Your `.env`, your `state/settings.json`, the layout of the `state/` folder and the compose files are covered by semver now. If a future release ever has to break one of them, it will be a major version with a migration path, not a surprise inside a minor bump.
 

--- a/web/content/news/2026-08-03-put-your-app-on-the-shelf.md
+++ b/web/content/news/2026-08-03-put-your-app-on-the-shelf.md
@@ -10,15 +10,15 @@ A station serves a plain HTTP API from the same origin it streams from, so nobod
 
 ## What's new
 
-The /apps page lists what the community has built against a station. There are four to start.
+The [/apps](/apps) page lists what the community has built against a station. There are four to start.
 
-One is a desk player that runs on a Raspberry Pi Pico 2 W, showing the current track on a small LCD with a physical skip button. A native desktop client covers macOS, Windows and Linux. A standalone MCP server lets you drive the booth from any MCP client. The fourth is the reference web player, which exists to be forked and restyled.
+One is a desk player that runs on a Raspberry Pi Pico 2 W, showing the current track on a small LCD with a physical skip button. A native desktop client covers macOS, Windows and Linux. A standalone MCP server lets you [drive the booth](/news/agent-in-the-booth) from any MCP client. The fourth is the reference web player, which exists to be forked and restyled.
 
-The masthead has a new Community item as well, gathering Skills, Personas, Shows and Apps behind one heading.
+The masthead has a new Community item as well, gathering [Skills](/skills), [Personas](/personas), [Shows](/shows) and Apps behind one heading.
 
 ## How to use it
 
-Browse the directory at /apps. The chips along the top filter by kind: mobile, web, desktop, terminal, bot, skin, integration.
+Browse the directory at [/apps](/apps). The chips along the top filter by kind: mobile, web, desktop, terminal, bot, skin, integration.
 
 If you built something, hit "Submit an app". That opens a GitHub issue form, so there is no fork and no JSON to write. Name, link and kind are the only fields you have to fill in. A bot turns your issue into a pull request, and once a maintainer merges it your app shows up on the next deploy. Edit the issue afterwards and the pull request follows.
 


### PR DESCRIPTION
## What

Added internal links throughout the news archive to connect articles to their corresponding manual pages, related features, and cross-references. This improves navigation and helps readers discover related documentation and features.

## Why

The news articles reference features, settings, and concepts that are documented in the manual and other news posts, but many of these references were plain text rather than links. Linking them:

- Helps readers find detailed documentation for features mentioned in announcements
- Creates a web of related content that improves discoverability
- Reduces friction when someone reads a news post and wants to learn more about a feature
- Establishes clearer relationships between the news archive and the rest of the site

## How tested

N/A — docs/content only. Links are to existing pages (`/manual/*`, `/news/*`, `/apps`, `/skills`, `/personas`, `/shows`, `/stations`, `/setup`, `/listen`).

## Notes for reviewers

The changes follow a consistent pattern:
- Feature names and settings are linked to their manual pages (e.g., `[DJ mode](/manual/dj)`, `[Skin & Themes](/manual/themes)`)
- Related news posts are linked when mentioned (e.g., `[your-dj-knows-your-library](/news/your-dj-knows-your-library)`)
- Community pages are linked (e.g., `[/skills](/skills)`, `[/apps](/apps)`)
- Setup and listening guides are linked where relevant

Some articles also received minor formatting improvements (e.g., converting code blocks to inline links where appropriate) to make the content more readable while preserving the original meaning.

https://claude.ai/code/session_01RWxwb6yEGvNjNhb7QHpfZq