### PR TITLE
fix(web): stop admin scroll areas chaining to the page and popping their scrollbar

### DIFF
--- a/web/components/ui/scroll-area.tsx
+++ b/web/components/ui/scroll-area.tsx
@@ -11,13 +11,34 @@ const ScrollArea = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
-    className={cn("relative overflow-hidden", className)}
+    className={cn("group/scroll-area relative overflow-hidden", className)}
     {...props}
   >
     {/* max-h-[inherit] mirrors any max-h-* cap from the root onto the viewport:
         `h-full` alone can't resolve against a parent whose height is only
-        max-constrained, so capped ScrollAreas would never scroll. */}
-    <ScrollAreaPrimitive.Viewport className="h-full max-h-[inherit] w-full rounded-[inherit]">
+        max-constrained, so capped ScrollAreas would never scroll.
+
+        overscroll-*-contain stops a capped list handing the wheel straight to
+        the page the instant it bottoms out. The admin pages stack several of
+        these in one column, so chaining reads as the page lurching out from
+        under the list you were reading — measured at a 400px jump on
+        /admin/dash. It also keeps a sideways swipe on the schedule board off
+        the browser's back-navigation gesture.
+
+        It has to be applied PER AXIS and only when that axis really scrolls.
+        Radix sets `overflow: scroll` on the viewport for any axis that has a
+        ScrollBar mounted, whether or not the content overflows, so a blanket
+        `overscroll-contain` swallows the wheel over the many admin areas that
+        never scroll — measured: the page froze completely. The scrollbar
+        element is the reliable signal, because Radix's auto layer mounts it
+        only while that axis overflows and keeps it in sync with a
+        ResizeObserver. Match it from the ROOT rather than as a sibling of the
+        viewport: the default vertical bar is a sibling, but a horizontal one is
+        passed as a CHILD by the caller and so renders inside the viewport —
+        a `:has(~ ...)` rule sees the first and misses the second. */}
+    <ScrollAreaPrimitive.Viewport
+      className="h-full max-h-[inherit] w-full rounded-[inherit] group-has-[div[data-orientation=horizontal]]/scroll-area:overscroll-x-contain group-has-[div[data-orientation=vertical]]/scroll-area:overscroll-y-contain"
+    >
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />
@@ -33,8 +54,17 @@ const ScrollBar = React.forwardRef<
   <ScrollAreaPrimitive.ScrollAreaScrollbar
     ref={ref}
     orientation={orientation}
+    // forceMount keeps the bar in the DOM for as long as the axis overflows, so
+    // hovering FADES it rather than mounting it — the default hover type mounts
+    // at opacity 1 and unmounts on pointerleave, which pops the bar in and out
+    // as the cursor drifts across the panel. Radix's hover wrapper deliberately
+    // does not forward forceMount to the auto layer beneath it, so an area with
+    // nothing to scroll still renders no bar at all, and the thumb's rAF loop
+    // still only runs while a scroll is in flight.
+    forceMount
     className={cn(
-      "flex touch-none transition-colors select-none",
+      "flex touch-none opacity-0 transition-opacity duration-150 select-none",
+      "data-[state=hidden]:pointer-events-none data-[state=visible]:opacity-100",
       orientation === "vertical" &&
         "h-full w-2.5 border-l border-l-transparent p-[1px]",
       orientation === "horizontal" &&


### PR DESCRIPTION
Two measured defects in the shared shadcn/Radix `ScrollArea`, both visible wherever the admin panel caps a list (dash, debug, stats, moods, playlists, schedule).

## What was glitchy

**1. Scroll chaining.** The viewport carried `overscroll-behavior: auto`, so wheeling a capped list past its end handed the scroll straight to the page — measured as a **400px page jump** on `/admin/dash`. On the schedule board the same thing let a sideways swipe past the last day reach the browser's back-navigation gesture. The admin pages stack several of these in one column, so it reads as the page lurching out from under whatever you were reading.

**2. The scrollbar popped in and out.** With Radix's default `type="hover"` the bar *mounts* at opacity 1 on `pointerenter` and *unmounts* on `pointerleave`, so it blinks as the cursor crosses the panel. The only transition on it was `transition-colors`, which animates nothing here (the thumb has no hover colour).

## The fix

Containment had to be applied **per axis, and only where that axis really scrolls**. Radix puts `overflow: scroll` on the viewport for any axis that has a ScrollBar mounted, overflow or not — so the obvious blanket `overscroll-contain` swallowed the wheel over the many admin areas that never scroll, and the page stopped scrolling entirely. That regression was caught by the harness, not by eye.

The scrollbar element turns out to be the reliable signal: Radix's auto layer mounts it only while that axis overflows and keeps it in sync with a `ResizeObserver`. It's matched from the root rather than as a sibling of the viewport, because the default vertical bar is a sibling while a caller-supplied horizontal one (`<ScrollBar orientation="horizontal" />`, passed as a child) renders *inside* the viewport — a `:has(~ ...)` rule sees the first and misses the second.

For the pop, `forceMount` keeps the bar in the DOM while the axis overflows, so hovering fades it instead of mounting it. Radix deliberately does not forward `forceMount` to the auto layer beneath, so an area with nothing to scroll still renders **no bar at all**, and the thumb's rAF loop still only runs while a scroll is in flight.

Appearance is unchanged — same 10px bar, same thumb, still hidden until hover.

## Verification

Playwright against a live dev stack:

- 18 scroll areas across 8 routes hold the invariant — contained iff that axis actually overflows.
- A wheel over a non-scrolling area still scrolls the page (the regression above).
- A capped list no longer chains at its bottom; it still scrolls normally.
- The schedule board still pans sideways, and its unused vertical axis is left free.
- A full hover cycle produces zero mount/unmount churn; bar is `opacity: 0` + `pointer-events: none` at rest, `opacity: 1` on hover.
- No page errors on any route.

## Deliberately not changed

Radix drives the thumb from a rAF polling loop, so it can never track a compositor-driven scroll. Measured before touching it: **30.3px** worst-case drift under a synthetic fast burst, but only **1.8px mean / 4.3px max** under realistic trackpad-speed scrolling on a 480px track, and 0.6px when scrolling slowly. That's imperceptible, so the scrollbar was left on Radix rather than swapped for a native styled one.

`ai-elements/suggestion.tsx` puts `overflow-x-auto` on the ScrollArea root, which looked like a second nested scroller. Measured: the root is not actually scrollable (`360/360` — the viewport is the real scroller at `360/1860`), so it's inert and was left alone.
