### PR TITLE
feat(shows): steer a show toward instrumental or vocal tracks (#1300 FR 13)

### DIFF
--- a/controller/scripts/picker-lock-forwarding.test.ts
+++ b/controller/scripts/picker-lock-forwarding.test.ts
@@ -1,0 +1,97 @@
+// Pins the hand-off of strict show locks from pickViaAgent (broadcast/dj-agent.ts)
+// to the agent's discovery tools (broadcast/dj-agent/agents.ts → buildPickerTools).
+//
+// Why this needs a test rather than the typechecker: agent-factory's run() takes
+// an untyped args bag and spreads it into buildTools, and buildTools destructures
+// the keys it wants by NAME. A lock that pickViaAgent resolves and passes but
+// that agents.ts forgets to name is not a type error and not a crash — it falls
+// through to buildPickerTools' `null` default and that whole dimension silently
+// stops being enforced on the agent path. The pool picker still honours it, so
+// the two pick paths drift on the same show, which is the exact thing
+// music/show-filter.ts exists to prevent. Caught in review on #1300 FR 13, where
+// vocalLock was resolved, passed, and then dropped by both lists in agents.ts.
+//
+// The check is deliberately source-level and name-based, because the defect is
+// name-based: there is no runtime seam between "passed" and "destructured".
+//
+// Run: npm test -- picker-lock-forwarding
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+let failures = 0;
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  ✗ ${name}\n    ${(err as Error).message}`);
+  }
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const djAgent = readFileSync(resolve(here, '../src/broadcast/dj-agent.ts'), 'utf8');
+const agents = readFileSync(resolve(here, '../src/broadcast/dj-agent/agents.ts'), 'utf8');
+
+// Take the text of a brace-delimited block starting at `marker`, matching braces
+// so a nested object literal can't end it early.
+function blockAfter(src: string, marker: string): string {
+  const start = src.indexOf(marker);
+  assert.notEqual(start, -1, `could not find ${JSON.stringify(marker)} — did the call site move?`);
+  const open = src.indexOf('{', start);
+  assert.notEqual(open, -1, `no opening brace after ${JSON.stringify(marker)}`);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}' && --depth === 0) return src.slice(open + 1, i);
+  }
+  throw new Error(`unbalanced braces after ${JSON.stringify(marker)}`);
+}
+
+// Object keys ending in `Lock`, in shorthand (`fooLock,`) or explicit
+// (`fooLock: bar`) form.
+const lockNames = (block: string): string[] =>
+  [...block.matchAll(/(?:^|[{,\s])(\w+Lock)\s*[,:}]/g)].map(m => m[1]).sort();
+
+const passed = lockNames(blockAfter(djAgent, 'pickerAgent.run('));
+const destructured = lockNames(blockAfter(agents, 'buildTools: ('));
+const forwarded = lockNames(blockAfter(agents, 'buildPickerTools('));
+
+test('pickViaAgent actually resolves some locks (the parse found something)', () => {
+  // Guards the two tests below from passing vacuously if the call site is
+  // reshaped past what blockAfter/lockNames understand.
+  assert.ok(passed.length >= 4, `expected several *Lock args, parsed: ${passed.join(', ') || '(none)'}`);
+});
+
+test('every lock pickViaAgent passes is destructured by pickerAgent.buildTools', () => {
+  const missing = passed.filter(l => !destructured.includes(l));
+  assert.deepEqual(
+    missing,
+    [],
+    `agents.ts buildTools drops ${missing.join(', ')} — resolved in pickViaAgent, never named here, so buildPickerTools falls back to null and the dimension goes unenforced on the agent path.`,
+  );
+});
+
+test('buildTools forwards exactly what it destructures', () => {
+  // A name can be destructured and still not handed on — same silent outcome.
+  assert.deepEqual(
+    forwarded,
+    destructured,
+    'the buildTools destructure and the buildPickerTools call must name the same locks',
+  );
+});
+
+test('buildPickerTools accepts every lock it is handed', () => {
+  const tools = readFileSync(resolve(here, '../src/llm/internal/tools/picker-tools.ts'), 'utf8');
+  const unknown = forwarded.filter(l => !new RegExp(`\\b${l}\\b`).test(tools));
+  assert.deepEqual(unknown, [], `picker-tools.ts has no ${unknown.join(', ')} — forwarded into a void`);
+});
+
+if (failures) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log('\nall tests passed');

--- a/controller/scripts/resolve-show.test.ts
+++ b/controller/scripts/resolve-show.test.ts
@@ -42,6 +42,7 @@ const settings = {
       genres: ['Jazz'],
       eras: [{ fromYear: 1960, toYear: 1979 }],
       energies: ['low'],
+      vocals: 'instrumental',
       filtersStrict: true,
       playlistIds: ['pl-anchor-1', 'pl-anchor-2'],
       playlistStrict: true,
@@ -77,6 +78,8 @@ await test('carries the strict music filters', () => {
   assert.deepEqual(show.moods, ['calm']);
   assert.deepEqual(show.energies, ['low']);
   assert.deepEqual(show.eras, [{ fromYear: 1960, toYear: 1979 }]);
+  // Scalar, not a list — but the same silent-disable failure mode as the rest.
+  assert.equal((show as any).vocals, 'instrumental');
 });
 
 await test('returns null on an unscheduled slot', () => {

--- a/controller/scripts/show-vocals.test.ts
+++ b/controller/scripts/show-vocals.test.ts
@@ -1,0 +1,130 @@
+// Regression tests for the show-level vocal/instrumental filter
+// (music/show-filter.ts: trackInstrumental / preferVocals / onlyVocals, and its
+// step inside applyStrictLocks). #1300 FR 13.
+//
+// The signal is Demucs vocal ranges, already load-bearing in bed-policy.ts
+// (instrumental => never bed) and embeddings.formatTrackText (an `instrumental`
+// minority marker). Its semantics are TRI-state and the whole feature rests on
+// keeping them that way:
+//
+//   []    measured instrumental
+//   [..]  measured vocal
+//   null  NEVER MEASURED
+//
+// Vocal analysis is the opt-in heavy tier, so on the overwhelming majority of
+// libraries every track is null. Collapsing null to "has vocals" — the obvious
+// boolean simplification — would make an instrumental show reject its entire
+// library while looking like it was working. That is what these tests exist to
+// stop, so the null cases below are the point, not edge cases.
+//
+// Run: `tsx scripts/show-vocals.test.ts`.
+
+import assert from 'node:assert/strict';
+import {
+  trackInstrumental,
+  preferVocals,
+  onlyVocals,
+  applyStrictLocks,
+} from '../src/music/show-filter.ts';
+
+// Bare shapes — no `id`, so nothing falls through to a library lookup and the
+// assertions are about the ranges alone.
+const inst = { vocalRanges: [] as unknown[] };
+const sung = { vocalRanges: [{ startMs: 12_000, endMs: 40_000 }] };
+const unknown = { vocalRanges: null };
+const absent = {};
+
+let failures = 0;
+function scenario(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failures++;
+    console.error(`  FAIL ${name}`);
+    console.error(`       ${(err as Error).message}`);
+  }
+}
+
+console.log('show vocal filter');
+
+scenario('trackInstrumental is tri-state, not boolean', () => {
+  assert.equal(trackInstrumental(inst), true);
+  assert.equal(trackInstrumental(sung), false);
+  // Both spellings of "nobody has looked" must read as unknown. An absent key
+  // is what a raw Subsonic child carries; explicit null is what the library row
+  // carries before a vocal pass.
+  assert.equal(trackInstrumental(unknown), null);
+  assert.equal(trackInstrumental(absent), null);
+});
+
+scenario('no mode set is a no-op on both paths', () => {
+  const pool = [inst, sung, unknown];
+  assert.deepEqual(preferVocals(pool, ''), pool);
+  assert.deepEqual(onlyVocals(pool, ''), pool);
+  assert.deepEqual(preferVocals(pool, null), pool);
+  // Byte-identical passthrough matters: '' is what every show predating this
+  // field carries, so an upgrade must not perturb a single pick.
+  assert.equal(preferVocals(pool, ''), pool);
+});
+
+scenario('soft lean keeps un-measured tracks eligible', () => {
+  const out = preferVocals([inst, sung, unknown], 'instrumental');
+  assert.deepEqual(out, [inst, unknown]);
+  assert.ok(!out.includes(sung));
+});
+
+scenario('soft lean never starves', () => {
+  // Nothing instrumental and nothing unknown — the lean would empty the pool,
+  // so it hands the whole thing back rather than leaving the show with nothing.
+  const pool = [sung, sung];
+  assert.deepEqual(preferVocals(pool, 'instrumental'), pool);
+});
+
+scenario('hard filter drops un-measured tracks', () => {
+  // Strict means strict: a track nobody has analysed is not known-instrumental,
+  // so it cannot satisfy an instrumental-only show.
+  assert.deepEqual(onlyVocals([inst, sung, unknown, absent], 'instrumental'), [inst]);
+  assert.deepEqual(onlyVocals([inst, sung, unknown, absent], 'vocal'), [sung]);
+});
+
+scenario('hard filter can empty the pool — that is the contract', () => {
+  // onlyGenre/onlyEnergy behave the same way. Dead-air is guarded at a wider
+  // scope (applyStrictLocks' starve:false, and the pool picker behind that),
+  // never by silently readmitting off-filter tracks here.
+  assert.deepEqual(onlyVocals([sung, unknown], 'instrumental'), []);
+});
+
+scenario('strict locks skip the vocal step rather than empty the pool', () => {
+  // The realistic un-analysed library: the operator sets an instrumental show
+  // on a station whose analyzer never ran Demucs. The dimension has zero
+  // coverage, so it is skipped and the OTHER dimensions' work survives.
+  const pool = [
+    { id: 'a', energy: 'low', vocalRanges: null },
+    { id: 'b', energy: 'high', vocalRanges: null },
+  ];
+  const out = applyStrictLocks(pool, { energies: ['low'], vocals: 'instrumental' }, { starve: false });
+  assert.deepEqual(out, [pool[0]], 'energy lock should survive a starved vocal lock');
+});
+
+scenario('strict locks apply the vocal step when there is coverage', () => {
+  const pool = [
+    { id: 'a', energy: 'low', vocalRanges: [] as unknown[] },
+    { id: 'b', energy: 'low', vocalRanges: [{ startMs: 1000, endMs: 2000 }] },
+  ];
+  const out = applyStrictLocks(pool, { energies: ['low'], vocals: 'instrumental' }, { starve: false });
+  assert.deepEqual(out, [pool[0]]);
+});
+
+scenario('starve:true lets the vocal lock empty the pool', () => {
+  // The agent-tool contract: a tool that ends up empty contributes nothing, and
+  // a run with zero candidates fails into the pool picker.
+  const pool = [{ id: 'a', vocalRanges: [{ startMs: 1, endMs: 2 }] }];
+  assert.deepEqual(applyStrictLocks(pool, { vocals: 'instrumental' }, { starve: true }), []);
+});
+
+if (failures) {
+  console.error(`\n${failures} scenario(s) failed`);
+  process.exit(1);
+}
+console.log('\nall scenarios passed');

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -36,7 +36,7 @@ import * as budget from './dj-budget.js';
 import { withTrace, logEvent } from '../observability/events.js';
 import { recencyWindowsForLibrary, effectiveNoRepeatWindow, artistRootKey } from '../music/recency.js';
 import { ARTIST_VARIETY_WINDOW, alternativeCandidates } from './dj-agent/artist-guard.js';
-import { hasEraBound, genreResolutionWarningOnce } from '../music/show-filter.js';
+import { hasEraBound, genreResolutionWarningOnce, type VocalMode } from '../music/show-filter.js';
 import { djCallsAllowed } from './listeners.js';
 import { autoVoiceAllowed } from './voice-policy.js';
 import { pickerAgent, requestAgent } from './dj-agent/agents.js';
@@ -232,6 +232,14 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
   const hasEnergyCoverage = Object.keys(stats.byEnergy ?? {}).length > 0;
   const moodLock = strict && activeShow?.moods?.length && hasMoodCoverage ? activeShow.moods : null;
   const energyLock = strict && activeShow?.energies?.length && hasEnergyCoverage ? activeShow.energies : null;
+  // Same coverage gate, one dimension further out: vocal ranges come from the
+  // OPT-IN heavy analyzer, so "no track has been measured" is the norm rather
+  // than the exception, and a hard lock would empty every tool for the whole
+  // show. Counted lazily — only a show that actually pins vocal steering pays
+  // for the query.
+  const vocalLock = strict && activeShow?.vocals && library.vocalAnalyzedCount() > 0
+    ? (activeShow.vocals as VocalMode)
+    : null;
   // A pinned anchor that resolves to nothing (deleted/recreated playlist →
   // stale id, or a Navidrome error — resolveShowPlaylistPool swallows both)
   // silently un-anchors the show: no lock, no showPlaylistTracks tool. Say so,
@@ -255,6 +263,7 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
     eraLock,
     moodLock,
     energyLock,
+    vocalLock,
     playlistLock,
     playlistTracks,
     excludedIds,

--- a/controller/src/broadcast/dj-agent/agents.ts
+++ b/controller/src/broadcast/dj-agent/agents.ts
@@ -30,9 +30,9 @@ export const pickerAgent = defineAgent({
   maxSteps: 2,
   timeoutMs: agentDeadline,
   buildSystem: ({ showAt, playlistTracks }: any = {}) => pickSystem(showAt ?? null, !!playlistTracks?.length),
-  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, moodLock, energyLock, playlistLock, playlistTracks, excludedIds }) => {
+  buildTools: ({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, moodLock, energyLock, vocalLock, playlistLock, playlistTracks, excludedIds }) => {
     // For a strict show (filtersStrict) EVERY set music filter — genre, era,
-    // mood, energy — becomes a hard lock the discovery tools enforce on
+    // mood, energy, vocals — becomes a hard lock the discovery tools enforce on
     // candidates, not just the prompt. The locks are ALL pre-resolved in
     // pickViaAgent and threaded through run() (async work — genre free text →
     // library tags, library-coverage gating — that this sync builder can't do),
@@ -40,7 +40,14 @@ export const pickerAgent = defineAgent({
     // one place off one show snapshot also keeps the prompt's brief and the
     // tools' locks agreeing across a show boundary. Track length is an on-air
     // cut, NOT a pick filter (#447), so no length cap is passed here.
-    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, moodLock, energyLock, playlistLock, playlistTracks, excludedIds });
+    //
+    // Every lock pickViaAgent passes must be named in BOTH the destructure above
+    // and the buildPickerTools call below. run() hands its args through untyped,
+    // so a lock missing from either list is not a type error — it silently takes
+    // buildPickerTools' `null` default and that dimension goes unenforced here
+    // while the pool picker still honours it, i.e. the two pick paths drift on
+    // the same show. Pinned by scripts/picker-lock-forwarding.test.ts.
+    const { tools, seen } = buildPickerTools({ recentIds, recentKeys, hardRecentIds, hardRecentKeys, audioWaypoint, genreLock, eraLock, moodLock, energyLock, vocalLock, playlistLock, playlistTracks, excludedIds });
     return { tools, extras: { seen } };
   },
   // Native-path acceptance: the picked id must be one a discovery tool actually

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -96,9 +96,10 @@ async function refreshAutoPlaylistInner() {
   const showGenres: string[] = show?.genres ?? [];
   const eras = (show?.eras ?? []) as { fromYear: number | null; toYear: number | null }[];
   const showEnergies: string[] = show?.energies ?? [];
-  // A genre or a year window narrows the pool; energy alone only soft-leans
-  // (mirrors picker.hasMusicFilter). Strict (show.filtersStrict) opts EVERY set
-  // filter — mood, genre, era, energy — into a hard filter on the pool.
+  // A genre or a year window narrows the pool; energy or vocals alone only
+  // soft-leans (mirrors picker.hasMusicFilter). Strict (show.filtersStrict) opts
+  // EVERY set filter — mood, genre, era, energy, vocals — into a hard filter on
+  // the pool.
   const narrow = !!(show && (showGenres.length || hasEraBound(eras)));
   const showMoods: string[] = show?.moods ?? [];
   const showVocals = (show?.vocals ?? '') as VocalMode;

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -13,7 +13,7 @@ import * as subsonic from '../music/subsonic.js';
 import * as dj from '../llm/dj.js';
 import * as library from '../music/library.js';
 import * as settings from '../settings.js';
-import { normGenre, genreMatches, genreResolutionWarningOnce, inYearRange, preferEnergy, preferEnergyStrict, preferMood, applyStrictLocks, hasEraBound, eraSpan } from '../music/show-filter.js';
+import { normGenre, genreMatches, genreResolutionWarningOnce, inYearRange, preferEnergy, preferEnergyStrict, preferMood, applyStrictLocks, hasEraBound, eraSpan, type VocalMode } from '../music/show-filter.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds } from '../music/show-playlist.js';
 import { getFullContext } from '../context.js';
 import { queue } from './queue.js';
@@ -101,7 +101,8 @@ async function refreshAutoPlaylistInner() {
   // filter — mood, genre, era, energy — into a hard filter on the pool.
   const narrow = !!(show && (showGenres.length || hasEraBound(eras)));
   const showMoods: string[] = show?.moods ?? [];
-  const strict = !!(show?.filtersStrict && (showGenres.length || showMoods.length || showEnergies.length || hasEraBound(eras)));
+  const showVocals = (show?.vocals ?? '') as VocalMode;
+  const strict = !!(show?.filtersStrict && (showGenres.length || showMoods.length || showEnergies.length || showVocals || hasEraBound(eras)));
 
   // Show playlist anchor: resolve the union once. The fallback must honour it
   // too, so the LLM-free coast (LLM down, budget-hard, zero listeners) still
@@ -361,6 +362,7 @@ async function refreshAutoPlaylistInner() {
       eras,
       moods: showMoods,
       energies: showEnergies,
+      vocals: showVocals,
     }, { starve: false });
     pool.length = 0;
     pool.push(...filtered);

--- a/controller/src/community/registry.ts
+++ b/controller/src/community/registry.ts
@@ -29,6 +29,7 @@ import {
   SHOW_FILTER_VALUES_MAX,
   SHOW_TOPIC_MAX,
   SOUL_MAX,
+  coerceShowVocals,
   type EraWindow,
 } from '../settings.js';
 
@@ -81,6 +82,8 @@ export interface CommunityShow {
   genres: string[];
   eras: EraWindow[];
   energies: string[];
+  /** '' = no constraint. See SHOW_VOCALS. */
+  vocals: string;
   filtersStrict: boolean;
   banter: boolean;
   programme: boolean;
@@ -232,6 +235,10 @@ function normalizeShow(raw: any): CommunityShow | null {
     genres: strList(raw?.genres, SHOW_FILTER_VALUES_MAX),
     eras: normalizeEras(raw?.eras),
     energies: strList(raw?.energies, SHOW_FILTER_VALUES_MAX).filter(e => (SHOW_ENERGY as string[]).includes(e)),
+    // Scalar, not a list — instrumental and vocal are mutually exclusive. Reuses
+    // the settings coercer so a catalog typo lands on '' (no constraint) here
+    // exactly as it does on a hand-edited show.
+    vocals: coerceShowVocals(raw),
     filtersStrict: raw?.filtersStrict === true,
     banter: raw?.banter === true,
     programme: raw?.programme === true,

--- a/controller/src/llm/internal/prompts/picker.ts
+++ b/controller/src/llm/internal/prompts/picker.ts
@@ -44,7 +44,7 @@ Use "normal" or null when nothing above applies — an ordinary same-lane pick n
 }
 
 export type ShowEra = { fromYear?: number | null; toYear?: number | null };
-export type ShowMusic = { name: string; topic: string; moods?: string[]; genres?: string[]; eras?: ShowEra[]; energies?: string[]; filtersStrict?: boolean };
+export type ShowMusic = { name: string; topic: string; moods?: string[]; genres?: string[]; eras?: ShowEra[]; energies?: string[]; vocals?: string | null; filtersStrict?: boolean };
 
 // One era window as prose ("1990–1999", "1970 onward", "up to 1989").
 function eraWindowText(e: ShowEra): string {
@@ -65,9 +65,14 @@ export function showMusicLean(show?: ShowMusic | null): string {
   const genres = show.genres ?? [];
   const moods = show.moods ?? [];
   const energies = show.energies ?? [];
+  // '' / absent = no constraint. Rendered as prose rather than the stored token,
+  // which reads as a flag name to a model rather than a property of the music.
+  const vocalText = show.vocals === 'instrumental'
+    ? 'instrumental tracks (no singing)'
+    : show.vocals === 'vocal' ? 'tracks with vocals' : '';
   const eraText = (show.eras ?? []).map(eraWindowText).filter(Boolean).join(' or ');
   // Strict only bites when there's actually a filter to lock to.
-  const hasFilter = !!(genres.length || moods.length || energies.length || eraText);
+  const hasFilter = !!(genres.length || moods.length || energies.length || vocalText || eraText);
   const strict = !!(show.filtersStrict && hasFilter);
   const or = (xs: string[]) => xs.join(' / ');
 
@@ -82,6 +87,7 @@ export function showMusicLean(show?: ShowMusic | null): string {
     if (eraText) locks.push(`the ${eraText} era${(show.eras?.length ?? 0) > 1 ? 's' : ''}`);
     if (moods.length) locks.push(`the ${or(moods)} mood${moods.length > 1 ? 's' : ''}`);
     if (energies.length) locks.push(`${or(energies)}-energy tracks`);
+    if (vocalText) locks.push(vocalText);
     return `\n\nThis show's music filters are STRICT — every pick must fit: ${locks.join('; ')}. Keep your talk inside them too; only step outside if there is genuinely nothing left that fits (never leave dead air).`;
   }
 
@@ -91,6 +97,7 @@ export function showMusicLean(show?: ShowMusic | null): string {
   if (genres.length) parts.push(`lean toward ${or(genres)}`);
   if (eraText) parts.push(`prefer tracks from ${eraText}`);
   if (energies.length) parts.push(`favour ${or(energies)}-energy tracks`);
+  if (vocalText) parts.push(`favour ${vocalText}`);
   return parts.length
     ? `\n\nMusic steer for this show — ${parts.join('; ')}. These are preferences, not hard filters: break them only when the flow genuinely demands it.`
     : '';

--- a/controller/src/llm/internal/tools/picker-tools.ts
+++ b/controller/src/llm/internal/tools/picker-tools.ts
@@ -15,7 +15,7 @@ import * as library from '../../../music/library.js';
 import * as embeddings from '../../../music/embeddings.js';
 import * as analyzer from '../../../music/analyzer.js';
 import { filterPickerCandidates, durationSeconds } from '../../../music/recency.js';
-import { applyStrictLocks } from '../../../music/show-filter.js';
+import { applyStrictLocks, type VocalMode } from '../../../music/show-filter.js';
 import { shuffle } from '../../../util/shuffle.js';
 import { SEED_NOT_A_PICK_CLAUSE } from '../../../util/pick-seed.js';
 import { searchWeb, searchReady } from '../../../skills/web-search.js';
@@ -107,6 +107,7 @@ export function buildPickerTools({
   eraLock = null,
   moodLock = null,
   energyLock = null,
+  vocalLock = null,
   playlistLock = null,
   playlistTracks = null,
   excludedIds = null,
@@ -139,6 +140,7 @@ export function buildPickerTools({
   // Hard energy-band constraint for a strict show — any-of list: candidates
   // are filtered to the analysed bands (onlyEnergy — HARD, unknowns dropped).
   energyLock?: string[] | null;
+  vocalLock?: VocalMode | null;
   // The active sonic journey's current waypoint vector (broadcast/dj-agent.ts).
   // When present, the tracksTowardJourney tool below is registered, closing
   // over it — the agent never sees the raw vector, only the tracks near it.
@@ -189,7 +191,7 @@ export function buildPickerTools({
     // library has no such tags) so an un-analysed library can't starve every
     // tool for the whole show.
     let pool = applyStrictLocks(shuffle((list || []) as any[]), {
-      genres: genreLock, eras: eraLock, moods: moodLock, energies: energyLock,
+      genres: genreLock, eras: eraLock, moods: moodLock, energies: energyLock, vocals: vocalLock,
     }, { starve: true });
     // Strict playlist: HARD-intersect with the lock set, with NO never-starve to
     // off-playlist (a playlist is an exact set, so a tool with no overlap simply
@@ -231,7 +233,7 @@ export function buildPickerTools({
   // them makes "matches exist but were filtered" a real cause the note should
   // name, not just recency (steering the model to its other results this round
   // — there is no second discovery step to retry in; see COMMIT_AFTER_STEPS).
-  const hasStrictLock = !!(genreLock?.length || eraLock?.length || moodLock?.length || energyLock?.length || playlistLock || excludedIds);
+  const hasStrictLock = !!(genreLock?.length || eraLock?.length || moodLock?.length || energyLock?.length || vocalLock || playlistLock || excludedIds);
   // The seed clause rides HERE as well as on the schema field (#1247): this is
   // the message sitting in the model's context at the exact moment it fails, and
   // "never invent a song id" is literally satisfied by echoing the on-air id

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -473,6 +473,16 @@ export function stats() {
   };
 }
 
+// How many tracks have had a vocal pass at all (vocal_ranges_json NOT NULL,
+// where a stored "[]" — analysed instrumental — counts as done). Deliberately
+// NOT folded into stats(): it's an extra COUNT that only the vocal show filter
+// needs, and only when a show actually pins one, so the callers that ask for it
+// pay for it. Zero here means the whole dimension has no coverage.
+export function vocalAnalyzedCount(): number {
+  if (!loaded) return 0;
+  try { return db.vocalAnalyzedCount(); } catch { return 0; }
+}
+
 // Re-export the filter contract — admin Library browse panel calls this.
 // Implementation is in library-db.ts as a SQL query (replaces the old ~50-line
 // in-memory loop).

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -16,7 +16,7 @@ import { bpmCompat, keyCompat } from './mix.js';
 import { shuffle } from '../util/shuffle.js';
 import { mapPool } from '../util/async-pool.js';
 import { artistRootKey, filterPickerCandidates, recencyWindowsForLibrary, effectiveNoRepeatWindow } from './recency.js';
-import { normGenre, genreMatches, genreResolutionWarningOnce, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood, applyStrictLocks, hasEraBound, eraSpan, type YearRange } from './show-filter.js';
+import { normGenre, genreMatches, genreResolutionWarningOnce, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood, preferVocals, applyStrictLocks, hasEraBound, eraSpan, type YearRange, type VocalMode } from './show-filter.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds, type PlaylistPool } from './show-playlist.js';
 import * as likes from '../broadcast/likes.js';
 
@@ -156,7 +156,7 @@ function softRankByCompat(pool: Candidate[], current: { bpm: number | null; key:
 
 // Multi-value lists (#929): OR within an attribute, AND across attributes.
 // Empty list = no constraint on that attribute.
-type ShowFilter = { moods: string[]; genres: string[]; eras: YearRange[]; energies: string[]; strict?: boolean } | null;
+type ShowFilter = { moods: string[]; genres: string[]; eras: YearRange[]; energies: string[]; vocals: VocalMode; strict?: boolean } | null;
 
 function hasMusicFilter(f: ShowFilter): boolean {
   return !!f && (f.genres.length > 0 || hasEraBound(f.eras));
@@ -217,7 +217,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   // Soft mode leaves the sources untouched (only the nz() shrink applies).
   const strict = !!(showFilter?.strict
     && (showFilter.genres.length || showFilter.moods.length || showFilter.energies.length
-      || hasEraBound(showFilter.eras)));
+      || showFilter.vocals || hasEraBound(showFilter.eras)));
   // Resolve the show's free-text genres to the library's exact tags ONCE, up
   // front. A resolution failure drops that entry (never-starve: none resolving
   // means no genre filter at all, so misspelled genres never strand the show).
@@ -245,6 +245,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     out = preferEra(out, showFilter!.eras);
     out = preferMood(out, showFilter!.moods);
     out = preferEnergyStrict(out, showFilter!.energies);
+    out = preferVocals(out, showFilter!.vocals);
     return out;
   };
 
@@ -535,6 +536,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
       eras: showFilter!.eras,
       moods: showFilter!.moods,
       energies: showFilter!.energies,
+      vocals: showFilter!.vocals,
     }, { starve: false });
   }
 
@@ -665,6 +667,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
         genres: activeShow.genres ?? [],
         eras: activeShow.eras ?? [],
         energies: activeShow.energies ?? [],
+        vocals: (activeShow.vocals ?? '') as VocalMode,
         strict: activeShow.filtersStrict,
       }
     : null;
@@ -755,6 +758,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
             genres: activeShow.genres,
             eras: activeShow.eras,
             energies: activeShow.energies,
+            vocals: activeShow.vocals,
             filtersStrict: activeShow.filtersStrict,
           }
         : null,

--- a/controller/src/music/show-filter.ts
+++ b/controller/src/music/show-filter.ts
@@ -391,8 +391,19 @@ export function trackInstrumental(t: FilterTrack | null | undefined): boolean | 
 }
 
 // Soft lean: tracks matching the mode are preferred, un-measured tracks stay
-// eligible, and a pool with no match falls back whole (never-starve). Mirrors
-// preferEnergy exactly — the un-measured track is the unknown-energy track.
+// eligible, and a pool with no match falls back whole (never-starve). Same
+// semantics as preferEnergy — the un-measured track is the unknown-energy track.
+//
+// Note which SLOT it fills, because the two differ: energy has a soft-mode lean
+// (preferEnergy) and a stricter one for filtersStrict (preferEnergyStrict, which
+// drops unknown-energy tracks). Vocals has no soft-mode lean at all — like
+// genre/era/mood, an un-strict show steers through the prompt only — and this is
+// what picker.ts's strict-only lean() calls, i.e. it fills preferEnergyStrict's
+// slot with preferEnergy's tolerance. Deliberate: un-measured is the NORM for
+// this dimension (opt-in Demucs), so dropping unknowns at the source level would
+// gut every discovery source before applyStrictLocks' coverage-gated onlyVocals
+// ever got to make that call. Don't "fix" the asymmetry by swapping in a
+// drop-unknown variant here.
 export function preferVocals<T extends FilterTrack>(tracks: T[], mode?: VocalMode | null): T[] {
   if (!mode) return tracks;
   const wantInstrumental = mode === 'instrumental';

--- a/controller/src/music/show-filter.ts
+++ b/controller/src/music/show-filter.ts
@@ -29,6 +29,9 @@ export interface FilterTrack {
   energy?: string | null;
   moods?: string[] | null;
   audioMoods?: string[] | null;
+  // Demucs vocal ranges. [] = instrumental, null/absent = never measured — the
+  // distinction trackInstrumental is built on.
+  vocalRanges?: unknown[] | null;
 }
 
 // ── Genre ──────────────────────────────────────────────────────────────────
@@ -362,6 +365,56 @@ export function onlyEnergy<T extends FilterTrack>(tracks: T[], energies?: string
   });
 }
 
+// ── Vocals (instrumental steering) ───────────────────────────────────────────
+
+// The show's vocal constraint. '' = no constraint, and is the default, so a
+// show saved before this field existed behaves byte-for-byte as it did.
+export type VocalMode = '' | 'instrumental' | 'vocal';
+
+// Is this track instrumental? Reads the same signal bed-policy.ts and
+// embeddings.formatTrackText already treat as canonical:
+//
+//   vocalRanges === []    → measured instrumental
+//   vocalRanges non-empty → measured vocal
+//   vocalRanges == null   → NOT MEASURED, which is not the same as "vocal"
+//
+// That third case is the whole reason this returns a tri-state instead of a
+// boolean. Vocal analysis is the opt-in heavy tier (Demucs), so on most
+// libraries every track is null — collapsing null to "has vocals" would make an
+// instrumental show reject its entire library while looking like it worked.
+export function trackInstrumental(t: FilterTrack | null | undefined): boolean | null {
+  const ranges = Array.isArray(t?.vocalRanges)
+    ? t.vocalRanges
+    : (t?.id ? library.get(t.id)?.vocalRanges : null);
+  if (!Array.isArray(ranges)) return null;
+  return ranges.length === 0;
+}
+
+// Soft lean: tracks matching the mode are preferred, un-measured tracks stay
+// eligible, and a pool with no match falls back whole (never-starve). Mirrors
+// preferEnergy exactly — the un-measured track is the unknown-energy track.
+export function preferVocals<T extends FilterTrack>(tracks: T[], mode?: VocalMode | null): T[] {
+  if (!mode) return tracks;
+  const wantInstrumental = mode === 'instrumental';
+  const match = tracks.filter((t) => {
+    const inst = trackInstrumental(t);
+    return inst == null || inst === wantInstrumental;
+  });
+  return match.length ? match : tracks;
+}
+
+// Hard filter — NO never-starve (see onlyGenre for the scoping contract), and
+// un-measured tracks drop, same as onlyEnergy drops unknown-energy ones: a
+// strict "instrumental only" show that admits tracks nobody has checked is not
+// strict. On a library with no vocal pass this empties the pool, which is
+// exactly what applyStrictLocks' starve:false step is there to catch — the
+// dimension is skipped and the show plays on unconstrained rather than silent.
+export function onlyVocals<T extends FilterTrack>(tracks: T[], mode?: VocalMode | null): T[] {
+  if (!mode) return tracks;
+  const wantInstrumental = mode === 'instrumental';
+  return tracks.filter((t) => trackInstrumental(t) === wantInstrumental);
+}
+
 // ── Strict lock composition ──────────────────────────────────────────────────
 
 // A show's strict music constraints, resolved to library-comparable values:
@@ -374,6 +427,7 @@ export type StrictLocks = {
   eras?: YearRange[] | null;
   moods?: string[] | null;
   energies?: string[] | null;
+  vocals?: VocalMode | null;
 };
 
 // Apply a show's strict music locks as a PER-DIMENSION cascade — the single
@@ -390,9 +444,11 @@ export type StrictLocks = {
 //     zero-coverage tag class (e.g. a mood on an un-tagged library) threw away
 //     an otherwise genre- and era-pure pool and leaked off-filter tracks back.
 //
-// Order is genre → era → mood → energy; with starve:false each step commits
-// only if it left something, so a starved late dimension can't undo an earlier
-// one's tightening.
+// Order is genre → era → mood → energy → vocals; with starve:false each step
+// commits only if it left something, so a starved late dimension can't undo an
+// earlier one's tightening. Vocals goes last deliberately: it's the dimension
+// most likely to have no coverage at all (Demucs is the opt-in heavy tier), and
+// last is where a skipped step costs the least.
 export function applyStrictLocks<T extends FilterTrack>(
   tracks: T[],
   locks: StrictLocks,
@@ -406,5 +462,6 @@ export function applyStrictLocks<T extends FilterTrack>(
   if (hasEraBound(locks.eras)) step(inYearRange(pool, locks.eras!));
   if (locks.moods?.length) step(onlyMood(pool, locks.moods));
   if (locks.energies?.length) step(onlyEnergy(pool, locks.energies));
+  if (locks.vocals) step(onlyVocals(pool, locks.vocals));
   return pool;
 }

--- a/controller/src/routes/shows.ts
+++ b/controller/src/routes/shows.ts
@@ -65,6 +65,7 @@ router.post('/shows/community/:slug/install', requireAdmin, async (req, res) => 
     genres: cs.genres,
     eras: cs.eras,
     energies: cs.energies,
+    vocals: cs.vocals,
     filtersStrict: cs.filtersStrict,
     maxTrackSeconds: cs.maxTrackSeconds,
     playlistIds: [],

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -172,6 +172,7 @@ export {
   clampMaxOutputTokens,
   clampTtsGain,
   clampTtsSpeed,
+  coerceShowVocals,
   normalizeDial,
   personaToneDirectives,
 } from './settings/vocab.js';

--- a/controller/src/settings/normalize.ts
+++ b/controller/src/settings/normalize.ts
@@ -37,6 +37,7 @@ import {
   coerceGuestPersonaIds,
   coercePlaylistIds,
   coerceShowEnergies,
+  coerceShowVocals,
   coerceShowEras,
   coerceShowGenres,
   coerceShowMoods,
@@ -258,6 +259,9 @@ export function normalizeShows(raw: unknown, personaIds: string[]): NormalizedSh
     const genres = coerceShowGenres(item);
     const eras = coerceShowEras(item);
     const energies = coerceShowEnergies(item);
+    // Vocal steering (#1300 FR 13): '' = no constraint, which is what every
+    // show predating the field carries, so loading one is a no-op.
+    const vocals = coerceShowVocals(item);
     // Opt-in: hard-filter the pick pool to EVERY set music filter (mood, genre,
     // era, energy) instead of the default soft leans. Only meaningful when at
     // least one filter is set; defaults OFF. The legacy genre-only `genreStrict`
@@ -306,6 +310,7 @@ export function normalizeShows(raw: unknown, personaIds: string[]): NormalizedSh
       genres,
       eras,
       energies,
+      vocals,
       filtersStrict,
       maxTrackSeconds,
       playlistIds,

--- a/controller/src/settings/persona.ts
+++ b/controller/src/settings/persona.ts
@@ -10,6 +10,7 @@ import {
   DJ_SOULS,
   FREQUENCIES,
   coerceShowEnergies,
+  coerceShowVocals,
   coerceShowEras,
   coerceShowGenres,
   coerceShowMoods,
@@ -127,6 +128,9 @@ function resolveShowShape(show, s) {
     genres: coerceShowGenres(show),
     eras: coerceShowEras(show),
     energies: coerceShowEnergies(show),
+    // Instrumental / vocal steering, backed by Demucs vocal ranges. '' = no
+    // constraint. Single-valued: the two states are mutually exclusive.
+    vocals: coerceShowVocals(show),
     // When true, every set music filter (mood, genre, era, energy) is a hard
     // filter on the pick pool instead of a soft lean; off-filter tracks only
     // survive as a never-starve fallback. Defaults off.

--- a/controller/src/settings/validate.ts
+++ b/controller/src/settings/validate.ts
@@ -29,6 +29,7 @@ import {
   SCRIPT_LENGTHS,
   SHOWS_LIMIT,
   SHOW_ENERGY,
+  SHOW_VOCALS,
   SHOW_FILTER_VALUES_MAX,
   SHOW_MOODS,
   SHOW_TOPIC_MAX,
@@ -48,6 +49,7 @@ import {
   coerceGuestPersonaIds,
   coercePlaylistIds,
   coerceShowEnergies,
+  coerceShowVocals,
   coerceShowGenres,
   coerceShowMoods,
   emptyWeek,
@@ -352,6 +354,15 @@ export function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>,
       }
     }
     const energies = coerceShowEnergies({ energies: rawEnergies });
+    // One value, not a list — instrumental and vocal are mutually exclusive and
+    // wanting both is wanting neither. Absent/'' is no constraint, so an
+    // existing show round-trips unchanged.
+    if (item.vocals != null && item.vocals !== '') {
+      if (typeof item.vocals !== 'string' || !SHOW_VOCALS.includes(item.vocals)) {
+        throw new Error(`shows[${i}].vocals must be '' or one of: ${SHOW_VOCALS.join(', ')}`);
+      }
+    }
+    const vocals = coerceShowVocals(item);
     // Opt-in hard filter across every set music constraint — mood, genre, era,
     // energy (vs the default soft leans). Boolean, defaults OFF. The legacy
     // genre-only `genreStrict` is deliberately NOT carried over (see the load
@@ -474,7 +485,7 @@ export function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>,
     let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('s_');
     if (seen.has(id)) id = mintId('s_');
     seen.add(id);
-    return { id, name, topic, personaId: item.personaId, guestPersonaIds, banter, programme, segmentSkill, moods, themeId, genres, eras, energies, filtersStrict, maxTrackSeconds, playlistIds, playlistStrict, excludedPlaylistIds };
+    return { id, name, topic, personaId: item.personaId, guestPersonaIds, banter, programme, segmentSkill, moods, themeId, genres, eras, energies, vocals, filtersStrict, maxTrackSeconds, playlistIds, playlistStrict, excludedPlaylistIds };
   });
 }
 

--- a/controller/src/settings/vocab.ts
+++ b/controller/src/settings/vocab.ts
@@ -648,6 +648,12 @@ export function normalizeMoodMap(
 // tagger's per-track energy classes and the `tracksByMood` agent-tool filter.
 export const SHOW_ENERGY = ['low', 'medium', 'high'];
 
+// Vocal steering a show can pin. Unlike the list filters above this is ONE
+// value, because the three states are mutually exclusive and "both" is just no
+// constraint — which is what '' means, and what every show that predates the
+// field carries. Backed by Demucs vocal ranges (music/show-filter.trackInstrumental).
+export const SHOW_VOCALS = ['instrumental', 'vocal'];
+
 // Default festival calendar — the seeded set the admin UI shows on first boot.
 // After the operator edits the list, persisted festivals replace these.
 export const FESTIVAL_DEFAULTS = [
@@ -914,6 +920,8 @@ export interface NormalizedShow {
   genres: string[];
   eras: EraWindow[];
   energies: string[];
+  /** '' = no constraint. See SHOW_VOCALS. */
+  vocals: string;
   filtersStrict: boolean;
   maxTrackSeconds: number | null;
   playlistIds: string[];
@@ -986,6 +994,14 @@ export function coerceShowEnergies(item: unknown): string[] {
   return coerceShowList(item, 'energies', 'energy',
     (v) => (typeof v === 'string' && SHOW_ENERGY.includes(v) ? v : null),
     (v) => v);
+}
+
+// Anything unrecognised — absent, null, 'any', a typo — reads as no constraint.
+// A show whose vocal steering silently stops applying is a much smaller failure
+// than one that stops playing music.
+export function coerceShowVocals(item: unknown): string {
+  const v = (item as { vocals?: unknown } | null | undefined)?.vocals;
+  return typeof v === 'string' && SHOW_VOCALS.includes(v) ? v : '';
 }
 
 export function coerceShowEras(item: unknown): EraWindow[] {

--- a/web/components/admin/ShowsPanel.tsx
+++ b/web/components/admin/ShowsPanel.tsx
@@ -206,7 +206,7 @@ export default function ShowsPanel() {
         shows: [...f.shows, {
           id, name: '', topic: '',
           personaId: personas[0]?.id || '', guestPersonaIds: [], banter: false, moods: [],
-          themeId: '', genres: [], eras: [], energies: [],
+          themeId: '', genres: [], eras: [], energies: [], vocals: '',
           filtersStrict: false, maxTrackSeconds: null,
           playlistIds: [], playlistStrict: false, excludedPlaylistIds: [],
           programme: false, segmentSkill: '',

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -33,6 +33,7 @@ import {
   GUESTS_MAX,
   NAME_MAX,
   TOPIC_MAX,
+  VOCAL_OPTIONS,
   eraLabelOf,
   sameEra,
 } from './types';
@@ -338,6 +339,26 @@ export function ShowEditor({
               })}
               cap={ENERGY_OPTIONS.length}
             />
+          </Field>
+
+          <Field>
+            <Label>vocals</Label>
+            {/* Single-valued, unlike the filters around it: instrumental and
+                vocal are mutually exclusive, and wanting both is wanting
+                neither. Picking one REPLACES the other rather than capping at
+                one selection, which would grey out the chip you're switching
+                to; clicking the selected chip clears back to any. */}
+            <ChipRow
+              options={VOCAL_OPTIONS}
+              selected={show.vocals ? [show.vocals] : []}
+              onToggle={v => update({ vocals: show.vocals === v ? '' : (v as Show['vocals']) })}
+              cap={VOCAL_OPTIONS.length}
+            />
+            <span className="field-hint">
+              None selected = any. Backed by vocal-activity analysis, so it only
+              steers tracks that have had a vocal pass — on a library without
+              one it simply doesn&apos;t apply, and the show plays as before.
+            </span>
           </Field>
 
           <Field>

--- a/web/components/admin/shows/lib.ts
+++ b/web/components/admin/shows/lib.ts
@@ -33,6 +33,10 @@ export function hydrateShow(s: Partial<Show>): Show {
       return fromYear != null || toYear != null ? [{ fromYear, toYear }] : [];
     })(),
     energies: Array.isArray(s.energies) ? s.energies : (s as { energy?: string }).energy ? [(s as { energy?: string }).energy!] : [],
+    // Anything unrecognised reads as no constraint, matching the controller's
+    // coerceShowVocals — a steering field that silently stops applying is a far
+    // smaller failure than a show that stops playing music.
+    vocals: s.vocals === 'instrumental' || s.vocals === 'vocal' ? s.vocals : '',
     filtersStrict: s.filtersStrict ?? false,
     maxTrackSeconds: s.maxTrackSeconds ?? null,
     playlistIds: Array.isArray(s.playlistIds) ? s.playlistIds : [],
@@ -64,7 +68,7 @@ export function showValid(s: Show): boolean {
 // At least one music filter set — the Strict filter toggle only means
 // something when there's a filter for it to harden.
 export function hasAnyMusicFilter(s: Show): boolean {
-  return !!(s.moods.length || s.genres.length || s.energies.length || s.eras.length);
+  return !!(s.moods.length || s.genres.length || s.energies.length || s.eras.length || s.vocals);
 }
 
 // Trimmed, with the "only-means-something-with" conditionals the server also
@@ -85,6 +89,7 @@ export function showPayload(s: Show) {
     genres: s.genres.map(g => g.trim()).filter(Boolean),
     eras: s.eras,
     energies: s.energies,
+    vocals: s.vocals || '',
     // Strict only means something with at least one music filter set.
     filtersStrict: hasAnyMusicFilter(s) && s.filtersStrict,
     maxTrackSeconds: s.maxTrackSeconds,
@@ -108,6 +113,7 @@ export function showFacets(s: Show): ShowFacet[] {
   s.genres.forEach(g => facets.push({ key: `genre-${g}`, label: g }));
   s.eras.forEach((e, idx) => facets.push({ key: `era-${idx}`, label: eraLabelOf(e) }));
   s.energies.forEach(en => facets.push({ key: `energy-${en}`, label: en }));
+  if (s.vocals) facets.push({ key: 'vocals', label: s.vocals === 'instrumental' ? 'instrumental' : 'vocals' });
   if (s.filtersStrict && hasAnyMusicFilter(s)) facets.push({ key: 'strict', label: 'strict', accent: true });
   const nPl = s.playlistIds?.length ?? 0;
   if (nPl) facets.push({ key: 'playlists', label: `${nPl} playlist${nPl > 1 ? 's' : ''}${s.playlistStrict ? ' · strict' : ''}` });

--- a/web/components/admin/shows/types.ts
+++ b/web/components/admin/shows/types.ts
@@ -30,6 +30,11 @@ export interface Show {
   genres: string[];
   eras: EraWindow[];
   energies: string[];
+  /** Single-valued, unlike the lists above: the two states are mutually
+   *  exclusive. '' = no constraint, and is what every show predating the field
+   *  carries. Backed by vocal-activity analysis, so it only steers tracks that
+   *  have had a vocal pass. */
+  vocals: '' | 'instrumental' | 'vocal';
   /** With ≥1 music filter set, EVERY set filter becomes HARD instead of a soft
    *  lean; off-filter tracks only play as a last resort. The controller does NOT
    *  auto-migrate legacy `genreStrict` shows — they load soft. */
@@ -89,6 +94,13 @@ export const DECADES: { key: string; label: string; from: number; to: number }[]
   { key: '1950', label: '50s', from: 1950, to: 1959 },
 ];
 export const ENERGY_OPTIONS = ['low', 'medium', 'high'];
+// Mirrors the controller's SHOW_VOCALS (settings/vocab.ts). '' is the absent
+// third state and deliberately has no chip — clearing the selection is how you
+// get back to it.
+export const VOCAL_OPTIONS = [
+  { key: 'instrumental', label: 'instrumental' },
+  { key: 'vocal', label: 'vocals' },
+];
 export const ANY_SENTINEL = '__any__';
 // Mirrors the controller's SHOW_FILTER_VALUES_MAX cap
 // (controller/src/settings/vocab.ts — read the comment there before changing


### PR DESCRIPTION
Ships **FR 13** from #1300 — *"Instrumental-only steering for shows"*.

## The ask

A show can lean on mood, genre, era and energy, but had no way to prefer instrumental music. The only lever was hoping the wording of the brief carried through, which it doesn't for track selection.

As the validation pass noted, the signal already exists and is already trusted: `vocal_ranges = []` is the canonical instrumental marker, load-bearing in `bed-policy.ts` (instrumental ⇒ never bed) and `embeddings.formatTrackText` (an `instrumental` minority marker). This exposes it as the show filter it always could have been.

## The shape

`shows[].vocals`, single-valued where its neighbours are lists — instrumental and vocal are mutually exclusive, and wanting both is wanting neither. `''` is no constraint and is what every existing show carries, so an upgrade changes nothing until someone sets it.

Lives in `music/show-filter.ts` so both pick paths **and** the auto-playlist coast share one definition, per the issue's note about the pool picker and the agent's discovery tools not being allowed to drift.

## The load-bearing detail: the signal is tri-state

```
[]     measured instrumental
[…]    measured vocal
null   never measured
```

Vocal analysis is the **opt-in heavy tier** (Demucs), so `null` isn't an edge case — on most libraries it's *every* track. Collapsing it to "has vocals", the obvious boolean simplification, would make an instrumental show reject its entire library while appearing to work. So unknown is carried as its own state end to end:

- **soft lean** (`preferVocals`) keeps un-measured tracks eligible, and never-starves — mirrors `preferEnergy` exactly, where the un-measured track is the unknown-energy track;
- **hard filter** (`onlyVocals`) drops them; strict means strict, same as `onlyEnergy` drops unknown-energy tracks;
- **`applyStrictLocks`** turns a zero-coverage library into a *skipped step* rather than a silent show, via the existing `starve: false` per-dimension never-starve.

Vocals sits **last** in the strict cascade deliberately: it's the dimension most likely to have no coverage at all, and last is where a skipped step costs the least.

## Agent path gets the same coverage gate, one step further out

`dj-agent.ts` already drops the mood and energy locks when the library has no such tags, so a hard lock can't empty every discovery tool for a whole show and trip the circuit breaker with a misleading *"model can't drive tools"* reading. Vocals needs it more than either, so it gets it:

```ts
const vocalLock = strict && activeShow?.vocals && library.vocalAnalyzedCount() > 0 ? … : null;
```

Counted **lazily** — only a show that actually pins vocal steering pays for the query, so `library.stats()` stays untouched on the hot path.

## Wiring

| where | what |
|---|---|
| `music/show-filter.ts` | `trackInstrumental` / `preferVocals` / `onlyVocals` + the `applyStrictLocks` step |
| `settings/{vocab,validate,normalize,persona}.ts` | `SHOW_VOCALS`, `coerceShowVocals`, schema + strict validation |
| `music/picker.ts` | soft lean in `lean()`, hard lock in the strict pool |
| `dj-agent.ts` → `picker-tools.ts` | the coverage-gated `vocalLock` |
| `prompts/picker.ts` | rendered as prose (*"instrumental tracks (no singing)"*), never the stored token — a flag name embeds as noise to a model |
| `scheduler.ts` | the auto-playlist coast, so the fallback stays on-brand |
| `web/` | a chip row in the show editor + the facet on the show card |

The chip row picks single-select by **replacing** rather than capping at one selection — a `cap={1}` would grey out the chip you're switching to.

## Testing

- `controller/scripts/show-vocals.test.ts` (new) — 9 scenarios, weighted at the tri-state semantics because that's what a future simplification would break: both spellings of unknown (`null` and an absent key), soft-keeps-unknown, hard-drops-unknown, never-starve, hard-filter-may-empty, and the two `applyStrictLocks` directions (skipped step on a zero-coverage library vs. applied when there's coverage).
- `npm run lint` clean in `web/` and `controller/`.
- `npm test` in `controller/`: 76/77 pass. The one failure (`analyzer-python.test.ts` → `vocal_gate_test.py`, missing `numpy`) reproduces unchanged on `develop`.
