### PR TITLE
chore(controller): remove dead exports found by a knip sweep

### DIFF
--- a/controller/scripts/show-theme-id.test.ts
+++ b/controller/scripts/show-theme-id.test.ts
@@ -10,7 +10,7 @@
 // single poisoned show bricked every show create/edit, schedule edit, and full
 // restore with `shows[N].themeId "sunset" is not a known theme id`. The theme
 // system already tolerates stale ids everywhere else (the lenient load path and
-// serve-time getTheme() fall back to the station default), so strict validation
+// serve-time GET /themes fall back to the station default), so strict validation
 // must DROP an unknown id to "" rather than throw. It must NOT weaken any other
 // strictness, and must never discard a valid (still-known) pick.
 //

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -24,23 +24,12 @@ import { energyForDaypart } from '../context.js';
 
 export const ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud', 'remote'];
 
-// Voice kinds the system speaks. `kind` is passed by the caller and used to
-// look up an engine override in settings. Unknown kinds fall back to default.
-export const VOICE_KINDS = [
-  'dj-speak',       // listener-request intros + ad-hoc dialogue
-  'link',           // between-track auto links (light-duck channel)
-  'station-id',     // :15/:45 idents
-  'hourly-check',   // top-of-hour time/weather mention
-  'weather',        // weather change announcements (segment capability)
-  'news',           // headline read (segment capability)
-  'now-playing-dig',   // search-grounded detail about the on-air track (segment capability)
-  'curiosity',      // on-this-day / oddly-specific factoid (segment capability)
-  'album-anniversary', // round-number anniversary of the on-air album (segment capability)
-  'library-deep-cut',  // tease a forgotten track by the on-air artist (segment capability)
-  'jingle',         // pre-rendered station idents (offline path)
-  'default',        // fallback when a kind isn't explicitly mapped
-];
-
+// `kind` is passed by the caller and used to look up an engine override in
+// settings; unknown kinds fall back to default. The live set of kinds comes
+// from the skills capability table (`skills/_agent.ts` CAPABILITIES) plus the
+// scheduled ones below — there is deliberately no second hardcoded list here
+// to drift out of step with it.
+//
 // Every spoken segment — track intros, links, idents, weather, news, digs,
 // facts — is voiced by the persona on air: engine and voice come from the
 // effective persona's `tts` config. Only jingle rendering (a pre-recorded,

--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -263,14 +263,11 @@ export async function getDjQueueIds(): Promise<Set<string>> {
   return _djQueueInflight;
 }
 
-// Resolve the Liquidsoap request id for a queued track. Always a fresh read —
-// cancel decisions can't ride a 4s-stale cache (the track may have gone on
-// air since). Returns null when the track is no longer pending in dj_queue.
-export async function resolveDjQueueRid(subsonicId: string): Promise<string | null> {
-  return (await resolveDjQueueRidWithBed(subsonicId)).rid;
-}
-
-// Same fresh read, plus the bed queued immediately ahead of the track, if any.
+// Resolve the Liquidsoap request id for a queued track, plus the bed queued
+// immediately ahead of it, if any. Always a fresh read — cancel decisions
+// can't ride a 4s-stale cache (the track may have gone on air since); `rid` is
+// null when the track is no longer pending in dj_queue.
+//
 // A bed is a separate dj_queue entry with no subsonic_id (queue.maybePushBed
 // writes it right before the track URI), so an id-keyed cancel can't see it —
 // this is how removeUpcoming finds it to cancel it along with its track.
@@ -286,7 +283,7 @@ export async function resolveDjQueueRidWithBed(
 }
 
 // Resolve the rid of a pending transition CLIP rendered for the given
-// incoming track (stem-blend transitions). Fresh read like resolveDjQueueRid;
+// incoming track (stem-blend transitions). Fresh read like the helper above;
 // null when no clip is pending for that id.
 export async function resolveClipRid(subsonicId: string): Promise<string | null> {
   const snap = await fetchDjQueue();

--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -332,10 +332,6 @@ export function setStreamIdle(v: boolean) {
   streamIdle = v;
 }
 
-export function isStreamIdle() {
-  return streamIdle;
-}
-
 // True when autonomous DJ LLM work is allowed right now. When the pause toggle
 // is off, always true. When on, allowed only if at least one listener is
 // counted — an unknown count (Icecast unreachable) is treated as occupied so a

--- a/controller/src/community/registry.ts
+++ b/controller/src/community/registry.ts
@@ -302,10 +302,6 @@ export async function communityPersonas(): Promise<CommunityPersona[]> {
 export async function communityShows(): Promise<CommunityShow[]> {
   return (await getCatalog()).shows;
 }
-export async function communityStations(): Promise<CommunityStation[]> {
-  return (await getCatalog()).stations;
-}
-
 export async function readCommunitySkill(slug: string): Promise<CommunitySkill | null> {
   if (!SLUG_RE.test(slug)) return null;
   return (await communitySkills()).find(s => s.slug === slug) ?? null;

--- a/controller/src/llm/internal/speech/fish-audio.ts
+++ b/controller/src/llm/internal/speech/fish-audio.ts
@@ -12,7 +12,6 @@ import { fetchWithTimeout } from '../../../util/fetch-timeout.js';
 
 export const FISH_API_ORIGIN = 'https://api.fish.audio';
 export const FISH_DEFAULT_MODEL = 's2.1-pro';
-export const FISH_MODELS = ['s2.1-pro', 's2.1-pro-free'] as const;
 export const FISH_LATENCIES = ['low', 'normal', 'balanced'] as const;
 
 const DEFAULT_TIMEOUT_MS = 60_000;

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -194,10 +194,6 @@ export function has(songId: string): boolean {
   return loaded ? db.hasTags(songId) : false;
 }
 
-export function allTaggedIds(): string[] {
-  return loaded ? db.allTaggedIds() : [];
-}
-
 // COUNT(*) of tagged tracks — for callers that only need the tally (e.g. the
 // coverage meter), not the id list. Avoids materialising a ~30k-element array
 // just to read its length (#723).

--- a/controller/src/music/playlist-recipes.ts
+++ b/controller/src/music/playlist-recipes.ts
@@ -73,10 +73,6 @@ export function get(playlistId: string): PlaylistRecipeEntry | undefined {
   return read().recipes.find((r) => r.playlistId === playlistId);
 }
 
-export function has(playlistId: string): boolean {
-  return read().recipes.some((r) => r.playlistId === playlistId);
-}
-
 export function count(): number {
   return read().recipes.length;
 }

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -483,8 +483,8 @@ export async function load() {
     theme: {
       // We only validate the *shape* here. The active id might reference a
       // theme file that's since been removed; the public /themes endpoint
-      // and getTheme() both fall back to the default id when that happens, so
-      // a stale id doesn't break the UI.
+      // falls back to the default id when that happens, so a stale id doesn't
+      // break the UI.
       active:
         typeof stored.theme?.active === 'string' && stored.theme.active.trim()
           ? stored.theme.active.trim()
@@ -1274,7 +1274,7 @@ export async function update(patch) {
       // A stale active theme (a retired built-in renamed in 58c3782b, or a
       // custom theme that isn't on disk) falls back to the built-in default
       // rather than failing the save — same tolerance as shows[].themeId above
-      // and the serve-time getTheme() fallback, and the same precedent as the
+      // and the serve-time fallback in GET /themes, and the same precedent as the
       // activeDjPromptId reset. Throwing here aborted the whole restore for any
       // install whose active theme id had since been retired (issue #917).
       next.theme.active = (await isValidThemeId(v)) ? v : DEFAULT_THEME_ID;

--- a/controller/src/settings/normalize.ts
+++ b/controller/src/settings/normalize.ts
@@ -242,8 +242,8 @@ export function normalizeShows(raw: unknown, personaIds: string[]): NormalizedSh
     seen.add(id);
     // themeId is the optional per-show theme override. Lenient path: we only
     // sanity-check the shape. A stale id (theme file deleted under our feet)
-    // is harmless — routes/public.ts falls back to the station default at
-    // serve time via getTheme()'s own fallback. Empty/missing means "no
+    // is harmless — routes/public.ts (GET /themes) falls back to the station
+    // default at serve time. Empty/missing means "no
     // override" and is stored as an empty string for round-trip cleanliness.
     const themeId =
       typeof item.themeId === 'string' && item.themeId.trim()

--- a/controller/src/settings/validate.ts
+++ b/controller/src/settings/validate.ts
@@ -309,7 +309,7 @@ export function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>,
     // A stale id (a retired built-in like the old "sunset"/"neon" palettes,
     // renamed in 58c3782b, or a custom theme file deleted under our feet) is
     // DROPPED to "" rather than throwing — same tolerance as the lenient load
-    // path and the serve-time getTheme() fallback. Throwing here bricked EVERY
+    // path and the serve-time fallback in GET /themes. Throwing here bricked EVERY
     // shows/schedule save and full restore for any install still carrying one
     // retired id on one show, because update() re-validates the whole array
     // (issue #917 is the theme.active twin of this). Self-heals: the dead id

--- a/controller/src/themes.ts
+++ b/controller/src/themes.ts
@@ -187,15 +187,6 @@ export async function listThemesAnnotated(): Promise<ThemeListItem[]> {
   return (await listThemes()).map(t => ({ ...t, builtin: BUILTIN_IDS.has(t.id) }));
 }
 
-export async function getTheme(id: string): Promise<Theme> {
-  const all = await listThemes();
-  return (
-    all.find(t => t.id === id)
-    ?? all.find(t => t.id === DEFAULT_THEME_ID)
-    ?? all[0]!
-  );
-}
-
 export async function isValidThemeId(id: string): Promise<boolean> {
   const all = await listThemes();
   return all.some(t => t.id === id);


### PR DESCRIPTION
Dead-code sweep over `controller/`. A knip pass with the real entry points declared — `src/server.ts`, `src/mcp/stdio.ts`, the two CLI entry modules (`music/tag-library.ts`, `music/analyze-library.ts`), `scripts/**` (the test suite auto-discovers `scripts/*.test.ts`, so those are entries, not orphans) and the skills' dynamically-loaded `tool.mjs` files — reported **8 unused exports and 0 unused dependencies** across 247 source files. Each was then grepped repo-wide (`web/`, `app/`, `cli/`, `mcp-subwave/`, docs, `.liq`, shell) before removal.

### Removed

| Symbol | Why it's dead |
|---|---|
| `audio/tts.ts` `VOICE_KINDS` | Hardcoded kind list with no reader, already drifted — it has no `traffic`, which `mcp/tools.ts` advertises. The live set comes from the skills `CAPABILITIES` table; the surrounding comment now points there instead of carrying a second list to drift. |
| `broadcast/liquidsoap-control.ts` `resolveDjQueueRid` | Thin wrapper over `resolveDjQueueRidWithBed`; every caller uses the latter directly. Its doc comment merged into the survivor. |
| `broadcast/listeners.ts` `isStreamIdle` | Unread getter for the `streamIdle` flag. `setStreamIdle` (the push-in half that avoids the `stream-idle.ts` import cycle) stays. |
| `community/registry.ts` `communityStations` | The catalog's `stations` are read by the web client (`web/lib/communityCatalog.ts`) and `catalogStatus()`, never through this accessor. |
| `llm/internal/speech/fish-audio.ts` `FISH_MODELS` | `FISH_DEFAULT_MODEL` and `FISH_LATENCIES` are the ones with callers. |
| `music/library.ts` `allTaggedIds` | Callers go straight to `db.allTaggedIds()`. |
| `music/playlist-recipes.ts` `has` | No caller. |
| `themes.ts` `getTheme` | No server-side caller resolves a whole `Theme` any more — `GET /themes` hands the list to the client, which picks by id. |

### Comment fix that rides along

Five comments (`settings.ts` ×2, `settings/validate.ts`, `settings/normalize.ts`, `scripts/show-theme-id.test.ts`) named `getTheme()` as the serve-time fallback that justifies stale-theme-id validation being lenient (#917). That fallback is real, but it lives in `GET /themes` — the comments now say so, rather than pointing at a function that no longer exists.

### Deliberately kept

- `music/project-map.ts` + `map-projection.ts` `runProjection` — knip calls the file unused because its only caller spawns it as a `tsx` child (`spawn('npx', ['tsx', 'src/music/project-map.ts'])`), an edge no static analysis sees.
- `theme-tokens.ts` `DisplayFontId` / `MonoFontId` — part of the generated mirror that the CI theme-token drift check regenerates and diffs.
- `mcp/client.ts` `SubwaveError.retryAfter` — populated at the 429 throw site. An error's data payload, not dead logic.

### Verification

- `npm run lint` (eslint + `tsc --noEmit`) — 0 errors (608 pre-existing `no-explicit-any` warnings, unchanged).
- `npm test` — 75/76 files pass. The one failure, `analyzer-python.test.ts`, is `ModuleNotFoundError: No module named 'numpy'` in this sandbox and fails identically on `develop`; it touches nothing in this diff.

No behaviour change — every removal is an export with zero readers.

The `web/` half of this sweep follows in a separate PR.

https://claude.ai/code/session_019SMq8DqWGJbv3hH4odxDG8