### PR TITLE
fix: backup restore no longer deletes the primary/fallback LLM API keys

### DIFF
--- a/controller/scripts/llm-key-backup.test.ts
+++ b/controller/scripts/llm-key-backup.test.ts
@@ -1,0 +1,168 @@
+// Backup restore must not delete the stored inline LLM API keys (issue #1351).
+//
+// `settings.llm.apiKey` is a legacy WRITE-ONLY channel: load() hardcodes it to
+// '' because the real store is the per-provider `llm.keys` map (#657). So
+// getRedacted()'s `s.llm?.apiKey ? 'set' : ''` could never emit the sentinel and
+// the backup always carried `llm.apiKey: ""` — which applyInlineKey() reads as
+// "clear this provider's key". Restoring a backup therefore deleted the key for
+// whichever provider was the primary leg, and for whichever was the fallback,
+// while every other provider's key (and every other secret in the file)
+// survived. The station came back up pointing at a provider whose key had just
+// been deleted, and failed auth on the first call with nothing in the logs.
+//
+// A COLD LOAD is load-bearing here, exactly as in llm-repeat-penalty.test.ts: an
+// in-process assertion passes on the broken code, because the bug needs load()'s
+// composition to have blanked llm.apiKey first.
+//
+// No credentials and no network — everything runs against a throwaway STATE_DIR.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+// STATE_DIR is redirected at a throwaway dir BEFORE the first import of
+// anything config-derived (same pattern as scripts/llm-repeat-penalty.test.ts).
+const stateRoot = mkdtempSync(path.join(tmpdir(), 'subwave-llm-key-backup-'));
+process.env.STATE_DIR = stateRoot;
+
+const { setCache } = await import('../src/settings/store.js');
+const settings = await import('../src/settings.js');
+
+const SETTINGS_PATH = path.join(stateRoot, 'settings.json');
+
+// Three providers with a key on file; two of them are the legs. openrouter is
+// the control — it is neither leg, and its key was never at risk.
+const THREE_KEYS = {
+  openrouter: 'sk-openrouter-CONTROL',
+  openai: 'sk-openai-PRIMARY',
+  anthropic: 'sk-anthropic-FALLBACK',
+};
+
+// Load a hand-written settings.json the way a controller restart would.
+async function coldLoad(llm: Record<string, unknown>) {
+  writeFileSync(SETTINGS_PATH, JSON.stringify({ llm }));
+  setCache(null);
+  await settings.load();
+  return settings.get().llm;
+}
+
+async function coldLoadThreeKeys() {
+  return coldLoad({
+    provider: 'openai',
+    model: 'gpt-4o-mini',
+    keys: { ...THREE_KEYS },
+    fallback: { enabled: true, provider: 'anthropic', model: 'claude-sonnet-4-5' },
+  });
+}
+
+// Exactly what routes/backup.ts:99 writes into the zip and :218 replays through
+// update() — the JSON round trip included, since that is what a real restore
+// hands back.
+async function roundTripThroughBackup() {
+  const backup = JSON.parse(JSON.stringify(settings.getRedacted()));
+  await settings.update(backup);
+  return settings.get().llm.keys;
+}
+
+test('the exported backup masks the legacy key field rather than blanking it', async () => {
+  const llm = await coldLoadThreeKeys();
+  // The premise: load() blanks the legacy field on both legs, always.
+  assert.equal(llm.apiKey, '', 'legacy primary slot is write-only');
+  assert.equal(llm.fallback.apiKey, '', 'legacy fallback slot is write-only');
+
+  const redacted = settings.getRedacted();
+  // Masked against the leg's RESOLVED key (keys[provider]) — the secret the
+  // field is a channel for — not against the always-empty field itself.
+  assert.equal(redacted.llm.apiKey, 'set', 'primary leg has a key on file');
+  assert.equal(redacted.llm.fallback.apiKey, 'set', 'fallback leg has a key on file');
+  // The map itself was already redacted correctly; pinned so it stays that way.
+  assert.deepEqual(redacted.llm.keys, { openrouter: 'set', openai: 'set', anthropic: 'set' });
+  // And no real key ever leaves the box.
+  const wire = JSON.stringify(redacted);
+  for (const v of Object.values(THREE_KEYS)) assert.ok(!wire.includes(v), `${v} must not be exported`);
+});
+
+test('a backup round trip keeps every stored provider key', async () => {
+  await coldLoadThreeKeys();
+  assert.deepEqual(await roundTripThroughBackup(), THREE_KEYS);
+
+  // And it still holds after the restart the restore prompts for — the restore
+  // writes settings.json, so a key that survives in memory but not on disk is
+  // the same outage one boot later.
+  setCache(null);
+  await settings.load();
+  assert.deepEqual(settings.get().llm.keys, THREE_KEYS, 'and survives the restart');
+});
+
+test('a leg whose provider has no key on file redacts to empty, and restores as a no-op', async () => {
+  // ollama takes no key: the primary leg's masked field must not claim one.
+  await coldLoad({
+    provider: 'ollama',
+    model: 'qwen3',
+    keys: { ...THREE_KEYS },
+    fallback: { enabled: true, provider: 'anthropic', model: 'claude-sonnet-4-5' },
+  });
+  const redacted = settings.getRedacted();
+  assert.equal(redacted.llm.apiKey, '', 'no ollama key on file');
+  assert.equal(redacted.llm.fallback.apiKey, 'set');
+
+  // '' still means "clear this provider's key" — it just clears nothing here.
+  assert.deepEqual(await roundTripThroughBackup(), THREE_KEYS);
+});
+
+test("'' still clears a key when an operator really sends one", async () => {
+  // The sentinel semantics are deliberate and stay intact: the fix is that the
+  // redaction layer stops emitting '' unconditionally, not that '' stops
+  // clearing. PUT /settings is the only affordance for dropping an inline key.
+  await coldLoadThreeKeys();
+  await settings.update({ llm: { apiKey: '' } } as never);
+  assert.deepEqual(settings.get().llm.keys, {
+    openrouter: THREE_KEYS.openrouter,
+    anthropic: THREE_KEYS.anthropic,
+  }, 'the primary leg key is cleared, the others are untouched');
+
+  // Same for the fallback leg, routed by ITS provider.
+  await coldLoadThreeKeys();
+  await settings.update({ llm: { fallback: { apiKey: '' } } } as never);
+  assert.deepEqual(settings.get().llm.keys, {
+    openrouter: THREE_KEYS.openrouter,
+    openai: THREE_KEYS.openai,
+  }, 'the fallback leg key is cleared, the others are untouched');
+});
+
+test('an llm patch that omits apiKey leaves every key alone', async () => {
+  // The invariant every non-key-bearing caller relies on — the admin LLM panel
+  // omits the field unless the operator typed one, and since #1351 so does the
+  // onboarding wizard, which used to send apiKey: '' on every re-run and
+  // deleted the primary provider's key with it.
+  await coldLoadThreeKeys();
+  await settings.update({
+    llm: { provider: 'openai', model: 'gpt-4o', baseUrl: '', ollamaUrl: 'http://ollama:11434' },
+  } as never);
+  assert.deepEqual(settings.get().llm.keys, THREE_KEYS);
+});
+
+test('the other redacted secrets keep round-tripping', async () => {
+  // Scope check from the issue: llm was the only field that lost its secret.
+  // These already worked; pinned so the fix cannot quietly change the shape of
+  // the sentinel for anyone else reading it.
+  await coldLoadThreeKeys();
+  await settings.update({
+    tts: { cloud: { apiKey: 'sk-tts' } },
+    search: { apiKey: 'sk-search' },
+    embedding: { apiKey: 'sk-embed' },
+    scrobble: { lastfm: { apiKey: 'sk-lastfm' }, listenbrainz: { userToken: 'tok-lb' } },
+    privacy: { password: 'hunter2' },
+  } as never);
+
+  await roundTripThroughBackup();
+  const s = settings.get();
+  assert.equal(s.tts.cloud.apiKey, 'sk-tts');
+  assert.equal(s.search.apiKey, 'sk-search');
+  assert.equal(s.embedding.apiKey, 'sk-embed');
+  assert.equal(s.scrobble.lastfm.apiKey, 'sk-lastfm');
+  assert.equal(s.scrobble.listenbrainz.userToken, 'tok-lb');
+  assert.equal(s.privacy.password, 'hunter2');
+});

--- a/controller/src/settings/store.ts
+++ b/controller/src/settings/store.ts
@@ -74,7 +74,18 @@ export function getRedacted() {
   const s = get();
   const clone = JSON.parse(JSON.stringify(s));
   if (clone.llm) {
-    clone.llm.apiKey = s.llm?.apiKey ? 'set' : '';
+    // Masked against the leg's RESOLVED key — keys[provider] — never against
+    // the field itself. `llm.apiKey` is a legacy WRITE-ONLY channel: load()
+    // hardcodes it to '' because the real store is the per-provider map
+    // (#657), so `s.llm.apiKey ? …` could only ever emit ''. And '' is not
+    // neutral here — applyInlineKey() reads it as "clear this provider's key".
+    // The backup path replays this whole object through update()
+    // (routes/backup.ts), so an unconditional '' deleted the stored key for
+    // whichever provider was the primary leg and for whichever was the
+    // fallback, leaving the station pointed at a provider whose credential had
+    // just been dropped (#1351). Every other provider's key was untouched,
+    // which is why it read as "backups are fine".
+    clone.llm.apiKey = llmKeyFor(s.llm?.provider ?? '') ? 'set' : '';
     // Per-provider inline keys masked to 'set' | '' per entry, so the admin UI
     // can show which providers have a key on file without exposing the value.
     clone.llm.keys = {};
@@ -82,7 +93,11 @@ export function getRedacted() {
       clone.llm.keys[p] = s.llm.keys[p] ? 'set' : '';
     }
   }
-  if (clone.llm?.fallback) clone.llm.fallback.apiKey = s.llm?.fallback?.apiKey ? 'set' : '';
+  // Same channel, same map — the fallback leg's key also lives in llm.keys,
+  // under ITS provider (update() routes it there via applyInlineKey).
+  if (clone.llm?.fallback) {
+    clone.llm.fallback.apiKey = llmKeyFor(s.llm?.fallback?.provider ?? '') ? 'set' : '';
+  }
   if (clone.tts?.cloud) {
     clone.tts.cloud.apiKey = s.tts?.cloud?.apiKey ? 'set' : '';
     clone.tts.cloud.compatApiKey = s.tts?.cloud?.compatApiKey ? 'set' : '';

--- a/web/components/onboarding/useWizard.ts
+++ b/web/components/onboarding/useWizard.ts
@@ -211,9 +211,13 @@ export function useWizard() {
       llm: {
         provider: data.llm.provider,
         model: data.llm.model,
-        // Cloud keys go to apiKeys (state/secrets.env); settings.json keeps only
-        // the provider/model/url, never the key.
-        apiKey: '',
+        // Deliberately NO apiKey field. Cloud keys go to apiKeys
+        // (state/secrets.env), so the wizard has none to offer here — but
+        // settings.llm.apiKey does not mean "no key", it means "CLEAR the
+        // stored key for this provider" (applyInlineKey, #657). This block sent
+        // '' on every save, so re-running onboarding deleted the inline key of
+        // whichever provider it selected (#1351). Absent = leave it alone; the
+        // admin LLM panel omits the field the same way unless one is typed.
         baseUrl: data.llm.baseUrl,
         ollamaUrl: data.llm.ollamaUrl,
       },


### PR DESCRIPTION
Closes #1351.

## The bug

Restoring a backup deleted the stored inline API key for whichever provider was the **primary** leg and for whichever was the **fallback**. Every other provider's key survived, and so did every other secret in the file — which is why it read as "backups are fine".

It never failed loudly: `llmKeyFor()` returns `''` and the registry falls through to the provider's env var, so on a box with no env var set every LLM call starts failing auth after a restore that reported success.

## Root cause

Two halves, neither wrong on its own.

`settings.llm.apiKey` is a legacy **write-only** channel — `load()` hardcodes it to `''` because the real store is the per-provider `llm.keys` map (#657). So `getRedacted()`'s

```ts
clone.llm.apiKey = s.llm?.apiKey ? 'set' : '';
```

could *never* emit the sentinel, and every backup carried `llm.apiKey: ""`. And `''` is not neutral — `applyInlineKey()` reads it as "clear this provider's key". `routes/backup.ts` replays the whole redacted object back through `update()`, so both legs got cleared on the way in.

The `keys` map itself was redacted correctly (`{openai: 'set', …}`), but `update()` has no channel for it, so those markers did nothing and the only thing reaching `applyInlineKey` was the always-empty legacy field.

## The fix

Option 1 from the issue. Mask each leg against its **resolved** key — `llmKeyFor(provider)`, the same helper `llmCfg()` already uses to answer "the key for this leg" — so the backup carries `'set'` and the restore leaves the map alone.

`''`-means-clear is deliberately **untouched**: it is still the only affordance for dropping an inline key (`PUT /settings`), it is just no longer emitted unconditionally by the redaction layer. Option 2 (a patch channel for `llm.keys`) would not have fixed this on its own — the deletion comes from the legacy field, not the map — and it adds a patchable surface that has deliberately never existed.

## Secondary path — confirmed, not just a lead

The issue flagged `routes/onboarding.ts:210` as worth checking. It is real: `useWizard.ts` sent `apiKey: ''` on **every** save, so re-running onboarding deleted the inline key of whichever provider it selected. It now omits the field entirely, the way `LlmSection` already does unless a key is typed. (The admin LLM panel was always safe — it omits on blank.)

## Verification

- New `controller/scripts/llm-key-backup.test.ts` — a **cold-load** round trip, following the `llm-repeat-penalty.test.ts` pattern. This is load-bearing: an in-process assertion passes on the broken code, because the bug needs `load()`'s composition to have blanked `llm.apiKey` first. Verified failing 3/6 before the fix with exactly the issue's measured deletion (`openai`, `anthropic` gone, `openrouter` surviving), 6/6 after.
- The issue's verbatim repro, re-run against the patched tree: `KEYS DELETED BY THE RESTORE: (none)`, all three values byte-identical, and no real key appears anywhere in the exported JSON.
- Full controller suite: 112/112 files pass. `npm run lint` clean (0 errors) in both `controller/` and `web/`.

The test also pins the guards against over-fixing: `''` still clears a key when an operator really sends one (both legs, routed by their own provider), a leg whose provider has no key still redacts to `''`, and the other six redacted secrets still round-trip.

## Notes

- Nothing reads the redacted `values.llm.apiKey` — the admin UI's "on file" placeholder reads `keys[provider] === 'set'` — so emitting the sentinel there changes no surface.
- `'set'` can never be persisted into `settings.json`: `getRedacted()` mutates a clone, and `applyLlmLegPatch` deliberately does not handle `apiKey`, so there is no writer of `next.llm.apiKey`.
- Pre-existing gap left alone (out of scope): the wizard still cannot carry an *inline* key at all — for `openai-compatible`/`locca` there is no env var to map to, so a key typed there is dropped. That was true before this PR too; it is a missing feature, not a regression.