### PR TITLE
feat: expose current track lyrics to players

### DIFF
--- a/controller/scripts/lyric-offsets.test.ts
+++ b/controller/scripts/lyric-offsets.test.ts
@@ -1,0 +1,54 @@
+// Integration coverage for the listener-scoped lyric-offset store and its
+// migration. Uses a real temporary SQLite database because an upsert that only
+// works in a mocked handle is not useful migration coverage.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+async function main() {
+  const stateDir = mkdtempSync(join(tmpdir(), 'subwave-lyrics-'));
+  process.env.STATE_DIR = stateDir;
+  const db = await import('../src/music/library-db.js');
+
+  try {
+    await db.open({ embeddingDim: 768, adoptStoredDim: true });
+    const raw = db.requireDb();
+    assert.equal(raw.pragma('user_version', { simple: true }), 26);
+
+    // Recreate the exact predecessor shape: a deployed v25 database has every
+    // prior migration but no lyric_offsets table. Reopen must apply v26.
+    raw.prepare('DROP TABLE lyric_offsets').run();
+    raw.pragma('user_version = 25');
+    db.close();
+    await db.open({ embeddingDim: 768, adoptStoredDim: true });
+
+    const migrated = db.requireDb();
+    assert.equal(migrated.pragma('user_version', { simple: true }), 26);
+    assert.equal(
+      migrated.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'lyric_offsets'").get()?.name,
+      'lyric_offsets',
+    );
+
+    db.setLyricOffset('client-alpha', 'song-1', 1200);
+    db.setLyricOffset('client-bravo', 'song-1', -400);
+    db.setLyricOffset('client-alpha', 'song-2', 900);
+    assert.equal(db.getLyricOffset('client-alpha', 'song-1'), 1200);
+    assert.equal(db.getLyricOffset('client-bravo', 'song-1'), -400);
+    assert.equal(db.getLyricOffset('client-alpha', 'song-2'), 900);
+
+    db.setLyricOffset('client-alpha', 'song-1', 1500);
+    assert.equal(db.getLyricOffset('client-alpha', 'song-1'), 1500, 'upsert replaces only that client/track pair');
+    assert.equal(db.getLyricOffset('client-bravo', 'song-1'), -400, 'one client cannot overwrite another client');
+    console.log('✓ lyric offset migration and isolation checks passed');
+  } finally {
+    db.close();
+    rmSync(stateDir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/controller/scripts/lyrics-cache.test.ts
+++ b/controller/scripts/lyrics-cache.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { BoundedLyricsCache } from '../src/music/lyrics-cache.js';
+
+let failures = 0;
+async function test(name: string, fn: () => void | Promise<void>) {
+  try {
+    await fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    failures++;
+    console.error(`  ✗ ${name}\n      ${err?.message || err}`);
+  }
+}
+
+console.log('public lyrics cache:');
+
+await test('coalesces concurrent requests for one track', async () => {
+  const cache = new BoundedLyricsCache<string>();
+  let calls = 0;
+  const load = async () => { calls++; return 'lyrics'; };
+  assert.deepEqual(await Promise.all([cache.get('song', load), cache.get('song', load)]), ['lyrics', 'lyrics']);
+  assert.equal(calls, 1);
+});
+
+await test('caches present lyrics longer than misses', async () => {
+  let now = 0;
+  const cache = new BoundedLyricsCache<string>({ positiveTtlMs: 30, negativeTtlMs: 10, now: () => now });
+  let hits = 0;
+  let misses = 0;
+  assert.equal(await cache.get('hit', async () => { hits++; return 'lyrics'; }), 'lyrics');
+  assert.equal(await cache.get('miss', async () => { misses++; return null; }), null);
+  now = 11;
+  assert.equal(await cache.get('hit', async () => { hits++; return 'lyrics'; }), 'lyrics');
+  assert.equal(await cache.get('miss', async () => { misses++; return null; }), null);
+  assert.equal(hits, 1);
+  assert.equal(misses, 2);
+});
+
+await test('briefly caches upstream failures to avoid a retry storm', async () => {
+  let now = 0;
+  const cache = new BoundedLyricsCache<string>({ negativeTtlMs: 10, now: () => now });
+  let calls = 0;
+  const fail = async () => { calls++; throw new Error('upstream unavailable'); };
+  await assert.rejects(() => cache.get('song', fail), /unavailable/);
+  await assert.rejects(() => cache.get('song', fail), /unavailable/);
+  assert.equal(calls, 1);
+  now = 11;
+  await assert.rejects(() => cache.get('song', fail), /unavailable/);
+  assert.equal(calls, 2);
+});
+
+if (failures) process.exit(1);
+console.log('✓ public lyrics cache checks passed');

--- a/controller/scripts/lyrics-public.test.ts
+++ b/controller/scripts/lyrics-public.test.ts
@@ -18,23 +18,29 @@ test('empty when there is no current library song', () => {
   assert.deepEqual(toPublicLyricsPayload(null, null), {
     songId: null,
     synced: false,
+    offsetMs: 0,
     lines: [],
   });
 });
 
 test('trims blank lines and preserves synced timing', () => {
   assert.deepEqual(
-    toPublicLyricsPayload('abc123', {
-      synced: true,
-      lines: [
-        { startMs: 1000, text: ' first line ' },
-        { startMs: 2000, text: '' },
-        { startMs: 3000, text: 'second line' },
-      ],
-    }),
+    toPublicLyricsPayload(
+      'abc123',
+      {
+        synced: true,
+        lines: [
+          { startMs: 1000, text: ' first line ' },
+          { startMs: 2000, text: '' },
+          { startMs: 3000, text: 'second line' },
+        ],
+      },
+      2500,
+    ),
     {
       songId: 'abc123',
       synced: true,
+      offsetMs: 2500,
       lines: [
         { startMs: 1000, text: 'first line' },
         { startMs: 3000, text: 'second line' },
@@ -45,13 +51,18 @@ test('trims blank lines and preserves synced timing', () => {
 
 test('unsynced lyrics publish null start offsets', () => {
   assert.deepEqual(
-    toPublicLyricsPayload('abc123', {
-      synced: false,
-      lines: [{ startMs: Number.NaN, text: 'plain lyric line' }],
-    }),
+    toPublicLyricsPayload(
+      'abc123',
+      {
+        synced: false,
+        lines: [{ startMs: Number.NaN, text: 'plain lyric line' }],
+      },
+      -400,
+    ),
     {
       songId: 'abc123',
       synced: false,
+      offsetMs: -400,
       lines: [{ startMs: null, text: 'plain lyric line' }],
     },
   );

--- a/controller/scripts/lyrics-public.test.ts
+++ b/controller/scripts/lyrics-public.test.ts
@@ -68,6 +68,56 @@ test('unsynced lyrics publish null start offsets', () => {
   );
 });
 
+test('an all-marker instrumental body publishes as no lyrics', () => {
+  // Timed at 0 and left unfiltered, this single line would read as a synced
+  // lyric the player highlights for the whole track.
+  assert.deepEqual(
+    toPublicLyricsPayload('abc123', {
+      synced: true,
+      lines: [{ startMs: 0, text: '[au: instrumental]' }],
+    }),
+    { songId: 'abc123', synced: false, offsetMs: 0, lines: [] },
+  );
+});
+
+test('every instrumental marker spelling is screened off', () => {
+  for (const marker of ['Instrumental', 'INSTRUMENTAL', '(instrumental)', '[Instrumental]']) {
+    assert.deepEqual(
+      toPublicLyricsPayload('abc123', { synced: true, lines: [{ startMs: 0, text: marker }] }).lines,
+      [],
+      `expected ${marker} to be screened off`,
+    );
+  }
+});
+
+test('a lyric that merely sings the word instrumental survives', () => {
+  assert.deepEqual(
+    toPublicLyricsPayload('abc123', {
+      synced: true,
+      lines: [{ startMs: 500, text: 'this is instrumental to me' }],
+    }).lines,
+    [{ startMs: 500, text: 'this is instrumental to me' }],
+  );
+});
+
+test('markers are dropped without discarding the real lines around them', () => {
+  assert.deepEqual(
+    toPublicLyricsPayload('abc123', {
+      synced: true,
+      lines: [
+        { startMs: 0, text: 'Instrumental' },
+        { startMs: 4000, text: 'the words start here' },
+      ],
+    }),
+    {
+      songId: 'abc123',
+      synced: true,
+      offsetMs: 0,
+      lines: [{ startMs: 4000, text: 'the words start here' }],
+    },
+  );
+});
+
 if (failures) {
   console.error(`\n✗ ${failures} check(s) failed`);
   process.exit(1);

--- a/controller/scripts/lyrics-public.test.ts
+++ b/controller/scripts/lyrics-public.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { toPublicLyricsPayload } from '../src/music/lyrics-public.js';
+
+let failures = 0;
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    failures++;
+    console.error(`  ✗ ${name}\n      ${err?.message || err}`);
+  }
+}
+
+console.log('public lyrics payload:');
+
+test('empty when there is no current library song', () => {
+  assert.deepEqual(toPublicLyricsPayload(null, null), {
+    songId: null,
+    synced: false,
+    lines: [],
+  });
+});
+
+test('trims blank lines and preserves synced timing', () => {
+  assert.deepEqual(
+    toPublicLyricsPayload('abc123', {
+      synced: true,
+      lines: [
+        { startMs: 1000, text: ' first line ' },
+        { startMs: 2000, text: '' },
+        { startMs: 3000, text: 'second line' },
+      ],
+    }),
+    {
+      songId: 'abc123',
+      synced: true,
+      lines: [
+        { startMs: 1000, text: 'first line' },
+        { startMs: 3000, text: 'second line' },
+      ],
+    },
+  );
+});
+
+test('unsynced lyrics publish null start offsets', () => {
+  assert.deepEqual(
+    toPublicLyricsPayload('abc123', {
+      synced: false,
+      lines: [{ startMs: Number.NaN, text: 'plain lyric line' }],
+    }),
+    {
+      songId: 'abc123',
+      synced: false,
+      lines: [{ startMs: null, text: 'plain lyric line' }],
+    },
+  );
+});
+
+if (failures) {
+  console.error(`\n✗ ${failures} check(s) failed`);
+  process.exit(1);
+}
+console.log('\n✓ all public lyrics payload checks passed');

--- a/controller/src/connect/catalog.ts
+++ b/controller/src/connect/catalog.ts
@@ -139,15 +139,47 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
           'connected Subsonic server\'s structured lyrics response. Empty `lines` ' +
           'means the current item is not a library track, no lyrics are indexed ' +
           'for the track, or the upstream lyrics lookup failed. Timed lyrics keep ' +
-          'their `startMs`; unsynced/plain lyrics use `null` timings.',
+          'their `startMs`; unsynced/plain lyrics use `null` timings. Pass a ' +
+          'stable opaque `clientId` query parameter to include that client\'s ' +
+          'saved per-track `offsetMs` correction.',
         auth: 'none',
+        queryParams: [
+          {
+            name: 'clientId',
+            description:
+              'Opaque listener/player id used only for that client\'s saved lyric timing corrections.',
+            example: 'player_7f2b9c',
+          },
+        ],
         responseExample: {
           songId: 'a1b2c3',
           synced: true,
+          offsetMs: 0,
           lines: [
             { startMs: 12500, text: 'First lyric line' },
             { startMs: 15300, text: 'Second lyric line' },
           ],
+        },
+      },
+      {
+        method: 'PUT',
+        path: '/lyrics/current/offset',
+        summary: 'Save lyric timing correction',
+        description:
+          'Stores this client\'s per-track lyric timing correction for the current ' +
+          'on-air library track. The client id is opaque and listener-scoped; this ' +
+          'does not alter station-wide lyric data or affect other players. The ' +
+          'request is rejected if `songId` no longer matches the current track.',
+        auth: 'none',
+        bodyExample: {
+          songId: 'a1b2c3',
+          clientId: 'player_7f2b9c',
+          offsetMs: 2900,
+        },
+        responseExample: {
+          ok: true,
+          songId: 'a1b2c3',
+          offsetMs: 2900,
         },
       },
       {

--- a/controller/src/connect/catalog.ts
+++ b/controller/src/connect/catalog.ts
@@ -132,6 +132,26 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
       },
       {
         method: 'GET',
+        path: '/lyrics/current',
+        summary: 'Current track lyrics',
+        description:
+          'Lyrics for the currently airing library track, normalized from the ' +
+          'connected Subsonic server\'s structured lyrics response. Empty `lines` ' +
+          'means the current item is not a library track, no lyrics are indexed ' +
+          'for the track, or the upstream lyrics lookup failed. Timed lyrics keep ' +
+          'their `startMs`; unsynced/plain lyrics use `null` timings.',
+        auth: 'none',
+        responseExample: {
+          songId: 'a1b2c3',
+          synced: true,
+          lines: [
+            { startMs: 12500, text: 'First lyric line' },
+            { startMs: 15300, text: 'Second lyric line' },
+          ],
+        },
+      },
+      {
+        method: 'GET',
         path: '/state',
         summary: 'Queue, history & DJ log',
         description:

--- a/controller/src/connect/catalog.ts
+++ b/controller/src/connect/catalog.ts
@@ -139,15 +139,16 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
           'connected Subsonic server\'s structured lyrics response. Empty `lines` ' +
           'means the current item is not a library track, no lyrics are indexed ' +
           'for the track, or the upstream lyrics lookup failed. Timed lyrics keep ' +
-          'their `startMs`; unsynced/plain lyrics use `null` timings. Pass a ' +
-          'stable opaque `clientId` query parameter to include that client\'s ' +
-          'saved per-track `offsetMs` correction.',
+          'their source `startMs`; unsynced/plain lyrics use `null` timings. ' +
+          '`offsetMs` is returned separately: add it to measured playback elapsed ' +
+          'time before choosing the active line. Pass a stable opaque `clientId` ' +
+          'query parameter to include that client\'s saved per-track correction.',
         auth: 'none',
         queryParams: [
           {
             name: 'clientId',
             description:
-              'Opaque listener/player id used only for that client\'s saved lyric timing corrections.',
+              'Stable opaque listener/player id used only for that client\'s saved lyric timing corrections. Do not use an account id or other personal identifier.',
             example: 'player_7f2b9c',
           },
         ],
@@ -168,8 +169,9 @@ export const ENDPOINT_GROUPS: EndpointGroup[] = [
         description:
           'Stores this client\'s per-track lyric timing correction for the current ' +
           'on-air library track. The client id is opaque and listener-scoped; this ' +
-          'does not alter station-wide lyric data or affect other players. The ' +
-          'request is rejected if `songId` no longer matches the current track.',
+          'does not alter station-wide lyric data or affect other players. Positive ' +
+          '`offsetMs` advances lyric highlighting sooner; negative values delay it. ' +
+          'The request is rejected if `songId` no longer matches the current track.',
         auth: 'none',
         bodyExample: {
           songId: 'a1b2c3',

--- a/controller/src/music/library-db.ts
+++ b/controller/src/music/library-db.ts
@@ -28,6 +28,7 @@
 //   queries.ts      mood- and tag-keyed reads, genre centroids
 //   browse.ts       the admin browse filter + Observatory rows
 //   plays.ts        play history
+//   lyrics.ts       per-client lyric timing offsets
 
 export * from './library-db/handle.js';
 export * from './library-db/types.js';
@@ -43,3 +44,4 @@ export * from './library-db/audio-moods.js';
 export * from './library-db/queries.js';
 export * from './library-db/browse.js';
 export * from './library-db/plays.js';
+export * from './library-db/lyrics.js';

--- a/controller/src/music/library-db/lyrics.ts
+++ b/controller/src/music/library-db/lyrics.ts
@@ -1,0 +1,38 @@
+import { requireDb } from './handle.js';
+
+export const LYRIC_OFFSET_MIN_MS = -30_000;
+export const LYRIC_OFFSET_MAX_MS = 30_000;
+
+export function clampLyricOffsetMs(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(LYRIC_OFFSET_MAX_MS, Math.max(LYRIC_OFFSET_MIN_MS, Math.round(value)));
+}
+
+export function getLyricOffset(clientId: string, trackId: string): number {
+  if (!clientId || !trackId) return 0;
+  const row = requireDb()
+    .prepare('SELECT offset_ms FROM lyric_offsets WHERE client_id = ? AND track_id = ?')
+    .get(clientId, trackId) as { offset_ms: number } | undefined;
+  return row ? clampLyricOffsetMs(row.offset_ms) : 0;
+}
+
+export function setLyricOffset(clientId: string, trackId: string, offsetMs: number): number {
+  const clamped = clampLyricOffsetMs(offsetMs);
+  requireDb()
+    .prepare(
+      `INSERT INTO lyric_offsets (client_id, track_id, offset_ms, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(client_id, track_id) DO UPDATE SET
+         offset_ms = excluded.offset_ms,
+         updated_at = excluded.updated_at`,
+    )
+    .run(clientId, trackId, clamped, new Date().toISOString());
+  return clamped;
+}
+
+export function clearLyricOffset(clientId: string, trackId: string): void {
+  if (!clientId || !trackId) return;
+  requireDb()
+    .prepare('DELETE FROM lyric_offsets WHERE client_id = ? AND track_id = ?')
+    .run(clientId, trackId);
+}

--- a/controller/src/music/library-db/lyrics.ts
+++ b/controller/src/music/library-db/lyrics.ts
@@ -29,10 +29,3 @@ export function setLyricOffset(clientId: string, trackId: string, offsetMs: numb
     .run(clientId, trackId, clamped, new Date().toISOString());
   return clamped;
 }
-
-export function clearLyricOffset(clientId: string, trackId: string): void {
-  if (!clientId || !trackId) return;
-  requireDb()
-    .prepare('DELETE FROM lyric_offsets WHERE client_id = ? AND track_id = ?')
-    .run(clientId, trackId);
-}

--- a/controller/src/music/library-db/schema.ts
+++ b/controller/src/music/library-db/schema.ts
@@ -520,6 +520,23 @@ export async function migrate(embeddingDim: number, reseed = false, adoptStoredD
     d.pragma('user_version = 25');
   }
 
+  if (userVersion < 26) {
+    // Per-client lyric timing corrections. These are listener/player
+    // preferences keyed by an opaque client id, not edits to the music files or
+    // station-wide lyric data. That lets a player remember "this song needs
+    // +2.9s" without letting any public listener retime lyrics for everyone.
+    runDdl(d, `
+      CREATE TABLE IF NOT EXISTS lyric_offsets (
+        client_id  TEXT NOT NULL,
+        track_id   TEXT NOT NULL,
+        offset_ms  INTEGER NOT NULL,
+        updated_at TEXT NOT NULL,
+        PRIMARY KEY (client_id, track_id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_lyric_offsets_track ON lyric_offsets(track_id);
+    `);
+    d.pragma('user_version = 26');
+  }
   // Reconcile the requested embedding dim against what physically exists.
   //
   // The vec0 table's `FLOAT[N]` schema is the authority for what inserts accept —

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -239,6 +239,21 @@ export function getPlaybackMeta(songId: string): db.TrackLite | null {
   return loaded ? db.getTrackLite(songId) : null;
 }
 
+export async function getLyricOffset(songId: string, clientId: string): Promise<number> {
+  await load();
+  return db.getLyricOffset(clientId, songId);
+}
+
+export async function setLyricOffset(songId: string, clientId: string, offsetMs: number): Promise<number> {
+  await load();
+  return db.setLyricOffset(clientId, songId, offsetMs);
+}
+
+export async function clearLyricOffset(songId: string, clientId: string): Promise<void> {
+  await load();
+  db.clearLyricOffset(clientId, songId);
+}
+
 // When a track entered the library (its `taggedAt` ISO string), or null if it's
 // not in the tagged index. The playlist sync engine keys "new since last sync"
 // off this — a Subsonic-only track (not in the DB) reads null and is never

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -249,11 +249,6 @@ export async function setLyricOffset(songId: string, clientId: string, offsetMs:
   return db.setLyricOffset(clientId, songId, offsetMs);
 }
 
-export async function clearLyricOffset(songId: string, clientId: string): Promise<void> {
-  await load();
-  db.clearLyricOffset(clientId, songId);
-}
-
 // When a track entered the library (its `taggedAt` ISO string), or null if it's
 // not in the tagged index. The playlist sync engine keys "new since last sync"
 // off this — a Subsonic-only track (not in the DB) reads null and is never

--- a/controller/src/music/lyric-vocal.ts
+++ b/controller/src/music/lyric-vocal.ts
@@ -42,6 +42,13 @@ export interface LyricVocalResult {
 // whole string so a song that merely SINGS the word "instrumental" isn't caught.
 const INSTRUMENTAL_RE = /^\s*[[(]?\s*(?:au\s*:\s*)?instrumental\s*[)\]]?\s*$/i;
 
+// Exported so the public lyrics payload (`music/lyrics-public.ts`) screens the
+// same markers off the same `getStructuredLyrics()` shape. One owner for the
+// pattern — a second copy would drift the moment a new marker spelling shows up.
+export function isInstrumentalMarker(text: string): boolean {
+  return INSTRUMENTAL_RE.test(text);
+}
+
 // Consecutive sung lines closer than this merge into one vocal range; a wider
 // gap (a solo, an instrumental bridge) splits them so the ranges expose real
 // vocal-free stretches. 8s keeps a verse together but still surfaces breaks.
@@ -61,7 +68,7 @@ export function deriveVocalFromLyrics(lyrics: StructuredLyrics | null): LyricVoc
   const lines = lyrics.lines.filter((l) => l.text.trim().length > 0);
 
   // Explicit instrumental marker: every non-empty line is the marker text.
-  if (lines.length > 0 && lines.every((l) => INSTRUMENTAL_RE.test(l.text))) {
+  if (lines.length > 0 && lines.every((l) => isInstrumentalMarker(l.text))) {
     return { instrumental: true, vocalRanges: [], introMs: null };
   }
 

--- a/controller/src/music/lyrics-cache.ts
+++ b/controller/src/music/lyrics-cache.ts
@@ -1,0 +1,65 @@
+// A small in-process cache for the public lyrics endpoint. Structured lyric
+// lookups authenticate to the station's Subsonic server, so a listener poll
+// must never turn into an upstream request on every render. Promise entries
+// deliberately coalesce concurrent misses as well as retaining recent values.
+
+export interface LyricsCacheOptions {
+  maxEntries?: number;
+  positiveTtlMs?: number;
+  negativeTtlMs?: number;
+  now?: () => number;
+}
+
+interface CacheEntry<T> {
+  expiresAt: number;
+  value: Promise<T | null>;
+}
+
+export class BoundedLyricsCache<T> {
+  private readonly entries = new Map<string, CacheEntry<T>>();
+  private readonly maxEntries: number;
+  private readonly positiveTtlMs: number;
+  private readonly negativeTtlMs: number;
+  private readonly now: () => number;
+
+  constructor(options: LyricsCacheOptions = {}) {
+    this.maxEntries = options.maxEntries ?? 100;
+    this.positiveTtlMs = options.positiveTtlMs ?? 30_000;
+    this.negativeTtlMs = options.negativeTtlMs ?? 10_000;
+    this.now = options.now ?? Date.now;
+  }
+
+  async get(key: string, load: () => Promise<T | null>): Promise<T | null> {
+    const now = this.now();
+    const existing = this.entries.get(key);
+    if (existing && existing.expiresAt > now) {
+      // Map order is our LRU order. Refreshing it here keeps frequently aired
+      // tracks warm without allowing the cache to grow without bound.
+      this.entries.delete(key);
+      this.entries.set(key, existing);
+      return existing.value;
+    }
+    if (existing) this.entries.delete(key);
+
+    // Start with the short TTL so an in-flight failure is bounded too. It is
+    // adjusted once the lookup resolves, while all concurrent callers await
+    // this same promise rather than fanning out to Subsonic.
+    const entry: CacheEntry<T> = {
+      expiresAt: now + this.negativeTtlMs,
+      value: Promise.resolve().then(load),
+    };
+    this.entries.set(key, entry);
+    while (this.entries.size > this.maxEntries) this.entries.delete(this.entries.keys().next().value!);
+
+    try {
+      const value = await entry.value;
+      entry.expiresAt = this.now() + (value == null ? this.negativeTtlMs : this.positiveTtlMs);
+      return value;
+    } catch (err) {
+      // Keep a failed lookup briefly as well. The endpoint still reports its
+      // normal error, but a flaky upstream cannot be amplified by listeners.
+      entry.expiresAt = this.now() + this.negativeTtlMs;
+      throw err;
+    }
+  }
+}

--- a/controller/src/music/lyrics-public.ts
+++ b/controller/src/music/lyrics-public.ts
@@ -6,6 +6,7 @@ export interface PublicLyricLine {
 export interface PublicLyricsPayload {
   songId: string | null;
   synced: boolean;
+  offsetMs: number;
   lines: PublicLyricLine[];
 }
 
@@ -17,8 +18,11 @@ export interface StructuredLyricsInput {
 export function toPublicLyricsPayload(
   songId: string | null,
   lyrics: StructuredLyricsInput | null,
+  offsetMs = 0,
 ): PublicLyricsPayload {
-  if (!songId || !lyrics) return { songId: songId || null, synced: false, lines: [] };
+  if (!songId || !lyrics) {
+    return { songId: songId || null, synced: false, offsetMs, lines: [] };
+  }
 
   const lines = lyrics.lines
     .map((line) => ({
@@ -30,6 +34,7 @@ export function toPublicLyricsPayload(
   return {
     songId,
     synced: lyrics.synced === true && lines.some((line) => line.startMs != null),
+    offsetMs,
     lines,
   };
 }

--- a/controller/src/music/lyrics-public.ts
+++ b/controller/src/music/lyrics-public.ts
@@ -6,6 +6,7 @@ export interface PublicLyricLine {
 export interface PublicLyricsPayload {
   songId: string | null;
   synced: boolean;
+  /** Add this to the player's measured elapsed time before choosing a line. */
   offsetMs: number;
   lines: PublicLyricLine[];
 }

--- a/controller/src/music/lyrics-public.ts
+++ b/controller/src/music/lyrics-public.ts
@@ -1,0 +1,35 @@
+export interface PublicLyricLine {
+  startMs: number | null;
+  text: string;
+}
+
+export interface PublicLyricsPayload {
+  songId: string | null;
+  synced: boolean;
+  lines: PublicLyricLine[];
+}
+
+export interface StructuredLyricsInput {
+  synced: boolean;
+  lines: Array<{ startMs: number; text: string }>;
+}
+
+export function toPublicLyricsPayload(
+  songId: string | null,
+  lyrics: StructuredLyricsInput | null,
+): PublicLyricsPayload {
+  if (!songId || !lyrics) return { songId: songId || null, synced: false, lines: [] };
+
+  const lines = lyrics.lines
+    .map((line) => ({
+      startMs: Number.isFinite(line.startMs) ? line.startMs : null,
+      text: typeof line.text === 'string' ? line.text.trim() : '',
+    }))
+    .filter((line) => line.text.length > 0);
+
+  return {
+    songId,
+    synced: lyrics.synced === true && lines.some((line) => line.startMs != null),
+    lines,
+  };
+}

--- a/controller/src/music/lyrics-public.ts
+++ b/controller/src/music/lyrics-public.ts
@@ -1,3 +1,5 @@
+import { isInstrumentalMarker } from './lyric-vocal.js';
+
 export interface PublicLyricLine {
   startMs: number | null;
   text: string;
@@ -25,12 +27,18 @@ export function toPublicLyricsPayload(
     return { songId: songId || null, synced: false, offsetMs, lines: [] };
   }
 
+  // Drop blank lines AND instrumental markers. Navidrome/LRC bodies commonly
+  // carry `[au: instrumental]` or a bare "Instrumental" as the whole lyric —
+  // that is metadata, not sung words. Left in, it renders as a lyric line the
+  // player highlights for the entire track (and, being timed at 0, is enough on
+  // its own to flip `synced`). An all-marker body reduces to [], which is the
+  // same empty payload a track with no lyrics returns.
   const lines = lyrics.lines
     .map((line) => ({
       startMs: Number.isFinite(line.startMs) ? line.startMs : null,
       text: typeof line.text === 'string' ? line.text.trim() : '',
     }))
-    .filter((line) => line.text.length > 0);
+    .filter((line) => line.text.length > 0 && !isInstrumentalMarker(line.text));
 
   return {
     songId,

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -32,6 +32,7 @@ import { resolveThemeProvenance } from '../util/theme-provenance.js';
 import { checkAuthRateLimit, clientIp, listenerAuthFailureDelayMs } from '../middleware/ratelimit.js';
 import { STATE_ROOT } from '../config.js';
 import { activeStationId } from '../stations/resolve.js';
+import { toPublicLyricsPayload } from '../music/lyrics-public.js';
 
 export const router = express.Router();
 
@@ -354,6 +355,21 @@ router.get('/now-playing', async (req, res) => {
     });
   } catch (err) {
     publicError(res, '/now-playing', err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /lyrics/current — lyrics for the currently airing library track.
+// ---------------------------------------------------------------------------
+router.get('/lyrics/current', async (_req, res) => {
+  try {
+    const nowPlaying = await queue.getNowPlaying();
+    const songId = nowPlaying?.subsonic_id ? String(nowPlaying.subsonic_id) : null;
+    const lyrics = songId ? await subsonic.getStructuredLyrics(songId) : null;
+    res.setHeader('Cache-Control', 'no-store');
+    res.json(toPublicLyricsPayload(songId, lyrics));
+  } catch (err) {
+    publicError(res, '/lyrics/current', err);
   }
 });
 

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -33,6 +33,7 @@ import { checkAuthRateLimit, clientIp, listenerAuthFailureDelayMs } from '../mid
 import { STATE_ROOT } from '../config.js';
 import { activeStationId } from '../stations/resolve.js';
 import { toPublicLyricsPayload } from '../music/lyrics-public.js';
+import { BoundedLyricsCache } from '../music/lyrics-cache.js';
 
 export const router = express.Router();
 
@@ -95,6 +96,7 @@ function lyricOffsetMs(value: unknown): number | null {
 }
 
 const lyricOffsetHits = new Map<string, { last: number; hits: number[] }>();
+const lyricCache = new BoundedLyricsCache<{ synced: boolean; lines: Array<{ startMs: number; text: string }> }>();
 function checkLyricOffsetLimit(ip: string): { ok: boolean; retryAfter?: number } {
   const now = Date.now();
   const oneHourAgo = now - 3_600_000;
@@ -399,7 +401,7 @@ router.get('/lyrics/current', async (_req, res) => {
   try {
     const nowPlaying = await queue.getNowPlaying();
     const songId = nowPlaying?.subsonic_id ? String(nowPlaying.subsonic_id) : null;
-    const lyrics = songId ? await subsonic.getStructuredLyrics(songId) : null;
+    const lyrics = songId ? await lyricCache.get(songId, () => subsonic.getStructuredLyrics(songId)) : null;
     const clientId = lyricClientId(_req.query?.clientId);
     const offsetMs = songId && clientId ? await library.getLyricOffset(songId, clientId) : 0;
     res.setHeader('Cache-Control', 'no-store');

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -83,6 +83,40 @@ function avatarUrlFor(personaId?: string | null): string {
   return personaId ? `/persona-avatar/${encodeURIComponent(personaId)}` : '';
 }
 
+function lyricClientId(value: unknown): string {
+  const id = typeof value === 'string' ? value.trim() : '';
+  return /^[A-Za-z0-9_-]{12,80}$/.test(id) ? id : '';
+}
+
+function lyricOffsetMs(value: unknown): number | null {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return null;
+  return Math.min(30_000, Math.max(-30_000, Math.round(n)));
+}
+
+const lyricOffsetHits = new Map<string, { last: number; hits: number[] }>();
+function checkLyricOffsetLimit(ip: string): { ok: boolean; retryAfter?: number } {
+  const now = Date.now();
+  const oneHourAgo = now - 3_600_000;
+  const rec = lyricOffsetHits.get(ip) || { last: 0, hits: [] };
+  rec.hits = rec.hits.filter((t) => t > oneHourAgo);
+  if (rec.last && now - rec.last < 250) {
+    return { ok: false, retryAfter: 1 };
+  }
+  if (rec.hits.length >= 600) {
+    return { ok: false, retryAfter: Math.ceil((rec.hits[0] + 3_600_000 - now) / 1000) };
+  }
+  rec.last = now;
+  rec.hits.push(now);
+  lyricOffsetHits.set(ip, rec);
+  if (lyricOffsetHits.size > 2000) {
+    for (const [key, value] of lyricOffsetHits) {
+      if (!value.hits.length && now - value.last > 3_600_000) lyricOffsetHits.delete(key);
+    }
+  }
+  return { ok: true };
+}
+
 // The listener-safe persona shape + the souls disclosure rule live in
 // util/public-persona.ts so GET /schedule and GET /personas can't drift apart
 // on what they publish, and so the rule is unit-pinnable. Read per-request
@@ -366,10 +400,48 @@ router.get('/lyrics/current', async (_req, res) => {
     const nowPlaying = await queue.getNowPlaying();
     const songId = nowPlaying?.subsonic_id ? String(nowPlaying.subsonic_id) : null;
     const lyrics = songId ? await subsonic.getStructuredLyrics(songId) : null;
+    const clientId = lyricClientId(_req.query?.clientId);
+    const offsetMs = songId && clientId ? await library.getLyricOffset(songId, clientId) : 0;
     res.setHeader('Cache-Control', 'no-store');
-    res.json(toPublicLyricsPayload(songId, lyrics));
+    res.json(toPublicLyricsPayload(songId, lyrics, offsetMs));
   } catch (err) {
     publicError(res, '/lyrics/current', err);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// PUT /lyrics/current/offset — remember this client's timing correction for
+// the currently airing track. Public but scoped to an opaque client id so a
+// listener can only affect their own players, not the station-wide lyric data.
+// ---------------------------------------------------------------------------
+router.put('/lyrics/current/offset', async (req, res) => {
+  try {
+    const gate = checkLyricOffsetLimit(clientIp(req));
+    if (!gate.ok) {
+      res.setHeader('Retry-After', String(gate.retryAfter));
+      return res.status(429).json({ error: 'Too many lyric offset updates', retryAfter: gate.retryAfter });
+    }
+
+    const nowPlaying = await queue.getNowPlaying();
+    const songId = nowPlaying?.subsonic_id ? String(nowPlaying.subsonic_id) : null;
+    if (!songId) return res.status(409).json({ error: 'No library track is on air' });
+
+    const asked = typeof req.body?.songId === 'string' ? req.body.songId : '';
+    if (asked && asked !== songId) {
+      return res.status(409).json({ error: 'That track just ended', songId });
+    }
+
+    const clientId = lyricClientId(req.body?.clientId);
+    const offsetMs = lyricOffsetMs(req.body?.offsetMs);
+    if (!clientId || offsetMs == null) {
+      return res.status(400).json({ error: 'clientId and offsetMs are required' });
+    }
+
+    const saved = await library.setLyricOffset(songId, clientId, offsetMs);
+    res.setHeader('Cache-Control', 'no-store');
+    res.json({ ok: true, songId, offsetMs: saved });
+  } catch (err) {
+    publicError(res, '/lyrics/current/offset', err);
   }
 });
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -62,7 +62,9 @@ players and custom skins. It resolves the current on-air item to its
 `subsonic_id`, asks the connected Subsonic server for structured lyrics, and
 returns a small normalized payload. Pass a stable opaque `clientId` query
 parameter when the player wants Subwave to include that listener/client's saved
-per-track timing correction.
+per-track timing correction. Generate the id inside the player and store it
+locally; it should not be an account id, email address, or other personal
+identifier.
 
 ```json
 {
@@ -79,9 +81,17 @@ per-track timing correction.
 `songId` is `null` when the on-air item is not a library track. `lines` is empty
 when no lyrics are indexed for the current track, when the current item is not a
 library track, or when the upstream lyrics lookup fails. Synced lyrics preserve
-line timing in `startMs`; unsynced/plain lyrics use `null` for `startMs` and set
-`synced` to `false`. `offsetMs` is a client-scoped correction for the current
-track; add it to elapsed playback time before selecting the active lyric line.
+source line timing in `startMs`; unsynced/plain lyrics use `null` for `startMs`
+and set `synced` to `false`.
+
+`offsetMs` is a client-scoped correction for the current track. It is not folded
+into each line's `startMs`; players apply it at render time:
+
+```text
+effectiveElapsedMs = measuredPlaybackElapsedMs + offsetMs
+```
+
+Positive values advance lyric highlighting sooner. Negative values delay it.
 
 `PUT /lyrics/current/offset` saves that correction for the current track and
 client:
@@ -96,7 +106,8 @@ client:
 
 The write is public but scoped by `clientId` and verified against the current
 on-air song, so one listener's correction does not change station-wide lyric
-data or affect other players.
+data or affect other players. The server rejects stale writes when the submitted
+`songId` no longer matches the current track.
 
 ## OpenAPI
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,12 +60,15 @@ soul regardless, as it always has.
 `GET /lyrics/current` is an unauthenticated public read for listener-facing
 players and custom skins. It resolves the current on-air item to its
 `subsonic_id`, asks the connected Subsonic server for structured lyrics, and
-returns a small normalized payload:
+returns a small normalized payload. Pass a stable opaque `clientId` query
+parameter when the player wants Subwave to include that listener/client's saved
+per-track timing correction.
 
 ```json
 {
   "songId": "abc123",
   "synced": true,
+  "offsetMs": 0,
   "lines": [
     { "startMs": 12500, "text": "First lyric line" },
     { "startMs": 15300, "text": "Second lyric line" }
@@ -77,7 +80,23 @@ returns a small normalized payload:
 when no lyrics are indexed for the current track, when the current item is not a
 library track, or when the upstream lyrics lookup fails. Synced lyrics preserve
 line timing in `startMs`; unsynced/plain lyrics use `null` for `startMs` and set
-`synced` to `false`.
+`synced` to `false`. `offsetMs` is a client-scoped correction for the current
+track; add it to elapsed playback time before selecting the active lyric line.
+
+`PUT /lyrics/current/offset` saves that correction for the current track and
+client:
+
+```json
+{
+  "songId": "abc123",
+  "clientId": "listener-device-or-app-id",
+  "offsetMs": 2900
+}
+```
+
+The write is public but scoped by `clientId` and verified against the current
+on-air song, so one listener's correction does not change station-wide lyric
+data or affect other players.
 
 ## OpenAPI
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -43,6 +43,8 @@ an admin credential:
   than `activePersonaId` behind the mic).
 - `GET /now-playing` — the current track, plus `context.activeShow` with the
   live show's host and guests already hydrated.
+- `GET /lyrics/current` — lyrics for the currently airing library track, when
+  the connected Subsonic server exposes them for that song.
 
 **Persona souls are opt-in.** A persona's `soul` is its system prompt rather
 than a written bio, so the roster-wide reads above publish it only when the
@@ -52,6 +54,30 @@ and `/personas` report which mode you're in via `soulsPublished`, so a client
 can hide the bio column instead of rendering blank cards. `tagline` is the field intended for
 public display and is always present. `GET /dj` publishes the on-air persona's
 soul regardless, as it always has.
+
+## Current-track lyrics
+
+`GET /lyrics/current` is an unauthenticated public read for listener-facing
+players and custom skins. It resolves the current on-air item to its
+`subsonic_id`, asks the connected Subsonic server for structured lyrics, and
+returns a small normalized payload:
+
+```json
+{
+  "songId": "abc123",
+  "synced": true,
+  "lines": [
+    { "startMs": 12500, "text": "First lyric line" },
+    { "startMs": 15300, "text": "Second lyric line" }
+  ]
+}
+```
+
+`songId` is `null` when the on-air item is not a library track. `lines` is empty
+when no lyrics are indexed for the current track, when the current item is not a
+library track, or when the upstream lyrics lookup fails. Synced lyrics preserve
+line timing in `startMs`; unsynced/plain lyrics use `null` for `startMs` and set
+`synced` to `false`.
 
 ## OpenAPI
 

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -487,6 +487,33 @@ body::after {
 .v3-drawer-content {
     animation: v3-slide-in-right 220ms cubic-bezier(0.2, 0.7, 0.2, 1);
 }
+
+.v3-drawer-content::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    border: 1px solid var(--ink);
+    z-index: 1;
+}
+
+.v3-drawer-content > * {
+    position: relative;
+    z-index: 2;
+}
+
+[data-lyric-offset] {
+    margin-top: 0.75rem;
+    border: 1px solid color-mix(in oklab, var(--line) 42%, transparent);
+    background:
+        linear-gradient(180deg, color-mix(in oklab, var(--bg) 18%, transparent), color-mix(in oklab, var(--bg) 42%, transparent)),
+        color-mix(in oklab, var(--surface) 16%, transparent);
+    opacity: 0.58;
+}
+
+[data-lyric-offset] input[type="range"] {
+    opacity: 0.72;
+}
 .v3-drawer-overlay {
     animation: v3-fade-in 220ms ease-out;
 }

--- a/web/components/skins/classic/ClassicSkin.tsx
+++ b/web/components/skins/classic/ClassicSkin.tsx
@@ -7,7 +7,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AnimatePresence } from 'motion/react';
 import { toast } from 'sonner';
-import { CalendarClock, History, Mic } from 'lucide-react';
+import { CalendarClock, Captions, History, Mic } from 'lucide-react';
 import TopBar from './TopBar';
 import CenterStage from './CenterStage';
 import Waveform from './Waveform';
@@ -20,6 +20,7 @@ import TimelineDrawer from './drawers/TimelineDrawer';
 import BoothDrawer from './drawers/BoothDrawer';
 import RequestDrawer from './drawers/RequestDrawer';
 import ScheduleDrawer from './drawers/ScheduleDrawer';
+import LyricsDrawer from './drawers/LyricsDrawer';
 import { Sheet } from '@/components/ui/sheet';
 import {
   usePlayerActions,
@@ -40,6 +41,7 @@ const DRAWER_TITLES: Record<PlayerDrawer, string> = {
   booth: 'Booth feed',
   request: 'Make a request',
   schedule: 'Schedule',
+  lyrics: 'Lyrics',
 };
 
 // Hoisted so the DotRail counts memo below keeps stable element references —
@@ -47,6 +49,7 @@ const DRAWER_TITLES: Record<PlayerDrawer, string> = {
 const TIMELINE_ICON = <History size={18} strokeWidth={1.5} />;
 const BOOTH_ICON = <Mic size={18} strokeWidth={1.5} />;
 const SCHEDULE_ICON = <CalendarClock size={18} strokeWidth={1.5} />;
+const LYRICS_ICON = <Captions size={18} strokeWidth={1.5} />;
 
 export default function ClassicSkin({ portalNode }: SkinProps) {
   const client = useStationClient();
@@ -91,6 +94,7 @@ export default function ClassicSkin({ portalNode }: SkinProps) {
       timeline: upcomingCount || TIMELINE_ICON,
       booth: BOOTH_ICON,
       schedule: SCHEDULE_ICON,
+      lyrics: LYRICS_ICON,
     }),
     [upcomingCount],
   );
@@ -150,6 +154,8 @@ export default function ClassicSkin({ portalNode }: SkinProps) {
       '2': () => setDrawer('booth'),
       '3': () => setDrawer('request'),
       '4': () => setDrawer('schedule'),
+      '5': () => setDrawer('lyrics'),
+      l: () => setDrawer('lyrics'),
       r: () => setDrawer('request'),
       '?': () => setShortcutsOpen(true),
       'mod+k': () => setPaletteOpen(o => !o),
@@ -251,6 +257,14 @@ export default function ClassicSkin({ portalNode }: SkinProps) {
           />
         )}
         {drawer === 'schedule' && <ScheduleDrawer activeShow={activeShow} context={context} />}
+        {drawer === 'lyrics' && (
+          <LyricsDrawer
+            songId={nowPlaying?.subsonic_id}
+            title={nowPlaying?.title}
+            artist={nowPlaying?.artist}
+            trackStartedAt={trackStartedAt}
+          />
+        )}
       </Sheet>
 
       <AnimatePresence>

--- a/web/components/skins/classic/CommandPalette.tsx
+++ b/web/components/skins/classic/CommandPalette.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/command';
 import { Kbd } from '@/components/ui/kbd';
 
-export type PlayerDrawer = 'timeline' | 'booth' | 'request' | 'schedule';
+export type PlayerDrawer = 'timeline' | 'booth' | 'request' | 'schedule' | 'lyrics';
 
 export interface CommandPaletteProps {
   open: boolean;
@@ -53,6 +53,7 @@ export default function CommandPalette({
     { label: 'Open Booth feed', hint: '2', onSelect: run(() => onOpenDrawer('booth')) },
     { label: 'Make a request', hint: '3', onSelect: run(() => onOpenDrawer('request')) },
     { label: 'Open Schedule', hint: '4', onSelect: run(() => onOpenDrawer('schedule')) },
+    { label: 'Open Lyrics', hint: '5', onSelect: run(() => onOpenDrawer('lyrics')) },
     { label: muted ? 'Unmute' : 'Mute', hint: 'M', onSelect: run(onToggleMute) },
     { label: 'Keyboard shortcuts', hint: '?', onSelect: run(onShowShortcuts) },
   ];

--- a/web/components/skins/classic/DotRail.tsx
+++ b/web/components/skins/classic/DotRail.tsx
@@ -15,6 +15,7 @@ const ITEMS: readonly RailItem[] = [
   { k: 'schedule', l: 'Schedule' },
   { k: 'timeline', l: 'Timeline' },
   { k: 'booth',    l: 'Booth' },
+  { k: 'lyrics',   l: 'Lyrics' },
   { k: 'request',  l: 'Request' },
 ];
 

--- a/web/components/skins/classic/ShortcutsDialog.tsx
+++ b/web/components/skins/classic/ShortcutsDialog.tsx
@@ -18,6 +18,7 @@ const SHORTCUTS: readonly Shortcut[] = [
   { keys: ['2'], label: 'Open Booth feed' },
   { keys: ['3', 'R'], label: 'Make a request' },
   { keys: ['4'], label: 'Open Schedule' },
+  { keys: ['5', 'L'], label: 'Open Lyrics' },
   { keys: ['S'], label: 'Next player skin' },
   { keys: ['T'], label: 'Next theme' },
   { keys: ['?'], label: 'This shortcuts list' },

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -4,6 +4,11 @@ import { useEffect, useRef, useState, type ChangeEvent } from 'react';
 import { Minus, Plus, RotateCcw, SlidersHorizontal } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
   LYRIC_OFFSET_MAX_MS,
   LYRIC_OFFSET_MIN_MS,
   LYRIC_OFFSET_NUDGE_MS,
@@ -19,8 +24,6 @@ export interface LyricsDrawerProps {
   trackStartedAt: number | null;
 }
 
-const OFFSET_VISIBLE_STORAGE_KEY = 'subwave:lyrics-offset-visible';
-
 export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: LyricsDrawerProps) {
   const [showOffset, setShowOffset] = useState(false);
   const activeRef = useRef<HTMLDivElement | null>(null);
@@ -33,22 +36,6 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
     activeLineIndex: active,
     updateOffset,
   } = useCurrentLyrics({ songId, trackStartedAt });
-
-  useEffect(() => {
-    try {
-      setShowOffset(window.localStorage.getItem(OFFSET_VISIBLE_STORAGE_KEY) === '1');
-    } catch {}
-  }, []);
-
-  const toggleOffset = () => {
-    setShowOffset(next => {
-      const visible = !next;
-      try {
-        window.localStorage.setItem(OFFSET_VISIBLE_STORAGE_KEY, visible ? '1' : '0');
-      } catch {}
-      return visible;
-    });
-  };
 
   const onOffsetInput = (event: ChangeEvent<HTMLInputElement>) => {
     updateOffset(Number(event.target.value));
@@ -109,78 +96,81 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
             {lyrics.synced && (
               <>
                 <div className="v3-tab-num text-[9px] tracking-[0.18em] text-muted uppercase">Synced</div>
-                <button
-                  type="button"
-                  className={cn(
-                    'v3-focus grid h-7 w-7 place-items-center border border-separator-soft bg-transparent text-muted transition-colors',
-                    showOffset && 'border-ink bg-ink text-bg',
-                  )}
-                  onClick={toggleOffset}
-                  aria-pressed={showOffset}
-                  aria-label="Lyrics offset controls"
-                  title="Lyrics offset controls"
-                >
-                  <SlidersHorizontal size={15} strokeWidth={1.7} />
-                </button>
+                <DropdownMenu open={showOffset} onOpenChange={setShowOffset}>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className={cn(
+                        'v3-focus grid h-7 w-7 place-items-center border border-separator-soft bg-transparent text-muted transition-colors',
+                        showOffset && 'border-ink bg-ink text-bg',
+                      )}
+                      aria-label="Lyrics offset controls"
+                      title="Lyrics offset controls"
+                    >
+                      <SlidersHorizontal size={15} strokeWidth={1.7} />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="end"
+                    side="top"
+                    sideOffset={8}
+                    className="z-[100] w-[min(420px,calc(100vw-2rem))] rounded-none border-separator-soft bg-[color-mix(in_oklab,var(--bg)_94%,black)] p-3 text-ink shadow-[0_18px_50px_rgba(0,0,0,0.45)]"
+                    data-lyric-offset
+                    onCloseAutoFocus={event => event.preventDefault()}
+                  >
+                    <div className="mb-2 flex items-center justify-between gap-3">
+                      <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Track offset</div>
+                      <div className="v3-tab-num shrink-0 text-[11px] tracking-[0.1em] text-ink">{formatLyricOffset(offsetMs)}</div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-ink"
+                        onClick={() => updateOffset(offsetMs - LYRIC_OFFSET_NUDGE_MS)}
+                        aria-label="Delay lyrics"
+                        title="Delay lyrics"
+                      >
+                        <Minus size={14} strokeWidth={1.8} />
+                      </button>
+                      <input
+                        type="range"
+                        min={LYRIC_OFFSET_MIN_MS}
+                        max={LYRIC_OFFSET_MAX_MS}
+                        step={LYRIC_OFFSET_STEP_MS}
+                        value={offsetMs}
+                        onChange={onOffsetInput}
+                        aria-label="Track lyric offset"
+                        className="h-8 min-w-0 flex-1 accent-[var(--accent)]"
+                      />
+                      <button
+                        type="button"
+                        className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-ink"
+                        onClick={() => updateOffset(offsetMs + LYRIC_OFFSET_NUDGE_MS)}
+                        aria-label="Advance lyrics"
+                        title="Advance lyrics"
+                      >
+                        <Plus size={14} strokeWidth={1.8} />
+                      </button>
+                      <button
+                        type="button"
+                        className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-muted"
+                        onClick={() => updateOffset(0)}
+                        aria-label="Reset lyrics offset"
+                        title="Reset lyrics offset"
+                      >
+                        <RotateCcw size={14} strokeWidth={1.8} />
+                      </button>
+                    </div>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </>
             )}
           </div>
         </div>
       </div>
 
-      {lyrics.synced && showOffset && (
-        <div
-          className="shrink-0 border-b border-separator-soft py-3"
-          data-lyric-offset
-        >
-          <div className="mb-2 flex items-center justify-between gap-3">
-            <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Track offset</div>
-            <div className="v3-tab-num shrink-0 text-[11px] tracking-[0.1em] text-ink">{formatLyricOffset(offsetMs)}</div>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-ink"
-              onClick={() => updateOffset(offsetMs - LYRIC_OFFSET_NUDGE_MS)}
-              aria-label="Delay lyrics"
-              title="Delay lyrics"
-            >
-              <Minus size={14} strokeWidth={1.8} />
-            </button>
-            <input
-              type="range"
-              min={LYRIC_OFFSET_MIN_MS}
-              max={LYRIC_OFFSET_MAX_MS}
-              step={LYRIC_OFFSET_STEP_MS}
-              value={offsetMs}
-              onChange={onOffsetInput}
-              aria-label="Track lyric offset"
-              className="h-8 min-w-0 flex-1 accent-[var(--accent)]"
-            />
-            <button
-              type="button"
-              className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-ink"
-              onClick={() => updateOffset(offsetMs + LYRIC_OFFSET_NUDGE_MS)}
-              aria-label="Advance lyrics"
-              title="Advance lyrics"
-            >
-              <Plus size={14} strokeWidth={1.8} />
-            </button>
-            <button
-              type="button"
-              className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-muted"
-              onClick={() => updateOffset(0)}
-              aria-label="Reset lyrics offset"
-              title="Reset lyrics offset"
-            >
-              <RotateCcw size={14} strokeWidth={1.8} />
-            </button>
-          </div>
-        </div>
-      )}
-
       <div className="v3-scroll mt-3 flex min-h-0 flex-1 flex-col overflow-y-auto pb-4">
-        {lyrics.synced && <div className="h-[35%] shrink-0" aria-hidden="true" />}
+        {lyrics.synced && <div className="h-[calc(50%-1.4rem)] shrink-0" aria-hidden="true" />}
         {lyrics.lines.map((line, index) => {
           const isActive = index === active;
           return (
@@ -199,7 +189,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
             </div>
           );
         })}
-        {lyrics.synced && <div className="h-[45%] shrink-0" aria-hidden="true" />}
+        {lyrics.synced && <div className="h-[calc(50%-1.4rem)] shrink-0" aria-hidden="true" />}
       </div>
     </div>
   );

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '@/lib/cn';
+import { useStationClient } from '@/lib/stationClient';
+import type { PublicLyricsPayload } from '@/lib/types';
+
+export interface LyricsDrawerProps {
+  songId?: string | null;
+  title?: string;
+  artist?: string;
+  trackStartedAt: number | null;
+}
+
+function activeLineIndex(lyrics: PublicLyricsPayload | null, elapsedMs: number): number {
+  if (!lyrics?.synced) return -1;
+  let active = -1;
+  for (let i = 0; i < lyrics.lines.length; i += 1) {
+    const startMs = lyrics.lines[i]?.startMs;
+    if (startMs == null) continue;
+    if (startMs > elapsedMs) break;
+    active = i;
+  }
+  return active;
+}
+
+export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: LyricsDrawerProps) {
+  const client = useStationClient();
+  const [lyrics, setLyrics] = useState<PublicLyricsPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const activeRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLyrics(null);
+    setFailed(false);
+    if (!songId) {
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+    client.currentLyrics()
+      .then((payload) => {
+        if (cancelled) return;
+        setLyrics(payload?.songId === songId ? payload : null);
+        setFailed(payload == null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [client, songId]);
+
+  useEffect(() => {
+    if (!lyrics?.synced) return;
+    const id = window.setInterval(() => setNowMs(Date.now()), 500);
+    return () => window.clearInterval(id);
+  }, [lyrics?.synced, trackStartedAt]);
+
+  const elapsedMs = trackStartedAt == null ? 0 : Math.max(0, nowMs - trackStartedAt);
+  const active = useMemo(() => activeLineIndex(lyrics, elapsedMs), [lyrics, elapsedMs]);
+
+  useEffect(() => {
+    if (active < 0) return;
+    activeRef.current?.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }, [active]);
+
+  if (!songId) {
+    return (
+      <div className="text-[13px] leading-relaxed text-muted">
+        Lyrics are available for library tracks once the station has indexed them.
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="text-[13px] leading-relaxed text-muted">
+        Pulling lyrics from the library…
+      </div>
+    );
+  }
+
+  if (failed) {
+    return (
+      <div className="text-[13px] leading-relaxed text-muted">
+        Lyrics are not reachable right now.
+      </div>
+    );
+  }
+
+  if (!lyrics?.lines.length) {
+    return (
+      <div>
+        <div className="text-[9px] tracking-[0.3em] text-muted uppercase">No lyrics indexed</div>
+        <div className="mt-3 text-[13px] leading-relaxed text-muted">
+          {title ? `${title}${artist ? ` by ${artist}` : ''}` : 'This track'} has no lyrics in the station library yet.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-4 border-b border-separator-soft pb-4">
+        <div className="truncate text-lg leading-tight font-semibold">{title || 'Now playing'}</div>
+        {artist && <div className="mt-0.5 truncate text-xs text-muted">{artist}</div>}
+        <div className="mt-3 text-[9px] tracking-[0.3em] text-muted uppercase">
+          {lyrics.synced ? 'Synced lyrics' : 'Lyrics'}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-1 pb-8">
+        {lyrics.lines.map((line, index) => {
+          const isActive = index === active;
+          return (
+            <div
+              key={`${line.startMs ?? 'plain'}-${index}`}
+              ref={isActive ? activeRef : undefined}
+              className={cn(
+                'border-l-2 py-2 pr-3 pl-4 text-[15px] leading-relaxed transition-colors',
+                isActive
+                  ? 'border-vermilion bg-[rgba(197,48,42,0.08)] text-ink'
+                  : 'border-transparent text-muted',
+                !lyrics.synced && 'border-separator-soft text-ink',
+              )}
+            >
+              {line.text}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -102,23 +102,23 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
             {artist && <div className="mt-1 truncate text-[10px] tracking-[0.16em] text-muted uppercase">{artist}</div>}
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <div className="v3-tab-num text-[9px] tracking-[0.18em] text-muted uppercase">
-              {lyrics.synced ? 'Synced' : 'Plain'}
-            </div>
             {lyrics.synced && (
-              <button
-                type="button"
-                className={cn(
-                  'v3-focus grid h-7 w-7 place-items-center border border-separator-soft bg-transparent text-muted transition-colors',
-                  showOffset && 'border-ink bg-ink text-bg',
-                )}
-                onClick={toggleOffset}
-                aria-pressed={showOffset}
-                aria-label="Lyrics offset controls"
-                title="Lyrics offset controls"
-              >
-                <SlidersHorizontal size={15} strokeWidth={1.7} />
-              </button>
+              <>
+                <div className="v3-tab-num text-[9px] tracking-[0.18em] text-muted uppercase">Synced</div>
+                <button
+                  type="button"
+                  className={cn(
+                    'v3-focus grid h-7 w-7 place-items-center border border-separator-soft bg-transparent text-muted transition-colors',
+                    showOffset && 'border-ink bg-ink text-bg',
+                  )}
+                  onClick={toggleOffset}
+                  aria-pressed={showOffset}
+                  aria-label="Lyrics offset controls"
+                  title="Lyrics offset controls"
+                >
+                  <SlidersHorizontal size={15} strokeWidth={1.7} />
+                </button>
+              </>
             )}
           </div>
         </div>

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -15,8 +15,8 @@ export interface LyricsDrawerProps {
 
 const OFFSET_STORAGE_KEY = 'subwave:lyrics-offset-ms';
 const OFFSET_VISIBLE_STORAGE_KEY = 'subwave:lyrics-offset-visible';
-const OFFSET_MIN_MS = -5000;
-const OFFSET_MAX_MS = 5000;
+const OFFSET_MIN_MS = -30000;
+const OFFSET_MAX_MS = 30000;
 const OFFSET_STEP_MS = 50;
 const OFFSET_NUDGE_MS = 100;
 
@@ -28,6 +28,13 @@ function clampOffsetMs(value: number): number {
 function formatOffset(ms: number): string {
   if (ms === 0) return '0.00s';
   return `${ms > 0 ? '+' : '-'}${(Math.abs(ms) / 1000).toFixed(2)}s`;
+}
+
+function formatLineTime(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, '0')}`;
 }
 
 function activeLineIndex(lyrics: PublicLyricsPayload | null, elapsedMs: number, offsetMs: number): number {
@@ -51,7 +58,8 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
   const [nowMs, setNowMs] = useState(() => Date.now());
   const [offsetMs, setOffsetMs] = useState(0);
   const [showOffset, setShowOffset] = useState(false);
-  const activeRef = useRef<HTMLDivElement | null>(null);
+  const [selectedLineIndex, setSelectedLineIndex] = useState<number | null>(null);
+  const activeRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     try {
@@ -83,6 +91,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
     let cancelled = false;
     setLyrics(null);
     setFailed(false);
+    setSelectedLineIndex(null);
     if (!songId) {
       setLoading(false);
       return;
@@ -110,9 +119,20 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
 
   const elapsedMs = trackStartedAt == null ? 0 : Math.max(0, nowMs - trackStartedAt);
   const active = useMemo(() => activeLineIndex(lyrics, elapsedMs, offsetMs), [lyrics, elapsedMs, offsetMs]);
+  const selectedLine = selectedLineIndex == null ? null : lyrics?.lines[selectedLineIndex] ?? null;
+  const canSyncSelectedLine = lyrics?.synced && selectedLine?.startMs != null && trackStartedAt != null;
 
   const onOffsetInput = (event: ChangeEvent<HTMLInputElement>) => {
     updateOffset(Number(event.target.value));
+  };
+
+  const syncSelectedLine = () => {
+    if (selectedLine?.startMs == null || trackStartedAt == null) return;
+    updateOffset(elapsedMs - selectedLine.startMs);
+    setShowOffset(true);
+    try {
+      window.localStorage.setItem(OFFSET_VISIBLE_STORAGE_KEY, '1');
+    } catch {}
   };
 
   useEffect(() => {
@@ -189,20 +209,33 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
       <div className="v3-scroll mt-4 flex min-h-0 flex-1 flex-col overflow-y-auto pb-5">
         {lyrics.lines.map((line, index) => {
           const isActive = index === active;
+          const isSelectable = lyrics.synced && line.startMs != null;
+          const isSelected = index === selectedLineIndex;
           return (
-            <div
+            <button
               key={`${line.startMs ?? 'plain'}-${index}`}
               ref={isActive ? activeRef : undefined}
+              type="button"
+              disabled={!isSelectable}
+              onClick={() => {
+                if (!isSelectable) return;
+                setSelectedLineIndex(index);
+                if (!showOffset) toggleOffset();
+              }}
               className={cn(
-                'border-l py-[9px] pr-3 pl-4 text-[15px] leading-relaxed transition-colors',
+                'w-full border-l py-[9px] pr-3 pl-4 text-left text-[15px] leading-relaxed transition-colors',
+                isSelectable && 'v3-focus cursor-pointer hover:border-ink hover:text-ink',
                 isActive
                   ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_9%,transparent)] text-ink shadow-[inset_1px_0_0_var(--accent)]'
                   : 'border-separator-soft text-muted',
+                isSelected && 'border-ink bg-[color-mix(in_oklab,var(--ink)_7%,transparent)] text-ink shadow-[inset_1px_0_0_var(--ink)]',
                 !lyrics.synced && 'border-separator-soft text-ink',
               )}
+              aria-pressed={isSelectable ? isSelected : undefined}
+              aria-label={isSelectable ? `Select lyric line at ${formatLineTime(line.startMs ?? 0)}` : undefined}
             >
               {line.text}
-            </div>
+            </button>
           );
         })}
       </div>
@@ -213,8 +246,15 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
           data-lyric-offset
         >
           <div className="mb-2 flex items-center justify-between gap-3">
-            <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Lyric offset</div>
-            <div className="v3-tab-num text-[11px] tracking-[0.1em] text-ink">{formatOffset(offsetMs)}</div>
+            <div className="min-w-0">
+              <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Lyric offset</div>
+              {selectedLine?.startMs != null && (
+                <div className="mt-1 truncate text-[10px] tracking-[0.08em] text-muted uppercase">
+                  Line {formatLineTime(selectedLine.startMs)}
+                </div>
+              )}
+            </div>
+            <div className="v3-tab-num shrink-0 text-[11px] tracking-[0.1em] text-ink">{formatOffset(offsetMs)}</div>
           </div>
           <div className="flex items-center gap-2">
             <button
@@ -249,6 +289,14 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
               onClick={() => updateOffset(0)}
             >
               Zero
+            </button>
+            <button
+              type="button"
+              className="v3-focus h-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent px-2 text-[9px] tracking-[0.18em] text-ink uppercase disabled:cursor-not-allowed disabled:opacity-35"
+              onClick={syncSelectedLine}
+              disabled={!canSyncSelectedLine}
+            >
+              Sync
             </button>
           </div>
         </div>

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -128,30 +128,9 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
         </div>
       </div>
 
-      <div className="v3-scroll mt-3 flex min-h-0 flex-1 flex-col overflow-y-auto pb-4">
-        {lyrics.lines.map((line, index) => {
-          const isActive = index === active;
-          return (
-            <div
-              key={`${line.startMs ?? 'plain'}-${index}`}
-              ref={isActive ? activeRef : undefined}
-              className={cn(
-                'border-l py-2 pr-3 pl-3 text-[14px] leading-relaxed transition-colors',
-                isActive
-                  ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_5%,transparent)] text-ink'
-                  : 'border-separator-soft text-muted',
-                !lyrics.synced && 'border-separator-soft text-ink',
-              )}
-            >
-              {line.text}
-            </div>
-          );
-        })}
-      </div>
-
       {lyrics.synced && showOffset && (
         <div
-          className="shrink-0 border-t border-separator-soft pt-3"
+          className="shrink-0 border-b border-separator-soft py-3"
           data-lyric-offset
         >
           <div className="mb-2 flex items-center justify-between gap-3">
@@ -199,6 +178,29 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
           </div>
         </div>
       )}
+
+      <div className="v3-scroll mt-3 flex min-h-0 flex-1 flex-col overflow-y-auto pb-4">
+        {lyrics.synced && <div className="h-[35%] shrink-0" aria-hidden="true" />}
+        {lyrics.lines.map((line, index) => {
+          const isActive = index === active;
+          return (
+            <div
+              key={`${line.startMs ?? 'plain'}-${index}`}
+              ref={isActive ? activeRef : undefined}
+              className={cn(
+                'border-l py-2 pr-3 pl-3 text-[14px] leading-relaxed transition-colors',
+                isActive
+                  ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_5%,transparent)] text-ink'
+                  : 'border-separator-soft text-muted',
+                !lyrics.synced && 'border-separator-soft text-ink',
+              )}
+            >
+              {line.text}
+            </div>
+          );
+        })}
+        {lyrics.synced && <div className="h-[45%] shrink-0" aria-hidden="true" />}
+      </div>
     </div>
   );
 }

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -28,6 +28,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
     lyrics,
     loading,
     failed,
+    stale,
     offsetMs,
     activeLineIndex: active,
     updateOffset,
@@ -66,7 +67,10 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
     );
   }
 
-  if (loading) {
+  // `stale` means the station is still answering for the previous track — we
+  // have no verdict for this one, so keep waiting rather than claiming it has
+  // no lyrics. The hook re-asks on its own.
+  if (loading || stale) {
     return (
       <div className="text-[13px] leading-relaxed text-muted">
         Pulling lyrics from the library…

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { SlidersHorizontal } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import { useStationClient } from '@/lib/stationClient';
 import type { PublicLyricsPayload } from '@/lib/types';
@@ -13,6 +14,7 @@ export interface LyricsDrawerProps {
 }
 
 const OFFSET_STORAGE_KEY = 'subwave:lyrics-offset-ms';
+const OFFSET_VISIBLE_STORAGE_KEY = 'subwave:lyrics-offset-visible';
 const OFFSET_MIN_MS = -5000;
 const OFFSET_MAX_MS = 5000;
 const OFFSET_STEP_MS = 50;
@@ -48,12 +50,14 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
   const [failed, setFailed] = useState(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
   const [offsetMs, setOffsetMs] = useState(0);
+  const [showOffset, setShowOffset] = useState(false);
   const activeRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     try {
       const stored = window.localStorage.getItem(OFFSET_STORAGE_KEY);
       if (stored != null) setOffsetMs(clampOffsetMs(Number(stored)));
+      setShowOffset(window.localStorage.getItem(OFFSET_VISIBLE_STORAGE_KEY) === '1');
     } catch {}
   }, []);
 
@@ -63,6 +67,16 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
     try {
       window.localStorage.setItem(OFFSET_STORAGE_KEY, String(clamped));
     } catch {}
+  };
+
+  const toggleOffset = () => {
+    setShowOffset(next => {
+      const visible = !next;
+      try {
+        window.localStorage.setItem(OFFSET_VISIBLE_STORAGE_KEY, visible ? '1' : '0');
+      } catch {}
+      return visible;
+    });
   };
 
   useEffect(() => {
@@ -149,8 +163,25 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
             <div className="truncate text-[16px] leading-tight font-semibold">{title || 'Now playing'}</div>
             {artist && <div className="mt-1 truncate text-[11px] tracking-[0.16em] text-muted uppercase">{artist}</div>}
           </div>
-          <div className="v3-tab-num shrink-0 text-[10px] tracking-[0.18em] text-vermilion uppercase">
-            {lyrics.synced ? 'Synced' : 'Plain'}
+          <div className="flex shrink-0 items-center gap-2">
+            <div className="v3-tab-num text-[10px] tracking-[0.18em] text-vermilion uppercase">
+              {lyrics.synced ? 'Synced' : 'Plain'}
+            </div>
+            {lyrics.synced && (
+              <button
+                type="button"
+                className={cn(
+                  'v3-focus grid h-8 w-8 place-items-center border border-separator-soft bg-transparent text-ink',
+                  showOffset && 'bg-ink text-bg',
+                )}
+                onClick={toggleOffset}
+                aria-pressed={showOffset}
+                aria-label="Lyrics offset controls"
+                title="Lyrics offset controls"
+              >
+                <SlidersHorizontal size={15} strokeWidth={1.7} />
+              </button>
+            )}
           </div>
         </div>
       </div>
@@ -176,8 +207,11 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
         })}
       </div>
 
-      {lyrics.synced && (
-        <div className="shrink-0 border-t border-separator-soft bg-[color-mix(in_oklab,var(--bg)_72%,transparent)] pt-3 [backdrop-filter:blur(18px)_saturate(1.4)] [-webkit-backdrop-filter:blur(18px)_saturate(1.4)]">
+      {lyrics.synced && showOffset && (
+        <div
+          className="shrink-0 px-4 pt-3 pb-4 [backdrop-filter:blur(18px)_saturate(1.4)] [-webkit-backdrop-filter:blur(18px)_saturate(1.4)] sm:px-5"
+          data-lyric-offset
+        >
           <div className="mb-2 flex items-center justify-between gap-3">
             <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Lyric offset</div>
             <div className="v3-tab-num text-[11px] tracking-[0.1em] text-ink">{formatOffset(offsetMs)}</div>

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -128,9 +128,30 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
         </div>
       </div>
 
+      <div className="v3-scroll mt-3 flex min-h-0 flex-1 flex-col overflow-y-auto pb-4">
+        {lyrics.lines.map((line, index) => {
+          const isActive = index === active;
+          return (
+            <div
+              key={`${line.startMs ?? 'plain'}-${index}`}
+              ref={isActive ? activeRef : undefined}
+              className={cn(
+                'border-l py-2 pr-3 pl-3 text-[14px] leading-relaxed transition-colors',
+                isActive
+                  ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_5%,transparent)] text-ink'
+                  : 'border-separator-soft text-muted',
+                !lyrics.synced && 'border-separator-soft text-ink',
+              )}
+            >
+              {line.text}
+            </div>
+          );
+        })}
+      </div>
+
       {lyrics.synced && showOffset && (
         <div
-          className="shrink-0 border-b border-separator-soft py-3"
+          className="shrink-0 border-t border-separator-soft pt-3"
           data-lyric-offset
         >
           <div className="mb-2 flex items-center justify-between gap-3">
@@ -178,29 +199,6 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
           </div>
         </div>
       )}
-
-      <div className="v3-scroll mt-3 flex min-h-0 flex-1 flex-col overflow-y-auto pb-4">
-        {lyrics.synced && <div className="h-[35%] shrink-0" aria-hidden="true" />}
-        {lyrics.lines.map((line, index) => {
-          const isActive = index === active;
-          return (
-            <div
-              key={`${line.startMs ?? 'plain'}-${index}`}
-              ref={isActive ? activeRef : undefined}
-              className={cn(
-                'border-l py-2 pr-3 pl-3 text-[14px] leading-relaxed transition-colors',
-                isActive
-                  ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_5%,transparent)] text-ink'
-                  : 'border-separator-soft text-muted',
-                !lyrics.synced && 'border-separator-soft text-ink',
-              )}
-            >
-              {line.text}
-            </div>
-          );
-        })}
-        {lyrics.synced && <div className="h-[45%] shrink-0" aria-hidden="true" />}
-      </div>
     </div>
   );
 }

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -120,15 +120,17 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
   const elapsedMs = trackStartedAt == null ? 0 : Math.max(0, nowMs - trackStartedAt);
   const active = useMemo(() => activeLineIndex(lyrics, elapsedMs, offsetMs), [lyrics, elapsedMs, offsetMs]);
   const selectedLine = selectedLineIndex == null ? null : lyrics?.lines[selectedLineIndex] ?? null;
-  const canSyncSelectedLine = lyrics?.synced && selectedLine?.startMs != null && trackStartedAt != null;
+  const activeLine = active < 0 ? null : lyrics?.lines[active] ?? null;
+  const syncTargetLine = selectedLine?.startMs != null ? selectedLine : activeLine;
+  const canSyncSelectedLine = lyrics?.synced && syncTargetLine?.startMs != null && trackStartedAt != null;
 
   const onOffsetInput = (event: ChangeEvent<HTMLInputElement>) => {
     updateOffset(Number(event.target.value));
   };
 
   const syncSelectedLine = () => {
-    if (selectedLine?.startMs == null || trackStartedAt == null) return;
-    updateOffset(elapsedMs - selectedLine.startMs);
+    if (syncTargetLine?.startMs == null || trackStartedAt == null) return;
+    updateOffset(syncTargetLine.startMs - elapsedMs);
     setShowOffset(true);
     try {
       window.localStorage.setItem(OFFSET_VISIBLE_STORAGE_KEY, '1');

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -4,11 +4,6 @@ import { useEffect, useRef, useState, type ChangeEvent } from 'react';
 import { Minus, Plus, RotateCcw, SlidersHorizontal } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import {
   LYRIC_OFFSET_MAX_MS,
   LYRIC_OFFSET_MIN_MS,
   LYRIC_OFFSET_NUDGE_MS,
@@ -24,6 +19,8 @@ export interface LyricsDrawerProps {
   trackStartedAt: number | null;
 }
 
+const OFFSET_VISIBLE_STORAGE_KEY = 'subwave:lyrics-offset-visible';
+
 export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: LyricsDrawerProps) {
   const [showOffset, setShowOffset] = useState(false);
   const activeRef = useRef<HTMLDivElement | null>(null);
@@ -36,6 +33,22 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
     activeLineIndex: active,
     updateOffset,
   } = useCurrentLyrics({ songId, trackStartedAt });
+
+  useEffect(() => {
+    try {
+      setShowOffset(window.localStorage.getItem(OFFSET_VISIBLE_STORAGE_KEY) === '1');
+    } catch {}
+  }, []);
+
+  const toggleOffset = () => {
+    setShowOffset(next => {
+      const visible = !next;
+      try {
+        window.localStorage.setItem(OFFSET_VISIBLE_STORAGE_KEY, visible ? '1' : '0');
+      } catch {}
+      return visible;
+    });
+  };
 
   const onOffsetInput = (event: ChangeEvent<HTMLInputElement>) => {
     updateOffset(Number(event.target.value));
@@ -96,81 +109,78 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
             {lyrics.synced && (
               <>
                 <div className="v3-tab-num text-[9px] tracking-[0.18em] text-muted uppercase">Synced</div>
-                <DropdownMenu open={showOffset} onOpenChange={setShowOffset}>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      className={cn(
-                        'v3-focus grid h-7 w-7 place-items-center border border-separator-soft bg-transparent text-muted transition-colors',
-                        showOffset && 'border-ink bg-ink text-bg',
-                      )}
-                      aria-label="Lyrics offset controls"
-                      title="Lyrics offset controls"
-                    >
-                      <SlidersHorizontal size={15} strokeWidth={1.7} />
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    align="end"
-                    side="top"
-                    sideOffset={8}
-                    className="z-[100] w-[min(420px,calc(100vw-2rem))] rounded-none border-separator-soft bg-[color-mix(in_oklab,var(--bg)_94%,black)] p-3 text-ink shadow-[0_18px_50px_rgba(0,0,0,0.45)]"
-                    data-lyric-offset
-                    onCloseAutoFocus={event => event.preventDefault()}
-                  >
-                    <div className="mb-2 flex items-center justify-between gap-3">
-                      <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Track offset</div>
-                      <div className="v3-tab-num shrink-0 text-[11px] tracking-[0.1em] text-ink">{formatLyricOffset(offsetMs)}</div>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <button
-                        type="button"
-                        className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-ink"
-                        onClick={() => updateOffset(offsetMs - LYRIC_OFFSET_NUDGE_MS)}
-                        aria-label="Delay lyrics"
-                        title="Delay lyrics"
-                      >
-                        <Minus size={14} strokeWidth={1.8} />
-                      </button>
-                      <input
-                        type="range"
-                        min={LYRIC_OFFSET_MIN_MS}
-                        max={LYRIC_OFFSET_MAX_MS}
-                        step={LYRIC_OFFSET_STEP_MS}
-                        value={offsetMs}
-                        onChange={onOffsetInput}
-                        aria-label="Track lyric offset"
-                        className="h-8 min-w-0 flex-1 accent-[var(--accent)]"
-                      />
-                      <button
-                        type="button"
-                        className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-ink"
-                        onClick={() => updateOffset(offsetMs + LYRIC_OFFSET_NUDGE_MS)}
-                        aria-label="Advance lyrics"
-                        title="Advance lyrics"
-                      >
-                        <Plus size={14} strokeWidth={1.8} />
-                      </button>
-                      <button
-                        type="button"
-                        className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-muted"
-                        onClick={() => updateOffset(0)}
-                        aria-label="Reset lyrics offset"
-                        title="Reset lyrics offset"
-                      >
-                        <RotateCcw size={14} strokeWidth={1.8} />
-                      </button>
-                    </div>
-                  </DropdownMenuContent>
-                </DropdownMenu>
+                <button
+                  type="button"
+                  className={cn(
+                    'v3-focus grid h-7 w-7 place-items-center border border-separator-soft bg-transparent text-muted transition-colors',
+                    showOffset && 'border-ink bg-ink text-bg',
+                  )}
+                  onClick={toggleOffset}
+                  aria-pressed={showOffset}
+                  aria-label="Lyrics offset controls"
+                  title="Lyrics offset controls"
+                >
+                  <SlidersHorizontal size={15} strokeWidth={1.7} />
+                </button>
               </>
             )}
           </div>
         </div>
       </div>
 
+      {lyrics.synced && showOffset && (
+        <div
+          className="shrink-0 border-b border-separator-soft py-3"
+          data-lyric-offset
+        >
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Track offset</div>
+            <div className="v3-tab-num shrink-0 text-[11px] tracking-[0.1em] text-ink">{formatLyricOffset(offsetMs)}</div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-ink"
+              onClick={() => updateOffset(offsetMs - LYRIC_OFFSET_NUDGE_MS)}
+              aria-label="Delay lyrics"
+              title="Delay lyrics"
+            >
+              <Minus size={14} strokeWidth={1.8} />
+            </button>
+            <input
+              type="range"
+              min={LYRIC_OFFSET_MIN_MS}
+              max={LYRIC_OFFSET_MAX_MS}
+              step={LYRIC_OFFSET_STEP_MS}
+              value={offsetMs}
+              onChange={onOffsetInput}
+              aria-label="Track lyric offset"
+              className="h-8 min-w-0 flex-1 accent-[var(--accent)]"
+            />
+            <button
+              type="button"
+              className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-ink"
+              onClick={() => updateOffset(offsetMs + LYRIC_OFFSET_NUDGE_MS)}
+              aria-label="Advance lyrics"
+              title="Advance lyrics"
+            >
+              <Plus size={14} strokeWidth={1.8} />
+            </button>
+            <button
+              type="button"
+              className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-muted"
+              onClick={() => updateOffset(0)}
+              aria-label="Reset lyrics offset"
+              title="Reset lyrics offset"
+            >
+              <RotateCcw size={14} strokeWidth={1.8} />
+            </button>
+          </div>
+        </div>
+      )}
+
       <div className="v3-scroll mt-3 flex min-h-0 flex-1 flex-col overflow-y-auto pb-4">
-        {lyrics.synced && <div className="h-[calc(50%-1.4rem)] shrink-0" aria-hidden="true" />}
+        {lyrics.synced && <div className="h-[35%] shrink-0" aria-hidden="true" />}
         {lyrics.lines.map((line, index) => {
           const isActive = index === active;
           return (
@@ -189,7 +199,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
             </div>
           );
         })}
-        {lyrics.synced && <div className="h-[calc(50%-1.4rem)] shrink-0" aria-hidden="true" />}
+        {lyrics.synced && <div className="h-[45%] shrink-0" aria-hidden="true" />}
       </div>
     </div>
   );

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -14,6 +14,7 @@ export interface LyricsDrawerProps {
 }
 
 const OFFSET_STORAGE_KEY = 'subwave:lyrics-offset-ms';
+const OFFSET_CLIENT_STORAGE_KEY = 'subwave:lyrics-offset-client-id';
 const OFFSET_VISIBLE_STORAGE_KEY = 'subwave:lyrics-offset-visible';
 const OFFSET_MIN_MS = -30000;
 const OFFSET_MAX_MS = 30000;
@@ -28,6 +29,26 @@ function clampOffsetMs(value: number): number {
 function formatOffset(ms: number): string {
   if (ms === 0) return '0.00s';
   return `${ms > 0 ? '+' : '-'}${(Math.abs(ms) / 1000).toFixed(2)}s`;
+}
+
+function offsetStorageKey(songId: string): string {
+  return `${OFFSET_STORAGE_KEY}:${songId}`;
+}
+
+function createFallbackClientId(): string {
+  return `sw_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 12)}`;
+}
+
+function readLyricOffsetClientId(): string {
+  try {
+    const stored = window.localStorage.getItem(OFFSET_CLIENT_STORAGE_KEY);
+    if (stored) return stored;
+    const next = window.crypto?.randomUUID?.() ?? createFallbackClientId();
+    window.localStorage.setItem(OFFSET_CLIENT_STORAGE_KEY, next);
+    return next;
+  } catch {
+    return createFallbackClientId();
+  }
 }
 
 function activeLineIndex(lyrics: PublicLyricsPayload | null, elapsedMs: number, offsetMs: number): number {
@@ -52,11 +73,12 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
   const [offsetMs, setOffsetMs] = useState(0);
   const [showOffset, setShowOffset] = useState(false);
   const activeRef = useRef<HTMLDivElement | null>(null);
+  const clientIdRef = useRef<string>('');
+  const loadedOffsetSongRef = useRef<string | null>(null);
 
   useEffect(() => {
+    clientIdRef.current = readLyricOffsetClientId();
     try {
-      const stored = window.localStorage.getItem(OFFSET_STORAGE_KEY);
-      if (stored != null) setOffsetMs(clampOffsetMs(Number(stored)));
       setShowOffset(window.localStorage.getItem(OFFSET_VISIBLE_STORAGE_KEY) === '1');
     } catch {}
   }, []);
@@ -65,7 +87,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
     const clamped = clampOffsetMs(next);
     setOffsetMs(clamped);
     try {
-      window.localStorage.setItem(OFFSET_STORAGE_KEY, String(clamped));
+      if (songId) window.localStorage.setItem(offsetStorageKey(songId), String(clamped));
     } catch {}
   };
 
@@ -89,10 +111,22 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
     }
 
     setLoading(true);
-    client.currentLyrics()
+    const clientId = clientIdRef.current || readLyricOffsetClientId();
+    clientIdRef.current = clientId;
+    client.currentLyrics(clientId)
       .then((payload) => {
         if (cancelled) return;
-        setLyrics(payload?.songId === songId ? payload : null);
+        const nextLyrics = payload?.songId === songId ? payload : null;
+        setLyrics(nextLyrics);
+        if (nextLyrics) {
+          let nextOffset = clampOffsetMs(nextLyrics.offsetMs ?? 0);
+          try {
+            const stored = window.localStorage.getItem(offsetStorageKey(songId));
+            if (stored != null && nextOffset === 0) nextOffset = clampOffsetMs(Number(stored));
+          } catch {}
+          loadedOffsetSongRef.current = songId;
+          setOffsetMs(nextOffset);
+        }
         setFailed(payload == null);
       })
       .finally(() => {
@@ -101,6 +135,23 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
 
     return () => { cancelled = true; };
   }, [client, songId]);
+
+  useEffect(() => {
+    if (!songId || !lyrics?.synced || loadedOffsetSongRef.current !== songId) return;
+    const id = window.setTimeout(() => {
+      client.setCurrentLyricOffset(songId, clientIdRef.current, offsetMs)
+        .then((saved) => {
+          if (saved?.songId === songId && typeof saved.offsetMs === 'number') {
+            const clamped = clampOffsetMs(saved.offsetMs);
+            setOffsetMs(clamped);
+            try {
+              window.localStorage.setItem(offsetStorageKey(songId), String(clamped));
+            } catch {}
+          }
+        });
+    }, 350);
+    return () => window.clearTimeout(id);
+  }, [client, songId, lyrics?.synced, offsetMs]);
 
   useEffect(() => {
     if (!lyrics?.synced) return;
@@ -213,7 +264,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
           data-lyric-offset
         >
           <div className="mb-2 flex items-center justify-between gap-3">
-            <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Lyric offset</div>
+            <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Track offset</div>
             <div className="v3-tab-num shrink-0 text-[11px] tracking-[0.1em] text-ink">{formatOffset(offsetMs)}</div>
           </div>
           <div className="flex items-center gap-2">
@@ -232,7 +283,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
               step={OFFSET_STEP_MS}
               value={offsetMs}
               onChange={onOffsetInput}
-              aria-label="Lyric offset"
+              aria-label="Track lyric offset"
               className="h-8 min-w-0 flex-1 accent-[var(--accent)]"
             />
             <button
@@ -248,7 +299,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
               className="v3-focus h-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent px-2 text-[9px] tracking-[0.18em] text-muted uppercase"
               onClick={() => updateOffset(0)}
             >
-              Zero
+              Reset
             </button>
           </div>
         </div>

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { cn } from '@/lib/cn';
 import { useStationClient } from '@/lib/stationClient';
 import type { PublicLyricsPayload } from '@/lib/types';
@@ -12,13 +12,30 @@ export interface LyricsDrawerProps {
   trackStartedAt: number | null;
 }
 
-function activeLineIndex(lyrics: PublicLyricsPayload | null, elapsedMs: number): number {
+const OFFSET_STORAGE_KEY = 'subwave:lyrics-offset-ms';
+const OFFSET_MIN_MS = -5000;
+const OFFSET_MAX_MS = 5000;
+const OFFSET_STEP_MS = 50;
+const OFFSET_NUDGE_MS = 100;
+
+function clampOffsetMs(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(OFFSET_MAX_MS, Math.max(OFFSET_MIN_MS, Math.round(value)));
+}
+
+function formatOffset(ms: number): string {
+  if (ms === 0) return '0.00s';
+  return `${ms > 0 ? '+' : '-'}${(Math.abs(ms) / 1000).toFixed(2)}s`;
+}
+
+function activeLineIndex(lyrics: PublicLyricsPayload | null, elapsedMs: number, offsetMs: number): number {
   if (!lyrics?.synced) return -1;
+  const adjustedElapsedMs = Math.max(0, elapsedMs + offsetMs);
   let active = -1;
   for (let i = 0; i < lyrics.lines.length; i += 1) {
     const startMs = lyrics.lines[i]?.startMs;
     if (startMs == null) continue;
-    if (startMs > elapsedMs) break;
+    if (startMs > adjustedElapsedMs) break;
     active = i;
   }
   return active;
@@ -30,7 +47,23 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
   const [loading, setLoading] = useState(false);
   const [failed, setFailed] = useState(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
+  const [offsetMs, setOffsetMs] = useState(0);
   const activeRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(OFFSET_STORAGE_KEY);
+      if (stored != null) setOffsetMs(clampOffsetMs(Number(stored)));
+    } catch {}
+  }, []);
+
+  const updateOffset = (next: number) => {
+    const clamped = clampOffsetMs(next);
+    setOffsetMs(clamped);
+    try {
+      window.localStorage.setItem(OFFSET_STORAGE_KEY, String(clamped));
+    } catch {}
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -62,7 +95,11 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
   }, [lyrics?.synced, trackStartedAt]);
 
   const elapsedMs = trackStartedAt == null ? 0 : Math.max(0, nowMs - trackStartedAt);
-  const active = useMemo(() => activeLineIndex(lyrics, elapsedMs), [lyrics, elapsedMs]);
+  const active = useMemo(() => activeLineIndex(lyrics, elapsedMs, offsetMs), [lyrics, elapsedMs, offsetMs]);
+
+  const onOffsetInput = (event: ChangeEvent<HTMLInputElement>) => {
+    updateOffset(Number(event.target.value));
+  };
 
   useEffect(() => {
     if (active < 0) return;
@@ -105,16 +142,64 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
   }
 
   return (
-    <div>
-      <div className="mb-4 border-b border-separator-soft pb-4">
-        <div className="truncate text-lg leading-tight font-semibold">{title || 'Now playing'}</div>
-        {artist && <div className="mt-0.5 truncate text-xs text-muted">{artist}</div>}
-        <div className="mt-3 text-[9px] tracking-[0.3em] text-muted uppercase">
-          {lyrics.synced ? 'Synced lyrics' : 'Lyrics'}
+    <div className="flex min-h-full flex-col">
+      <div className="border-y border-separator-soft py-3">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="truncate text-[16px] leading-tight font-semibold">{title || 'Now playing'}</div>
+            {artist && <div className="mt-1 truncate text-[11px] tracking-[0.16em] text-muted uppercase">{artist}</div>}
+          </div>
+          <div className="v3-tab-num shrink-0 text-[10px] tracking-[0.18em] text-vermilion uppercase">
+            {lyrics.synced ? 'Synced' : 'Plain'}
+          </div>
         </div>
       </div>
 
-      <div className="flex flex-col gap-1 pb-8">
+      {lyrics.synced && (
+        <div className="my-4 border border-separator-soft bg-[color-mix(in_oklab,var(--ink)_5%,transparent)] px-3 py-3">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Lyric offset</div>
+            <div className="v3-tab-num text-[11px] tracking-[0.1em] text-ink">{formatOffset(offsetMs)}</div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="v3-focus h-8 w-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent text-[15px] leading-none text-ink"
+              onClick={() => updateOffset(offsetMs - OFFSET_NUDGE_MS)}
+              aria-label="Delay lyrics"
+            >
+              -
+            </button>
+            <input
+              type="range"
+              min={OFFSET_MIN_MS}
+              max={OFFSET_MAX_MS}
+              step={OFFSET_STEP_MS}
+              value={offsetMs}
+              onChange={onOffsetInput}
+              aria-label="Lyric offset"
+              className="h-8 min-w-0 flex-1 accent-[var(--accent)]"
+            />
+            <button
+              type="button"
+              className="v3-focus h-8 w-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent text-[15px] leading-none text-ink"
+              onClick={() => updateOffset(offsetMs + OFFSET_NUDGE_MS)}
+              aria-label="Advance lyrics"
+            >
+              +
+            </button>
+            <button
+              type="button"
+              className="v3-focus h-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent px-2 text-[9px] tracking-[0.18em] text-muted uppercase"
+              onClick={() => updateOffset(0)}
+            >
+              Zero
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="flex flex-col pb-8">
         {lyrics.lines.map((line, index) => {
           const isActive = index === active;
           return (
@@ -122,10 +207,10 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
               key={`${line.startMs ?? 'plain'}-${index}`}
               ref={isActive ? activeRef : undefined}
               className={cn(
-                'border-l-2 py-2 pr-3 pl-4 text-[15px] leading-relaxed transition-colors',
+                'border-l py-[9px] pr-3 pl-4 text-[15px] leading-relaxed transition-colors',
                 isActive
-                  ? 'border-vermilion bg-[rgba(197,48,42,0.08)] text-ink'
-                  : 'border-transparent text-muted',
+                  ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_9%,transparent)] text-ink shadow-[inset_1px_0_0_var(--accent)]'
+                  : 'border-separator-soft text-muted',
                 !lyrics.synced && 'border-separator-soft text-ink',
               )}
             >

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -30,13 +30,6 @@ function formatOffset(ms: number): string {
   return `${ms > 0 ? '+' : '-'}${(Math.abs(ms) / 1000).toFixed(2)}s`;
 }
 
-function formatLineTime(ms: number): string {
-  const totalSeconds = Math.max(0, Math.round(ms / 1000));
-  const minutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  return `${minutes}:${String(seconds).padStart(2, '0')}`;
-}
-
 function activeLineIndex(lyrics: PublicLyricsPayload | null, elapsedMs: number, offsetMs: number): number {
   if (!lyrics?.synced) return -1;
   const adjustedElapsedMs = Math.max(0, elapsedMs + offsetMs);
@@ -58,8 +51,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
   const [nowMs, setNowMs] = useState(() => Date.now());
   const [offsetMs, setOffsetMs] = useState(0);
   const [showOffset, setShowOffset] = useState(false);
-  const [selectedLineIndex, setSelectedLineIndex] = useState<number | null>(null);
-  const activeRef = useRef<HTMLButtonElement | null>(null);
+  const activeRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     try {
@@ -91,7 +83,6 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
     let cancelled = false;
     setLyrics(null);
     setFailed(false);
-    setSelectedLineIndex(null);
     if (!songId) {
       setLoading(false);
       return;
@@ -119,22 +110,9 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
 
   const elapsedMs = trackStartedAt == null ? 0 : Math.max(0, nowMs - trackStartedAt);
   const active = useMemo(() => activeLineIndex(lyrics, elapsedMs, offsetMs), [lyrics, elapsedMs, offsetMs]);
-  const selectedLine = selectedLineIndex == null ? null : lyrics?.lines[selectedLineIndex] ?? null;
-  const activeLine = active < 0 ? null : lyrics?.lines[active] ?? null;
-  const syncTargetLine = selectedLine?.startMs != null ? selectedLine : activeLine;
-  const canSyncSelectedLine = lyrics?.synced && syncTargetLine?.startMs != null && trackStartedAt != null;
 
   const onOffsetInput = (event: ChangeEvent<HTMLInputElement>) => {
     updateOffset(Number(event.target.value));
-  };
-
-  const syncSelectedLine = () => {
-    if (syncTargetLine?.startMs == null || trackStartedAt == null) return;
-    updateOffset(syncTargetLine.startMs - elapsedMs);
-    setShowOffset(true);
-    try {
-      window.localStorage.setItem(OFFSET_VISIBLE_STORAGE_KEY, '1');
-    } catch {}
   };
 
   useEffect(() => {
@@ -211,33 +189,20 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
       <div className="v3-scroll mt-4 flex min-h-0 flex-1 flex-col overflow-y-auto pb-5">
         {lyrics.lines.map((line, index) => {
           const isActive = index === active;
-          const isSelectable = lyrics.synced && line.startMs != null;
-          const isSelected = index === selectedLineIndex;
           return (
-            <button
+            <div
               key={`${line.startMs ?? 'plain'}-${index}`}
               ref={isActive ? activeRef : undefined}
-              type="button"
-              disabled={!isSelectable}
-              onClick={() => {
-                if (!isSelectable) return;
-                setSelectedLineIndex(index);
-                if (!showOffset) toggleOffset();
-              }}
               className={cn(
-                'w-full border-l py-[9px] pr-3 pl-4 text-left text-[15px] leading-relaxed transition-colors',
-                isSelectable && 'v3-focus cursor-pointer hover:border-ink hover:text-ink',
+                'border-l py-[9px] pr-3 pl-4 text-[15px] leading-relaxed transition-colors',
                 isActive
                   ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_9%,transparent)] text-ink shadow-[inset_1px_0_0_var(--accent)]'
                   : 'border-separator-soft text-muted',
-                isSelected && 'border-ink bg-[color-mix(in_oklab,var(--ink)_7%,transparent)] text-ink shadow-[inset_1px_0_0_var(--ink)]',
                 !lyrics.synced && 'border-separator-soft text-ink',
               )}
-              aria-pressed={isSelectable ? isSelected : undefined}
-              aria-label={isSelectable ? `Select lyric line at ${formatLineTime(line.startMs ?? 0)}` : undefined}
             >
               {line.text}
-            </button>
+            </div>
           );
         })}
       </div>
@@ -248,14 +213,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
           data-lyric-offset
         >
           <div className="mb-2 flex items-center justify-between gap-3">
-            <div className="min-w-0">
-              <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Lyric offset</div>
-              {selectedLine?.startMs != null && (
-                <div className="mt-1 truncate text-[10px] tracking-[0.08em] text-muted uppercase">
-                  Line {formatLineTime(selectedLine.startMs)}
-                </div>
-              )}
-            </div>
+            <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Lyric offset</div>
             <div className="v3-tab-num shrink-0 text-[11px] tracking-[0.1em] text-ink">{formatOffset(offsetMs)}</div>
           </div>
           <div className="flex items-center gap-2">
@@ -291,14 +249,6 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
               onClick={() => updateOffset(0)}
             >
               Zero
-            </button>
-            <button
-              type="button"
-              className="v3-focus h-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent px-2 text-[9px] tracking-[0.18em] text-ink uppercase disabled:cursor-not-allowed disabled:opacity-35"
-              onClick={syncSelectedLine}
-              disabled={!canSyncSelectedLine}
-            >
-              Sync
             </button>
           </div>
         </div>

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -142,8 +142,8 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
   }
 
   return (
-    <div className="flex min-h-full flex-col">
-      <div className="border-y border-separator-soft py-3">
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0 border-y border-separator-soft py-3">
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
             <div className="truncate text-[16px] leading-tight font-semibold">{title || 'Now playing'}</div>
@@ -155,9 +155,30 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
         </div>
       </div>
 
+      <div className="v3-scroll mt-4 flex min-h-0 flex-1 flex-col overflow-y-auto pb-5">
+        {lyrics.lines.map((line, index) => {
+          const isActive = index === active;
+          return (
+            <div
+              key={`${line.startMs ?? 'plain'}-${index}`}
+              ref={isActive ? activeRef : undefined}
+              className={cn(
+                'border-l py-[9px] pr-3 pl-4 text-[15px] leading-relaxed transition-colors',
+                isActive
+                  ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_9%,transparent)] text-ink shadow-[inset_1px_0_0_var(--accent)]'
+                  : 'border-separator-soft text-muted',
+                !lyrics.synced && 'border-separator-soft text-ink',
+              )}
+            >
+              {line.text}
+            </div>
+          );
+        })}
+      </div>
+
       {lyrics.synced && (
-        <div className="my-4 border border-separator-soft bg-[color-mix(in_oklab,var(--ink)_5%,transparent)] px-3 py-3">
-          <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="shrink-0 border-t border-separator-soft bg-[color-mix(in_oklab,var(--bg)_72%,transparent)] pt-3 [backdrop-filter:blur(18px)_saturate(1.4)] [-webkit-backdrop-filter:blur(18px)_saturate(1.4)]">
+          <div className="mb-2 flex items-center justify-between gap-3">
             <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Lyric offset</div>
             <div className="v3-tab-num text-[11px] tracking-[0.1em] text-ink">{formatOffset(offsetMs)}</div>
           </div>
@@ -198,27 +219,6 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
           </div>
         </div>
       )}
-
-      <div className="flex flex-col pb-8">
-        {lyrics.lines.map((line, index) => {
-          const isActive = index === active;
-          return (
-            <div
-              key={`${line.startMs ?? 'plain'}-${index}`}
-              ref={isActive ? activeRef : undefined}
-              className={cn(
-                'border-l py-[9px] pr-3 pl-4 text-[15px] leading-relaxed transition-colors',
-                isActive
-                  ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_9%,transparent)] text-ink shadow-[inset_1px_0_0_var(--accent)]'
-                  : 'border-separator-soft text-muted',
-                !lyrics.synced && 'border-separator-soft text-ink',
-              )}
-            >
-              {line.text}
-            </div>
-          );
-        })}
-      </div>
     </div>
   );
 }

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState, type ChangeEvent } from 'react';
-import { SlidersHorizontal } from 'lucide-react';
+import { Minus, Plus, RotateCcw, SlidersHorizontal } from 'lucide-react';
 import { cn } from '@/lib/cn';
 import {
   LYRIC_OFFSET_MAX_MS,
@@ -95,22 +95,22 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="shrink-0 border-y border-separator-soft py-3">
-        <div className="flex items-start justify-between gap-4">
+      <div className="shrink-0 border-b border-separator-soft pb-3">
+        <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <div className="truncate text-[16px] leading-tight font-semibold">{title || 'Now playing'}</div>
-            {artist && <div className="mt-1 truncate text-[11px] tracking-[0.16em] text-muted uppercase">{artist}</div>}
+            <div className="truncate text-[14px] leading-tight font-semibold">{title || 'Now playing'}</div>
+            {artist && <div className="mt-1 truncate text-[10px] tracking-[0.16em] text-muted uppercase">{artist}</div>}
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            <div className="v3-tab-num text-[10px] tracking-[0.18em] text-vermilion uppercase">
+            <div className="v3-tab-num text-[9px] tracking-[0.18em] text-muted uppercase">
               {lyrics.synced ? 'Synced' : 'Plain'}
             </div>
             {lyrics.synced && (
               <button
                 type="button"
                 className={cn(
-                  'v3-focus grid h-8 w-8 place-items-center border border-separator-soft bg-transparent text-ink',
-                  showOffset && 'bg-ink text-bg',
+                  'v3-focus grid h-7 w-7 place-items-center border border-separator-soft bg-transparent text-muted transition-colors',
+                  showOffset && 'border-ink bg-ink text-bg',
                 )}
                 onClick={toggleOffset}
                 aria-pressed={showOffset}
@@ -124,7 +124,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
         </div>
       </div>
 
-      <div className="v3-scroll mt-4 flex min-h-0 flex-1 flex-col overflow-y-auto pb-5">
+      <div className="v3-scroll mt-3 flex min-h-0 flex-1 flex-col overflow-y-auto pb-4">
         {lyrics.lines.map((line, index) => {
           const isActive = index === active;
           return (
@@ -132,9 +132,9 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
               key={`${line.startMs ?? 'plain'}-${index}`}
               ref={isActive ? activeRef : undefined}
               className={cn(
-                'border-l py-[9px] pr-3 pl-4 text-[15px] leading-relaxed transition-colors',
+                'border-l py-2 pr-3 pl-3 text-[14px] leading-relaxed transition-colors',
                 isActive
-                  ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_9%,transparent)] text-ink shadow-[inset_1px_0_0_var(--accent)]'
+                  ? 'border-vermilion bg-[color-mix(in_oklab,var(--accent)_5%,transparent)] text-ink'
                   : 'border-separator-soft text-muted',
                 !lyrics.synced && 'border-separator-soft text-ink',
               )}
@@ -147,7 +147,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
 
       {lyrics.synced && showOffset && (
         <div
-          className="shrink-0 px-4 pt-3 pb-4 [backdrop-filter:blur(18px)_saturate(1.4)] [-webkit-backdrop-filter:blur(18px)_saturate(1.4)] sm:px-5"
+          className="shrink-0 border-t border-separator-soft pt-3"
           data-lyric-offset
         >
           <div className="mb-2 flex items-center justify-between gap-3">
@@ -157,11 +157,12 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
           <div className="flex items-center gap-2">
             <button
               type="button"
-              className="v3-focus h-8 w-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent text-[15px] leading-none text-ink"
+              className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-ink"
               onClick={() => updateOffset(offsetMs - LYRIC_OFFSET_NUDGE_MS)}
               aria-label="Delay lyrics"
+              title="Delay lyrics"
             >
-              -
+              <Minus size={14} strokeWidth={1.8} />
             </button>
             <input
               type="range"
@@ -175,18 +176,21 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
             />
             <button
               type="button"
-              className="v3-focus h-8 w-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent text-[15px] leading-none text-ink"
+              className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-ink"
               onClick={() => updateOffset(offsetMs + LYRIC_OFFSET_NUDGE_MS)}
               aria-label="Advance lyrics"
+              title="Advance lyrics"
             >
-              +
+              <Plus size={14} strokeWidth={1.8} />
             </button>
             <button
               type="button"
-              className="v3-focus h-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent px-2 text-[9px] tracking-[0.18em] text-muted uppercase"
+              className="v3-focus grid h-8 w-8 shrink-0 cursor-pointer place-items-center border border-separator-soft bg-transparent text-muted"
               onClick={() => updateOffset(0)}
+              aria-label="Reset lyrics offset"
+              title="Reset lyrics offset"
             >
-              Reset
+              <RotateCcw size={14} strokeWidth={1.8} />
             </button>
           </div>
         </div>

--- a/web/components/skins/classic/drawers/LyricsDrawer.tsx
+++ b/web/components/skins/classic/drawers/LyricsDrawer.tsx
@@ -1,10 +1,16 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { useEffect, useRef, useState, type ChangeEvent } from 'react';
 import { SlidersHorizontal } from 'lucide-react';
 import { cn } from '@/lib/cn';
-import { useStationClient } from '@/lib/stationClient';
-import type { PublicLyricsPayload } from '@/lib/types';
+import {
+  LYRIC_OFFSET_MAX_MS,
+  LYRIC_OFFSET_MIN_MS,
+  LYRIC_OFFSET_NUDGE_MS,
+  LYRIC_OFFSET_STEP_MS,
+  formatLyricOffset,
+  useCurrentLyrics,
+} from '@/components/skins/lyrics';
 
 export interface LyricsDrawerProps {
   songId?: string | null;
@@ -13,83 +19,25 @@ export interface LyricsDrawerProps {
   trackStartedAt: number | null;
 }
 
-const OFFSET_STORAGE_KEY = 'subwave:lyrics-offset-ms';
-const OFFSET_CLIENT_STORAGE_KEY = 'subwave:lyrics-offset-client-id';
 const OFFSET_VISIBLE_STORAGE_KEY = 'subwave:lyrics-offset-visible';
-const OFFSET_MIN_MS = -30000;
-const OFFSET_MAX_MS = 30000;
-const OFFSET_STEP_MS = 50;
-const OFFSET_NUDGE_MS = 100;
-
-function clampOffsetMs(value: number): number {
-  if (!Number.isFinite(value)) return 0;
-  return Math.min(OFFSET_MAX_MS, Math.max(OFFSET_MIN_MS, Math.round(value)));
-}
-
-function formatOffset(ms: number): string {
-  if (ms === 0) return '0.00s';
-  return `${ms > 0 ? '+' : '-'}${(Math.abs(ms) / 1000).toFixed(2)}s`;
-}
-
-function offsetStorageKey(songId: string): string {
-  return `${OFFSET_STORAGE_KEY}:${songId}`;
-}
-
-function createFallbackClientId(): string {
-  return `sw_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 12)}`;
-}
-
-function readLyricOffsetClientId(): string {
-  try {
-    const stored = window.localStorage.getItem(OFFSET_CLIENT_STORAGE_KEY);
-    if (stored) return stored;
-    const next = window.crypto?.randomUUID?.() ?? createFallbackClientId();
-    window.localStorage.setItem(OFFSET_CLIENT_STORAGE_KEY, next);
-    return next;
-  } catch {
-    return createFallbackClientId();
-  }
-}
-
-function activeLineIndex(lyrics: PublicLyricsPayload | null, elapsedMs: number, offsetMs: number): number {
-  if (!lyrics?.synced) return -1;
-  const adjustedElapsedMs = Math.max(0, elapsedMs + offsetMs);
-  let active = -1;
-  for (let i = 0; i < lyrics.lines.length; i += 1) {
-    const startMs = lyrics.lines[i]?.startMs;
-    if (startMs == null) continue;
-    if (startMs > adjustedElapsedMs) break;
-    active = i;
-  }
-  return active;
-}
 
 export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: LyricsDrawerProps) {
-  const client = useStationClient();
-  const [lyrics, setLyrics] = useState<PublicLyricsPayload | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [failed, setFailed] = useState(false);
-  const [nowMs, setNowMs] = useState(() => Date.now());
-  const [offsetMs, setOffsetMs] = useState(0);
   const [showOffset, setShowOffset] = useState(false);
   const activeRef = useRef<HTMLDivElement | null>(null);
-  const clientIdRef = useRef<string>('');
-  const loadedOffsetSongRef = useRef<string | null>(null);
+  const {
+    lyrics,
+    loading,
+    failed,
+    offsetMs,
+    activeLineIndex: active,
+    updateOffset,
+  } = useCurrentLyrics({ songId, trackStartedAt });
 
   useEffect(() => {
-    clientIdRef.current = readLyricOffsetClientId();
     try {
       setShowOffset(window.localStorage.getItem(OFFSET_VISIBLE_STORAGE_KEY) === '1');
     } catch {}
   }, []);
-
-  const updateOffset = (next: number) => {
-    const clamped = clampOffsetMs(next);
-    setOffsetMs(clamped);
-    try {
-      if (songId) window.localStorage.setItem(offsetStorageKey(songId), String(clamped));
-    } catch {}
-  };
 
   const toggleOffset = () => {
     setShowOffset(next => {
@@ -100,67 +48,6 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
       return visible;
     });
   };
-
-  useEffect(() => {
-    let cancelled = false;
-    setLyrics(null);
-    setFailed(false);
-    if (!songId) {
-      setLoading(false);
-      return;
-    }
-
-    setLoading(true);
-    const clientId = clientIdRef.current || readLyricOffsetClientId();
-    clientIdRef.current = clientId;
-    client.currentLyrics(clientId)
-      .then((payload) => {
-        if (cancelled) return;
-        const nextLyrics = payload?.songId === songId ? payload : null;
-        setLyrics(nextLyrics);
-        if (nextLyrics) {
-          let nextOffset = clampOffsetMs(nextLyrics.offsetMs ?? 0);
-          try {
-            const stored = window.localStorage.getItem(offsetStorageKey(songId));
-            if (stored != null && nextOffset === 0) nextOffset = clampOffsetMs(Number(stored));
-          } catch {}
-          loadedOffsetSongRef.current = songId;
-          setOffsetMs(nextOffset);
-        }
-        setFailed(payload == null);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => { cancelled = true; };
-  }, [client, songId]);
-
-  useEffect(() => {
-    if (!songId || !lyrics?.synced || loadedOffsetSongRef.current !== songId) return;
-    const id = window.setTimeout(() => {
-      client.setCurrentLyricOffset(songId, clientIdRef.current, offsetMs)
-        .then((saved) => {
-          if (saved?.songId === songId && typeof saved.offsetMs === 'number') {
-            const clamped = clampOffsetMs(saved.offsetMs);
-            setOffsetMs(clamped);
-            try {
-              window.localStorage.setItem(offsetStorageKey(songId), String(clamped));
-            } catch {}
-          }
-        });
-    }, 350);
-    return () => window.clearTimeout(id);
-  }, [client, songId, lyrics?.synced, offsetMs]);
-
-  useEffect(() => {
-    if (!lyrics?.synced) return;
-    const id = window.setInterval(() => setNowMs(Date.now()), 500);
-    return () => window.clearInterval(id);
-  }, [lyrics?.synced, trackStartedAt]);
-
-  const elapsedMs = trackStartedAt == null ? 0 : Math.max(0, nowMs - trackStartedAt);
-  const active = useMemo(() => activeLineIndex(lyrics, elapsedMs, offsetMs), [lyrics, elapsedMs, offsetMs]);
 
   const onOffsetInput = (event: ChangeEvent<HTMLInputElement>) => {
     updateOffset(Number(event.target.value));
@@ -265,22 +152,22 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
         >
           <div className="mb-2 flex items-center justify-between gap-3">
             <div className="text-[9px] tracking-[0.28em] text-muted uppercase">Track offset</div>
-            <div className="v3-tab-num shrink-0 text-[11px] tracking-[0.1em] text-ink">{formatOffset(offsetMs)}</div>
+            <div className="v3-tab-num shrink-0 text-[11px] tracking-[0.1em] text-ink">{formatLyricOffset(offsetMs)}</div>
           </div>
           <div className="flex items-center gap-2">
             <button
               type="button"
               className="v3-focus h-8 w-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent text-[15px] leading-none text-ink"
-              onClick={() => updateOffset(offsetMs - OFFSET_NUDGE_MS)}
+              onClick={() => updateOffset(offsetMs - LYRIC_OFFSET_NUDGE_MS)}
               aria-label="Delay lyrics"
             >
               -
             </button>
             <input
               type="range"
-              min={OFFSET_MIN_MS}
-              max={OFFSET_MAX_MS}
-              step={OFFSET_STEP_MS}
+              min={LYRIC_OFFSET_MIN_MS}
+              max={LYRIC_OFFSET_MAX_MS}
+              step={LYRIC_OFFSET_STEP_MS}
               value={offsetMs}
               onChange={onOffsetInput}
               aria-label="Track lyric offset"
@@ -289,7 +176,7 @@ export default function LyricsDrawer({ songId, title, artist, trackStartedAt }: 
             <button
               type="button"
               className="v3-focus h-8 w-8 shrink-0 cursor-pointer border border-separator-soft bg-transparent text-[15px] leading-none text-ink"
-              onClick={() => updateOffset(offsetMs + OFFSET_NUDGE_MS)}
+              onClick={() => updateOffset(offsetMs + LYRIC_OFFSET_NUDGE_MS)}
               aria-label="Advance lyrics"
             >
               +

--- a/web/components/skins/lyrics.ts
+++ b/web/components/skins/lyrics.ts
@@ -1,0 +1,188 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useStationClient } from '@/lib/stationClient';
+import type { PublicLyricsPayload } from '@/lib/types';
+
+export const LYRIC_OFFSET_MIN_MS = -30000;
+export const LYRIC_OFFSET_MAX_MS = 30000;
+export const LYRIC_OFFSET_STEP_MS = 50;
+export const LYRIC_OFFSET_NUDGE_MS = 100;
+
+const OFFSET_STORAGE_KEY = 'subwave:lyrics-offset-ms';
+const OFFSET_CLIENT_STORAGE_KEY = 'subwave:lyrics-offset-client-id';
+
+export interface UseCurrentLyricsOptions {
+  songId?: string | null;
+  trackStartedAt: number | null;
+}
+
+export interface CurrentLyricsState {
+  lyrics: PublicLyricsPayload | null;
+  loading: boolean;
+  failed: boolean;
+  offsetMs: number;
+  elapsedMs: number;
+  activeLineIndex: number;
+  updateOffset: (next: number) => void;
+}
+
+export function clampLyricOffsetMs(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(LYRIC_OFFSET_MAX_MS, Math.max(LYRIC_OFFSET_MIN_MS, Math.round(value)));
+}
+
+export function formatLyricOffset(ms: number): string {
+  if (ms === 0) return '0.00s';
+  return `${ms > 0 ? '+' : '-'}${(Math.abs(ms) / 1000).toFixed(2)}s`;
+}
+
+export function activeLyricLineIndex(
+  lyrics: PublicLyricsPayload | null,
+  elapsedMs: number,
+  offsetMs: number,
+): number {
+  if (!lyrics?.synced) return -1;
+  const adjustedElapsedMs = Math.max(0, elapsedMs + offsetMs);
+  let active = -1;
+  for (let i = 0; i < lyrics.lines.length; i += 1) {
+    const startMs = lyrics.lines[i]?.startMs;
+    if (startMs == null) continue;
+    if (startMs > adjustedElapsedMs) break;
+    active = i;
+  }
+  return active;
+}
+
+function offsetStorageKey(songId: string): string {
+  return `${OFFSET_STORAGE_KEY}:${songId}`;
+}
+
+function createFallbackClientId(): string {
+  return `sw_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 12)}`;
+}
+
+function readLyricOffsetClientId(): string {
+  try {
+    const stored = window.localStorage.getItem(OFFSET_CLIENT_STORAGE_KEY);
+    if (stored) return stored;
+    const next = window.crypto?.randomUUID?.() ?? createFallbackClientId();
+    window.localStorage.setItem(OFFSET_CLIENT_STORAGE_KEY, next);
+    return next;
+  } catch {
+    return createFallbackClientId();
+  }
+}
+
+function readStoredOffset(songId: string): number | null {
+  try {
+    const stored = window.localStorage.getItem(offsetStorageKey(songId));
+    return stored == null ? null : clampLyricOffsetMs(Number(stored));
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredOffset(songId: string, offsetMs: number): void {
+  try {
+    window.localStorage.setItem(offsetStorageKey(songId), String(clampLyricOffsetMs(offsetMs)));
+  } catch {}
+}
+
+export function useCurrentLyrics({
+  songId,
+  trackStartedAt,
+}: UseCurrentLyricsOptions): CurrentLyricsState {
+  const client = useStationClient();
+  const [lyrics, setLyrics] = useState<PublicLyricsPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const [offsetMs, setOffsetMs] = useState(0);
+  const clientIdRef = useRef<string>('');
+  const loadedOffsetSongRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    clientIdRef.current = readLyricOffsetClientId();
+  }, []);
+
+  const updateOffset = useCallback((next: number) => {
+    const clamped = clampLyricOffsetMs(next);
+    setOffsetMs(clamped);
+    if (songId) writeStoredOffset(songId, clamped);
+  }, [songId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLyrics(null);
+    setFailed(false);
+    loadedOffsetSongRef.current = null;
+    if (!songId) {
+      setLoading(false);
+      setOffsetMs(0);
+      return;
+    }
+
+    setLoading(true);
+    const clientId = clientIdRef.current || readLyricOffsetClientId();
+    clientIdRef.current = clientId;
+    client.currentLyrics(clientId)
+      .then((payload) => {
+        if (cancelled) return;
+        const nextLyrics = payload?.songId === songId ? payload : null;
+        setLyrics(nextLyrics);
+        if (nextLyrics) {
+          const apiOffset = clampLyricOffsetMs(nextLyrics.offsetMs ?? 0);
+          const storedOffset = readStoredOffset(songId);
+          const nextOffset = apiOffset === 0 && storedOffset != null ? storedOffset : apiOffset;
+          loadedOffsetSongRef.current = songId;
+          setOffsetMs(nextOffset);
+        } else {
+          setOffsetMs(0);
+        }
+        setFailed(payload == null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [client, songId]);
+
+  useEffect(() => {
+    if (!songId || !lyrics?.synced || loadedOffsetSongRef.current !== songId) return;
+    const id = window.setTimeout(() => {
+      client.setCurrentLyricOffset(songId, clientIdRef.current, offsetMs)
+        .then((saved) => {
+          if (saved?.songId === songId && typeof saved.offsetMs === 'number') {
+            const clamped = clampLyricOffsetMs(saved.offsetMs);
+            setOffsetMs(clamped);
+            writeStoredOffset(songId, clamped);
+          }
+        });
+    }, 350);
+    return () => window.clearTimeout(id);
+  }, [client, songId, lyrics?.synced, offsetMs]);
+
+  useEffect(() => {
+    if (!lyrics?.synced) return;
+    const id = window.setInterval(() => setNowMs(Date.now()), 500);
+    return () => window.clearInterval(id);
+  }, [lyrics?.synced, trackStartedAt]);
+
+  const elapsedMs = trackStartedAt == null ? 0 : Math.max(0, nowMs - trackStartedAt);
+  const activeLine = useMemo(
+    () => activeLyricLineIndex(lyrics, elapsedMs, offsetMs),
+    [lyrics, elapsedMs, offsetMs],
+  );
+
+  return {
+    lyrics,
+    loading,
+    failed,
+    offsetMs,
+    elapsedMs,
+    activeLineIndex: activeLine,
+    updateOffset,
+  };
+}

--- a/web/components/skins/lyrics.ts
+++ b/web/components/skins/lyrics.ts
@@ -12,6 +12,12 @@ export const LYRIC_OFFSET_NUDGE_MS = 100;
 const OFFSET_STORAGE_KEY = 'subwave:lyrics-offset-ms';
 const OFFSET_CLIENT_STORAGE_KEY = 'subwave:lyrics-offset-client-id';
 
+// Re-ask cadence while the station is still answering for the previous track.
+// The listener sits a stream-buffer behind the live edge, so the window can run
+// to ~30s on a deep buffer; the limit covers it without polling indefinitely.
+const STALE_RETRY_MS = 2000;
+const STALE_RETRY_LIMIT = 20;
+
 export interface UseCurrentLyricsOptions {
   /** Current Subsonic/library song id from now-playing. */
   songId?: string | null;
@@ -23,6 +29,13 @@ export interface CurrentLyricsState {
   lyrics: PublicLyricsPayload | null;
   loading: boolean;
   failed: boolean;
+  /**
+   * The station answered for a different track than the one we asked about, so
+   * we have no verdict yet. Distinct from `failed` (the call errored) and from
+   * an empty payload (the track genuinely has no lyrics) — render it as "still
+   * resolving", never as "no lyrics".
+   */
+  stale: boolean;
   /** Add this to measured elapsed time. Positive values advance lyrics sooner. */
   offsetMs: number;
   elapsedMs: number;
@@ -104,8 +117,15 @@ export function useCurrentLyrics({
   const [failed, setFailed] = useState(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
   const [offsetMs, setOffsetMs] = useState(0);
+  const [stale, setStale] = useState(false);
+  const [retryTick, setRetryTick] = useState(0);
   const clientIdRef = useRef<string>('');
   const loadedOffsetSongRef = useRef<string | null>(null);
+  // What the station is known to hold for this track. The save effect writes
+  // only when the local offset diverges from it, so simply loading a track
+  // never PUTs the value straight back.
+  const savedOffsetRef = useRef<number | null>(null);
+  const retryCountRef = useRef(0);
 
   useEffect(() => {
     clientIdRef.current = readLyricOffsetClientId();
@@ -121,7 +141,9 @@ export function useCurrentLyrics({
     let cancelled = false;
     setLyrics(null);
     setFailed(false);
+    setStale(false);
     loadedOffsetSongRef.current = null;
+    savedOffsetRef.current = null;
     if (!songId) {
       setLoading(false);
       setOffsetMs(0);
@@ -134,33 +156,63 @@ export function useCurrentLyrics({
     client.currentLyrics(clientId)
       .then((payload) => {
         if (cancelled) return;
-        const nextLyrics = payload?.songId === songId ? payload : null;
-        setLyrics(nextLyrics);
-        if (nextLyrics) {
-          const apiOffset = clampLyricOffsetMs(nextLyrics.offsetMs ?? 0);
+        // `/lyrics/current` answers for whatever is on air at the live edge,
+        // while the station feed deliberately holds us ~bufferSeconds behind it.
+        // So a well-formed answer for another track is routine around every
+        // transition, and means "ask again", not "this track has no lyrics".
+        const matched = payload != null && payload.songId === songId;
+        setLyrics(matched ? payload : null);
+        if (matched) {
+          const apiOffset = clampLyricOffsetMs(payload.offsetMs ?? 0);
           const storedOffset = readStoredOffset(songId);
           const nextOffset = apiOffset === 0 && storedOffset != null ? storedOffset : apiOffset;
           loadedOffsetSongRef.current = songId;
+          // The station holds apiOffset; nextOffset may be a local value it has
+          // never seen, in which case the save effect below syncs it up once.
+          savedOffsetRef.current = apiOffset;
           setOffsetMs(nextOffset);
         } else {
           setOffsetMs(0);
         }
         setFailed(payload == null);
+        setStale(payload != null && !matched);
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
       });
 
     return () => { cancelled = true; };
-  }, [client, songId]);
+  }, [client, songId, retryTick]);
+
+  // Keyed on songId, NOT on `stale`: each retry re-runs the fetch effect, which
+  // clears `stale` on its way back out, so resetting the count there would zero
+  // it every cycle and the limit below would never bite.
+  useEffect(() => { retryCountRef.current = 0; }, [songId]);
+
+  // Re-ask while the station is answering for a different track. Bounded so a
+  // songId that never lines up can't leave the drawer polling forever; giving
+  // up just falls through to the ordinary empty state.
+  useEffect(() => {
+    if (!stale || retryCountRef.current >= STALE_RETRY_LIMIT) return;
+    const id = window.setTimeout(() => {
+      retryCountRef.current += 1;
+      setRetryTick((n) => n + 1);
+    }, STALE_RETRY_MS);
+    return () => window.clearTimeout(id);
+  }, [stale, retryTick]);
 
   useEffect(() => {
     if (!songId || !lyrics?.synced || loadedOffsetSongRef.current !== songId) return;
+    // Only write a real change. Without this the load itself sets `offsetMs`,
+    // which re-runs this effect and PUTs the just-loaded value straight back —
+    // a network write plus a row upsert per listener on every single track.
+    if (savedOffsetRef.current === offsetMs) return;
     const id = window.setTimeout(() => {
       client.setCurrentLyricOffset(songId, clientIdRef.current, offsetMs)
         .then((saved) => {
           if (saved?.songId === songId && typeof saved.offsetMs === 'number') {
             const clamped = clampLyricOffsetMs(saved.offsetMs);
+            savedOffsetRef.current = clamped;
             setOffsetMs(clamped);
             writeStoredOffset(songId, clamped);
           }
@@ -185,6 +237,7 @@ export function useCurrentLyrics({
     lyrics,
     loading,
     failed,
+    stale,
     offsetMs,
     elapsedMs,
     activeLineIndex: activeLine,

--- a/web/components/skins/lyrics.ts
+++ b/web/components/skins/lyrics.ts
@@ -13,7 +13,9 @@ const OFFSET_STORAGE_KEY = 'subwave:lyrics-offset-ms';
 const OFFSET_CLIENT_STORAGE_KEY = 'subwave:lyrics-offset-client-id';
 
 export interface UseCurrentLyricsOptions {
+  /** Current Subsonic/library song id from now-playing. */
   songId?: string | null;
+  /** Millisecond epoch timestamp from now-playing; used for player elapsed time. */
   trackStartedAt: number | null;
 }
 
@@ -21,6 +23,7 @@ export interface CurrentLyricsState {
   lyrics: PublicLyricsPayload | null;
   loading: boolean;
   failed: boolean;
+  /** Add this to measured elapsed time. Positive values advance lyrics sooner. */
   offsetMs: number;
   elapsedMs: number;
   activeLineIndex: number;
@@ -43,6 +46,8 @@ export function activeLyricLineIndex(
   offsetMs: number,
 ): number {
   if (!lyrics?.synced) return -1;
+  // Keep source lyric timestamps immutable; apply the player correction only
+  // when selecting the active line.
   const adjustedElapsedMs = Math.max(0, elapsedMs + offsetMs);
   let active = -1;
   for (let i = 0; i < lyrics.lines.length; i += 1) {

--- a/web/components/skins/lyrics.ts
+++ b/web/components/skins/lyrics.ts
@@ -12,11 +12,10 @@ export const LYRIC_OFFSET_NUDGE_MS = 100;
 const OFFSET_STORAGE_KEY = 'subwave:lyrics-offset-ms';
 const OFFSET_CLIENT_STORAGE_KEY = 'subwave:lyrics-offset-client-id';
 
-// Re-ask cadence while the station is still answering for the previous track.
-// The listener sits a stream-buffer behind the live edge, so the window can run
-// to ~30s on a deep buffer; the limit covers it without polling indefinitely.
-const STALE_RETRY_MS = 2000;
-const STALE_RETRY_LIMIT = 20;
+// Re-ask at a low rate while the drawer is open and the station is still
+// answering for the live-edge track. Listener buffers are operator-configured
+// and can outlast any fixed retry window, so this intentionally has no cap.
+const STALE_RETRY_MS = 5000;
 
 export interface UseCurrentLyricsOptions {
   /** Current Subsonic/library song id from now-playing. */
@@ -125,7 +124,6 @@ export function useCurrentLyrics({
   // only when the local offset diverges from it, so simply loading a track
   // never PUTs the value straight back.
   const savedOffsetRef = useRef<number | null>(null);
-  const retryCountRef = useRef(0);
 
   useEffect(() => {
     clientIdRef.current = readLyricOffsetClientId();
@@ -184,18 +182,11 @@ export function useCurrentLyrics({
     return () => { cancelled = true; };
   }, [client, songId, retryTick]);
 
-  // Keyed on songId, NOT on `stale`: each retry re-runs the fetch effect, which
-  // clears `stale` on its way back out, so resetting the count there would zero
-  // it every cycle and the limit below would never bite.
-  useEffect(() => { retryCountRef.current = 0; }, [songId]);
-
-  // Re-ask while the station is answering for a different track. Bounded so a
-  // songId that never lines up can't leave the drawer polling forever; giving
-  // up just falls through to the ordinary empty state.
+  // Re-ask while the station is answering for a different track. This hook is
+  // mounted only while the drawer is open, so closing it cancels the poll.
   useEffect(() => {
-    if (!stale || retryCountRef.current >= STALE_RETRY_LIMIT) return;
+    if (!stale) return;
     const id = window.setTimeout(() => {
-      retryCountRef.current += 1;
       setRetryTick((n) => n + 1);
     }, STALE_RETRY_MS);
     return () => window.clearTimeout(id);

--- a/web/components/ui/sheet.tsx
+++ b/web/components/ui/sheet.tsx
@@ -117,7 +117,12 @@ export function Sheet({ open, onOpenChange, title, children, container }: SheetP
                 // lets the spread through; motion's own handler wins.
                 {...((gestureEnabled ? bind() : {}) as Record<string, unknown>)}
                 className={cn(
-                  'v3-drawer-content relative z-50 flex touch-pan-y flex-col border border-ink text-ink shadow-drawer',
+                  // No border utility here: `.v3-drawer-content::before` paints
+                  // the frame (above the backdrop-filter, below the content).
+                  // Carrying both draws two 1px lines — the pseudo-element's
+                  // `inset: 0` resolves to the padding box, so it lands flush
+                  // inside this element's own border rather than over it.
+                  'v3-drawer-content relative z-50 flex touch-pan-y flex-col text-ink shadow-drawer',
                   'bg-[color-mix(in_oklab,var(--bg)_30%,transparent)]',
                   '[backdrop-filter:blur(28px)_saturate(1.9)_brightness(1.07)]',
                   '[-webkit-backdrop-filter:blur(28px)_saturate(1.9)_brightness(1.07)]',

--- a/web/components/ui/sheet.tsx
+++ b/web/components/ui/sheet.tsx
@@ -117,7 +117,7 @@ export function Sheet({ open, onOpenChange, title, children, container }: SheetP
                 // lets the spread through; motion's own handler wins.
                 {...((gestureEnabled ? bind() : {}) as Record<string, unknown>)}
                 className={cn(
-                  'v3-drawer-content z-50 flex touch-pan-y flex-col border-x border-ink text-ink shadow-drawer',
+                  'v3-drawer-content relative z-50 flex touch-pan-y flex-col border border-ink text-ink shadow-drawer',
                   'bg-[color-mix(in_oklab,var(--bg)_30%,transparent)]',
                   '[backdrop-filter:blur(28px)_saturate(1.9)_brightness(1.07)]',
                   '[-webkit-backdrop-filter:blur(28px)_saturate(1.9)_brightness(1.07)]',

--- a/web/lib/stationClient.ts
+++ b/web/lib/stationClient.ts
@@ -86,7 +86,9 @@ export interface StationClient {
   /** null on network error. */
   likeStatus(): Promise<LikeStatus | null>;
   /** Structured lyrics for the currently airing library track. null on network error. */
-  currentLyrics(): Promise<PublicLyricsPayload | null>;
+  currentLyrics(clientId?: string): Promise<PublicLyricsPayload | null>;
+  /** Persist this client's timing correction for the currently airing lyric track. */
+  setCurrentLyricOffset(songId: string, clientId: string, offsetMs: number): Promise<{ ok?: boolean; songId?: string | null; offsetMs?: number } | null>;
   /** One-shot audience beacon. Best-effort: never throws, never blocks. */
   beacon(payload: BeaconPayload): void;
   /** null on any failure; callers treat that as "configured" and stay put. */
@@ -152,10 +154,23 @@ export function createStationClient(origin: StationOrigin): StationClient {
         return null;
       }
     },
-    currentLyrics: async () => {
+    currentLyrics: async (clientId) => {
       try {
-        const r = await fetch(`${api}/lyrics/current`, { cache: 'no-store' });
+        const qs = clientId ? `?clientId=${encodeURIComponent(clientId)}` : '';
+        const r = await fetch(`${api}/lyrics/current${qs}`, { cache: 'no-store' });
         return r.ok ? await json<PublicLyricsPayload>(r) : null;
+      } catch {
+        return null;
+      }
+    },
+    setCurrentLyricOffset: async (songId, clientId, offsetMs) => {
+      try {
+        const r = await fetch(`${api}/lyrics/current/offset`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ songId, clientId, offsetMs }),
+        });
+        return r.ok ? await json<{ ok?: boolean; songId?: string | null; offsetMs?: number }>(r) : null;
       } catch {
         return null;
       }

--- a/web/lib/stationClient.ts
+++ b/web/lib/stationClient.ts
@@ -23,6 +23,7 @@ import type {
   SchedulePayload,
   SessionPayload,
   StationState,
+  PublicLyricsPayload,
 } from '@/lib/types';
 
 export interface ThemesPayload {
@@ -84,7 +85,9 @@ export interface StationClient {
   likeCurrent(songId: string): Promise<LikeResult | null>;
   /** null on network error. */
   likeStatus(): Promise<LikeStatus | null>;
-  /** Best-effort: never throws, never blocks. */
+  /** Structured lyrics for the currently airing library track. null on network error. */
+  currentLyrics(): Promise<PublicLyricsPayload | null>;
+  /** One-shot audience beacon. Best-effort: never throws, never blocks. */
   beacon(payload: BeaconPayload): void;
   /** null on any failure; callers treat that as "configured" and stay put. */
   onboardingStatus(): Promise<{ needsSetup?: boolean } | null>;
@@ -145,6 +148,14 @@ export function createStationClient(origin: StationOrigin): StationClient {
       try {
         const r = await fetch(`${api}/like`);
         return await json<LikeStatus>(r);
+      } catch {
+        return null;
+      }
+    },
+    currentLyrics: async () => {
+      try {
+        const r = await fetch(`${api}/lyrics/current`, { cache: 'no-store' });
+        return r.ok ? await json<PublicLyricsPayload>(r) : null;
       } catch {
         return null;
       }

--- a/web/lib/stationClient.ts
+++ b/web/lib/stationClient.ts
@@ -64,6 +64,12 @@ export interface LikeStatus {
   count?: number;
 }
 
+export interface LyricOffsetResult {
+  ok?: boolean;
+  songId?: string | null;
+  offsetMs?: number;
+}
+
 export interface StationClient {
   origin: StationOrigin;
   /** Prefix a controller-relative path with the station's API base.
@@ -85,10 +91,12 @@ export interface StationClient {
   likeCurrent(songId: string): Promise<LikeResult | null>;
   /** null on network error. */
   likeStatus(): Promise<LikeStatus | null>;
-  /** Structured lyrics for the currently airing library track. null on network error. */
+  /** Structured lyrics for the current library track. `clientId` only selects that
+   *  listener/player's saved per-track timing correction. null on network error. */
   currentLyrics(clientId?: string): Promise<PublicLyricsPayload | null>;
-  /** Persist this client's timing correction for the currently airing lyric track. */
-  setCurrentLyricOffset(songId: string, clientId: string, offsetMs: number): Promise<{ ok?: boolean; songId?: string | null; offsetMs?: number } | null>;
+  /** Persist a listener/player-scoped timing correction for the current track.
+   *  Positive offset means the player should advance lyrics sooner. */
+  setCurrentLyricOffset(songId: string, clientId: string, offsetMs: number): Promise<LyricOffsetResult | null>;
   /** One-shot audience beacon. Best-effort: never throws, never blocks. */
   beacon(payload: BeaconPayload): void;
   /** null on any failure; callers treat that as "configured" and stay put. */
@@ -170,7 +178,7 @@ export function createStationClient(origin: StationOrigin): StationClient {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ songId, clientId, offsetMs }),
         });
-        return r.ok ? await json<{ ok?: boolean; songId?: string | null; offsetMs?: number }>(r) : null;
+        return r.ok ? await json<LyricOffsetResult>(r) : null;
       } catch {
         return null;
       }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -166,7 +166,7 @@ export interface PublicLyricLine {
 export interface PublicLyricsPayload {
   songId: string | null;
   synced: boolean;
-  /** Per-client correction in ms. Positive means lyrics advance sooner. */
+  /** Add this to measured playback elapsed time before choosing the active line. */
   offsetMs: number;
   lines: PublicLyricLine[];
 }

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -166,6 +166,8 @@ export interface PublicLyricLine {
 export interface PublicLyricsPayload {
   songId: string | null;
   synced: boolean;
+  /** Per-client correction in ms. Positive means lyrics advance sooner. */
+  offsetMs: number;
   lines: PublicLyricLine[];
 }
 

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -158,6 +158,17 @@ export interface QueueEntry {
   [key: string]: unknown;
 }
 
+export interface PublicLyricLine {
+  startMs: number | null;
+  text: string;
+}
+
+export interface PublicLyricsPayload {
+  songId: string | null;
+  synced: boolean;
+  lines: PublicLyricLine[];
+}
+
 /** Status returned by `/request/:id`. */
 export type RequestStatus = 'pending' | 'resolved' | 'failed' | 'unknown';
 


### PR DESCRIPTION
## Summary

- expose current-track lyrics and client-scoped per-track timing offsets to players
- rebase the feature onto current `develop`, preserving released migrations and adding `lyric_offsets` as schema v26
- protect public structured-lyrics lookups with a bounded per-track cache (30s hit, 10s miss/failure) that coalesces concurrent requests
- keep the Classic lyrics drawer polling at a low rate while the listener is buffered behind the live edge instead of resolving a fixed timeout as no lyrics
- remove the unused clear-offset API

## Validation

- `cd controller && npm test -- lyric`
- controller migration/isolation test with a real SQLite v25-to-v26 upgrade
- `cd controller && npm run lint` reaches an existing upstream TypeScript error in `src/broadcast/scheduler.ts` (`ScheduledTask.destroy`); lint otherwise has warnings only
- `cd web && npm run lint` passes with five existing warnings
- broader controller suite ran but is blocked by existing environment failures: `aio-log-link.test.ts` and Python analyzer tests require unavailable host dependencies (`numpy`)

## Rollout

No deployment is included. The migration is additive and rollback leaves the unused `lyric_offsets` table harmless.
