### PR TITLE
perf(admin): cache the Liquidsoap on-air status (#1300 bug 16b)

### DIFF
--- a/controller/scripts/ttl-cache.test.ts
+++ b/controller/scripts/ttl-cache.test.ts
@@ -1,0 +1,178 @@
+// Unit tests for util/ttl-cache.ts — the TTL + single-flight wrapper behind
+// the cached Liquidsoap on-air status (issue #1300, bug 16b).
+//
+// The bug: GET /settings called streamStatus(), which opens a FRESH telnet
+// connection, and the admin UI polls that endpoint every 3s. radio.liq logs a
+// `New client` / `Client disconnected` pair per connection, so the mixer log
+// filled with them forever for anyone with an admin tab open — indistinguishable
+// from a real client churning. (The frequency had teeth beyond noise:
+// restartLiquidsoap already carries a comment about a restart command racing "a
+// concurrent stream_status poll".)
+//
+// What must hold: reads inside the window cost nothing, concurrent reads share
+// ONE take, an operator action that changes the answer invalidates immediately,
+// and a failed take is never cached or served stale.
+//
+// Run: `tsx scripts/ttl-cache.test.ts`.
+
+import assert from 'node:assert/strict';
+import { cachedAsync } from '../src/util/ttl-cache.js';
+
+// Injectable clock — no timers, no sleeps.
+function fakeClock(start = 1_000_000) {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+}
+
+// ── the reported bug: repeat polls inside the window take ONE reading ────────
+
+{
+  const clock = fakeClock();
+  let takes = 0;
+  const cache = cachedAsync(async () => { takes++; return true; }, { ttlMs: 10_000, now: clock.now });
+
+  // The admin UI's 3s cadence over 30s: 11 polls.
+  for (let i = 0; i < 11; i++) {
+    assert.equal(await cache.get(), true);
+    clock.advance(3_000);
+  }
+  assert.equal(takes, 3, '11 polls across 30s at a 10s TTL take 3 readings, not 11');
+}
+
+// A reading is served until the TTL expires, then re-taken exactly once.
+{
+  const clock = fakeClock();
+  let takes = 0;
+  const cache = cachedAsync(async () => ++takes, { ttlMs: 10_000, now: clock.now });
+
+  assert.equal(await cache.get(), 1);
+  clock.advance(9_999);
+  assert.equal(await cache.get(), 1, 'still fresh at ttl-1ms');
+  clock.advance(1);
+  assert.equal(await cache.get(), 2, 're-taken at exactly ttl');
+  assert.equal(takes, 2);
+}
+
+// ── single flight: concurrent callers share one take ─────────────────────────
+
+{
+  const clock = fakeClock();
+  let takes = 0;
+  let release: (v: string) => void = () => {};
+  const cache = cachedAsync(
+    () => { takes++; return new Promise<string>(res => { release = res; }); },
+    { ttlMs: 10_000, now: clock.now },
+  );
+
+  const all = Promise.all([cache.get(), cache.get(), cache.get()]);
+  assert.equal(takes, 1, 'three concurrent callers open ONE connection');
+  release('on');
+  assert.deepEqual(await all, ['on', 'on', 'on'], 'every waiter gets the shared result');
+  assert.equal(await cache.get(), 'on', 'and it lands in the cache');
+  assert.equal(takes, 1);
+}
+
+// ── invalidate: an operator toggle is visible immediately ────────────────────
+
+{
+  const clock = fakeClock();
+  let onAir = true;
+  let takes = 0;
+  const cache = cachedAsync(async () => { takes++; return onAir; }, { ttlMs: 10_000, now: clock.now });
+
+  assert.equal(await cache.get(), true);
+  onAir = false;                       // stopStream() lands
+  assert.equal(await cache.get(), true, 'still cached without an invalidate');
+  cache.invalidate();                  // ...which is why stopStream() calls this
+  assert.equal(await cache.get(), false, 'the toggle shows up at once, not after the TTL');
+  assert.equal(takes, 2);
+}
+
+// A take that was already in flight when invalidate() ran predates the change,
+// so it must not become the cached entry.
+{
+  const clock = fakeClock();
+  let release: (v: string) => void = () => {};
+  let takes = 0;
+  const cache = cachedAsync(
+    () => { takes++; return new Promise<string>(res => { release = res; }); },
+    { ttlMs: 10_000, now: clock.now },
+  );
+
+  const pending = cache.get();
+  cache.invalidate();
+  release('stale');
+  assert.equal(await pending, 'stale', 'the in-flight caller still gets its answer');
+  assert.equal(cache.peek(), null, 'but it is not published to the cache');
+  void cache.get();
+  assert.equal(takes, 2, 'the next reader takes a fresh reading');
+}
+
+// ── failures are never cached, and never masked by a stale value ─────────────
+
+{
+  const clock = fakeClock();
+  let fail = true;
+  let takes = 0;
+  const cache = cachedAsync(
+    async () => { takes++; if (fail) throw new Error('liquidsoap telnet timeout'); return 'on'; },
+    { ttlMs: 10_000, now: clock.now },
+  );
+
+  await assert.rejects(() => cache.get(), /telnet timeout/);
+  await assert.rejects(() => cache.get(), /telnet timeout/, 'a rejection is not cached — the next call retries');
+  assert.equal(takes, 2);
+  fail = false;
+  assert.equal(await cache.get(), 'on', 'recovers as soon as the mixer answers');
+}
+
+// A cached value does NOT paper over a later failure: the caller decides what an
+// unreachable mixer means (routes/settings reports streamOnAir: null).
+{
+  const clock = fakeClock();
+  let fail = false;
+  const cache = cachedAsync(
+    async () => { if (fail) throw new Error('down'); return 'on'; },
+    { ttlMs: 10_000, now: clock.now },
+  );
+
+  assert.equal(await cache.get(), 'on');
+  clock.advance(10_000);
+  fail = true;
+  await assert.rejects(() => cache.get(), /down/, 'stale values are not served in place of an error');
+}
+
+// Concurrent callers on a failing take all see the error, and the in-flight slot
+// is released rather than wedged.
+{
+  const clock = fakeClock();
+  let takes = 0;
+  let boom: (e: Error) => void = () => {};
+  const cache = cachedAsync(
+    () => { takes++; return new Promise<string>((_res, rej) => { boom = rej; }); },
+    { ttlMs: 10_000, now: clock.now },
+  );
+
+  const a = cache.get();
+  const b = cache.get();
+  assert.equal(takes, 1);
+  boom(new Error('ECONNRESET'));
+  await assert.rejects(() => a, /ECONNRESET/);
+  await assert.rejects(() => b, /ECONNRESET/);
+  void cache.get().catch(() => {});
+  assert.equal(takes, 2, 'not wedged — a later caller starts a new take');
+}
+
+// peek() never takes a reading.
+{
+  const clock = fakeClock();
+  let takes = 0;
+  const cache = cachedAsync(async () => { takes++; return 1; }, { ttlMs: 10_000, now: clock.now });
+  assert.equal(cache.peek(), null);
+  assert.equal(takes, 0);
+  await cache.get();
+  assert.deepEqual(cache.peek(), { value: 1, at: clock.now() });
+  assert.equal(takes, 1);
+}
+
+console.log('ttl-cache.test.ts — all assertions passed');

--- a/controller/scripts/ttl-cache.test.ts
+++ b/controller/scripts/ttl-cache.test.ts
@@ -108,6 +108,34 @@ function fakeClock(start = 1_000_000) {
   assert.equal(takes, 2, 'the next reader takes a fresh reading');
 }
 
+// invalidate() + get() is a LIVE read — the guarantee streamStatusFresh() rests
+// on. Invalidating drops the in-flight slot as well as the entry, so the get()
+// that follows opens its own connection instead of being handed a poll that was
+// already running. Without that, Doctor could "prove the mixer is reachable"
+// off a take started before the operator hit Run diagnostics.
+{
+  const clock = fakeClock();
+  const releases: ((v: string) => void)[] = [];
+  let takes = 0;
+  const cache = cachedAsync(
+    () => { takes++; return new Promise<string>(res => { releases.push(res); }); },
+    { ttlMs: 10_000, now: clock.now },
+  );
+
+  const poll = cache.get();           // a /settings poll, still in flight
+  assert.equal(takes, 1);
+
+  cache.invalidate();                 // ...then Doctor asks for a live reading
+  const fresh = cache.get();
+  assert.equal(takes, 2, 'the fresh read opens its OWN take, not the in-flight one');
+  assert.notEqual(poll, fresh, 'and is not handed the in-flight promise');
+
+  releases[0]('on');                  // the older take answers first...
+  releases[1]('off');                 // ...but the mixer has since gone off air
+  assert.equal(await fresh, 'off', 'the live reading is the one the caller gets');
+  assert.deepEqual(cache.peek(), { value: 'off', at: clock.now() }, 'and the one that lands in the cache');
+}
+
 // ── failures are never cached, and never masked by a stale value ─────────────
 
 {

--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -4,6 +4,7 @@
 // with whatever updated settings the controller just wrote to disk.
 
 import net from 'node:net';
+import { cachedAsync } from '../util/ttl-cache.js';
 
 // Liquidsoap shares a container with icecast2 under the `broadcast` service
 // (see docker-compose.yml). The legacy `liquidsoap` hostname is still honoured
@@ -85,6 +86,10 @@ export async function restartLiquidsoap() {
   // "no error" would let /restart-mixer report success while pending settings
   // silently never apply. Confirm by watching the port actually go down, and
   // resend if it doesn't.
+  //
+  // The mixer is about to disappear and come back, so any cached on-air reading
+  // is about to be wrong either way.
+  invalidateStreamStatus();
   let lastErr: Error | null = null;
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
@@ -138,18 +143,48 @@ export async function reloadAutoPlaylist(): Promise<boolean> {
 // output down so the /stream.mp3 mount disconnects (the station goes off
 // air); stream_on recreates it. The mixer process keeps running throughout.
 export async function startStream() {
-  return sendCommand('stream_on', 2000);
+  try {
+    return await sendCommand('stream_on', 2000);
+  } finally {
+    invalidateStreamStatus();
+  }
 }
 
 export async function stopStream() {
-  return sendCommand('stream_off', 2000);
+  try {
+    return await sendCommand('stream_off', 2000);
+  } finally {
+    invalidateStreamStatus();
+  }
 }
 
+// How long an on-air reading is reused. Every telnet take costs a connection,
+// and radio.liq logs a `New client` / `Client disconnected` pair for each one at
+// its default log level — with the admin UI polling GET /settings every 3s, an
+// uncached read filled the mixer log forever for anyone with an admin tab open
+// (issue #1300, bug 16b). 10s keeps the badge honest (the operator's own on/off
+// toggle invalidates below, so a deliberate change is never stale) while making
+// the connect rate independent of how many admin tabs are watching.
+const STREAM_STATUS_TTL_MS = 10_000;
+
+const streamStatusCache = cachedAsync(
+  async () => /\bon\b/i.test(await sendCommand('stream_status', 2000)),
+  { ttlMs: STREAM_STATUS_TTL_MS },
+);
+
 // Returns true when on air, false otherwise. `stream_status` replies "on" /
-// "off".
+// "off". Cached — see STREAM_STATUS_TTL_MS. A telnet failure still rejects
+// (never cached, never served stale), so callers keep deciding what an
+// unreachable mixer means.
 export async function streamStatus() {
-  const res = await sendCommand('stream_status', 2000);
-  return /\bon\b/i.test(res);
+  return streamStatusCache.get();
+}
+
+// Drop the cached reading. Called by anything that changes what stream_status
+// would report, so an operator toggle shows up immediately rather than after
+// the TTL.
+export function invalidateStreamStatus(): void {
+  streamStatusCache.invalidate();
 }
 
 // Pause / resume / query the idle gate (radio.liq `idle_gate`). Unlike

--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -165,6 +165,12 @@ export async function stopStream() {
 // (issue #1300, bug 16b). 10s keeps the badge honest (the operator's own on/off
 // toggle invalidates below, so a deliberate change is never stale) while making
 // the connect rate independent of how many admin tabs are watching.
+//
+// What the TTL does NOT cover: a mixer that goes off air OUTSIDE the controller
+// (`docker compose restart broadcast`, an OOM kill, the restart policy cycling
+// it) invalidates nothing, so the badge can lag the truth by up to the TTL. That
+// is bounded and self-correcting — and anything that needs the live answer
+// instead of the cheap one reads through streamStatusFresh() below.
 const STREAM_STATUS_TTL_MS = 10_000;
 
 const streamStatusCache = cachedAsync(
@@ -177,6 +183,20 @@ const streamStatusCache = cachedAsync(
 // (never cached, never served stale), so callers keep deciding what an
 // unreachable mixer means.
 export async function streamStatus() {
+  return streamStatusCache.get();
+}
+
+// The same reading, but guaranteed to be a real telnet round-trip: invalidating
+// first drops any in-flight take too, so this can't be handed a poll that was
+// already running. For callers whose whole point is proving the mixer is alive
+// RIGHT NOW — Doctor's mixer check reports "telnet reachable", and served from
+// a warm cache it would report that for a process that died seconds ago,
+// precisely when an operator is running diagnostics to find that out.
+//
+// Operator-triggered surfaces only. Putting this on a poll would reinstate the
+// per-request connection this cache exists to remove.
+export async function streamStatusFresh(): Promise<boolean> {
+  streamStatusCache.invalidate();
   return streamStatusCache.get();
 }
 

--- a/controller/src/doctor/checks-services.ts
+++ b/controller/src/doctor/checks-services.ts
@@ -11,7 +11,7 @@ import * as library from '../music/library.js';
 import * as embeddings from '../music/embeddings.js';
 import * as tts from '../audio/tts.js';
 import { getStreamStatus } from '../broadcast/listeners.js';
-import { streamStatus } from '../broadcast/liquidsoap-control.js';
+import { streamStatusFresh } from '../broadcast/liquidsoap-control.js';
 import {
   primaryLeg,
   fallbackLeg,
@@ -278,9 +278,12 @@ export async function checkBroadcast(): Promise<Finding[]> {
     out.push({ label: 'Icecast stream', status: 'skip', detail: err?.message || 'status unavailable' });
   }
 
-  // Liquidsoap telnet — proves the mixer process is alive and reachable.
+  // Liquidsoap telnet — proves the mixer process is alive and reachable. Reads
+  // FRESH, never the /settings badge's cached figure: "proves" is the whole
+  // contract here, and a cached reading would let Doctor report a dead mixer as
+  // reachable. Doctor is operator-triggered, so the extra connection is rare.
   try {
-    const on = await streamStatus();
+    const on = await streamStatusFresh();
     out.push({
       label: 'mixer (Liquidsoap)',
       status: on ? 'ok' : 'warn',

--- a/controller/src/util/ttl-cache.ts
+++ b/controller/src/util/ttl-cache.ts
@@ -24,7 +24,10 @@
 export interface CachedAsync<T> {
   /** Cached value if fresh, else take a new one (coalescing concurrent calls). */
   get(): Promise<T>;
-  /** The cached entry without ever taking a new reading. null when empty. */
+  /** The cached entry as-is, without ever taking a new reading. null when
+   *  empty. NOT TTL-checked — an expired entry is still returned, so a caller
+   *  that cares about freshness must compare `at` itself. Only get() honours
+   *  the TTL. */
   peek(): { value: T; at: number } | null;
   /** Drop the cached value so the next get() takes a fresh reading. Call this
    *  after any action that CHANGES what the producer would report. */
@@ -48,7 +51,7 @@ export function cachedAsync<T>(fn: () => Promise<T>, { ttlMs, now = Date.now }: 
       entry = null;
       // A take already in flight is left alone: it was started before the
       // change and its result would be stale, so it must not become the cached
-      // entry. The `settled === inFlight` guard below is what drops it.
+      // entry. The `take === inFlight` guard below is what drops it.
       inFlight = null;
     },
 

--- a/controller/src/util/ttl-cache.ts
+++ b/controller/src/util/ttl-cache.ts
@@ -1,0 +1,79 @@
+// A TTL cache around one async producer, with single-flight coalescing.
+//
+// For a reading that is CHEAP to be slightly stale but EXPENSIVE (or noisy) to
+// take: the Liquidsoap telnet status is the motivating case — `GET /settings`
+// opened a fresh telnet connection on every request, and the admin UI polls that
+// endpoint every 3s, so radio.liq logged a `New client` / `disconnected` pair
+// forever for anyone with an admin tab open (issue #1300, bug 16b).
+//
+// Two properties, both load-bearing:
+//   • TTL — a reading younger than ttlMs is served from memory, so the cost is
+//     bounded by the clock rather than by how many clients are polling.
+//   • single flight — concurrent callers during an in-flight take share the ONE
+//     promise instead of racing each other into parallel connections. This is
+//     the same coalescing the Icecast status poll uses (#1256), where racing
+//     cadences were turning into spurious AbortErrors.
+//
+// A rejection is NOT cached: the in-flight promise is dropped and the error
+// propagates to every waiter, so the next call retries. Stale values are never
+// served in place of an error either — the caller decides what a failed take
+// means, exactly as it did before the cache existed.
+//
+// Pure except for the clock, which is injectable — see scripts/ttl-cache.test.ts.
+
+export interface CachedAsync<T> {
+  /** Cached value if fresh, else take a new one (coalescing concurrent calls). */
+  get(): Promise<T>;
+  /** The cached entry without ever taking a new reading. null when empty. */
+  peek(): { value: T; at: number } | null;
+  /** Drop the cached value so the next get() takes a fresh reading. Call this
+   *  after any action that CHANGES what the producer would report. */
+  invalidate(): void;
+}
+
+export interface CachedAsyncOptions {
+  ttlMs: number;
+  /** Injectable clock for tests. Defaults to Date.now. */
+  now?: () => number;
+}
+
+export function cachedAsync<T>(fn: () => Promise<T>, { ttlMs, now = Date.now }: CachedAsyncOptions): CachedAsync<T> {
+  let entry: { value: T; at: number } | null = null;
+  let inFlight: Promise<T> | null = null;
+
+  return {
+    peek: () => entry,
+
+    invalidate() {
+      entry = null;
+      // A take already in flight is left alone: it was started before the
+      // change and its result would be stale, so it must not become the cached
+      // entry. The `settled === inFlight` guard below is what drops it.
+      inFlight = null;
+    },
+
+    get(): Promise<T> {
+      if (entry && now() - entry.at < ttlMs) return Promise.resolve(entry.value);
+      if (inFlight) return inFlight;
+
+      const take = fn().then(
+        value => {
+          // Only the take that is still the current one may publish. An
+          // invalidate() during the take means this reading predates a known
+          // change — return it to this caller, but don't cache it.
+          if (take === inFlight) {
+            entry = { value, at: now() };
+            inFlight = null;
+          }
+          return value;
+        },
+        err => {
+          if (take === inFlight) inFlight = null;
+          throw err;
+        },
+      );
+      inFlight = take;
+      return take;
+    },
+  };
+}


### PR DESCRIPTION
Ships the third item on the **Ship first** list in #1300 — *"Bug 16b — stop `GET /settings` opening a telnet socket every 3s."*

## The bug

> the controller's health probe spams the Liquidsoap log every ~2s
> ```
> [server:3] New client: 192.168.x.x.
> [server:3] Client 192.168.x.x disconnected.
> ```

It isn't the health probe — `isLiquidsoapReachable` only runs during restarts. `GET /settings` calls `streamStatus()`, which opens a **fresh telnet connection** every time, and the admin UI polls that endpoint every 3s. With `radio.liq` at `settings.log.level := 3` that's one connect/disconnect pair per poll, forever, for anyone with an admin tab open — and it scales with the number of tabs.

The frequency has teeth beyond the noise: `restartLiquidsoap` already carries a comment about the restart command racing *"a concurrent `stream_status` poll"* and resolving on an empty buffer.

## The fix

`util/ttl-cache.ts` — a TTL cache around one async producer, with single-flight coalescing:

- **TTL (10s)** — the connect rate is bounded by the clock, not by how many clients are polling. 11 polls across 30s take 3 readings instead of 11.
- **single flight** — concurrent callers share the one in-flight take instead of racing into parallel connections. Same coalescing the Icecast status poll got in #1256, for the same reason.

`startStream` / `stopStream` / `restartLiquidsoap` invalidate the entry, so an operator toggle shows up immediately — the badge can only ever be stale about a change nobody asked for. An invalidate during an in-flight take drops that reading rather than publishing it (it predates the change).

Failure semantics are unchanged on purpose: a rejection is **never** cached, and a stale value is **never** served in place of an error, so `routes/settings` still reports `streamOnAir: null` on an unreachable mixer exactly as before.

## Testing

- `controller/scripts/ttl-cache.test.ts` (new) — fake clock, no timers. Pins the polling-cadence saving, TTL boundaries, single-flight sharing, invalidate-on-toggle, the in-flight-invalidate case, uncached rejections, no-stale-on-error, and that a failed take doesn't wedge the slot.
- `npm test` in `controller/`: 76/77 files pass; the one failure (`analyzer-python.test.ts` → `vocal_gate_test.py`) reproduces unchanged on `develop`.
- `npm run lint` clean.

Note the other half of bug 16 (analyzer/librosa/mpg123 stderr noise) is untouched here — it's a separate change in the Python worker.

Refs #1300