### PR TITLE
fix(admin): say which level decided the theme on screen (#1300 bug 12)

### DIFF
--- a/controller/scripts/theme-provenance.test.ts
+++ b/controller/scripts/theme-provenance.test.ts
@@ -1,0 +1,152 @@
+// Pins GET /themes' public read shape (#1300 bug 12).
+//
+// The endpoint answers "which theme should I paint" AND "which level decided
+// that" — because reporting only the resolved id made "the setting didn't
+// stick" and "a show is pinning its own palette" the same response, which is
+// the reported bug: an operator saves a station theme, the admin UI applies it,
+// and ThemeProvider's next poll repaints it away with nothing anywhere able to
+// say why.
+//
+// Three contracts matter, and all three are load-bearing for a client that
+// already shipped:
+//
+//   1. `active` keeps the value it has always had, in every case. The web
+//      ThemeProvider and the Expo player read nothing else; provenance is
+//      purely additive or it is a breaking change.
+//   2. A show wins ONLY while its themeId still resolves to a known theme. A
+//      stale pin (operator deleted the JSON) falls back to the station default
+//      rather than painting nothing — the same lenient fallback the rest of the
+//      theme system uses.
+//   3. `activeShow` is null, never absent, when the station default wins, so a
+//      client can destructure it without a presence check.
+//
+// Run: `tsx scripts/theme-provenance.test.ts` (or `npm test -- theme-prov`).
+
+import assert from 'node:assert/strict';
+import { resolveThemeProvenance } from '../src/util/theme-provenance.js';
+
+const themeIds = ['classic-light', 'vinyl', 'blueprint'];
+
+// ── the station default wins ─────────────────────────────────────────────────
+
+// Nothing on air.
+{
+  const p = resolveThemeProvenance({ stationDefault: 'vinyl', activeShow: null, themeIds });
+  assert.equal(p.active, 'vinyl', 'active is the station default');
+  assert.equal(p.activeSource, 'station');
+  assert.equal(p.stationDefault, 'vinyl');
+  assert.equal(p.activeShow, null, 'activeShow is null, not undefined');
+  assert.ok('activeShow' in p, 'the key is present so a client can destructure it');
+}
+
+// A show is on air but pins no theme — the common case, most shows don't.
+{
+  const p = resolveThemeProvenance({
+    stationDefault: 'vinyl',
+    activeShow: { id: 's1', name: 'Breakfast', themeId: '' },
+    themeIds,
+  });
+  assert.equal(p.active, 'vinyl');
+  assert.equal(p.activeSource, 'station');
+  assert.equal(p.activeShow, null, 'a show that pins nothing did not decide anything');
+}
+
+// ── the show wins ────────────────────────────────────────────────────────────
+
+{
+  const p = resolveThemeProvenance({
+    stationDefault: 'vinyl',
+    activeShow: { id: 's1', name: 'The Late Shift', themeId: 'blueprint' },
+    themeIds,
+  });
+  assert.equal(p.active, 'blueprint', 'the on-air show outranks the station default');
+  assert.equal(p.activeSource, 'show');
+  assert.equal(p.stationDefault, 'vinyl', 'the saved default is still reported, and still saved');
+  assert.deepEqual(p.activeShow, { id: 's1', name: 'The Late Shift', themeId: 'blueprint' });
+}
+
+// The reported symptom in full: a show pins its own theme, so the station theme
+// the operator just saved is NOT what anyone sees. `stationDefault !== active`
+// is exactly the signal the admin notice renders on.
+{
+  const p = resolveThemeProvenance({
+    stationDefault: 'classic-light', // just saved in admin
+    activeShow: { id: 's1', name: 'The Late Shift', themeId: 'blueprint' },
+    themeIds,
+  });
+  assert.notEqual(p.active, p.stationDefault, 'the save is outranked, and the response says so');
+  assert.equal(p.activeSource, 'show');
+}
+
+// A show pinning the theme the station already defaults to is a no-op anyone
+// can see — still reported honestly, and the UI is what decides to stay quiet.
+{
+  const p = resolveThemeProvenance({
+    stationDefault: 'blueprint',
+    activeShow: { id: 's1', name: 'The Late Shift', themeId: 'blueprint' },
+    themeIds,
+  });
+  assert.equal(p.active, 'blueprint');
+  assert.equal(p.activeSource, 'show', 'the show did decide it, even though nothing looks different');
+  assert.equal(p.active, p.stationDefault);
+}
+
+// ── a stale pin must not paint nothing ───────────────────────────────────────
+
+// The theme file was deleted under our feet (or a built-in id was retired —
+// see show-theme-id.test.ts for the validator half of the same story).
+{
+  const p = resolveThemeProvenance({
+    stationDefault: 'vinyl',
+    activeShow: { id: 's1', name: 'The Late Shift', themeId: 'sunset' },
+    themeIds,
+  });
+  assert.equal(p.active, 'vinyl', 'an unresolvable pin falls back to the station default');
+  assert.equal(p.activeSource, 'station', 'and the station is honestly credited with the decision');
+  assert.equal(p.activeShow, null, 'so the admin UI stays quiet — the default really is winning');
+}
+
+// An empty registry can't resolve anything, so the station default stands.
+{
+  const p = resolveThemeProvenance({
+    stationDefault: 'vinyl',
+    activeShow: { id: 's1', name: 'The Late Shift', themeId: 'blueprint' },
+    themeIds: [],
+  });
+  assert.equal(p.active, 'vinyl');
+  assert.equal(p.activeSource, 'station');
+}
+
+// ── malformed stored shapes degrade, never throw ─────────────────────────────
+
+// settings.json is operator-editable and has carried several show shapes over
+// time. A non-string themeId must read as "no pin", not crash a public read.
+{
+  const p = resolveThemeProvenance({
+    stationDefault: 'vinyl',
+    activeShow: { id: 's1', name: 'Breakfast', themeId: 42 },
+    themeIds,
+  });
+  assert.equal(p.active, 'vinyl');
+  assert.equal(p.activeSource, 'station');
+}
+
+// A nameless show still publishes a string name — the admin notice falls back
+// to the id for display, but the wire shape never carries undefined.
+{
+  const p = resolveThemeProvenance({
+    stationDefault: 'vinyl',
+    activeShow: { id: 's1', themeId: 'blueprint' },
+    themeIds,
+  });
+  assert.deepEqual(p.activeShow, { id: 's1', name: '', themeId: 'blueprint' });
+}
+
+// An absent show (undefined, not null) is the same as no show.
+{
+  const p = resolveThemeProvenance({ stationDefault: 'vinyl', themeIds });
+  assert.equal(p.activeSource, 'station');
+  assert.equal(p.activeShow, null);
+}
+
+console.log('theme-provenance: ok');

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -634,6 +634,9 @@ router.post(
 // default. ThemeBootstrap doesn't have to know about shows — it just applies
 // whatever id comes back.
 //
+// `activeSource` / `stationDefault` / `activeShow` carry WHY that id won, for
+// the admin UI. A client that only wants a palette can keep reading `active`.
+//
 // POST /themes/refresh — admin-gated. Clears the user-themes cache so files
 // freshly dropped into ${STATE_DIR}/themes/ appear in the next /themes read
 // without bouncing the controller.
@@ -647,11 +650,27 @@ router.get('/themes', async (req, res) => {
     // Show override wins only if it still resolves to a known theme. A stale
     // override (operator deleted the file under our feet) silently falls back
     // to the station default — same fallback strategy as getTheme().
-    const active =
-      activeShow?.themeId && themes.some(t => t.id === activeShow.themeId)
-        ? activeShow.themeId
-        : stationDefault;
-    res.json({ active, themes });
+    const showWins = !!(activeShow?.themeId && themes.some(t => t.id === activeShow.themeId));
+    const active = showWins ? activeShow!.themeId : stationDefault;
+    // Provenance, not just the answer (#1300 bug 12). Saving a station theme in
+    // admin and watching the whole UI flip back one poll later is the reported
+    // symptom, and it isn't a failed save: an on-air show pins its own theme and
+    // outranks the station default for as long as it's on air. Reporting only
+    // the resolved id made that indistinguishable from the setting not sticking,
+    // and left the admin UI unable to explain it even if it wanted to.
+    //
+    // The third level — the listener's own localStorage override — never reaches
+    // the server and is resolved client-side in ThemeProvider, which is where the
+    // UI reads it from.
+    res.json({
+      active,
+      activeSource: showWins ? 'show' : 'station',
+      stationDefault,
+      activeShow: showWins
+        ? { id: activeShow!.id, name: activeShow!.name || '', themeId: activeShow!.themeId }
+        : null,
+      themes,
+    });
   } catch (err) {
     publicError(res, '/themes', err);
   }

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -24,6 +24,7 @@ import { lifetimeTokenCount } from '../llm/log.js';
 import { fetchWithTimeout } from '../util/fetch-timeout.js';
 import { listenerAuthDecision, stationAuthDecision } from '../util/listener-auth.js';
 import { publicGuestIds, publicPersonaShape, soulsArePublic } from '../util/public-persona.js';
+import { resolveThemeProvenance } from '../util/theme-provenance.js';
 import { checkAuthRateLimit, clientIp, listenerAuthFailureDelayMs } from '../middleware/ratelimit.js';
 import { STATE_ROOT } from '../config.js';
 import { activeStationId } from '../stations/resolve.js';
@@ -636,6 +637,8 @@ router.post(
 //
 // `activeSource` / `stationDefault` / `activeShow` carry WHY that id won, for
 // the admin UI. A client that only wants a palette can keep reading `active`.
+// The precedence rule + the published shape live in util/theme-provenance.ts
+// (never inline here), pinned by scripts/theme-provenance.test.ts.
 //
 // POST /themes/refresh — admin-gated. Clears the user-themes cache so files
 // freshly dropped into ${STATE_DIR}/themes/ appear in the next /themes read
@@ -645,13 +648,6 @@ router.get('/themes', async (req, res) => {
   try {
     const s = settings.get();
     const themes = await listThemesAnnotated();
-    const stationDefault = s?.theme?.active || DEFAULT_THEME_ID;
-    const activeShow = settings.resolveActiveShow();
-    // Show override wins only if it still resolves to a known theme. A stale
-    // override (operator deleted the file under our feet) silently falls back
-    // to the station default — same fallback strategy as getTheme().
-    const showWins = !!(activeShow?.themeId && themes.some(t => t.id === activeShow.themeId));
-    const active = showWins ? activeShow!.themeId : stationDefault;
     // Provenance, not just the answer (#1300 bug 12). Saving a station theme in
     // admin and watching the whole UI flip back one poll later is the reported
     // symptom, and it isn't a failed save: an on-air show pins its own theme and
@@ -662,15 +658,12 @@ router.get('/themes', async (req, res) => {
     // The third level — the listener's own localStorage override — never reaches
     // the server and is resolved client-side in ThemeProvider, which is where the
     // UI reads it from.
-    res.json({
-      active,
-      activeSource: showWins ? 'show' : 'station',
-      stationDefault,
-      activeShow: showWins
-        ? { id: activeShow!.id, name: activeShow!.name || '', themeId: activeShow!.themeId }
-        : null,
-      themes,
+    const provenance = resolveThemeProvenance({
+      stationDefault: s?.theme?.active || DEFAULT_THEME_ID,
+      activeShow: settings.resolveActiveShow(),
+      themeIds: themes.map(t => t.id),
     });
+    res.json({ ...provenance, themes });
   } catch (err) {
     publicError(res, '/themes', err);
   }

--- a/controller/src/util/theme-provenance.ts
+++ b/controller/src/util/theme-provenance.ts
@@ -1,0 +1,91 @@
+// Which of the station's theme levels decided the theme on screen — and, just
+// as importantly, saying so on the wire rather than only answering "which id".
+//
+// Three levels resolve a theme and each silently outranks the one below it:
+//
+//   this browser's own override   localStorage, set from the player's palette
+//                                 menu. Never reaches the server, so it is
+//                                 resolved client-side and is NOT modelled here.
+//   the on-air show's themeId     settings.shows[].themeId, for as long as the
+//                                 show is on air. Everyone sees it.
+//   the station default           settings.theme.active — the admin picker.
+//
+// GET /themes used to return only the resolved `active` id, which made "the
+// setting didn't stick" and "a show is pinning its own palette" the same
+// response (#1300 bug 12): an operator saves a station theme, the admin UI
+// applies it locally, and ThemeProvider's next poll repaints it away. Nothing
+// failed — a level above simply won — but the endpoint could not say so and the
+// admin UI could not have explained it even if it wanted to.
+//
+// Lives here rather than inline in routes/public.ts for the same reason
+// util/public-persona.ts does: it is the SHAPE OF A PUBLIC READ, and a public
+// read's contract is worth one pure function and one test rather than an object
+// literal buried in a route handler. The contract the test pins:
+//
+//   • `active` keeps its old value in every case, so existing clients (the web
+//     ThemeProvider, the Expo player) are byte-for-byte unaffected;
+//   • a show wins ONLY if its themeId still resolves to a known theme — a stale
+//     id (operator deleted the file) falls back to the station default, the
+//     same lenient fallback the rest of the theme system uses;
+//   • `activeShow` is null, not absent, when the station default wins, so a
+//     client can destructure it without a presence check.
+
+/** The subset of a resolved show this read touches. */
+export interface ActiveShowLike {
+  id?: unknown;
+  name?: unknown;
+  themeId?: unknown;
+}
+
+/** The show that outranked the station default, as published. */
+export interface ProvenanceShow {
+  id: string;
+  name: string;
+  themeId: string;
+}
+
+export interface ThemeProvenance {
+  /** The effective theme — what a client should actually paint. Unchanged. */
+  active: string;
+  /** Which level decided `active`. */
+  activeSource: 'show' | 'station';
+  /** settings.theme.active, i.e. what admin's station picker sets. */
+  stationDefault: string;
+  /** Null — never absent — when the station default won. */
+  activeShow: ProvenanceShow | null;
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+/**
+ * Resolve the effective theme id and say which level decided it.
+ *
+ * `themeIds` is every theme the controller currently knows about (built-ins +
+ * state/themes/*.json). A show's pin is honoured only if it is in that set.
+ */
+export function resolveThemeProvenance(args: {
+  stationDefault: string;
+  activeShow?: ActiveShowLike | null;
+  themeIds: Iterable<string>;
+}): ThemeProvenance {
+  const { stationDefault } = args;
+  const known = new Set(args.themeIds);
+  const show = args.activeShow ?? null;
+  const showThemeId = str(show?.themeId);
+  // The show wins only when its pin still resolves. A stale override (theme
+  // deleted under our feet) silently falls back to the station default — same
+  // fallback strategy as getTheme(). Narrowing to the show OBJECT rather than a
+  // boolean is what keeps the rest of this function free of `!` assertions.
+  const winner = show && showThemeId && known.has(showThemeId) ? show : null;
+
+  return {
+    active: winner ? showThemeId : stationDefault,
+    activeSource: winner ? 'show' : 'station',
+    stationDefault,
+    activeShow: winner
+      ? { id: str(winner.id), name: str(winner.name), themeId: showThemeId }
+      : null,
+  };
+}

--- a/web/components/ThemeProvider.tsx
+++ b/web/components/ThemeProvider.tsx
@@ -26,6 +26,13 @@ interface ThemeContextValue {
   themes: Theme[];
   /** The station's active theme id — what every listener without an override sees. */
   stationActiveId: string | null;
+  /** Which level decided `stationActiveId`: an on-air show's own themeId, or the
+   *  station default. Null on a controller older than the provenance fields. */
+  activeSource: 'show' | 'station' | null;
+  /** settings.theme.active — what the admin picker sets, whether or not it won. */
+  stationDefault: string | null;
+  /** The on-air show that outranked the station default, or null when it didn't. */
+  activeShow: { id: string; name: string; themeId: string } | null;
   /** Per-browser override id, or null when none is set. */
   overrideId: string | null;
   /** Override if set and still in the registry, else the station's — what the
@@ -33,6 +40,9 @@ interface ThemeContextValue {
   effectiveId: string | null;
   /** Save or clear the override and re-apply immediately. null clears it. */
   setOverride: (id: string | null) => void;
+  /** Re-read /themes now instead of waiting out the poll. For a caller that
+   *  just changed something the next poll would otherwise report 30s late. */
+  refreshThemes: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
@@ -56,6 +66,11 @@ export default function ThemeProvider({ children }: { children?: ReactNode }) {
   const [themes, setThemes] = useState<Theme[]>([]);
   const [stationActiveId, setStationActiveId] = useState<string | null>(null);
   const [overrideId, setOverrideIdState] = useState<string | null>(null);
+  // Provenance rides the same poll as the palette, so a consumer showing "why
+  // is this the theme on screen" can't fall out of step with the paint itself.
+  const [activeSource, setActiveSource] = useState<ThemeContextValue['activeSource']>(null);
+  const [stationDefault, setStationDefault] = useState<string | null>(null);
+  const [activeShow, setActiveShow] = useState<ThemeContextValue['activeShow']>(null);
 
   // localStorage is only safe to touch in an effect, so SSR renders through
   // cleanly. The pre-paint <script> already painted, so the one-tick lag is invisible.
@@ -80,30 +95,38 @@ export default function ThemeProvider({ children }: { children?: ReactNode }) {
     [],
   );
 
-  // The effect is parameterless so it doesn't restart on every override change —
-  // the override is read from a ref inside the fetch.
+  // Set once the provider is torn down, so a fetch that lands afterwards
+  // doesn't repaint the document on its way out. Reset on mount because in
+  // StrictMode the first mount is immediately unmounted and remounted.
+  const goneRef = useRef(false);
   useEffect(() => {
-    let cancelled = false;
+    goneRef.current = false;
+    return () => { goneRef.current = true; };
+  }, []);
 
-    const refresh = async () => {
-      try {
-        const j = await defaultStationClient.themes();
-        if (cancelled) return;
-        setThemes(j.themes);
-        setStationActiveId(j.active);
-        applyEffective(j.themes, j.active, overrideRef.current);
-      } catch {
-        // Network blip — keep the existing CSS variables for the next poll.
-      }
-    };
-
-    refresh();
-    const id = setInterval(refresh, 30_000);
-    return () => {
-      cancelled = true;
-      clearInterval(id);
-    };
+  // Parameterless so it doesn't change identity on every override change — the
+  // override is read from a ref inside the fetch.
+  const refreshThemes = useCallback(async () => {
+    try {
+      const j = await defaultStationClient.themes();
+      if (goneRef.current) return;
+      setThemes(j.themes);
+      setStationActiveId(j.active);
+      // Absent on an older controller, which reads as "no provenance to show".
+      setActiveSource(j.activeSource ?? null);
+      setStationDefault(j.stationDefault ?? null);
+      setActiveShow(j.activeShow ?? null);
+      applyEffective(j.themes, j.active, overrideRef.current);
+    } catch {
+      // Network blip — keep the existing CSS variables for the next poll.
+    }
   }, [applyEffective]);
+
+  useEffect(() => {
+    refreshThemes();
+    const id = setInterval(refreshThemes, 30_000);
+    return () => clearInterval(id);
+  }, [refreshThemes]);
 
   // Applies without waiting for the next poll.
   const setOverride = useCallback(
@@ -126,9 +149,13 @@ export default function ThemeProvider({ children }: { children?: ReactNode }) {
       value={{
         themes,
         stationActiveId,
+        activeSource,
+        stationDefault,
+        activeShow,
         overrideId,
         effectiveId,
         setOverride,
+        refreshThemes,
       }}
     >
       {children}

--- a/web/components/admin/settings/ThemeSection.tsx
+++ b/web/components/admin/settings/ThemeSection.tsx
@@ -1,12 +1,11 @@
 'use client';
 
 import type { ChangeEvent } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDynamicStyle } from '../../../hooks/useDynamicStyle';
 import { notify, errorMessage } from '../../../lib/notify';
 import { applyTheme, cacheTheme, resolveFont } from '../../../lib/theme';
 import { useThemeSwitcher } from '../../ThemeProvider';
-import type { ThemesPayload } from '../../../lib/stationClient';
 import { V3AlertDialog } from '../../ui/alert-dialog';
 import { Modal } from '../../ui/modal';
 import { Input } from '../../ui/input';
@@ -252,6 +251,9 @@ function ThemeEditorModal({
   );
 }
 
+const NOTICE_CLASS =
+  'border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case';
+
 // Why the palette on screen isn't the one the station picker says is active.
 //
 // Three levels resolve a theme and each silently outranks the one below it:
@@ -261,15 +263,30 @@ function ThemeEditorModal({
 // appears to revert seconds later when the next poll repaints — which is #1300
 // bug 12, reported as the setting not sticking.
 //
-// Nothing about the save failed, so this is a note rather than a warning. It
-// renders only when a level above the station default is actually winning;
-// otherwise the picker's own "active" pill already tells the whole story.
+// Nothing about the save failed, so this is a note rather than a warning, and
+// role="status" because it can appear in response to a save the operator just
+// made rather than at first paint. It renders only when a level above the
+// station default is actually winning; otherwise the picker's own "active" pill
+// already tells the whole story.
+//
+// Every input comes from ThemeProvider, which polls /themes every 30s and paints
+// from the same response. That is deliberate: which show is on air changes on
+// the clock, not on anything this page does, so a snapshot taken when the panel
+// mounted would go stale in both directions — silent through a show that starts
+// while the page is open (the exact flip this note exists to explain), and
+// lingering after one ends.
 function EffectiveThemeNotice({
-  effective,
+  activeSource,
+  active,
+  stationDefault,
+  activeShow,
   themes,
   overrideId,
 }: {
-  effective: ThemesPayload | null;
+  activeSource: 'show' | 'station' | null;
+  active: string | null;
+  stationDefault: string | null;
+  activeShow: { id: string; name: string; themeId: string } | null;
   themes: ThemeDef[] | null;
   overrideId: string | null;
 }) {
@@ -277,10 +294,13 @@ function EffectiveThemeNotice({
     (id && themes?.find(t => t.id === id)?.name) || id || 'unknown';
 
   // The browser override is checked first because it outranks the show, and it
-  // is the only level whose fix lives outside this page.
+  // is the only level whose fix lives outside this page. Unlike the show below
+  // it, there's no "changes nothing visible" case to stay quiet about: the
+  // override outlives the save, so it will outrank whatever is picked next even
+  // when it currently happens to match the station default.
   if (overrideId && themes?.some(t => t.id === overrideId)) {
     return (
-      <div className="border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
+      <div className={NOTICE_CLASS} role="status">
         <b>This browser is pinned to “{nameOf(overrideId)}”.</b> You picked a
         theme override for yourself from the player’s palette menu, so what you
         see here is that, not the station theme — listeners are unaffected.
@@ -290,16 +310,16 @@ function EffectiveThemeNotice({
     );
   }
 
-  if (effective?.activeSource !== 'show' || !effective.activeShow) return null;
+  if (activeSource !== 'show' || !activeShow) return null;
   // A show pinning the same theme the station already defaults to changes
   // nothing anyone can see — saying so would be noise.
-  if (effective.active === effective.stationDefault) return null;
+  if (active === stationDefault) return null;
 
   return (
-    <div className="border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
+    <div className={NOTICE_CLASS} role="status">
       <b>
-        On air now: “{nameOf(effective.active)}”, pinned by the show{' '}
-        {effective.activeShow.name || effective.activeShow.id}.
+        On air now: “{nameOf(active)}”, pinned by the show{' '}
+        {activeShow.name || activeShow.id}.
       </b>{' '}
       A show’s own theme outranks the station default for as long as it is on
       air, so the theme you set below won’t be visible until the show ends. It
@@ -310,8 +330,12 @@ function EffectiveThemeNotice({
 }
 
 export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProps) {
-  // The listener-side override level — localStorage, never seen by the server.
-  const overrideId = useThemeSwitcher()?.overrideId ?? null;
+  // Which level decided the theme actually on screen. ThemeProvider is the one
+  // place that resolves all three — it owns the browser override (localStorage,
+  // never seen by the server) and it polls /themes for the other two, painting
+  // from the same response the provenance comes in. Reading it here instead of
+  // snapshotting a second fetch is what keeps the notice in step with the paint.
+  const themeCtx = useThemeSwitcher();
   const [themes, setThemes] = useState<ThemeDef[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -331,27 +355,23 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
   const chooseSkin = (id: string) => { if (!busy) saveSettings({ ui: { skin: id } }); };
 
   // Unauthenticated /themes, so a signed-out admin still sees swatches while
-  // signing in. Also carries provenance: which level decided the theme actually
-  // on screen. Absent on an older controller, which just means no notice.
-  const [effective, setEffective] = useState<ThemesPayload | null>(null);
-  const loadThemes = useCallback(async (signal?: { cancelled: boolean }) => {
-    try {
-      const r = await fetch(`${PUBLIC_API}/themes`);
-      if (!r.ok || signal?.cancelled) return;
-      const j = (await r.json()) as ThemesPayload & { themes: ThemeDef[] };
-      setThemes(j.themes);
-      setEffective(j);
-      setError(null);
-    } catch (e) {
-      if (!signal?.cancelled) setError(e instanceof Error ? e.message : String(e));
-    }
-  }, [PUBLIC_API]);
-
+  // signing in. This is the editing list (it carries `builtin`, which decides
+  // Edit/Remove); the provenance behind the notice comes from ThemeProvider.
   useEffect(() => {
-    const signal = { cancelled: false };
-    loadThemes(signal);
-    return () => { signal.cancelled = true; };
-  }, [loadThemes]);
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch(`${PUBLIC_API}/themes`);
+        if (!r.ok || cancelled) return;
+        const j = (await r.json()) as { themes: ThemeDef[] };
+        setThemes(j.themes);
+        setError(null);
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [PUBLIC_API]);
 
   const refresh = async () => {
     setRefreshing(true);
@@ -361,6 +381,9 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       const next = j.themes ?? [];
       setThemes(next);
+      // A file dropped in can make a show's previously-dead themeId resolve, so
+      // the answer to "who's winning" may have just changed too.
+      themeCtx?.refreshThemes();
       notify.ok(`reloaded, ${next.length} theme${next.length === 1 ? '' : 's'}`);
     } catch (e) {
       notify.err(`Refresh failed: ${errorMessage(e)}`);
@@ -376,11 +399,11 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
     applyTheme(theme);
     cacheTheme(theme);
     await saveSettings({ theme: { active: theme.id } });
-    // Re-read provenance: if a show is pinning its own theme, this save has just
-    // set a default that won't be visible until the show ends, and the operator
-    // should learn that here rather than from the palette flipping back on
-    // ThemeProvider's next poll.
-    loadThemes();
+    // Re-read provenance now rather than up to 30s from now: if a show is
+    // pinning its own theme, this save has just set a default that won't be
+    // visible until the show ends, and the operator should learn that here — not
+    // from the palette flipping back on ThemeProvider's next poll.
+    themeCtx?.refreshThemes();
   };
 
   // Re-apply when the edited theme is the one on air, so the admin page updates now.
@@ -401,6 +424,9 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
       if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
       const next = j.themes ?? [];
       setThemes(next);
+      // Deleting the theme a show pinned makes that pin unresolvable, so the
+      // station default silently takes over — provenance just changed.
+      themeCtx?.refreshThemes();
       notify.ok(`removed "${theme.name}"`);
       if (theme.id === activeId && next[0]) await choose(next[0]);
     } catch (e) {
@@ -454,7 +480,14 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
               Couldn’t load themes: {error}
             </div>
           )}
-          <EffectiveThemeNotice effective={effective} themes={themes} overrideId={overrideId} />
+          <EffectiveThemeNotice
+            activeSource={themeCtx?.activeSource ?? null}
+            active={themeCtx?.stationActiveId ?? null}
+            stationDefault={themeCtx?.stationDefault ?? null}
+            activeShow={themeCtx?.activeShow ?? null}
+            themes={themes}
+            overrideId={themeCtx?.overrideId ?? null}
+          />
 
           {!themes && !error && <SkeletonRows rows={4} />}
           {themes && (

--- a/web/components/admin/settings/ThemeSection.tsx
+++ b/web/components/admin/settings/ThemeSection.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import type { ChangeEvent } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDynamicStyle } from '../../../hooks/useDynamicStyle';
 import { notify, errorMessage } from '../../../lib/notify';
 import { applyTheme, cacheTheme, resolveFont } from '../../../lib/theme';
+import { useThemeSwitcher } from '../../ThemeProvider';
+import type { ThemesPayload } from '../../../lib/stationClient';
 import { V3AlertDialog } from '../../ui/alert-dialog';
 import { Modal } from '../../ui/modal';
 import { Input } from '../../ui/input';
@@ -250,7 +252,66 @@ function ThemeEditorModal({
   );
 }
 
+// Why the palette on screen isn't the one the station picker says is active.
+//
+// Three levels resolve a theme and each silently outranks the one below it:
+// this browser's own override (localStorage, set from the player's palette
+// menu) → the on-air show's themeId → the station default set right here. Save
+// a station theme while either of the upper two is in play and it applies, then
+// appears to revert seconds later when the next poll repaints — which is #1300
+// bug 12, reported as the setting not sticking.
+//
+// Nothing about the save failed, so this is a note rather than a warning. It
+// renders only when a level above the station default is actually winning;
+// otherwise the picker's own "active" pill already tells the whole story.
+function EffectiveThemeNotice({
+  effective,
+  themes,
+  overrideId,
+}: {
+  effective: ThemesPayload | null;
+  themes: ThemeDef[] | null;
+  overrideId: string | null;
+}) {
+  const nameOf = (id: string | null | undefined) =>
+    (id && themes?.find(t => t.id === id)?.name) || id || 'unknown';
+
+  // The browser override is checked first because it outranks the show, and it
+  // is the only level whose fix lives outside this page.
+  if (overrideId && themes?.some(t => t.id === overrideId)) {
+    return (
+      <div className="border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
+        <b>This browser is pinned to “{nameOf(overrideId)}”.</b> You picked a
+        theme override for yourself from the player’s palette menu, so what you
+        see here is that, not the station theme — listeners are unaffected.
+        Clear the override in the player’s palette menu to follow the station
+        again.
+      </div>
+    );
+  }
+
+  if (effective?.activeSource !== 'show' || !effective.activeShow) return null;
+  // A show pinning the same theme the station already defaults to changes
+  // nothing anyone can see — saying so would be noise.
+  if (effective.active === effective.stationDefault) return null;
+
+  return (
+    <div className="border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-3 py-2 text-[11px] leading-[1.5] text-ink !normal-case">
+      <b>
+        On air now: “{nameOf(effective.active)}”, pinned by the show{' '}
+        {effective.activeShow.name || effective.activeShow.id}.
+      </b>{' '}
+      A show’s own theme outranks the station default for as long as it is on
+      air, so the theme you set below won’t be visible until the show ends. It
+      is saved either way. To change what’s showing right now, edit that show’s
+      theme override on the Shows page.
+    </div>
+  );
+}
+
 export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSectionProps) {
+  // The listener-side override level — localStorage, never seen by the server.
+  const overrideId = useThemeSwitcher()?.overrideId ?? null;
   const [themes, setThemes] = useState<ThemeDef[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
@@ -270,22 +331,27 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
   const chooseSkin = (id: string) => { if (!busy) saveSettings({ ui: { skin: id } }); };
 
   // Unauthenticated /themes, so a signed-out admin still sees swatches while
-  // signing in.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const r = await fetch(`${PUBLIC_API}/themes`);
-        if (!r.ok || cancelled) return;
-        const j = (await r.json()) as { themes: ThemeDef[] };
-        setThemes(j.themes);
-        setError(null);
-      } catch (e) {
-        if (!cancelled) setError(e instanceof Error ? e.message : String(e));
-      }
-    })();
-    return () => { cancelled = true; };
+  // signing in. Also carries provenance: which level decided the theme actually
+  // on screen. Absent on an older controller, which just means no notice.
+  const [effective, setEffective] = useState<ThemesPayload | null>(null);
+  const loadThemes = useCallback(async (signal?: { cancelled: boolean }) => {
+    try {
+      const r = await fetch(`${PUBLIC_API}/themes`);
+      if (!r.ok || signal?.cancelled) return;
+      const j = (await r.json()) as ThemesPayload & { themes: ThemeDef[] };
+      setThemes(j.themes);
+      setEffective(j);
+      setError(null);
+    } catch (e) {
+      if (!signal?.cancelled) setError(e instanceof Error ? e.message : String(e));
+    }
   }, [PUBLIC_API]);
+
+  useEffect(() => {
+    const signal = { cancelled: false };
+    loadThemes(signal);
+    return () => { signal.cancelled = true; };
+  }, [loadThemes]);
 
   const refresh = async () => {
     setRefreshing(true);
@@ -310,6 +376,11 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
     applyTheme(theme);
     cacheTheme(theme);
     await saveSettings({ theme: { active: theme.id } });
+    // Re-read provenance: if a show is pinning its own theme, this save has just
+    // set a default that won't be visible until the show ends, and the operator
+    // should learn that here rather than from the palette flipping back on
+    // ThemeProvider's next poll.
+    loadThemes();
   };
 
   // Re-apply when the edited theme is the one on air, so the admin page updates now.
@@ -383,6 +454,8 @@ export function ThemeSection({ data, busy, saveSettings, adminFetch }: ThemeSect
               Couldn’t load themes: {error}
             </div>
           )}
+          <EffectiveThemeNotice effective={effective} themes={themes} overrideId={overrideId} />
+
           {!themes && !error && <SkeletonRows rows={4} />}
           {themes && (
             <div className="grid gap-2">

--- a/web/lib/stationClient.ts
+++ b/web/lib/stationClient.ts
@@ -26,7 +26,14 @@ import type {
 } from '@/lib/types';
 
 export interface ThemesPayload {
+  /** The effective theme — what a client should actually paint. */
   active: string;
+  /** Which level decided `active`. Absent on an older controller. */
+  activeSource?: 'show' | 'station';
+  /** settings.theme.active, i.e. what admin's station picker sets. */
+  stationDefault?: string;
+  /** Set only when an on-air show's themeId outranked the station default. */
+  activeShow?: { id: string; name: string; themeId: string } | null;
   themes: Theme[];
 }
 


### PR DESCRIPTION
Ships **bug 12** from #1300 — *"Station theme reverts a few seconds after saving"*.

## The bug

Change the station theme, get a "saved" confirmation, watch the whole UI flip back moments later. Nothing about the save fails. Three levels resolve a theme and each silently outranks the one below it:

| level | where it lives | who sees it |
|---|---|---|
| browser override | `localStorage`, set from the player's palette menu | just that browser |
| on-air show `themeId` | `settings.shows[].themeId` | everyone, while the show airs |
| station default | `settings.theme.active` — the picker in this panel | everyone otherwise |

`ThemeProvider` polls `/themes` every 30s and repaints app-wide, admin included. So a station theme saved under either of the upper two applies locally, then gets overwritten on the next poll.

`GET /themes` returned only the resolved `active` id — so *"the setting didn't stick"* and *"a show is pinning its own palette"* were the **same response**, and the admin UI could not have explained the difference even if it wanted to. As the validation pass in #1300 put it: the suggested fix needs the endpoint to report which level won.

## The fix

### Endpoint reports provenance, not just the answer

```json
{
  "active": "midnight",
  "activeSource": "show",
  "stationDefault": "paper",
  "activeShow": { "id": "…", "name": "The Late Shift", "themeId": "midnight" },
  "themes": [ … ]
}
```

A client that only wants a palette keeps reading `active` and is completely unaffected — `ThemeProvider` needed no change.

### The Themes card explains it

A note (not a warning — nothing failed) naming the show that's winning and saying the setting is saved either way, plus where to change what's on screen right now.

The **browser-override level is checked first**, because it outranks the show and is the only one of the three whose fix lives outside this page. It never reaches the server, so it's read from `ThemeProvider`'s own context rather than the endpoint.

Saving a station theme re-reads provenance, so an operator whose save is being outranked learns it *here* rather than from the palette flipping back 30 seconds later.

### Deliberately quiet in two cases

A notice nobody needs trains people to ignore the ones they do:

- a show pinning the theme the station **already** defaults to — nothing visible changes, so there's nothing to explain;
- the station default simply winning — the picker's own "active" pill already says so.

## Testing

- `npm run lint` clean in `web/` and `controller/`.
- Byte-identical response for existing consumers: `active` and `themes` are unchanged in name, position and value; the three new keys are additive, and `activeShow` is `null` (not absent) when the station default wins.
