### PR TITLE
chore(web): remove dead exports found by a knip sweep

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4047,25 +4047,6 @@ html:has(.admin-root.paper) {
     }
 }
 
-/* Waveform */
-.admin-root .wave {
-    display: flex;
-    align-items: flex-end;
-    gap: 2px;
-    height: 60px;
-}
-.admin-root .wave span {
-    display: block;
-    width: 3px;
-    background: var(--ink);
-}
-.admin-root .wave.accent span {
-    background: var(--accent);
-}
-.admin-root .wave.muted span {
-    background: var(--muted);
-}
-
 /* Terminal-style log block */
 .admin-root .term {
     margin: 0;

--- a/web/components/admin/RosterAvatar.tsx
+++ b/web/components/admin/RosterAvatar.tsx
@@ -37,4 +37,3 @@ export function RosterAvatar({ src, initials, size = 'sm', className }: RosterAv
   );
 }
 
-export default RosterAvatar;

--- a/web/components/admin/RosterTable.tsx
+++ b/web/components/admin/RosterTable.tsx
@@ -158,4 +158,3 @@ export function RosterTable<R>({
   );
 }
 
-export default RosterTable;

--- a/web/components/admin/imaging/parts.tsx
+++ b/web/components/admin/imaging/parts.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 /* Presentational helpers for the Imaging page. Every static style is a Tailwind
-   utility — inline `style` is eslint-forbidden here (issue #50) — so dynamic bar
-   heights ride the shared `Wave` component's DOM-mutation path instead. */
+   utility — inline `style` is eslint-forbidden here (issue #50) — so anything
+   with a computed pixel value sets it by DOM mutation in a layout effect
+   instead. */
 
 import type { ReactNode } from 'react';
 import { cn } from '../../../lib/cn';

--- a/web/components/admin/schedule/lib.ts
+++ b/web/components/admin/schedule/lib.ts
@@ -72,10 +72,6 @@ export function dayName(day: number): string {
   return DAYS.find(d => d.key === day)?.name ?? '';
 }
 
-export function dayLabel(day: number): string {
-  return DAYS.find(d => d.key === day)?.label ?? '';
-}
-
 /** '06' — board-card style hour. 24 stays '24' so a day-end reads as a close. */
 export function hh(h: number): string {
   return String(h).padStart(2, '0');

--- a/web/components/admin/ui.tsx
+++ b/web/components/admin/ui.tsx
@@ -5,8 +5,7 @@
    resolve to the admin-scoped rules in globals.css. Btn / Seg / Toggle wrap
    shadcn primitives while keeping the original prop API. */
 
-import type { CSSProperties, ReactNode, MouseEvent, Ref } from 'react';
-import { useLayoutEffect, useRef } from 'react';
+import type { ReactNode, MouseEvent, Ref } from 'react';
 import { cn } from '../../lib/cn';
 import { Button } from '../ui/button';
 import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
@@ -246,60 +245,3 @@ export function Metric({ n, l, accent }: MetricProps) {
   );
 }
 
-export interface WaveProps {
-  bars?: number;
-  seed?: number;
-  h?: number;
-  tone?: string;
-  maxHeight?: number;
-}
-
-/* Stable seeded pseudo-random waveform bars. Heights are set via DOM
-   mutation in useLayoutEffect because Tailwind can't express per-element
-   dynamic pixel values without inline `style`. */
-export function Wave({ bars = 60, seed = 1, h = 60, tone = '', maxHeight }: WaveProps) {
-  const ref = useRef<HTMLDivElement | null>(null);
-  const heights: number[] = [];
-  let x = seed * 9301 + 49297;
-  for (let i = 0; i < bars; i++) {
-    x = (x * 9301 + 49297) % 233280;
-    heights.push(Math.round(8 + (x / 233280) * (h - 8)));
-  }
-
-  useLayoutEffect(() => {
-    const root = ref.current;
-    if (!root) return;
-    const max = maxHeight ?? h;
-    root.style.setProperty('--wave-h', `${h}px`);
-    root.style.setProperty('--wave-max-h', `${max}px`);
-    const spans = root.querySelectorAll<HTMLSpanElement>(':scope > span');
-    spans.forEach((span, i) => {
-      const bar = heights[i];
-      if (bar != null) span.style.height = `${bar}px`;
-    });
-  });
-
-  return (
-    <div
-      ref={ref}
-      className={cn(
-        'wave h-[var(--wave-h)] max-h-[var(--wave-max-h)]',
-        tone,
-      )}
-    >
-      {heights.map((_, i) => <span key={i} />)}
-    </div>
-  );
-}
-
-/* Turns a `CSSProperties`-shaped object into an inline `style` prop. Only for
-   values Tailwind can't encode (computed colours, geometry); routing them
-   through here keeps the lint allow-list scoped to truly dynamic styles. */
-export function styleVars(vars: Record<string, string | number | undefined>): CSSProperties {
-  const out: Record<string, string | number> = {};
-  for (const [k, v] of Object.entries(vars)) {
-    if (v == null || v === '') continue;
-    out[k] = v;
-  }
-  return out as CSSProperties;
-}

--- a/web/components/ui/animated-link.tsx
+++ b/web/components/ui/animated-link.tsx
@@ -103,4 +103,3 @@ export function AnimatedLink({
   );
 }
 
-export default AnimatedLink;

--- a/web/lib/adminAuth.ts
+++ b/web/lib/adminAuth.ts
@@ -93,4 +93,4 @@ export function useAdminAuth(): AdminAuth {
   return { auth, needsAuth, hydrated, signIn, signOut, adminFetch };
 }
 
-export { API_URL as ADMIN_API_URL, STORAGE_KEY as ADMIN_STORAGE_KEY };
+export { API_URL as ADMIN_API_URL };

--- a/web/lib/news.ts
+++ b/web/lib/news.ts
@@ -93,10 +93,6 @@ export function getAllNews(): NewsMeta[] {
   return _cache;
 }
 
-export function getNewsSlugs(): string[] {
-  return getAllNews().map((a) => a.slug);
-}
-
 /** Null if the slug is unknown. */
 export function getNewsArticle(slug: string): NewsArticle | null {
   const hit = readRaw().find((r) => r.slug === slug);

--- a/web/lib/repo.ts
+++ b/web/lib/repo.ts
@@ -1,7 +1,5 @@
 // Canonical GitHub URLs, one place for every share-to-community flow.
 
-export const REPO_URL = 'https://github.com/perminder-klair/subwave';
-
 // The community catalog repo, split out of the code repo so contributions
 // review and publish on their own cadence (stations fetch the catalog live).
 // COMMUNITY_CATALOG_URL overrides the FETCH url; this is only the human link.

--- a/web/lib/sessionFeed.ts
+++ b/web/lib/sessionFeed.ts
@@ -21,9 +21,6 @@ export function turnClass(turn: SessionTurn | null | undefined): TurnDisplayClas
   }
 }
 
-export const isVoice = (turn: SessionTurn | null | undefined): boolean =>
-  turnClass(turn) === 'voice';
-
 // "DJ" view = everything the DJ personally said or decided.
 export const isDjTurn = (turn: SessionTurn | null | undefined): boolean => {
   const c = turnClass(turn);

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -46,18 +46,6 @@ export interface ActiveShow {
   guests?: { id?: string; name?: string; avatar?: string }[];
 }
 
-/** `/dj` response used by Landing + lock-screen artwork. */
-export interface DjPublic {
-  name?: string;
-  tagline?: string;
-  soul?: string;
-  frequency?: string;
-  avatar?: string;
-  station?: string;
-  location?: string;
-  locale?: StationLocale;
-}
-
 /** `/schedule` response — listener-safe view of the week. */
 export interface SchedulePersona {
   id: string;


### PR DESCRIPTION
The `web/` half of the dead-code sweep. Companion to #1307 (controller). Knip with its Next plugin resolving the App Router entry points; every candidate then grepped repo-wide before removal.

### Removed

| Symbol | Why it's dead |
|---|---|
| `components/admin/ui.tsx` `Wave`, `WaveProps`, `styleVars` | No importer. Removing `Wave` also takes the `.admin-root .wave` rules in `globals.css` (nothing else uses the class) and the `CSSProperties` / `useLayoutEffect` / `useRef` imports these two were the last users of. |
| `components/admin/schedule/lib.ts` `dayLabel` | `dayName` is the one with callers; the other `dayLabel` hits in the tree are unrelated object properties on the debug types. |
| `lib/adminAuth.ts` `ADMIN_STORAGE_KEY` | Half of a two-symbol re-export line. `ADMIN_API_URL` is used; this alias never was. |
| `lib/news.ts` `getNewsSlugs` | No caller — the `[slug]` route resolves through `getNewsArticle`. |
| `lib/repo.ts` `REPO_URL` | Every share-to-community flow builds on `COMMUNITY_REPO_URL`. |
| `lib/sessionFeed.ts` `isVoice` | Its pair `isDjTurn` is used; this one isn't. The `isVoice` identifiers in `BoothDrawer.tsx` are local `const`s, not this import. |
| `lib/types.ts` `DjPublic` | Unreferenced interface. |
| `export default` on `RosterAvatar`, `RosterTable`, `AnimatedLink` | Redundant aliases — all three are imported by name at every call site, and the default had zero importers. |

### One comment fix that rides along

`components/admin/imaging/parts.tsx` opened by citing `Wave` as the worked example of the "compute the pixel value, set it by DOM mutation in a layout effect" pattern that keeps inline `style` out of that file (#50). Reworded to describe the pattern rather than name a component that no longer exists.

### Deliberately kept

- **`components/ui/**` and `components/ai-elements/**`** — 89 of the 99 reported unused exports live here. Both are vendored registries (`components.json` is a shadcn config; `ai-elements` is the Vercel AI Elements registry) that get regenerated wholesale on the next `shadcn add` / registry pull, so pruning sub-components there buys nothing and would be undone. The four remaining `Name|default` duplicate-export pairs (`PersonaTable`, `RosterViewToggle`, `ShowsTable`, `SkillsTable`) are imported as defaults — a style nit, not dead code.
- **`public/sw.js`** — registered by URL at runtime, invisible to static analysis.
- **`scripts/capture-gallery.mjs`, `scripts/observatory-stress.mjs`** — documented manual tools, run ad hoc with `npx tsx`.
- **`lib/audienceStats.test.ts`** — a real test carrying its own run command (`npx tsx web/lib/audienceStats.test.ts`). `web/` has no test runner wired up, which is the only reason knip sees it as an orphan. Still passes.

### Verification

- `npm run lint` (eslint + `tsc --noEmit`) — 0 errors (3 pre-existing `no-explicit-any` warnings, unchanged).
- `npm run build` — succeeds, full route table renders.
- `npx tsx lib/audienceStats.test.ts` — all pass.

No behaviour change.

https://claude.ai/code/session_019SMq8DqWGJbv3hH4odxDG8