### PR TITLE
fix(aio): say that ANALYZER_HEAVY does nothing on the all-in-one image (#1300 bug 9)

### DIFF
--- a/controller/scripts/aio-analyzer-heavy.test.ts
+++ b/controller/scripts/aio-analyzer-heavy.test.ts
@@ -1,0 +1,136 @@
+// Regression tests for the AIO supervisor's ANALYZER_HEAVY warning
+// (docker/aio/supervisor.sh: warn_if_analyzer_heavy_ignored).
+//
+// ANALYZER_HEAVY picks an image TAG, and it does it by docker-compose variable
+// interpolation (`subwave-analyzer${ANALYZER_HEAVY:+-heavy}`). The all-in-one
+// image has no analyzer service to select — CLAP and Demucs are baked into the
+// venv at build time — so the variable is unreachable there, not merely
+// unsupported. #1300 bug 9: operators set it, watch nothing change, and
+// conclude stem transitions are broken. The caveat existed in docs/unraid.md
+// and the doctor; nothing said it at the moment they were looking.
+//
+// The load-bearing properties:
+//   1. Set + lean build  -> a warning that names the -aio-heavy IMAGE, since
+//      that is the only thing that actually changes the outcome.
+//   2. Set + heavy build -> a note, not a warning. The variable is still inert,
+//      but the capability the operator wanted is present, so there is nothing
+//      to fix and a red herring would send them chasing it.
+//   3. Unset             -> silence on both builds. This runs on every AIO boot.
+//
+// Run: `tsx scripts/aio-analyzer-heavy.test.ts`.
+//
+// node:assert-via-tsx style, matching scripts/aio-log-link.test.ts.
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SUPERVISOR = join(here, '..', '..', 'docker', 'aio', 'supervisor.sh');
+
+assert.ok(existsSync(SUPERVISOR), `supervisor.sh not found at ${SUPERVISOR}`);
+
+// Drive warn_if_analyzer_heavy_ignored() against a scratch venv by sourcing the
+// supervisor in library mode. Returns its stderr (the log lines the operator
+// would see in `docker logs`), folded into stdout.
+function runWarn(venvDir: string, analyzerHeavy: string | null): string {
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
+    SUBWAVE_ANALYZER_VENV: venvDir,
+  };
+  if (analyzerHeavy === null) delete env.ANALYZER_HEAVY;
+  else env.ANALYZER_HEAVY = analyzerHeavy;
+  return execFileSync(
+    'bash',
+    [
+      '-c',
+      `set -u; SUBWAVE_SUPERVISOR_LIB=1 source "$1"; warn_if_analyzer_heavy_ignored 2>&1`,
+      'bash',
+      SUPERVISOR,
+    ],
+    { env, encoding: 'utf8' },
+  );
+}
+
+// A lean venv: librosa only, no torch. Mirrors WITH_CLAP=0.
+function leanVenv(root: string): string {
+  const venv = join(root, 'venv');
+  mkdirSync(join(venv, 'lib', 'python3.13', 'site-packages', 'librosa'), { recursive: true });
+  return venv;
+}
+
+// A heavy venv: torch present, the thing that actually makes CLAP/Demucs work.
+function heavyVenv(root: string): string {
+  const venv = leanVenv(root);
+  const torch = join(venv, 'lib', 'python3.13', 'site-packages', 'torch');
+  mkdirSync(torch, { recursive: true });
+  writeFileSync(join(torch, '__init__.py'), '');
+  return venv;
+}
+
+const tmp = mkdtempSync(join(tmpdir(), 'subwave-aio-heavy-'));
+let failures = 0;
+
+function scenario(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}`);
+    console.error(`       ${(err as Error).message}`);
+  }
+}
+
+console.log('aio ANALYZER_HEAVY warning');
+
+// 1. The reported case: set on a lean AIO. Must warn, and must name the image
+//    swap — the variable itself is a dead end, so repeating it would be the
+//    same non-advice the operator already followed.
+scenario('set on a lean build warns and names the -aio-heavy image', () => {
+  const out = runWarn(leanVenv(mkdtempSync(join(tmp, 'lean-'))), '1');
+  assert.match(out, /WARNING: ANALYZER_HEAVY is set, and it does NOTHING/);
+  assert.match(out, /subwave-aio-heavy/);
+  // Pointing an AIO operator at the bare analyzer image replaces their whole
+  // station with an analysis micro-service (#966), so the warning has to
+  // disclaim it rather than stay silent.
+  assert.match(out, /NOT subwave-analyzer-heavy/);
+});
+
+// 2. Set on a heavy build. Still inert, but the capability is there — so this
+//    is a note, not a warning. Anything alarming here sends an operator whose
+//    setup is FINE looking for a problem.
+scenario('set on a heavy build notes without warning', () => {
+  const out = runWarn(heavyVenv(mkdtempSync(join(tmp, 'heavy-'))), '1');
+  assert.match(out, /no effect on/);
+  assert.doesNotMatch(out, /WARNING/);
+  assert.doesNotMatch(out, /###/);
+});
+
+// 3. Unset is the overwhelmingly common case and runs on every boot. Both
+//    builds must say nothing at all.
+scenario('unset stays silent on a lean build', () => {
+  assert.equal(runWarn(leanVenv(mkdtempSync(join(tmp, 'lean-quiet-'))), null).trim(), '');
+});
+scenario('unset stays silent on a heavy build', () => {
+  assert.equal(runWarn(heavyVenv(mkdtempSync(join(tmp, 'heavy-quiet-'))), null).trim(), '');
+});
+
+// 4. An empty value is what `ANALYZER_HEAVY=` in a .env file yields, and it is
+//    also what compose treats as unset (`${ANALYZER_HEAVY:+-heavy}` expands to
+//    nothing). Warning there would contradict the compose semantics the
+//    variable is named after.
+scenario('empty value is treated as unset', () => {
+  assert.equal(runWarn(leanVenv(mkdtempSync(join(tmp, 'lean-empty-'))), '').trim(), '');
+});
+
+rmSync(tmp, { recursive: true, force: true });
+
+if (failures) {
+  console.error(`\n${failures} scenario(s) failed`);
+  process.exit(1);
+}
+console.log('\nall scenarios passed');

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -219,6 +219,52 @@ warn_if_state_unmounted() {
 }
 
 # ---------------------------------------------------------------------------
+# ANALYZER_HEAVY selects an IMAGE TAG, and it does so by docker-compose variable
+# interpolation (`subwave-analyzer${ANALYZER_HEAVY:+-heavy}` in
+# docker-compose.yml). The all-in-one image has no analyzer service to select:
+# CLAP and Demucs are baked into the venv at build time or they are not, decided
+# entirely by which tag was pulled. So the variable is inert here by
+# construction — not unsupported, unreachable.
+#
+# Operators set it, see no stem-transitions card appear, and reasonably conclude
+# the feature is broken (#1300 bug 9). The caveat was written down (docs/unraid.md,
+# the doctor) but nothing said it at the moment they were actually looking: the
+# boot right after setting it.
+#
+# Probed rather than read from a baked marker, because torch in the venv IS what
+# makes the heavy tier work — a probe cannot disagree with the thing it describes,
+# a marker can.
+# ---------------------------------------------------------------------------
+ANALYZER_VENV="${SUBWAVE_ANALYZER_VENV:-/opt/analyzer/venv}"
+
+analyzer_venv_is_heavy() {
+	compgen -G "$ANALYZER_VENV/lib/python*/site-packages/torch/__init__.py" >/dev/null 2>&1
+}
+
+warn_if_analyzer_heavy_ignored() {
+	[ -n "${ANALYZER_HEAVY:-}" ] || return 0
+	if analyzer_venv_is_heavy; then
+		log "note: ANALYZER_HEAVY is a docker-compose setting and has no effect on"
+		log "  the all-in-one image — but this IS a heavy build, so CLAP and Demucs"
+		log "  are available anyway. Nothing to do."
+		return 0
+	fi
+	log "################################################################"
+	log "WARNING: ANALYZER_HEAVY is set, and it does NOTHING on this image."
+	log "  It is a docker-compose variable that picks the analyzer service's"
+	log "  image tag. The all-in-one image has no analyzer service — CLAP and"
+	log "  Demucs are baked in at build time, and this build does not have them."
+	log "  Sounds-like search, vocal-aware timing and stem transitions will stay"
+	log "  unavailable no matter what this variable is set to."
+	log "  To get them, change this container's IMAGE to:"
+	log "    ghcr.io/perminder-klair/subwave-aio-heavy"
+	log "  (or -aio-cuda on an NVIDIA host). NOT subwave-analyzer-heavy — that is"
+	log "  the bare analyzer micro-service, not a station image."
+	log "  https://github.com/perminder-klair/subwave/issues/1300"
+	log "################################################################"
+}
+
+# ---------------------------------------------------------------------------
 # Resolve the ICECAST_*_PASSWORD values. Precedence: env override > persisted
 # secrets file > freshly generated. Written back for operator visibility + the
 # documented rotate path; exported for liquidsoap.
@@ -502,6 +548,7 @@ if [ "${SUBWAVE_SUPERVISOR_LIB:-}" = "1" ]; then
 fi
 
 warn_if_state_unmounted
+warn_if_analyzer_heavy_ignored
 init_state
 init_secrets
 

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -365,19 +365,21 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   // wrong there, where this one is merely incomplete.
   const analyzerIsLocal = p.coverage?.analysisBackend === 'local';
   const heavyUpgradeShort = analyzerIsLocal
-    ? 'Needs the heavy image (subwave-aio-heavy).'
+    ? 'Needs the heavy build (subwave-aio-heavy, or heavy Python deps on a dev venv).'
     : 'Needs the heavy analyzer (ANALYZER_HEAVY=1).';
   const heavyUpgradeBox = analyzerIsLocal ? (
     <>
-      Switch this container&rsquo;s image to{' '}
+      On the all-in-one image, switch this container&rsquo;s image to{' '}
       <code>ghcr.io/perminder-klair/subwave-aio-heavy</code> (or{' '}
-      <code>-aio-cuda</code> on an NVIDIA host) and recreate it — analysis then
-      kicks in automatically, nothing to re-enable here.{' '}
+      <code>-aio-cuda</code> on an NVIDIA host) and recreate it; on a dev{' '}
+      <code>ANALYZE_PYTHON</code> venv, install the heavy Python deps. Analysis
+      then kicks in automatically, nothing to re-enable here.{' '}
       <b>
-        <code>ANALYZER_HEAVY</code> does nothing on this image
+        <code>ANALYZER_HEAVY</code> does nothing here
       </b>{' '}
-      — it is a docker-compose setting, and there is no analyzer service here to
-      point it at. The heavy image is amd64-only.
+      — it is a docker-compose setting that picks the analyzer service&rsquo;s
+      image, and there is no analyzer service on this backend. The heavy image is
+      amd64-only.
     </>
   ) : (
     <>

--- a/web/components/admin/LibraryTaggingPanel.tsx
+++ b/web/components/admin/LibraryTaggingPanel.tsx
@@ -352,6 +352,41 @@ export default function TaggingPanel(p: TaggingPanelProps) {
   const audioStatus = p.coverage?.audioStatus;
   const vocalStatus = p.coverage?.vocalStatus;
 
+  // How you actually GET the heavy analyzer depends on which backend is running,
+  // and the two answers don't overlap. 'local' is the in-process venv — the
+  // all-in-one image, or a dev ANALYZE_PYTHON venv — where ANALYZER_HEAVY is a
+  // docker-compose variable with no analyzer service to select, so setting it
+  // does precisely nothing (#1300 bug 9). This panel telling AIO operators to
+  // set it is a large part of why they set it, saw no change, and filed the
+  // feature as broken. Mirrors the doctor's split in doctor/checks-station.ts.
+  //
+  // Unknown backend (older controller, or still probing) keeps the compose
+  // wording: it's the majority install and the AIO advice would be actively
+  // wrong there, where this one is merely incomplete.
+  const analyzerIsLocal = p.coverage?.analysisBackend === 'local';
+  const heavyUpgradeShort = analyzerIsLocal
+    ? 'Needs the heavy image (subwave-aio-heavy).'
+    : 'Needs the heavy analyzer (ANALYZER_HEAVY=1).';
+  const heavyUpgradeBox = analyzerIsLocal ? (
+    <>
+      Switch this container&rsquo;s image to{' '}
+      <code>ghcr.io/perminder-klair/subwave-aio-heavy</code> (or{' '}
+      <code>-aio-cuda</code> on an NVIDIA host) and recreate it — analysis then
+      kicks in automatically, nothing to re-enable here.{' '}
+      <b>
+        <code>ANALYZER_HEAVY</code> does nothing on this image
+      </b>{' '}
+      — it is a docker-compose setting, and there is no analyzer service here to
+      point it at. The heavy image is amd64-only.
+    </>
+  ) : (
+    <>
+      Set <code>ANALYZER_HEAVY=1</code> in <code>.env</code> and recreate the
+      analyzer (<code>docker compose up -d analyzer</code>) — analysis then kicks
+      in automatically, nothing to re-enable here. The heavy image is amd64-only.
+    </>
+  );
+
   // Forced open while an analyze/backfill run is in flight so progress and Pause
   // stay visible; reverts to the manual choice when the run finishes.
   const [analysisOpen, setAnalysisOpen] = useState(false);
@@ -745,7 +780,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                   p.audioEnabled
                     ? 'Pause fingerprinting newly-added tracks. Existing “sounds-like” data stays and keeps driving picks.'
                     : audioStatus === 'pending-heavy'
-                      ? 'Needs the heavy analyzer (ANALYZER_HEAVY=1). You can enable now — fingerprinting starts automatically once it’s up.'
+                      ? `${heavyUpgradeShort} You can enable now — fingerprinting starts automatically once it’s up.`
                       : 'Start fingerprinting new tracks for “sounds-like” picks (~1-2s each on the analysis engine).'
                 }
               >
@@ -837,7 +872,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                     disabled={p.busy || running}
                     title={
                       vocalStatus === 'pending-heavy'
-                        ? 'Needs the heavy analyzer (ANALYZER_HEAVY=1). You can enable now — separation starts automatically once it’s up.'
+                        ? `${heavyUpgradeShort} You can enable now — separation starts automatically once it’s up.`
                         : 'Start Demucs vocal separation on new tracks (~10-30s each — CPU-heavy).'
                     }
                   >
@@ -847,7 +882,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
                 <span className="caption basis-full !tracking-[0.04em] !normal-case">
                   Separates vocals so the DJ can talk before lyrics (Demucs, ~10-30s/track —
                   CPU-heavy). Off by default.
-                  {vocalStatus === 'pending-heavy' && ' Needs the heavy analyzer (ANALYZER_HEAVY=1).'}
+                  {vocalStatus === 'pending-heavy' && ` ${heavyUpgradeShort}`}
                 </span>
               </>
             )}
@@ -911,10 +946,8 @@ export default function TaggingPanel(p: TaggingPanelProps) {
         {audioStatus === 'pending-heavy' && p.audioEnabled ? (
           <div className="border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
             <b>Sounds-like is enabled — fingerprinting starts once your analyzer can do it.</b> The
-            default analyzer is the lean image (bpm/key only); CLAP needs the heavy build. Set{' '}
-            <code>ANALYZER_HEAVY=1</code> in <code>.env</code> and recreate the analyzer
-            (<code>docker compose up -d analyzer</code>) — analysis then kicks in automatically,
-            nothing to re-enable here. The heavy image is amd64-only.{' '}
+            default analyzer is the lean image (bpm/key only); CLAP needs the heavy build.{' '}
+            {heavyUpgradeBox}{' '}
             <a href="/manual/analysis" className="font-bold text-vermilion underline-offset-2 hover:underline">
               Manual → Acoustic analysis
             </a>
@@ -923,9 +956,7 @@ export default function TaggingPanel(p: TaggingPanelProps) {
         {vocalStatus === 'pending-heavy' && p.vocalEnabled ? (
           <div className="border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
             <b>Vocal-activity is enabled — separation starts once your analyzer can do it.</b> Demucs
-            needs the heavy build. Set <code>ANALYZER_HEAVY=1</code> in <code>.env</code> and recreate
-            the analyzer (<code>docker compose up -d analyzer</code>) — analysis then kicks in
-            automatically, nothing to re-enable here. The heavy image is amd64-only.{' '}
+            needs the heavy build. {heavyUpgradeBox}{' '}
             <a href="/manual/analysis" className="font-bold text-vermilion underline-offset-2 hover:underline">
               Manual → Acoustic analysis
             </a>


### PR DESCRIPTION
Ships **bug 9** from #1300 — *"`ANALYZER_HEAVY=1` silently does nothing on the AIO image"*.

## The bug

`ANALYZER_HEAVY` selects an image **tag**, and it does it by docker-compose variable interpolation:

```yaml
image: ghcr.io/…/subwave-analyzer${ANALYZER_HEAVY:+-heavy}:${SUBWAVE_VERSION:-latest}
```

The all-in-one image has no analyzer service to select — CLAP and Demucs are baked into the venv at build time, fixed by the tag you pulled. So on AIO the variable isn't merely unsupported, it's **unreachable**: zero references in `Dockerfile.aio` or `docker/aio/`.

Operators set it, watch no stem-transitions card appear, and reasonably file the feature as broken. The caveat *was* written down (`docs/unraid.md:190`, `doctor-knowledge.ts:163`) — just never at either moment the operator was actually looking.

## The fix

**Two places now say it**, and the second turned out to be the more consequential one.

### 1. A boot warning in the AIO supervisor

`warn_if_analyzer_heavy_ignored`, alongside the existing `warn_if_state_unmounted`. Fires only when the variable is set, and names the thing that actually changes the outcome:

```
WARNING: ANALYZER_HEAVY is set, and it does NOTHING on this image.
  …change this container's IMAGE to:
    ghcr.io/perminder-klair/subwave-aio-heavy
  (or -aio-cuda on an NVIDIA host). NOT subwave-analyzer-heavy — that is
  the bare analyzer micro-service, not a station image.
```

That disclaimer is load-bearing: pointing an AIO operator at `subwave-analyzer-heavy` replaces their whole station with an analysis micro-service (#966).

On a **heavy** build it's a note rather than a warning — the variable is still inert, but the capability the operator wanted is present, so there is nothing to fix and an alarming message would send someone whose setup is fine hunting a problem.

The tier is **probed** (torch in `/opt/analyzer/venv`) rather than read from a baked marker file, because torch *is* what makes the heavy tier work — a probe can't disagree with the thing it describes, a marker can drift.

### 2. The admin panel, which was actively giving AIO operators the wrong instruction

`LibraryTaggingPanel` told **every** operator to *"Set `ANALYZER_HEAVY=1` in `.env` and recreate the analyzer"* — in five places, including to AIO/Unraid users who have no `.env` at all. That copy is a large part of *why* people set the variable.

It now branches on `analysisBackend`, which `GET /library/coverage` already publishes and the panel's `Coverage` interface already declared — the same `backendLabel() === 'local'` split `doctor/checks-station.ts` makes. On a local backend the advice becomes the image swap; unknown/absent keeps the compose wording, since that's the majority install where the AIO advice would be actively wrong rather than merely incomplete.

## Testing

- `controller/scripts/aio-analyzer-heavy.test.ts` (new) — drives the function against scratch lean/heavy venvs through the existing `SUBWAVE_SUPERVISOR_LIB=1` seam (same harness as `aio-log-link.test.ts`). Pins: warn-and-name-the-image on lean; note-not-warning on heavy; **silence when unset** on both builds; and an empty value treated as unset, matching what `${ANALYZER_HEAVY:+…}` itself does with it.
- `npm run lint` clean in `web/` and `controller/`; `bash -n` clean on the supervisor.
- `npm test` in `controller/`: 76/77 pass. The one failure (`analyzer-python.test.ts` → `vocal_gate_test.py`, missing `numpy`) reproduces unchanged on `develop`.
