### PR TITLE
feat(web): sort /apps directory latest-first

### DIFF
--- a/web/lib/apps.ts
+++ b/web/lib/apps.ts
@@ -132,6 +132,10 @@ export async function getAllApps(): Promise<CommunityApp[]> {
     .filter((a): a is CommunityApp => a !== null)
     .sort((a, b) => {
       if (a.featured !== b.featured) return a.featured ? -1 : 1;
+      // Newest first; ISO yyyy-mm-dd compares lexicographically, and an entry
+      // without a date sorts after every dated one.
+      const byDate = (b.submitted ?? '').localeCompare(a.submitted ?? '');
+      if (byDate !== 0) return byDate;
       return a.name.localeCompare(b.name);
     });
 }


### PR DESCRIPTION
## What

The public `/apps` directory now lists apps newest-first by their `submitted` date instead of alphabetically.

## How

`getAllApps()` in `web/lib/apps.ts` keeps its featured-first tier, then sorts by `submitted` descending (ISO `yyyy-mm-dd` compares lexicographically). Entries without a date sort after every dated one, and name stays as the deterministic tie-break — same-day submissions still list alphabetically.

All five entries in the live community catalog carry a `submitted` date, so the whole directory orders by it today.