### PR TITLE
fix(admin): let a show drop a playlist anchor Navidrome no longer has (#1300 bug 2)

### DIFF
--- a/controller/scripts/playlists-cap.test.ts
+++ b/controller/scripts/playlists-cap.test.ts
@@ -1,0 +1,114 @@
+// Pins PLAYLISTS_PER_SHOW / EXCLUDED_PLAYLISTS_PER_SHOW — the per-show caps on
+// pinned playlist anchors and playlist exclusions — and the web mirror that has
+// to agree with them.
+//
+// Why this needs a test rather than "it's just a number": the cap is enforced in
+// three independent layers that each hardcoded it at some point. The validator
+// throws above it, the loader (coercePlaylistIds / coerceExcludedPlaylistIds)
+// silently truncates at it, and the admin UI disables the checkboxes at its own
+// copy. A UI copy ABOVE the controller's turns a legal-looking save into a 400;
+// one BELOW hides anchors the operator is allowed to add. Nothing else catches
+// that — the symptom is silent, not a crash. This is the playlist twin of
+// show-filter-cap.test.ts.
+//
+// The web mirror is a single PLAYLISTS_MAX because the two controller constants
+// are the same figure, so the test also fails if they ever diverge — at which
+// point the UI needs two constants, not a re-pointed regex.
+//
+// Run: npm test -- playlists-cap
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  PLAYLISTS_PER_SHOW,
+  EXCLUDED_PLAYLISTS_PER_SHOW,
+  coercePlaylistIds,
+  coerceExcludedPlaylistIds,
+} from '../src/settings/vocab.js';
+import { validateShowsStrict } from '../src/settings/validate.js';
+
+let failures = 0;
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  ✗ ${name}\n    ${(err as Error).message}`);
+  }
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const personas = [{ id: 'p1' }];
+const themes = new Set<string>();
+const ids = (n: number) => Array.from({ length: n }, (_, i) => `pl-${i + 1}`);
+const showWith = (extra: Record<string, unknown>) => ([{
+  id: 's1', name: 'Test Show', personaId: 'p1', topic: '', ...extra,
+}]);
+
+test('validator accepts exactly the cap and rejects one over — playlistIds', () => {
+  const ok = validateShowsStrict(showWith({ playlistIds: ids(PLAYLISTS_PER_SHOW) }), personas, themes);
+  assert.equal(ok[0].playlistIds.length, PLAYLISTS_PER_SHOW);
+  assert.throws(
+    () => validateShowsStrict(showWith({ playlistIds: ids(PLAYLISTS_PER_SHOW + 1) }), personas, themes),
+    /playlistIds must have at most/,
+  );
+});
+
+test('validator accepts exactly the cap and rejects one over — excludedPlaylistIds', () => {
+  const ok = validateShowsStrict(
+    showWith({ excludedPlaylistIds: ids(EXCLUDED_PLAYLISTS_PER_SHOW) }), personas, themes,
+  );
+  assert.equal(ok[0].excludedPlaylistIds.length, EXCLUDED_PLAYLISTS_PER_SHOW);
+  assert.throws(
+    () => validateShowsStrict(
+      showWith({ excludedPlaylistIds: ids(EXCLUDED_PLAYLISTS_PER_SHOW + 1) }), personas, themes,
+    ),
+    /excludedPlaylistIds must have at most/,
+  );
+});
+
+test('the loader truncates at the same cap it validates against', () => {
+  // The LOAD path (settings.json written by an older build, or by hand). It
+  // truncates silently, so a cap here below the validator's would quietly drop a
+  // legally-saved show's anchors on the next boot.
+  assert.equal(coercePlaylistIds(ids(PLAYLISTS_PER_SHOW + 5)).length, PLAYLISTS_PER_SHOW);
+  assert.equal(
+    coerceExcludedPlaylistIds(ids(EXCLUDED_PLAYLISTS_PER_SHOW + 5)).length,
+    EXCLUDED_PLAYLISTS_PER_SHOW,
+  );
+});
+
+test('a stale id still counts against the cap', () => {
+  // The admin picker counts ids it cannot resolve against the live Navidrome
+  // index toward its own cap. That only matches the controller because nothing
+  // here filters unresolvable ids out before counting — resolveShowPlaylistPool
+  // drops them at pick time, never at save time.
+  const ok = validateShowsStrict(
+    showWith({ playlistIds: ids(PLAYLISTS_PER_SHOW - 1).concat('deleted-in-navidrome') }),
+    personas, themes,
+  );
+  assert.equal(ok[0].playlistIds.length, PLAYLISTS_PER_SHOW);
+});
+
+test('web admin mirror (PLAYLISTS_MAX) matches both controller caps', () => {
+  const src = readFileSync(resolve(here, '../../web/components/admin/shows/types.ts'), 'utf8');
+  const m = src.match(/export const PLAYLISTS_MAX = (\d+);/);
+  assert.ok(m, 'PLAYLISTS_MAX not found in web/components/admin/shows/types.ts');
+  assert.equal(
+    PLAYLISTS_PER_SHOW, EXCLUDED_PLAYLISTS_PER_SHOW,
+    'the two controller caps diverged — the web mirror can no longer be one constant',
+  );
+  assert.equal(
+    Number(m![1]), PLAYLISTS_PER_SHOW,
+    `web mirror is ${m![1]}, controller cap is ${PLAYLISTS_PER_SHOW}`,
+  );
+});
+
+if (failures) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log('\nplaylists-cap: all tests passed');

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -67,6 +67,9 @@ export default function ShowsPanel() {
   const [genres, setGenres] = useState<string[]>([]);
   // Admin-gated; failures are silent (the picker just offers no options).
   const [playlists, setPlaylists] = useState<{ id: string; name: string; songCount: number | null }[]>([]);
+  // A failed fetch leaves `playlists` empty too, so the editor needs to know the
+  // difference before it calls a show's pinned id missing.
+  const [playlistsLoaded, setPlaylistsLoaded] = useState(false);
   // Guarded by scrollToEditorRef so unrelated re-renders don't yank the page.
   useEffect(() => {
     if (!scrollToEditorRef.current) return;
@@ -157,7 +160,10 @@ export default function ShowsPanel() {
         const r = await adminFetch('/dj/playlists');
         if (!r.ok || cancelled) return;
         const j = (await r.json()) as { results?: { id: string; name: string; songCount: number | null }[] };
-        if (Array.isArray(j.results)) setPlaylists(j.results);
+        if (Array.isArray(j.results)) {
+          setPlaylists(j.results);
+          setPlaylistsLoaded(true);
+        }
       } catch {}
     })();
     return () => { cancelled = true; };
@@ -434,6 +440,7 @@ export default function ShowsPanel() {
           activeThemeId={activeThemeId}
           genres={genres}
           playlists={playlists}
+          playlistsLoaded={playlistsLoaded}
           apiBase={apiBase}
           adminFetch={adminFetch}
           minTrackSeconds={data?.values?.minTrackSeconds}

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -28,6 +28,7 @@ import type {
   CommunityShow,
   FormState,
   Persona,
+  PlaylistIndexStatus,
   Schedule,
   SettingsResponse,
   Show,
@@ -65,11 +66,12 @@ export default function ShowsPanel() {
   // Admin-gated, so it runs after sign-in; failures are silent (the field still
   // accepts free text).
   const [genres, setGenres] = useState<string[]>([]);
-  // Admin-gated; failures are silent (the picker just offers no options).
+  // Admin-gated. A failure is no longer silent in the picker — see below.
   const [playlists, setPlaylists] = useState<{ id: string; name: string; songCount: number | null }[]>([]);
-  // A failed fetch leaves `playlists` empty too, so the editor needs to know the
-  // difference before it calls a show's pinned id missing.
-  const [playlistsLoaded, setPlaylistsLoaded] = useState(false);
+  // A pending or failed fetch leaves `playlists` empty too, so the editor needs
+  // to tell those apart from a genuinely empty Navidrome before it calls a show's
+  // pinned id missing (or tells the operator they have no playlists).
+  const [playlistsStatus, setPlaylistsStatus] = useState<PlaylistIndexStatus>('loading');
   // Guarded by scrollToEditorRef so unrelated re-renders don't yank the page.
   useEffect(() => {
     if (!scrollToEditorRef.current) return;
@@ -156,15 +158,25 @@ export default function ShowsPanel() {
     if (!hydrated || needsAuth) return;
     let cancelled = false;
     (async () => {
+      // Every exit that isn't a well-formed list lands on 'error', including a
+      // 200 with no `results` array: the index is unknown either way, and leaving
+      // it on 'loading' would spin forever. `cancelled` is checked before each
+      // set so an unmount/re-run never reports a state for a dead effect.
       try {
         const r = await adminFetch('/dj/playlists');
-        if (!r.ok || cancelled) return;
+        if (cancelled) return;
+        if (!r.ok) { setPlaylistsStatus('error'); return; }
         const j = (await r.json()) as { results?: { id: string; name: string; songCount: number | null }[] };
+        if (cancelled) return;
         if (Array.isArray(j.results)) {
           setPlaylists(j.results);
-          setPlaylistsLoaded(true);
+          setPlaylistsStatus('ready');
+        } else {
+          setPlaylistsStatus('error');
         }
-      } catch {}
+      } catch {
+        if (!cancelled) setPlaylistsStatus('error');
+      }
     })();
     return () => { cancelled = true; };
   }, [hydrated, needsAuth]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -440,7 +452,7 @@ export default function ShowsPanel() {
           activeThemeId={activeThemeId}
           genres={genres}
           playlists={playlists}
-          playlistsLoaded={playlistsLoaded}
+          playlistsStatus={playlistsStatus}
           apiBase={apiBase}
           adminFetch={adminFetch}
           minTrackSeconds={data?.values?.minTrackSeconds}

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -37,7 +37,7 @@ import {
   eraLabelOf,
   sameEra,
 } from './types';
-import type { Persona, Show, SkillOption, ThemeOption } from './types';
+import type { Persona, PlaylistIndexStatus, Show, SkillOption, ThemeOption } from './types';
 import { hasAnyMusicFilter, showValid } from './lib';
 import { ChipRow } from './ChipRow';
 
@@ -51,9 +51,9 @@ interface ShowEditorProps {
   activeThemeId: string;
   genres: string[];
   playlists: { id: string; name: string; songCount: number | null }[];
-  // False until /dj/playlists has actually answered, so an id absent from
+  // Only 'ready' means /dj/playlists actually answered, so an id absent from
   // `playlists` can't be called missing while the index is merely unknown.
-  playlistsLoaded: boolean;
+  playlistsStatus: PlaylistIndexStatus;
   apiBase: string;
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
   minTrackSeconds?: number;
@@ -67,7 +67,7 @@ interface ShowEditorProps {
 
 export function ShowEditor({
   show, editorRef, personas, moods, themes, skills, activeThemeId, genres, playlists,
-  playlistsLoaded, apiBase,
+  playlistsStatus, apiBase,
   adminFetch, minTrackSeconds, busy, isNew,
   update, onSave, onClose, onRemove,
 }: ShowEditorProps) {
@@ -445,7 +445,7 @@ export function ShowEditor({
             </span>
             <PlaylistPicker
               playlists={playlists}
-              loaded={playlistsLoaded}
+              status={playlistsStatus}
               selected={show.playlistIds}
               max={PLAYLISTS_MAX}
               onChange={playlistIds => update({ playlistIds })}
@@ -483,7 +483,7 @@ export function ShowEditor({
             </span>
             <PlaylistPicker
               playlists={playlists}
-              loaded={playlistsLoaded}
+              status={playlistsStatus}
               selected={show.excludedPlaylistIds}
               max={PLAYLISTS_MAX}
               onChange={excludedPlaylistIds => update({ excludedPlaylistIds })}

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -23,7 +23,7 @@ import { Card, Btn, Eyebrow, Toggle } from '../ui';
 import { EditorDialog, EditorFooter } from '../../ui/editor-dialog';
 import { AiFill } from '../AiFill';
 import GenreSuggest from '../GenreSuggest';
-import { PersonaPicker, GuestPersonaPicker, ThemePicker } from './ShowPickers';
+import { PersonaPicker, GuestPersonaPicker, ThemePicker, PlaylistPicker } from './ShowPickers';
 import { cn } from '../../../lib/cn';
 import {
   ANY_SENTINEL,
@@ -32,6 +32,7 @@ import {
   FILTER_VALUES_MAX,
   GUESTS_MAX,
   NAME_MAX,
+  PLAYLISTS_MAX,
   TOPIC_MAX,
   eraLabelOf,
   sameEra,
@@ -50,6 +51,9 @@ interface ShowEditorProps {
   activeThemeId: string;
   genres: string[];
   playlists: { id: string; name: string; songCount: number | null }[];
+  // False until /dj/playlists has actually answered, so an id absent from
+  // `playlists` can't be called missing while the index is merely unknown.
+  playlistsLoaded: boolean;
   apiBase: string;
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
   minTrackSeconds?: number;
@@ -62,7 +66,8 @@ interface ShowEditorProps {
 }
 
 export function ShowEditor({
-  show, editorRef, personas, moods, themes, skills, activeThemeId, genres, playlists, apiBase,
+  show, editorRef, personas, moods, themes, skills, activeThemeId, genres, playlists,
+  playlistsLoaded, apiBase,
   adminFetch, minTrackSeconds, busy, isNew,
   update, onSave, onClose, onRemove,
 }: ShowEditorProps) {
@@ -438,40 +443,13 @@ export function ShowEditor({
               over them. Pick none to let genre/era/mood drive selection
               (up to 10).
             </span>
-            {playlists.length === 0 ? (
-              <span className="field-hint opacity-60">
-                No Navidrome playlists found yet. Create some in Navidrome, then
-                reopen this panel.
-              </span>
-            ) : (
-              <div className="grid max-h-44 gap-1 overflow-y-auto border border-ink bg-[var(--ink-softer)] p-2">
-                {playlists.map(pl => {
-                  const checked = show.playlistIds.includes(pl.id);
-                  const atCap = !checked && show.playlistIds.length >= 10;
-                  return (
-                    <label
-                      key={pl.id}
-                      className={`flex items-center gap-2 text-sm ${atCap ? 'opacity-40' : 'cursor-pointer'}`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        disabled={atCap}
-                        onChange={() => update({
-                          playlistIds: checked
-                            ? show.playlistIds.filter(id => id !== pl.id)
-                            : [...show.playlistIds, pl.id],
-                        })}
-                      />
-                      <span className="truncate">{pl.name}</span>
-                      {pl.songCount != null && (
-                        <span className="field-hint">({pl.songCount})</span>
-                      )}
-                    </label>
-                  );
-                })}
-              </div>
-            )}
+            <PlaylistPicker
+              playlists={playlists}
+              loaded={playlistsLoaded}
+              selected={show.playlistIds}
+              max={PLAYLISTS_MAX}
+              onChange={playlistIds => update({ playlistIds })}
+            />
           </Field>
 
           {show.playlistIds.length > 0 && (
@@ -503,40 +481,13 @@ export function ShowEditor({
               don&apos;t fit: gather them in a Navidrome playlist and exclude it
               here (up to 10).
             </span>
-            {playlists.length === 0 ? (
-              <span className="field-hint opacity-60">
-                No Navidrome playlists found yet. Create some in Navidrome, then
-                reopen this panel.
-              </span>
-            ) : (
-              <div className="grid max-h-44 gap-1 overflow-y-auto border border-ink bg-[var(--ink-softer)] p-2">
-                {playlists.map(pl => {
-                  const checked = show.excludedPlaylistIds.includes(pl.id);
-                  const atCap = !checked && show.excludedPlaylistIds.length >= 10;
-                  return (
-                    <label
-                      key={pl.id}
-                      className={`flex items-center gap-2 text-sm ${atCap ? 'opacity-40' : 'cursor-pointer'}`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        disabled={atCap}
-                        onChange={() => update({
-                          excludedPlaylistIds: checked
-                            ? show.excludedPlaylistIds.filter(id => id !== pl.id)
-                            : [...show.excludedPlaylistIds, pl.id],
-                        })}
-                      />
-                      <span className="truncate">{pl.name}</span>
-                      {pl.songCount != null && (
-                        <span className="field-hint">({pl.songCount})</span>
-                      )}
-                    </label>
-                  );
-                })}
-              </div>
-            )}
+            <PlaylistPicker
+              playlists={playlists}
+              loaded={playlistsLoaded}
+              selected={show.excludedPlaylistIds}
+              max={PLAYLISTS_MAX}
+              onChange={excludedPlaylistIds => update({ excludedPlaylistIds })}
+            />
           </Field>
         </Card>
 

--- a/web/components/admin/shows/ShowPickers.tsx
+++ b/web/components/admin/shows/ShowPickers.tsx
@@ -7,7 +7,9 @@
 import { useRef } from 'react';
 import { cn } from '../../../lib/cn';
 import { useDynamicStyle } from '../../../hooks/useDynamicStyle';
+import { SkeletonText } from '../../ui/skeleton';
 import { SWATCH_KEYS } from '../../../lib/theme-tokens.generated';
+import type { PlaylistIndexStatus } from './types';
 
 interface PersonaOpt {
   id: string;
@@ -216,25 +218,49 @@ interface PlaylistOpt {
 // and unremovable from the UI, while failing to resolve on every pick cycle. The
 // only way out was hand-editing settings.json.
 //
-// `loaded` gates the whole idea: a failed `/dj/playlists` fetch also leaves the
-// index empty, and flagging every working anchor as missing there would invite the
-// operator to delete good config. Unknown means "say nothing", not "say gone".
+// `status` gates the whole idea: a pending or failed `/dj/playlists` fetch also
+// leaves the index empty, and flagging every working anchor as missing there would
+// invite the operator to delete good config. Unknown means "say nothing", not
+// "say gone" — and each flavour of unknown says why, because an empty index is
+// only genuinely empty under `ready`. Rendering the three states the same way is
+// what made a slow or unreachable Navidrome read as "you have no playlists".
 export function PlaylistPicker({
   playlists,
-  loaded,
+  status,
   selected,
   max,
   onChange,
 }: {
   playlists: PlaylistOpt[];
-  loaded: boolean;
+  status: PlaylistIndexStatus;
   selected: string[];
   max: number;
   onChange: (next: string[]) => void;
 }) {
-  const missing = loaded
+  const missing = status === 'ready'
     ? selected.filter((id) => !playlists.some((p) => p.id === id))
     : [];
+
+  // Same box as the loaded list so the field doesn't jump when it resolves.
+  if (status === 'loading') {
+    return (
+      <div className="grid max-h-44 gap-1 overflow-y-auto border border-ink bg-[var(--ink-softer)] p-2">
+        <SkeletonText lines={4} label="Loading Navidrome playlists" />
+      </div>
+    );
+  }
+
+  // No rows at all here: without the index there is no name to put beside a
+  // pinned id, and a bare id list is the "is this gone?" ambiguity this picker
+  // exists to remove. Say the index is unavailable and leave the config alone.
+  if (status === 'error') {
+    return (
+      <span className="field-hint opacity-60">
+        Couldn&apos;t reach Navidrome to list playlists, so this show&apos;s pinned
+        playlists are left as they are. Reopen this panel to try again.
+      </span>
+    );
+  }
 
   if (!playlists.length && !missing.length) {
     return (

--- a/web/components/admin/shows/ShowPickers.tsx
+++ b/web/components/admin/shows/ShowPickers.tsx
@@ -202,6 +202,101 @@ function ThemeCard({
   );
 }
 
+interface PlaylistOpt {
+  id: string;
+  name: string;
+  songCount: number | null;
+}
+
+// Checkbox list for the show's playlist anchor / exclusion sets.
+//
+// Ids pinned on the show that no longer resolve get a row of their own. A playlist
+// deleted (or deleted and recreated) in Navidrome leaves its old id behind on the
+// show, and rendering only the live index meant that id had no checkbox — invisible
+// and unremovable from the UI, while failing to resolve on every pick cycle. The
+// only way out was hand-editing settings.json.
+//
+// `loaded` gates the whole idea: a failed `/dj/playlists` fetch also leaves the
+// index empty, and flagging every working anchor as missing there would invite the
+// operator to delete good config. Unknown means "say nothing", not "say gone".
+export function PlaylistPicker({
+  playlists,
+  loaded,
+  selected,
+  max,
+  onChange,
+}: {
+  playlists: PlaylistOpt[];
+  loaded: boolean;
+  selected: string[];
+  max: number;
+  onChange: (next: string[]) => void;
+}) {
+  const missing = loaded
+    ? selected.filter((id) => !playlists.some((p) => p.id === id))
+    : [];
+
+  if (!playlists.length && !missing.length) {
+    return (
+      <span className="field-hint opacity-60">
+        No Navidrome playlists found yet. Create some in Navidrome, then reopen
+        this panel.
+      </span>
+    );
+  }
+
+  const atCap = selected.length >= max;
+  return (
+    <div className="grid max-h-44 gap-1 overflow-y-auto border border-ink bg-[var(--ink-softer)] p-2">
+      {playlists.map((pl) => {
+        const checked = selected.includes(pl.id);
+        const capped = !checked && atCap;
+        return (
+          <label
+            key={pl.id}
+            className={cn(
+              'flex items-center gap-2 text-sm',
+              capped ? 'opacity-40' : 'cursor-pointer',
+            )}
+          >
+            <input
+              type="checkbox"
+              checked={checked}
+              disabled={capped}
+              onChange={() =>
+                onChange(
+                  checked
+                    ? selected.filter((id) => id !== pl.id)
+                    : [...selected, pl.id],
+                )
+              }
+            />
+            <span className="truncate">{pl.name}</span>
+            {pl.songCount != null && (
+              <span className="field-hint">({pl.songCount})</span>
+            )}
+          </label>
+        );
+      })}
+      {missing.map((id) => (
+        <label
+          key={id}
+          className="flex cursor-pointer items-center gap-2 text-sm opacity-70"
+          title={`Playlist ${id} no longer exists in Navidrome. Uncheck to remove it from this show.`}
+        >
+          <input
+            type="checkbox"
+            checked
+            onChange={() => onChange(selected.filter((x) => x !== id))}
+          />
+          <span className="truncate">(missing) {id}</span>
+          <span className="field-hint">deleted in Navidrome</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
 export function ThemePicker({
   themes,
   activeThemeId,

--- a/web/components/admin/shows/types.ts
+++ b/web/components/admin/shows/types.ts
@@ -7,6 +7,9 @@ export const TOPIC_MAX = 2000;
 export const SHOWS_MAX = 64;
 // Mirrors the controller's GUESTS_PER_SHOW cap (settings.ts).
 export const GUESTS_MAX = 3;
+// Mirrors the controller's PLAYLISTS_PER_SHOW / EXCLUDED_PLAYLISTS_PER_SHOW
+// caps (settings/vocab.ts), which are the same figure.
+export const PLAYLISTS_MAX = 10;
 
 export interface Show {
   id: string;

--- a/web/components/admin/shows/types.ts
+++ b/web/components/admin/shows/types.ts
@@ -8,8 +8,19 @@ export const SHOWS_MAX = 64;
 // Mirrors the controller's GUESTS_PER_SHOW cap (settings.ts).
 export const GUESTS_MAX = 3;
 // Mirrors the controller's PLAYLISTS_PER_SHOW / EXCLUDED_PLAYLISTS_PER_SHOW
-// caps (settings/vocab.ts), which are the same figure.
+// caps (settings/vocab.ts), which are the same figure. Pinned against drift by
+// controller/scripts/playlists-cap.test.ts.
 export const PLAYLISTS_MAX = 10;
+
+/** How much the panel knows about the live Navidrome playlist index.
+ *
+ * Three states, not a loaded/not-loaded boolean: an empty `playlists` array
+ * means something different in each, and only `ready` licenses the editor to
+ * call a show's pinned id missing. A boolean collapses `loading` and `error`
+ * into one bucket, and whichever way that bucket renders is wrong for the other
+ * half of it — a spinner that never resolves, or a "no playlists" line shown
+ * while the fetch is still in flight. */
+export type PlaylistIndexStatus = 'loading' | 'ready' | 'error';
 
 export interface Show {
   id: string;


### PR DESCRIPTION
Ships **bug 2** from #1300 — *"Deleted Navidrome playlist leaves an unremovable anchor on a show"*.

## The bug

Delete a playlist in Navidrome — or delete and recreate it, which mints a new id — and its old id stays behind on any show that pinned it. The show editor built its checkbox list by mapping the **live** Navidrome index, so an id with no matching playlist had no row at all: invisible in the UI, impossible to uncheck, and failing to resolve on every pick cycle.

```
anchor playlist <id> failed to resolve: Subsonic error: playlist not found
```

The only way out was unzipping a backup or hand-editing `state/settings.json`.

The controller half is already sound — `resolveShowPlaylistPool` (`music/show-playlist.ts:69-83`) catches per id and degrades rather than throwing, so a stale anchor never stranded the stream. This is the UI half the validation pass in #1300 identified as the live bug.

## The fix

Ids pinned on the show that aren't in the live index render as their own row:

```
☑ (missing) 8f2a…c41    deleted in Navidrome
```

Checked, because the id genuinely *is* on the show — unchecking removes it exactly like any other row, and the row then disappears.

**Gated on the index having actually loaded.** A failed `/dj/playlists` fetch also leaves `playlists` empty (it's the `useState([])` initial value and the catch is silent), so without that gate every working anchor on every show would be labelled missing the moment Navidrome hiccupped — inviting the operator to delete good config. `ShowsPanel` now tracks a `playlistsLoaded` flag set only on a successful parse. Unknown says nothing rather than "gone".

Both lists get the treatment — the anchor set and `excludedPlaylistIds`, as the issue asks — through one shared `PlaylistPicker` in `ShowPickers.tsx`, which also collapses the two near-identical copies of the checkbox block the editor was carrying (net **−71 lines** of duplication against +127 of new component).

`PLAYLISTS_MAX` joins the other mirrored caps in `shows/types.ts` rather than staying a bare `10` inline in two places.

## Testing

- `npm run lint` clean in both `web/` and `controller/`.
- No behaviour change when nothing is stale: with every pinned id present in the index, `missing` is empty and the rendered output is the same rows as before.
