### PR TITLE
docs(app): credentials for a basic-auth station, and a 401 that says so (#1300 bug 8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ bin/subwave        Operator CLI entry: setup, status, doctor, lifecycle
 - **[`DEPLOY.md`](DEPLOY.md):** production deployment, updates, backup.
 - **[`docs/unraid.md`](docs/unraid.md):** running on Unraid — one-click from Community Applications, or the Compose Manager Plus stack.
 - **[`docs/tts-heavy.md`](docs/tts-heavy.md):** the opt-in `tts-heavy` voices and the default-on acoustic `analyzer` service — what each does and how to toggle them.
+- **[`docs/private-station.md`](docs/private-station.md):** locking the player and the stream behind a password — and how to tune in from apps, VLC and hardware once it's on, including a station behind reverse-proxy HTTP Basic Auth.
 - **[`docs/navidrome-libraries.md`](docs/navidrome-libraries.md):** keeping audiobooks / seasonal collections off air with a dedicated, library-scoped Navidrome user.
 - **[`CLAUDE.md`](CLAUDE.md):** deep architecture reference and the
   non-obvious constraints behind each subsystem.

--- a/app/src/app/onboarding.tsx
+++ b/app/src/app/onboarding.tsx
@@ -71,6 +71,14 @@ function describeFail(fail: HealthResult | null, candidates: string[]): string |
   if (!fail || fail.ok) return undefined;
   if (fail.kind === 'timeout')
     return 'No response in time — the box may be asleep, on another network, or blocked by a firewall.';
+  // 401/407 is its own diagnosis, not a routing problem: the station sits
+  // behind HTTP Basic Auth (a reverse-proxy or Cloudflare Access password), and
+  // the generic "check your /api/* route" advice below sends people hunting a
+  // proxy bug that isn't there — the reported symptom is "works in the browser,
+  // in VLC and in curl, fails in the app" (#1300, bug 8). The app DOES support
+  // it, via credentials in the URL, which nothing told anyone.
+  if (fail.kind === 'http' && (fail.status === 401 || fail.status === 407))
+    return `The station asked for a password (HTTP ${fail.status}) — it's behind HTTP Basic Auth. Put the credentials in the address as user:pass@host (e.g. dj:secret@radio.yourhost.com) and the app sends them as proper Basic Auth on every request, including the audio stream.`;
   if (fail.kind === 'http')
     return `The server answered with HTTP ${fail.status ?? '?'}, so the address is reachable but the request never reached the controller. Check that your reverse proxy routes /api/* to the controller on port 7701.`;
   // The device doesn't trust the station's cert. Two real-world causes, same
@@ -369,6 +377,7 @@ export default function Onboarding() {
                   the prefix to force one or the other. */}
               <Text className="font-mono text-muted" style={{ fontSize: 10.5, lineHeight: 16, marginTop: 7 }}>
                 Tap the prefix to switch HTTPS / HTTP. HTTPS auto-falls back to HTTP.
+                {'\n'}Password-protected station? Type user:pass@host.
               </Text>
 
               <Pressable

--- a/app/src/app/onboarding.tsx
+++ b/app/src/app/onboarding.tsx
@@ -63,6 +63,11 @@ const DANGER = '#c5302a';
 const isUntrustedCa = (msg?: string) =>
   !!msg && /trust anchor|certpathvalidator|certification path|certificate.*(invalid|not trusted)/i.test(msg);
 
+// Did the address we probed already carry `user:pass@` userinfo? Same shape
+// splitCredentials() matches in lib/api.ts, so "the app read credentials off
+// this URL" and "this returns true" are the same question.
+const hasUserinfo = (candidates: string[]) => candidates.some((c) => /^https?:\/\/[^/@]+@/i.test(c));
+
 // Turn a failed health probe into a human diagnostic for the failure card. The
 // network case names the usual "works in the browser, fails in the app" culprit
 // (a TLS chain Android rejects but the browser tolerates) — the most common and
@@ -71,14 +76,25 @@ function describeFail(fail: HealthResult | null, candidates: string[]): string |
   if (!fail || fail.ok) return undefined;
   if (fail.kind === 'timeout')
     return 'No response in time — the box may be asleep, on another network, or blocked by a firewall.';
-  // 401/407 is its own diagnosis, not a routing problem: the station sits
-  // behind HTTP Basic Auth (a reverse-proxy or Cloudflare Access password), and
-  // the generic "check your /api/* route" advice below sends people hunting a
-  // proxy bug that isn't there — the reported symptom is "works in the browser,
-  // in VLC and in curl, fails in the app" (#1300, bug 8). The app DOES support
-  // it, via credentials in the URL, which nothing told anyone.
-  if (fail.kind === 'http' && (fail.status === 401 || fail.status === 407))
-    return `The station asked for a password (HTTP ${fail.status}) — it's behind HTTP Basic Auth. Put the credentials in the address as user:pass@host (e.g. dj:secret@radio.yourhost.com) and the app sends them as proper Basic Auth on every request, including the audio stream.`;
+  // 401 is its own diagnosis, not a routing problem: the station sits behind
+  // HTTP Basic Auth (auth_basic on the reverse proxy, or SUB/WAVE's own stream
+  // password), and the generic "check your /api/* route" advice below sends
+  // people hunting a proxy bug that isn't there — the reported symptom is
+  // "works in the browser, in VLC and in curl, fails in the app" (#1300, bug
+  // 8). The app DOES support it, via credentials in the URL, which nothing
+  // told anyone. Split on whether the tried address ALREADY carried them: if it
+  // did, they were rejected, and the usual reason is an unencoded special
+  // character (splitCredentials cuts the userinfo at the first `@`, so a raw
+  // `@` in the password takes the host with it).
+  if (fail.kind === 'http' && fail.status === 401)
+    return hasUserinfo(candidates)
+      ? "The station rejected the credentials in the address (HTTP 401). Check the username and password — and percent-encode an @ inside them as %40, since the address is cut at the first @: the password p@ss is typed dj:p%40ss@radio.yourhost.com."
+      : "The station asked for a password (HTTP 401) — it sits behind HTTP Basic Auth, either on the reverse proxy in front of it or via SUB/WAVE's own stream password. Put the credentials in the address as user:pass@host (e.g. dj:secret@radio.yourhost.com); the app carries them through to the API, the artwork and the audio stream.";
+  // 407 comes from a proxy between THIS DEVICE and the station, not from the
+  // station — credentials in the station address never reach it, so the advice
+  // above would be actively wrong here.
+  if (fail.kind === 'http' && fail.status === 407)
+    return "A proxy on this network is asking for a password (HTTP 407) — that sits between this device and the station, so credentials in the station address never reach it. Check this network's proxy settings, or try another network.";
   if (fail.kind === 'http')
     return `The server answered with HTTP ${fail.status ?? '?'}, so the address is reachable but the request never reached the controller. Check that your reverse proxy routes /api/* to the controller on port 7701.`;
   // The device doesn't trust the station's cert. Two real-world causes, same

--- a/docs/private-station.md
+++ b/docs/private-station.md
@@ -68,6 +68,48 @@ every listener connect, so:
 While the password is on, `/listen.pls` and `/listen.m3u` return 403 — they
 would otherwise hand out credential-less URLs that no longer play.
 
+## A different thing: HTTP Basic Auth in front of the whole station
+
+Everything above is SUB/WAVE's *own* privacy lock. Plenty of operators instead
+put **HTTP Basic Auth on the reverse proxy** (nginx `auth_basic`, Caddy
+`basicauth`, Traefik middleware, Cloudflare Access), which gates the admin UI,
+the player, the API and the streams in one go — before a request ever reaches
+the controller.
+
+That works, and the mobile apps support it. The credential form is the same:
+
+```
+https://dj:secret@radio.yourhost.com
+```
+
+Enter that as the **station address** (iOS and Android; on the add-station
+screen just type `dj:secret@radio.yourhost.com`). The app splits the
+credentials out and re-sends them as a proper `Authorization: Basic` header on
+every request — the API polls, the cover artwork, and the audio stream.
+
+That last one is the reason the credentials can't simply be left in the URL:
+**iOS's AVPlayer silently drops `user:pass@` userinfo from a media URL** (and
+Android's player is no more reliable about it), which is why a basic-auth
+station could report *Stream Unreachable* / HTTP 401 in the app while the exact
+same URL played fine in a browser, in VLC and via `curl`. The app converts the
+userinfo into a stream header instead (#764).
+
+Two things to know:
+
+- **The URL is stored as you typed it**, credentials included, in the app's
+  saved-stations list. It's a shared listening password, not an account —
+  don't reuse a password that matters.
+- **Special characters must be percent-encoded** in the userinfo, as in any
+  URL: an `@` in the password becomes `%40`, a `:` becomes `%3A`.
+
+Percent-encoded values are decoded before the header is built, so
+`dj:p%40ss@radio.example` sends the password `p@ss`.
+
+Basic auth on the proxy and SUB/WAVE's own stream password are independent and
+can be combined, but there's rarely a reason to: the proxy lock is broader
+(it covers admin too) while the stream password is what lets you hand a
+listener the stream without handing them the console.
+
 ## Known limits
 
 - One shared password for both locks; rotating it logs every listener out

--- a/docs/private-station.md
+++ b/docs/private-station.md
@@ -72,38 +72,55 @@ would otherwise hand out credential-less URLs that no longer play.
 
 Everything above is SUB/WAVE's *own* privacy lock. Plenty of operators instead
 put **HTTP Basic Auth on the reverse proxy** (nginx `auth_basic`, Caddy
-`basicauth`, Traefik middleware, Cloudflare Access), which gates the admin UI,
-the player, the API and the streams in one go — before a request ever reaches
-the controller.
+`basic_auth`, Traefik's `BasicAuth` middleware), which gates the admin UI, the
+player, the API and the streams in one go — before a request ever reaches the
+controller.
 
-That works, and the mobile apps support it. The credential form is the same:
+> Identity proxies like **Cloudflare Access** are a different mechanism and are
+> **not** supported by the apps: they authenticate with an SSO session cookie
+> (or `CF-Access-Client-*` service-token headers), not HTTP Basic Auth, so
+> there is no `user:pass@` form to type. Everything below is about plain basic
+> auth.
+
+Plain basic auth works, and the mobile apps support it. The credential form is
+the same:
 
 ```
 https://dj:secret@radio.yourhost.com
 ```
 
 Enter that as the **station address** (iOS and Android; on the add-station
-screen just type `dj:secret@radio.yourhost.com`). The app splits the
-credentials out and re-sends them as a proper `Authorization: Basic` header on
-every request — the API polls, the cover artwork, and the audio stream.
+screen just type `dj:secret@radio.yourhost.com`). From there the app takes two
+different routes with the same credentials, which is worth knowing when
+something half-works:
 
-That last one is the reason the credentials can't simply be left in the URL:
-**iOS's AVPlayer silently drops `user:pass@` userinfo from a media URL** (and
-Android's player is no more reliable about it), which is why a basic-auth
-station could report *Stream Unreachable* / HTTP 401 in the app while the exact
-same URL played fine in a browser, in VLC and via `curl`. The app converts the
-userinfo into a stream header instead (#764).
+- **API polls and cover artwork** keep the credentials **on the URL**. RN's
+  `fetch` and `<Image>` sit on NSURLSession / OkHttp, which answer the server's
+  basic-auth challenge from the userinfo themselves — nothing to do.
+- **The audio stream** gets a credential-free URL plus an explicit
+  `Authorization: Basic` header, because **iOS's AVPlayer silently drops
+  `user:pass@` userinfo from a media URL** (and Android's player is no more
+  reliable about it). That is why a basic-auth station could report *Stream
+  Unreachable* / HTTP 401 in the app while the exact same URL played fine in a
+  browser, in VLC and via `curl` (#764).
 
-Two things to know:
+Three things to know:
 
 - **The URL is stored as you typed it**, credentials included, in the app's
   saved-stations list. It's a shared listening password, not an account —
   don't reuse a password that matters.
-- **Special characters must be percent-encoded** in the userinfo, as in any
-  URL: an `@` in the password becomes `%40`, a `:` becomes `%3A`.
+- **Google Cast is unavailable** for a station whose address carries
+  credentials (the cast button doesn't appear). A Chromecast fetches the stream
+  itself, and it has no way to send the header — this applies to SUB/WAVE's own
+  stream password too, since that also travels as userinfo.
+- **An `@` in the password must be percent-encoded** as `%40`. The app cuts the
+  userinfo at the first `@`, so an unencoded one takes part of the hostname
+  with it and the address silently points somewhere else. A `:` is only a
+  problem in the **username** (`%3A`) — the split is on the first colon, so a
+  password may contain them freely.
 
-Percent-encoded values are decoded before the header is built, so
-`dj:p%40ss@radio.example` sends the password `p@ss`.
+Percent-encoded values are decoded before the credentials are used, so
+`dj:p%40ss@radio.example` authenticates as `dj` / `p@ss`.
 
 Basic auth on the proxy and SUB/WAVE's own stream password are independent and
 can be combined, but there's rarely a reason to: the proxy lock is broader

--- a/web/components/manual/Clients.tsx
+++ b/web/components/manual/Clients.tsx
@@ -100,6 +100,24 @@ export default function Clients() {
             players below at a stream URL.
           </p>
         </div>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">STATION BEHIND A PASSWORD</div>
+          <p>
+            If a station sits behind HTTP Basic Auth &mdash; a reverse proxy or Cloudflare
+            Access asking for a username and password &mdash; put the credentials in the
+            address you add:{' '}
+            <code className="bs-code-inline">https://dj:secret@radio.example.com</code>.
+            The app strips them out and re-sends them as proper Basic Auth on every
+            request, the API and the audio stream included. That last part is why the
+            credentials can&rsquo;t simply be left in the URL: iOS&rsquo;s AVPlayer
+            silently drops <code className="bs-code-inline">user:pass@</code> from a media
+            URL, so the app converts it into an{' '}
+            <code className="bs-code-inline">Authorization</code> header for the stream.
+            The same form works for a station using SUB/WAVE&rsquo;s own{' '}
+            <strong>stream password</strong> &mdash; any username, the password is what
+            gets checked.
+          </p>
+        </div>
       </section>
 
       <section className="bs-section">

--- a/web/components/manual/Clients.tsx
+++ b/web/components/manual/Clients.tsx
@@ -103,19 +103,23 @@ export default function Clients() {
         <div className="bs-callout">
           <div className="bs-eyebrow">STATION BEHIND A PASSWORD</div>
           <p>
-            If a station sits behind HTTP Basic Auth &mdash; a reverse proxy or Cloudflare
-            Access asking for a username and password &mdash; put the credentials in the
-            address you add:{' '}
+            If a station sits behind HTTP Basic Auth &mdash; a reverse proxy asking for a
+            username and password before anything reaches the controller &mdash; put the
+            credentials in the address you add:{' '}
             <code className="bs-code-inline">https://dj:secret@radio.example.com</code>.
-            The app strips them out and re-sends them as proper Basic Auth on every
-            request, the API and the audio stream included. That last part is why the
-            credentials can&rsquo;t simply be left in the URL: iOS&rsquo;s AVPlayer
-            silently drops <code className="bs-code-inline">user:pass@</code> from a media
-            URL, so the app converts it into an{' '}
-            <code className="bs-code-inline">Authorization</code> header for the stream.
-            The same form works for a station using SUB/WAVE&rsquo;s own{' '}
-            <strong>stream password</strong> &mdash; any username, the password is what
-            gets checked.
+            The API polls and the artwork authenticate straight off that URL; the audio
+            stream gets an explicit{' '}
+            <code className="bs-code-inline">Authorization</code> header instead, because
+            iOS&rsquo;s AVPlayer silently drops{' '}
+            <code className="bs-code-inline">user:pass@</code> from a media URL &mdash;
+            which is why such a station could fail in the app while the same address
+            played fine in a browser. The same form works for a station using
+            SUB/WAVE&rsquo;s own <strong>stream password</strong> &mdash; any username,
+            the password is what gets checked. Percent-encode an{' '}
+            <code className="bs-code-inline">@</code> in the password as{' '}
+            <code className="bs-code-inline">%40</code>, and note that casting to a
+            Chromecast isn&rsquo;t available for a station with credentials in its
+            address.
           </p>
         </div>
       </section>


### PR DESCRIPTION
Ships the last item on the **Ship first** list in #1300 — *"Bug 8 docs line — the costliest item in the dataset, and the mechanism already works."*

## The bug

> With Basic Auth in front of the station, both the Android and iOS apps report `Stream Unreachable` / HTTP 401 while the exact same URL works in a browser, in VLC, and via `curl`. The working method — embedding credentials as `https://user:pass@host` — is undocumented.

Confirmed as a discoverability failure, not a functional one. `app/src/lib/api.ts` parses `user:pass@` userinfo into an `Authorization: Basic …` header (with its own base64, since Hermes' `btoa` is latin1-only) and `app/src/audio/player.ts` attaches it to the stream request — because iOS AVPlayer silently drops userinfo from a media URL (#764). The credentials deliberately stay on `base` so RN `fetch` and `<Image>` honour them for the API and artwork.

So the "workaround" is the designed path. Nothing said so anywhere.

## Three places, cheapest first

**1. The 401 itself.** `describeFail` lumped every non-2xx into *"the address is reachable but the request never reached the controller. Check that your reverse proxy routes /api/* to the controller on port 7701."* For a 401 that's wrong, and it's what sends people hunting a proxy bug that doesn't exist. 401/407 now names the cause and gives the credential form. This is the highest-value line in the PR — it reaches the person mid-failure, not the person reading docs.

**2. The address field**, one line under the input: *Password-protected station? Type user:pass@host.*

**3. `docs/private-station.md`**, a new section. The doc already covered SUB/WAVE's *own* stream password (including the app's credential form for it); what was missing is the other mechanism people actually use — Basic Auth on the reverse proxy / Cloudflare Access, which gates admin, player, API and streams before a request reaches the controller. The section separates the two, explains why the app converts userinfo into a header rather than passing the URL through, and adds two things a reader will otherwise get wrong:

- special characters must be **percent-encoded** in the userinfo (`@` → `%40`) — verified against `splitCredentials`, which decodes per-component before building the header;
- the URL is **stored as typed**, credentials included, in the saved-stations list — so it's a shared listening password, not an account.

Linked from the README docs index (`private-station.md` wasn't listed at all) and mirrored as a callout in the in-app manual's Clients page.

## Scope

First-class credential *fields* in the apps remain the real fix and stay open — this is the "document the current behaviour in the meantime" half that #1300 asked to ship now.

Both app changes are JS-only, so they can ride an OTA update rather than needing a store build.

## Testing

- `tsc --noEmit` in `app/` — no errors in the changed file (the pre-existing `react-native-google-cast` module-resolution errors reproduce on `develop`; that package isn't installed locally).
- `eslint` + `tsc --noEmit` clean on the changed `web/` file.

Refs #1300