### PR TITLE
docs: bring-your-own TTS server, and offloading analysis to another box (#1300 FR 7 + FR 12)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,13 @@ SITE_URL=
 #   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
 # (AIO one-click users: no overlay — pull subwave-aio-cuda and pass the GPU to
 # the container. See docs/unraid.md.)
+#
+# GPU in a DIFFERENT machine? Run the analyzer there and point the station at
+# it — no need to move the stack or copy state around. Requires that the
+# analyzer sees this host's state dir at the same /var/sub-wave path (the
+# controller hands it pre-fetched file paths, not audio):
+#   docs/tts-heavy.md#running-the-analyzer-on-another-machine
+# ANALYZE_URL=http://192.168.1.101:8080   # overrides the in-compose analyzer
 # ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
 #                    # only meaningful on the cuda analyzer flavour
 # ANALYZE_IDLE_UNLOAD_S=  # seconds of no CLAP/Demucs use before the models are
@@ -222,6 +229,12 @@ SITE_URL=
 # never loads. Comma-separated; default loads both. Only matters with
 # --profile tts-heavy.
 # TTS_HEAVY_ENGINES=pocket-tts     # or: chatterbox  |  chatterbox,pocket-tts
+#
+# Own TTS server? There's nothing to set here — the *Remote* engine points the
+# DJ at any HTTP server that answers GET /health and returns rendered audio from
+# POST /speak (a GPU box, a Tailscale peer, a bridge in front of a vendor API
+# like Gemini TTS). It's a station setting, not env: admin → Settings → Voices →
+# Remote. Contract + a 20-line reference server: docs/custom-tts.md
 #
 # Memory ceilings for the model-loading sidecars (OOM containment — keeps a
 # runaway model load from taking down the host's other services). Defaults are

--- a/README.md
+++ b/README.md
@@ -317,7 +317,9 @@ bin/subwave        Operator CLI entry: setup, status, doctor, lifecycle
 
 - **[`DEPLOY.md`](DEPLOY.md):** production deployment, updates, backup.
 - **[`docs/unraid.md`](docs/unraid.md):** running on Unraid — one-click from Community Applications, or the Compose Manager Plus stack.
-- **[`docs/tts-heavy.md`](docs/tts-heavy.md):** the opt-in `tts-heavy` voices and the default-on acoustic `analyzer` service — what each does and how to toggle them.
+- **[`docs/tts-heavy.md`](docs/tts-heavy.md):** the opt-in `tts-heavy` voices and the default-on acoustic `analyzer` service — what each does and how to toggle them, including [running analysis on another machine](docs/tts-heavy.md#running-the-analyzer-on-another-machine) (a GPU box elsewhere on the network).
+- **[`docs/custom-tts.md`](docs/custom-tts.md):** bring your own TTS server — point the DJ at any HTTP endpoint you run (your GPU box, a bridge in front of a vendor API), the same way the LLM side takes a custom base URL.
+- **[`docs/gpu-tts.md`](docs/gpu-tts.md):** running Chatterbox on an NVIDIA GPU — via the OpenAI layer, or by GPU-enabling the bundled sidecar.
 - **[`docs/navidrome-libraries.md`](docs/navidrome-libraries.md):** keeping audiobooks / seasonal collections off air with a dedicated, library-scoped Navidrome user.
 - **[`CLAUDE.md`](CLAUDE.md):** deep architecture reference and the
   non-obvious constraints behind each subsystem.

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -1074,6 +1074,13 @@ SITE_URL=
 #   docker compose -f docker-compose.yml -f docker-compose.analyzer-gpu.yml up -d
 # (AIO one-click users: no overlay — pull subwave-aio-cuda and pass the GPU to
 # the container. See docs/unraid.md.)
+#
+# GPU in a DIFFERENT machine? Run the analyzer there and point the station at
+# it — no need to move the stack or copy state around. Requires that the
+# analyzer sees this host's state dir at the same /var/sub-wave path (the
+# controller hands it pre-fetched file paths, not audio):
+#   docs/tts-heavy.md#running-the-analyzer-on-another-machine
+# ANALYZE_URL=http://192.168.1.101:8080   # overrides the in-compose analyzer
 # ANALYZE_DEVICE=    # auto (default) / cpu / cuda — torch device for CLAP/Demucs;
 #                    # only meaningful on the cuda analyzer flavour
 # ANALYZE_IDLE_UNLOAD_S=  # seconds of no CLAP/Demucs use before the models are
@@ -1136,6 +1143,12 @@ SITE_URL=
 # never loads. Comma-separated; default loads both. Only matters with
 # --profile tts-heavy.
 # TTS_HEAVY_ENGINES=pocket-tts     # or: chatterbox  |  chatterbox,pocket-tts
+#
+# Own TTS server? There's nothing to set here — the *Remote* engine points the
+# DJ at any HTTP server that answers GET /health and returns rendered audio from
+# POST /speak (a GPU box, a Tailscale peer, a bridge in front of a vendor API
+# like Gemini TTS). It's a station setting, not env: admin → Settings → Voices →
+# Remote. Contract + a 20-line reference server: docs/custom-tts.md
 #
 # Memory ceilings for the model-loading sidecars (OOM containment — keeps a
 # runaway model load from taking down the host's other services). Defaults are

--- a/docs/custom-tts.md
+++ b/docs/custom-tts.md
@@ -1,0 +1,174 @@
+# Bring your own TTS server
+
+SUB/WAVE can speak through **any HTTP server you run**, the same way the LLM
+side can point at any OpenAI-compatible endpoint. It's a first-class engine
+called **Remote** — not a workaround, not an impersonation of one of the bundled
+engines.
+
+> Running a station already? The same material with screenshots lives in the
+> in-app manual at **/manual/voices → Remote**. This page is the repo-side copy,
+> plus the operational detail (fallback behaviour, timeouts, what Remote
+> deliberately doesn't do) for someone deciding whether to build the adapter.
+
+Reach for it when:
+
+- local TTS is pegging the box the station runs on (heavy engines rendering on
+  the same CPU as Liquidsoap is how you get a distorted broadcast),
+- the cloud engines are too expensive for a station that talks a lot,
+- you need a **language or a voice** none of the bundled engines cover,
+- or you already run a TTS server (Qwen3-TTS, F5-TTS, CosyVoice, XTTS, Piper as
+  a service, a homegrown one) and want the DJ to use it.
+
+The audio comes back **in the HTTP response body**, so — unlike the `tts-heavy`
+sidecar, which hands back a path on the shared volume — the server can live on
+any host the controller can reach: another box on the LAN, a GPU machine, a
+Tailscale peer. No shared filesystem.
+
+---
+
+## Turn it on
+
+**Admin → Settings → Voices → Default engine → Remote**, then fill in
+**Server URL**.
+
+```
+http://192.168.1.101:5001
+```
+
+Use the host's LAN or Tailscale address — `127.0.0.1` is the *controller
+container's* loopback, not your machine's. The URL is a station setting (it
+lives in `state/settings.json`), not an env var, so it applies live with no
+restart and no rebuild.
+
+Remote is selectable **per persona** as well, like every other engine, so one DJ
+can speak through your server while the rest stay on Piper.
+
+---
+
+## The contract
+
+Two endpoints. That's the whole thing.
+
+### `GET /health`
+
+```json
+{ "ok": true }
+```
+
+Probed every 30s (and immediately when you change the URL). `ok: true` is what
+makes the engine *available*; anything else — non-200, unparseable body,
+timeout, connection refused — marks it unavailable and the dispatcher routes
+around it. There is no engine-name check: the endpoint is a generic bridge and
+decides for itself what it supports.
+
+### `POST /speak`
+
+Request:
+
+```json
+{ "text": "Coming up next, something loud.", "voice": "alba" }
+```
+
+Response: **200 with the rendered audio as the body** (WAV, `Content-Type:
+audio/*`). Not JSON, not a path — the bytes. The controller writes them into its
+own voice directory where Liquidsoap can read them.
+
+`voice` is whatever *your* server means by a voice — a built-in id, a reference
+clip filename, a style prompt. SUB/WAVE passes the persona's configured voice
+string through untouched and never validates it against a list, precisely
+because that vocabulary is yours. An empty string means "use your default".
+
+Optional response headers make a silent voice substitution visible in the
+station log (issue #238) — set them if your server ever renders something other
+than what was asked for:
+
+| Header | Meaning |
+|---|---|
+| `X-TTS-Fell-Back` | present ⇒ the requested voice was not used |
+| `X-TTS-Voice-Used` | what was rendered instead |
+| `X-TTS-Fell-Back-Reason` | why |
+
+An empty response body is treated as a failure rather than aired, so a broken
+render can't hand Liquidsoap a zero-byte file (a silent segment with no error).
+
+### A minimal server
+
+```python
+# pip install fastapi uvicorn
+from fastapi import FastAPI
+from fastapi.responses import Response
+from pydantic import BaseModel
+
+app = FastAPI()
+
+class SpeakRequest(BaseModel):
+    text: str
+    voice: str = ""
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+@app.post("/speak")
+def speak(req: SpeakRequest):
+    wav_bytes = your_tts_engine(req.text, voice=req.voice or "default")
+    return Response(content=wav_bytes, media_type="audio/wav")
+```
+
+Run it on the GPU box, point the station at it, done. Nothing about the DJ
+changes — this only swaps where the voice is rendered.
+
+---
+
+## How it behaves when your server is down
+
+Remote participates in the **rescue chain** like any other engine
+(`audio/tts-fallback.ts`): if it's unreachable at dispatch time, or fails
+mid-render, the station falls through to your configured fallback voice, then
+`defaultEngine` → `piper` → `kokoro`. **The DJ never goes silent because your
+box is rebooting.** The Voices settings panel shows a warning while the endpoint
+is unreachable, and a rescue is recorded as `fellBack` in admin → Stats — worth
+checking there first if a persona ever sounds like the wrong voice.
+
+Timeout is 180s per render, which is generous on purpose: a cold model load on
+the far side shouldn't lose the segment.
+
+---
+
+## What Remote doesn't do
+
+- **Speed shaping** — the daypart speed dial is ignored (your server owns
+  pacing). Per-engine gain trim *is* applied.
+- **Voice previews by name** — the preview button works, but auditions your
+  server's *default* voice: the panel can't enumerate a vocabulary it doesn't
+  own.
+- **Paralinguistic tags** — `[laugh]` / `[sigh]` are only injected into the
+  system prompt when the on-air engine is Chatterbox, so the DJ won't emit them
+  for your server. If yours supports its own tag vocabulary, teach it to the DJ
+  through **station house rules** (admin → Personas → System prompt) — that
+  block is appended to both prompt paths.
+
+---
+
+## Gemini TTS, ElevenLabs, OpenAI
+
+Two different doors, so pick by shape:
+
+- Speaks the **OpenAI speech API** (`POST /v1/audio/speech`)? Use the **Cloud**
+  engine with the `OpenAI-compatible` provider and a base URL — no bridge
+  needed. That's also the easy route for a self-hosted Chatterbox server; see
+  [docs/gpu-tts.md](gpu-tts.md).
+- Speaks something else — **Gemini's TTS API**, a vendor SDK, an in-house
+  format? Put ~20 lines in front of it in the shape above. The Remote contract
+  exists so that adapter is the only thing you write, and it stays yours to
+  update when the vendor's API moves.
+
+---
+
+## See also
+
+- [docs/gpu-tts.md](gpu-tts.md) — running Chatterbox on an NVIDIA GPU, either
+  via the OpenAI layer or by GPU-enabling the bundled sidecar.
+- [docs/tts-heavy.md](tts-heavy.md) — the bundled heavy voices (Chatterbox,
+  PocketTTS) and the acoustic analyzer, including running analysis on another
+  machine.

--- a/docs/gpu-tts.md
+++ b/docs/gpu-tts.md
@@ -5,6 +5,11 @@ CPU it pegs every core and still renders slower than real time, so a chatty
 station can fall behind. If you have an NVIDIA GPU, there are two ways to put it
 to work.
 
+> **Not Chatterbox?** If you just want the DJ to speak through a TTS server you
+> already run — any engine, any language, on any host — that's the **Remote**
+> engine, and it needs no rebuild and no OpenAI compatibility. See
+> [docs/custom-tts.md](custom-tts.md).
+
 > **Not TTS?** Library *analysis* (CLAP "sounds-like" + Demucs vocals) has its
 > own GPU path — the `docker-compose.analyzer-gpu.yml` overlay, no rebuild
 > needed. See [docs/tts-heavy.md → Heavy analysis on an NVIDIA GPU](tts-heavy.md#heavy-analysis-on-an-nvidia-gpu-cuda).
@@ -208,6 +213,10 @@ page in the in-app manual for the cloning workflow).
   and select it by name.
 - **Want SUB/WAVE to manage a reference WAV per persona, plus paralinguistic
   tags and daypart speed?** Native route, with the custom CUDA build.
+
+- **Want a different engine entirely** — a language Chatterbox and Kokoro don't
+  cover, or a server you already run? Neither route: use the **Remote** engine
+  ([docs/custom-tts.md](custom-tts.md)).
 
 Either way the DJ logic is untouched; this only changes *where* the Chatterbox
 voice is rendered.

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -113,9 +113,22 @@ Unraid, including the driver plugin and the extra parameters, are in
 anywhere else it's `--gpus all` on your `docker run`. Everything below about
 device selection and VRAM applies there unchanged.
 
-### Running the analyzer on ANOTHER machine
+Sharing the card with a local TTS or LLM? The worker plays nice: after ~5
+minutes with no CLAP/Demucs use it drops its models out of VRAM and reloads
+them on the next request (`ANALYZE_IDLE_UNLOAD_S` in `.env` tunes the window;
+`0` keeps them resident; CPU-only hosts get the same release with a longer
+30-minute default — #1204). The trade: the first heavy request after a release
+pays a cold reload from the on-disk cache — a few seconds for CLAP on a typical
+box (measured ~2s; a "sounds like ..." search may feel it on slower hardware),
+longer for Demucs. If your station leans on sound search and RAM is plentiful,
+`ANALYZE_IDLE_UNLOAD_S=0` restores the old always-resident behaviour. A few
+hundred MB of CUDA context remain until the analyzer container stops. Pair it with the **quiet times** toggle on the admin
+Library page and a long scan pauses — and frees the GPU — whenever listeners
+are tuned in.
 
-The GPU overlay above assumes the card is in the same host as the station. If it
+### Running the analyzer on another machine
+
+Everything above assumes the card is in the same host as the station. If it
 isn't — the station lives on a NAS or a mini-PC and the GPU is in a desktop
 somewhere else — you do **not** have to move the station, and you certainly
 don't have to stop the stack and copy `appdata` to the GPU box and back.
@@ -147,7 +160,9 @@ So, on the GPU host:
 # docker-compose.yml on the GPU MACHINE — analyzer only.
 services:
   analyzer:
-    image: ghcr.io/perminder-klair/subwave-analyzer-heavy:latest   # or -cuda + the GPU reservation
+    # -heavy is CLAP + Demucs on the CPU, and is amd64-only. For the GPU, swap
+    # in subwave-analyzer-cuda and add the `deploy:` block below.
+    image: ghcr.io/perminder-klair/subwave-analyzer-heavy:latest
     restart: unless-stopped
     ports:
       - "8080:8080"
@@ -157,6 +172,15 @@ services:
       # the usual way; the AIO's equivalent is the appdata share.
       - /mnt/subwave-state:/var/sub-wave
       - analyzer-cache:/opt/analyzer/hf-cache
+    # CUDA image only — same reservation docker-compose.analyzer-gpu.yml applies
+    # (that file also documents the legacy `runtime: nvidia` fallback).
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: all
+    #           capabilities: [gpu]
 volumes:
   analyzer-cache:
 ```
@@ -170,27 +194,18 @@ checks, in order:
    host while a scan runs — if that's empty or errors, the share is the problem,
    not the URL.
 3. Watch the station's analyze log: path-open errors mean the mount point
-   differs; timeouts mean the URL.
+   differs. Timeouts are ambiguous — the per-track deadline is
+   `ANALYZE_REQUEST_TIMEOUT_MS` (120s by default), and reading a long track
+   across a slow share *plus* the DSP can outrun it on a link that is otherwise
+   working. Raise it before concluding the URL is wrong.
 
-Keep the local `analyzer` service stopped (`docker compose stop analyzer`) so
-you aren't paying for an idle image, and mind that the share needs write
-permission for the analyzer's user — it writes stems and reads temp audio.
+Keep the local `analyzer` service stopped (`docker compose stop analyzer` after
+each `up -d`, which restarts it) so you aren't paying for an idle image, and
+mind that the share needs write permission for the analyzer's user — it writes
+stems and reads temp audio.
 
 > **Not the same as sharing your music library.** Navidrome's music files aren't
 > involved here; the shared directory is SUB/WAVE's own `state/`.
-
-Sharing the card with a local TTS or LLM? The worker plays nice: after ~5
-minutes with no CLAP/Demucs use it drops its models out of VRAM and reloads
-them on the next request (`ANALYZE_IDLE_UNLOAD_S` in `.env` tunes the window;
-`0` keeps them resident; CPU-only hosts get the same release with a longer
-30-minute default — #1204). The trade: the first heavy request after a release
-pays a cold reload from the on-disk cache — a few seconds for CLAP on a typical
-box (measured ~2s; a "sounds like ..." search may feel it on slower hardware),
-longer for Demucs. If your station leans on sound search and RAM is plentiful,
-`ANALYZE_IDLE_UNLOAD_S=0` restores the old always-resident behaviour. A few
-hundred MB of CUDA context remain until the analyzer container stops. Pair it with the **quiet times** toggle on the admin
-Library page and a long scan pauses — and frees the GPU — whenever listeners
-are tuned in.
 
 ---
 

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -113,6 +113,72 @@ Unraid, including the driver plugin and the extra parameters, are in
 anywhere else it's `--gpus all` on your `docker run`. Everything below about
 device selection and VRAM applies there unchanged.
 
+### Running the analyzer on ANOTHER machine
+
+The GPU overlay above assumes the card is in the same host as the station. If it
+isn't — the station lives on a NAS or a mini-PC and the GPU is in a desktop
+somewhere else — you do **not** have to move the station, and you certainly
+don't have to stop the stack and copy `appdata` to the GPU box and back.
+
+The analyzer is a plain HTTP service, and the controller resolves its backend
+from one variable:
+
+```ini
+# root .env, on the STATION host
+ANALYZE_URL=http://192.168.1.101:8080
+```
+
+It probes `{ANALYZE_URL}/health` for the `analyze` capability and, when that
+answers, sends analysis there instead of to the local `analyzer` container. Use
+a LAN or Tailscale address — `localhost` is the *controller container's*
+loopback.
+
+**One requirement, and it is the whole reason network-share attempts fail:
+both machines must see the state directory at the same path.** The controller
+pre-fetches each track to `/var/sub-wave/analyze-tmp/` and hands the analyzer a
+*path*, not the audio (network fetch on the controller overlaps DSP on the
+analyzer — that's most of the throughput). If the analyzer can't open that path,
+every track fails. Stem-cache rendering (`state/stems/`) writes back through the
+same shared dir.
+
+So, on the GPU host:
+
+```yaml
+# docker-compose.yml on the GPU MACHINE — analyzer only.
+services:
+  analyzer:
+    image: ghcr.io/perminder-klair/subwave-analyzer-heavy:latest   # or -cuda + the GPU reservation
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      # MUST resolve to the same files the station's /var/sub-wave holds, at
+      # this exact mount point. An NFS/SMB export of the station's state dir is
+      # the usual way; the AIO's equivalent is the appdata share.
+      - /mnt/subwave-state:/var/sub-wave
+      - analyzer-cache:/opt/analyzer/hf-cache
+volumes:
+  analyzer-cache:
+```
+
+Then set `ANALYZE_URL` on the station host and `docker compose up -d`. Sanity
+checks, in order:
+
+1. `curl http://<gpu-host>:8080/health` from the **station** host — expect
+   `"ok": true` with `analyze` in `engines`.
+2. `docker compose exec analyzer ls /var/sub-wave/analyze-tmp` on the **GPU**
+   host while a scan runs — if that's empty or errors, the share is the problem,
+   not the URL.
+3. Watch the station's analyze log: path-open errors mean the mount point
+   differs; timeouts mean the URL.
+
+Keep the local `analyzer` service stopped (`docker compose stop analyzer`) so
+you aren't paying for an idle image, and mind that the share needs write
+permission for the analyzer's user — it writes stems and reads temp audio.
+
+> **Not the same as sharing your music library.** Navidrome's music files aren't
+> involved here; the shared directory is SUB/WAVE's own `state/`.
+
 Sharing the card with a local TTS or LLM? The worker plays nice: after ~5
 minutes with no CLAP/Demucs use it drops its models out of VRAM and reloads
 them on the next request (`ANALYZE_IDLE_UNLOAD_S` in `.env` tunes the window;


### PR DESCRIPTION
Ships the fourth item on the **Ship first** list in #1300 — *"FR 7 + FR 12 docs — two features that already exist and are being requested as missing. Cheapest wins in the whole list."*

## FR 7 — custom / bring-your-own TTS endpoint

Requested twice, with the same rationale each time: local TTS overloads the box and distorts the broadcast, ElevenLabs is too expensive, Kokoro doesn't cover the language. The `remote` engine (`controller/src/audio/remoteTts.ts`) has done exactly this all along — `/health`-probed, selectable per persona, in the fallback chain.

**One correction to the validation in #1300**, found while writing this: the in-app manual *does* already document Remote, thoroughly, with the contract and a Flask example (`/manual/voices → Remote`, shipped with the feature in #672). So it isn't undocumented — it's **unsignposted**. Nothing in the README index, `docs/gpu-tts.md` or `.env.example` mentioned the engine, so someone whose problem is *"local TTS distorts my broadcast"* or *"no voice for my language"* had no path from their symptom to the feature. All three now point at it.

**`docs/custom-tts.md`** (new) is the repo-side copy for people reading on GitHub before they have a station running, and it says so at the top rather than pretending to be the only source. It carries the operational detail the manual page doesn't: rescue-chain behaviour when your box reboots, the 180s render timeout, and what Remote deliberately doesn't do (speed shaping is ignored; the preview button auditions your server's *default* voice; `[laugh]`/`[sigh]` are Chatterbox-only, so teach your own tag vocabulary through station house rules).

It also answers the Gemini-TTS ask by shape rather than by vendor: OpenAI-compatible endpoints go through the **Cloud** engine's custom base URL with no bridge; anything else needs the small adapter this contract exists to keep small.

## FR 12 — distributed / offloaded analysis

> Current workarounds people resort to: stopping the stack, copying the whole appdata directory to a Windows PC, running the container there, and copying it back.

`ANALYZE_URL` has always pointed the controller at a remote analyzer, and the only mention anywhere in the docs was one incidental line in `docs/tts-heavy.md`. New section: **Running the analyzer on another machine**.

**A second correction, and this one changes the advice.** The issue concluded *"The network-share attempts failed because a share is the wrong mechanism — the split is HTTP, not filesystem."* Reading the code, the split is HTTP **and** filesystem:

- `music/analyze.ts` prefetches each track to `/var/sub-wave/analyze-tmp/` and calls `analyzer.analyzePath(...)`, handing the backend a **path**, not audio — the controller's network fetch overlapping the analyzer's DSP is most of the throughput.
- `sidecarRequest` has no url-fallback after a path handoff, so if the analyzer can't open that path, every track fails.
- The compose `analyzer` service mounts the state volume for exactly this reason (*"reads tracks pre-fetched into /var/sub-wave/analyze-tmp"*), and stem-cache rendering writes back through the same dir.

So the people trying network shares had the right mechanism and needed the mount point to match. The section leads with that requirement, gives the analyzer-only compose service for the GPU host, and ends with three ordered checks that separate a share problem from a URL problem. `.env.example` gains a commented `ANALYZE_URL` pointing at it.

(Worth a follow-up issue, out of scope here: falling back to the `url` path when a `path` handoff fails would make a share-less remote analyzer work outright, at the cost of the prefetch overlap.)

## Testing

Docs only — no code changes. Every claim was read out of the code rather than the issue: the `/speak` contract and fallback headers from `audio/remoteTts.ts`, the ignored-speed / applied-gain split from `web/components/admin/settings/TtsSection.tsx`, the analyzer port and health capability from `docker/Dockerfile.analyzer` + `music/analyzer.ts` (`probeSidecar` requires `engines` to include `analyze`), and the `ANALYZE_URL` override precedence from the three compose files.

Refs #1300