### PR TITLE
docs(docker): make comments leaner

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -10,13 +10,12 @@
 	#
 	# A Cloudflare TUNNEL is different: cloudflared is a container beside this
 	# one, so the peer is a private Docker address and Caddy discards the
-	# forwarded header — tunnel operators must append `private_ranges`. That is
-	# NOT the default because it's a real trust decision: anything reaching
-	# Caddy from private address space could then forge X-Forwarded-For, faking
-	# admin → Listeners rows and defeating every per-IP limit in
-	# middleware/ratelimit.ts (request caps, admin lockout, station-password
-	# throttle, like dedup). Safe when the tunnel is the only ingress; not when
-	# the host port is also reachable from a shared LAN. See docs/deployment.md.
+	# forwarded header — tunnel operators must append `private_ranges`. NOT the
+	# default, because anything reaching Caddy from private address space could
+	# then forge X-Forwarded-For, faking admin → Listeners rows and defeating
+	# every per-IP limit in middleware/ratelimit.ts. Safe when the tunnel is the
+	# only ingress; not when the host port is also reachable from a shared LAN.
+	# See docs/deployment.md.
 	servers {
 		trusted_proxies static \
  173.245.48.0/20 103.21.244.0/22 103.22.200.0/22 103.31.4.0/22 \

--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -115,14 +115,12 @@ ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \
 # CLAP + Demucs are OFF by default (lean image); `subwave-aio-heavy` bakes
 # them, and `subwave-aio-cuda` (#1186) adds cu124 torch — WITH_CUDA implies the
 # heavy tier (CUDA torch alone would be dead weight), and the worker still
-# picks the device itself (ANALYZE_DEVICE=auto), so it degrades to CPU on a
-# driverless host. Host needs only the NVIDIA driver + container runtime; on
-# Unraid see docs/unraid.md.
+# picks its device (ANALYZE_DEVICE=auto), so it degrades to CPU on a driverless
+# host. See docs/unraid.md.
 #
 # Pins mirror docker/Dockerfile.analyzer — keep the two in lockstep. This venv
 # runs on the system python3 (trixie → 3.13, unlike the analyzer image's 3.11);
-# torch 2.6.0 publishes cp313 wheels on both the cpu and cu124 indexes, so the
-# shared pin holds.
+# torch 2.6.0 publishes cp313 wheels on both indexes, so the shared pin holds.
 ARG WITH_CLAP=0
 ARG WITH_DEMUCS=0
 ARG WITH_CUDA=0
@@ -141,9 +139,9 @@ RUN TORCH_INDEX="https://download.pytorch.org/whl/cpu" && \
       /opt/analyzer/venv/bin/python -c "import torch, transformers, onnxruntime" ; \
     fi && \
     if [ "$WITH_DEMUCS" = "1" ]; then \
-      # diffq (quantized-checkpoint decompressor) ships sdist-only: lend it a
-      # toolchain and purge in the SAME layer. Unlike the analyzer image, this
-      # base's apt python3 has no headers — python3-dev supplies Python.h.
+      # diffq ships sdist-only: lend it a toolchain and purge in the SAME
+      # layer (see docker/Dockerfile.analyzer). Unlike that image, this base's
+      # apt python3 has no headers — python3-dev supplies Python.h.
       apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev python3-dev && \
       /opt/analyzer/venv/bin/pip install --no-cache-dir \
         --index-url "$TORCH_INDEX" \

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -28,7 +28,6 @@ RUN cd /tmp && \
     ln -s /opt/piper/piper /usr/local/bin/piper && \
     rm piper_linux_${piper_arch}.tar.gz
 
-# British English voice
 RUN mkdir -p /opt/piper/voices && \
     wget -q ${WGET_RETRY} -O /opt/piper/voices/en_GB-alan-medium.onnx \
       https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_GB/alan/medium/en_GB-alan-medium.onnx && \
@@ -56,9 +55,9 @@ ENV KOKORO_MODEL=/opt/kokoro/models/kokoro-v1.0.onnx \
 # --- Chatterbox (opt-in, --build-arg WITH_CHATTERBOX=1) ---------------------
 # Resemble AI's Chatterbox Turbo: zero-shot voice cloning + paralinguistic tags.
 # PyTorch-only (~2-3GB + slow CPU inference), so deliberately NOT in the default
-# image. The from_pretrained call doubles as a build-time smoke test and
-# pre-warms the HF cache. With the venv absent, chatterbox.isAvailable() reports
-# false and the dispatcher falls back to Piper.
+# image — with the venv absent, chatterbox.isAvailable() reports false and the
+# dispatcher falls back to Piper. The from_pretrained call below doubles as a
+# build-time smoke test and pre-warms the HF cache.
 ENV HF_HOME=/opt/chatterbox/hf-cache
 ARG WITH_CHATTERBOX=0
 ARG CHATTERBOX_PIP_PKG=chatterbox-tts
@@ -101,9 +100,8 @@ RUN if [ "$WITH_CHATTERBOX" = "1" ]; then \
 # --- PocketTTS (opt-in, --build-arg WITH_POCKETTTS=1) -----------------------
 # kyutai-labs' PocketTTS: 100M-param CPU model between Piper (fast, robotic)
 # and Chatterbox (heavy, expressive). Still drags PyTorch in, so NOT in the
-# default image; same venv-isolation pattern as Chatterbox, model preload as
-# build-time smoke test. With the venv absent, pocketTts.isAvailable() reports
-# false and the dispatcher falls back to Piper.
+# default image; same venv isolation, absence handling and preload-as-smoke-
+# test as Chatterbox above.
 # HF_TOKEN (optional) unlocks voice cloning (#238) — the cloning weights are
 # gated; without it the pre-warm loads the open weights and cloned .wav voices
 # revert to a built-in. Runtime env also works (lazy download); a build-arg

--- a/docker/Dockerfile.tts-heavy
+++ b/docker/Dockerfile.tts-heavy
@@ -4,6 +4,9 @@
 # `docker compose --profile tts-heavy up -d`; the controller POSTs speech
 # requests via TTS_HEAVY_URL.
 #
+# TTS-only: acoustic analysis lives in the standalone subwave-analyzer sidecar
+# (docker/Dockerfile.analyzer).
+#
 # TWO isolated venvs, one per engine, driven by the existing stdio workers
 # (controller/scripts/{chatterbox,pocket_tts}_worker.py) behind a thin FastAPI
 # front (docker/tts-heavy/server.py). Two venvs because the engines need
@@ -98,9 +101,6 @@ RUN python3 -m venv /opt/server/venv && \
     /opt/server/venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/server/venv/bin/pip install --no-cache-dir \
       fastapi==0.139.0 "uvicorn[standard]==0.49.0" pydantic==2.13.4
-
-# This image is TTS-only — acoustic analysis lives in the standalone
-# subwave-analyzer sidecar (docker/Dockerfile.analyzer).
 
 # Strip the build toolchain now that pkuseg has compiled (~500MB).
 RUN apt-get update && apt-get purge -y --auto-remove build-essential && \

--- a/docker/aio/supervisor.sh
+++ b/docker/aio/supervisor.sh
@@ -41,24 +41,20 @@ resolve_state_dir() {
 log() { echo "[subwave-aio] $*" >&2; }
 
 # ---------------------------------------------------------------------------
-# Shared state bootstrap. Mode 777 because the services run under different
-# uids (icecast2 / liquidsoap / root) and, in compose, in other containers.
+# Shared state bootstrap — same functions, list and messages as
+# docker/broadcast-entrypoint.sh, which carries the full rationale (#1300 bug
+# 10); scripts/state-bootstrap.test.ts drives both through one table, because
+# them drifting apart is how the bug returns.
 #
-# Nothing here is fatal (#1300 bug 10): a state path on a mount that refuses
-# mkdir/chmod — a read-only bind, an NFS export, the exFAT/NTFS disk people
-# move the stem cache to — warns and the boot continues. This script runs
-# under `set -u` (not -e), so its copy of the old bulk chmod merely printed a
-# raw `chmod:` line naming no cause; the broadcast entrypoint's identical
-# block ran under `set -eu` and aborted the container outright. Same block,
-# same list, same messages in both — scripts/state-bootstrap.test.ts drives
-# the two through one table, because them drifting apart is how this returns.
+# Nothing here is fatal. This script runs under `set -u` (not -e), so its copy
+# of the old bulk chmod merely printed a raw `chmod:` line naming no cause;
+# the entrypoint's identical block ran under `set -eu` and aborted the
+# container outright.
 # ---------------------------------------------------------------------------
 state_warn() { log "WARNING $*"; }
 
-# True when `other` can write the dir. This — not chmod's exit status — is
-# what the warning keys on: a mount that is already world-writable and simply
-# refuses chmod is a WORKING configuration, and a line printed on every boot of
-# a healthy station is a line operators learn to skip past.
+# True when `other` can write the dir — see the entrypoint on why the warning
+# keys on this rather than on chmod's exit status.
 state_writable_by_others() {
 	case "$(stat -c %a "$1" 2>/dev/null || echo 0)" in
 		*[2367]) return 0 ;;
@@ -98,13 +94,9 @@ bootstrap_state_dirs() {
 	local sub
 	state_prepare_dir "$root"
 	state_prepare_dir "$dir"
-	# stems + transitions belong to the analyzer — the stem cache and the
-	# rendered transition clips. They are also the only two dirs worth
-	# relocating to a bigger disk, and the ONLY way to do that is a bind mount
-	# at <state>/stems (music/stem-cache.ts stemsRoot() is <stateDir>/stems,
-	# with no setting behind it). A fresh bind mount lands root-owned 755, so
-	# without the same 777 treatment the rest of the state dir gets, the
-	# analyzer cannot write the cache it was just pointed at.
+	# stems + transitions are the analyzer's, and the only two dirs worth
+	# relocating to a bigger disk — a bind mount at <state>/stems lands
+	# root-owned 755, which the analyzer cannot write without this chmod.
 	for sub in voice voices archive jingles logs sessions sfx stems transitions; do
 		state_prepare_dir "$dir/$sub"
 	done
@@ -141,11 +133,10 @@ init_state() {
 # degraded log. Every branch below must end in a path liquidsoap can open,
 # verified by probe.
 #
-# The original #1196 fix created the link unconditionally and guarded on -L
-# only. If <state>/logs was itself a symlink back at /var/log/liquidsoap (a
-# natural pre-#1196 host-side workaround), the two links closed an ELOOP cycle
-# ("Too many levels of symbolic links") that the guard then never repaired —
-# an unbreakable crash loop the "Restart mixer" button couldn't touch.
+# #1196's original fix linked unconditionally and guarded on -L only. If
+# <state>/logs was itself a symlink back at /var/log/liquidsoap (a natural
+# pre-#1196 host-side workaround), the two closed an ELOOP cycle the guard
+# never repaired — an unbreakable crash loop "Restart mixer" couldn't touch.
 # ---------------------------------------------------------------------------
 link_liquidsoap_log() {
 	local target="$STATE_ROOT/logs"
@@ -269,21 +260,16 @@ warn_if_state_unmounted() {
 }
 
 # ---------------------------------------------------------------------------
-# ANALYZER_HEAVY selects an IMAGE TAG, and it does so by docker-compose variable
-# interpolation (`subwave-analyzer${ANALYZER_HEAVY:+-heavy}` in
-# docker-compose.yml). The all-in-one image has no analyzer service to select:
-# CLAP and Demucs are baked into the venv at build time or they are not, decided
-# entirely by which tag was pulled. So the variable is inert here by
-# construction — not unsupported, unreachable.
+# ANALYZER_HEAVY selects an IMAGE TAG by compose variable interpolation
+# (`subwave-analyzer${ANALYZER_HEAVY:+-heavy}`). The AIO has no analyzer
+# service to select — CLAP and Demucs are baked into the venv at build time or
+# they are not — so the variable is inert here by construction. Operators set
+# it, see no stem-transitions card, and conclude the feature is broken (#1300
+# bug 9); the caveat was documented (docs/unraid.md, the doctor) but nothing
+# said it at the boot right after they set it.
 #
-# Operators set it, see no stem-transitions card appear, and reasonably conclude
-# the feature is broken (#1300 bug 9). The caveat was written down (docs/unraid.md,
-# the doctor) but nothing said it at the moment they were actually looking: the
-# boot right after setting it.
-#
-# Probed rather than read from a baked marker, because torch in the venv IS what
-# makes the heavy tier work — a probe cannot disagree with the thing it describes,
-# a marker can.
+# Probed rather than read from a baked marker: torch in the venv IS what makes
+# the heavy tier work, so a probe cannot disagree with what it describes.
 # ---------------------------------------------------------------------------
 ANALYZER_VENV="${SUBWAVE_ANALYZER_VENV:-/opt/analyzer/venv}"
 
@@ -490,8 +476,6 @@ run_broadcast() {
 	# by init_state at boot; a non-root station dir needs its own here).
 	bootstrap_state_dirs "$STATE_DIR" "$STATE_DIR"
 
-	# Re-render on every pair launch so a flipped listener-auth flag lands
-	# after a restart-mixer (which bounces this pair, not the container).
 	render_icecast
 	log "starting icecast2"
 	sudo -E -u icecast2 icecast2 -n -c "$RENDERED" &
@@ -510,10 +494,8 @@ run_broadcast() {
 
 	log "starting liquidsoap"
 	# TEMPORARY (re-harden later): run liquidsoap as root — same reason as
-	# docker/broadcast-entrypoint.sh (savonet base bump changed the liquidsoap
-	# uid 10000 → 100, making persisted state files unwritable). Restore the
-	# privilege drop once state files are chowned to the new uid
-	# (radio.liq's settings.init.allow_root is set for the same reason).
+	# docker/broadcast-entrypoint.sh (the savonet base bump changed the
+	# liquidsoap uid, making persisted state files unwritable).
 	liquidsoap /etc/liquidsoap/radio.liq &
 	local lq=$!
 

--- a/docker/analyzer/server.py
+++ b/docker/analyzer/server.py
@@ -38,10 +38,9 @@ ANALYZER_HF_HOME = os.environ.get("ANALYZER_HF_HOME", "/opt/analyzer/hf-cache")
 # the CLAP/Demucs singletons, but ~1GB of librosa/numba/torch scratch stays
 # resident — restarting the worker is the only full reclaim. After this many
 # seconds with no HEAVY use (lean bpm/key traffic doesn't count, same clock as
-# the worker's release) the shim terminates the worker and run() respawns it.
-# The recycle holds the request lock, so a request landing mid-recycle queues
-# behind the respawn instead of 500ing. Default sits above the worker's
-# largest release window so the cheap release always fires first; 0 disables.
+# the worker's release) the shim terminates it and run() respawns. Default
+# sits above the worker's largest release window so the cheap release always
+# fires first; 0 disables.
 _RECYCLE_ENV = os.environ.get("ANALYZE_RECYCLE_IDLE_S", "").strip()
 try:
     RECYCLE_IDLE_S = float(_RECYCLE_ENV) if _RECYCLE_ENV else 3600.0
@@ -76,9 +75,8 @@ log = logging.getLogger("analyzer")
 class StdioWorker:
     """Async wrapper around a long-lived stdio worker subprocess.
 
-    One JSON object per line over stdin/stdout; no multiplexing — one request
-    in flight, gated by a lock. run() supervises the lifecycle from the
-    FastAPI lifespan: start → wait-for-exit → respawn with a short backoff.
+    No multiplexing — one request in flight, gated by a lock. run() drives the
+    lifecycle from the FastAPI lifespan.
     """
 
     START_BACKOFF_S = 5.0
@@ -104,14 +102,14 @@ class StdioWorker:
         self.models_resident = False
         self.recycles = 0
         # Capabilities the worker advertised at ready but LOST when the model
-        # was actually asked to load — {"audio_embedding": "<why>"}. Harvested
-        # from every response (analyze_worker.capability_loss) and deliberately
-        # NOT cleared by _reset(), which is the whole point: the worker's own
-        # _embed_failed dies with the process, and recycle_loop respawns the
-        # process on idle, so a purely in-worker latch resets itself every hour
-        # and the controller re-widens its backfill to the same doomed track
-        # set forever (#1300 bug 3). Cleared only by restarting THIS container,
-        # which is also the operator's retry after fixing the cause.
+        # was actually asked to load — {"audio_embedding": "<why>"}, harvested
+        # from every response (analyze_worker.capability_loss). Deliberately
+        # NOT cleared by _reset(): the worker's own latch dies with the
+        # process, and recycle_loop respawns that process every idle hour, so
+        # an in-worker-only latch would reset itself and the controller would
+        # re-widen its backfill to the same doomed tracks forever (#1300 bug
+        # 3). Cleared only by restarting THIS container — which is also the
+        # operator's retry after fixing the cause.
         self.capability_errors: dict[str, str] = {}
 
     async def run(self) -> None:
@@ -390,10 +388,10 @@ async def health():
             "vocal_activity_capable", "vocal_activity"
         ),
         # WHY a capability is false, when the reason is a failed load rather
-        # than a lean build — null in every other case, including a lean image.
-        # The distinction is the actionable part: "rebuild with the heavy image"
-        # and "give this host reach to huggingface.co, or pre-seed its cache"
-        # are opposite instructions, and a bare false can't tell them apart.
+        # than a lean build (null in every other case). The distinction is the
+        # actionable part: "rebuild with the heavy image" and "give this host
+        # reach to huggingface.co" are opposite instructions, and a bare false
+        # can't tell them apart.
         "analyze_audio_error": analyzer_worker.capability_errors.get("audio_embedding"),
         "analyze_vocal_error": analyzer_worker.capability_errors.get("vocal_activity"),
         # Tail vocal ranges — a worker-version signal as much as a capability:

--- a/docker/broadcast-entrypoint.sh
+++ b/docker/broadcast-entrypoint.sh
@@ -9,30 +9,26 @@
 set -eu
 
 # ---- Shared state bootstrap -------------------------------------------------
-# Creates the dirs the controller, analyzer and liquidsoap share and opens them
-# to mode 777: those containers write here as OTHER uids, so an operator would
-# otherwise have to chown every bind-mount source before first boot.
+# Mode 777 because the controller, analyzer and liquidsoap write here as OTHER
+# uids; without it an operator must chown every bind-mount source by hand.
 #
 # NOTHING in here is fatal (#1300 bug 10). Under `set -eu` the old bulk
 # `mkdir -p a b c` / `chmod 777 a b c` made every state path load-bearing: one
-# on a mount that refuses the change — a read-only bind, an NFS export without
-# the right perms, the exFAT/NTFS disk people move the stem cache to — aborted
-# this script BEFORE icecast started, and compose surfaced that as
-# `dependency failed to start: container sub-wave-broadcast is unhealthy`,
-# naming neither the path nor the chmod. A station that refuses to boot over a
-# permission convenience is strictly worse than one running on a degraded
-# mount: icecast still serves and the dead-air guard still airs the emergency
-# loop, but an exited container airs nothing.
+# on a mount that refuses the change (read-only bind, NFS export, the
+# exFAT/NTFS disk people move the stem cache to) aborted this script BEFORE
+# icecast started, and compose reported only `dependency failed to start:
+# container sub-wave-broadcast is unhealthy` — naming neither path nor cause.
+# A station running on a degraded mount still serves and still airs the
+# emergency loop; an exited container airs nothing.
 #
-# Kept byte-for-byte in step with docker/aio/supervisor.sh's copy (same
-# function, same list, same messages) — scripts/state-bootstrap.test.ts drives
-# both through one table.
+# docker/aio/supervisor.sh keeps the same functions, list and messages;
+# scripts/state-bootstrap.test.ts drives both through one table.
 state_warn() { echo "broadcast: WARNING $*" >&2; }
 
-# True when `other` can write the dir. This — not chmod's exit status — is
-# what the warning keys on: a mount that is already world-writable and simply
-# refuses chmod is a WORKING configuration, and a line printed on every boot of
-# a healthy station is a line operators learn to skip past.
+# True when `other` can write the dir. The warning keys on this rather than on
+# chmod's exit status: a mount that is already world-writable and merely
+# refuses chmod is a WORKING config, and a line printed on every healthy boot
+# is a line operators learn to skip.
 state_writable_by_others() {
     case "$(stat -c %a "$1" 2>/dev/null || echo 0)" in
         *[2367]) return 0 ;;
@@ -72,13 +68,11 @@ bootstrap_state_dirs() {
     local sub
     state_prepare_dir "$root"
     state_prepare_dir "$dir"
-    # stems + transitions belong to the analyzer (uid 10001) — the stem cache
-    # and the rendered transition clips. They are also the only two dirs worth
-    # relocating to a bigger disk, and the ONLY way to do that is a bind mount
-    # at <state>/stems (music/stem-cache.ts stemsRoot() is <stateDir>/stems,
-    # with no setting behind it). A fresh bind mount lands root-owned 755, so
-    # without the same 777 treatment the rest of the state dir gets, the
-    # analyzer cannot write the cache it was just pointed at.
+    # stems + transitions are the analyzer's (uid 10001), and the only two
+    # dirs worth relocating to a bigger disk — the ONLY way to do that being a
+    # bind mount at <state>/stems (music/stem-cache.ts stemsRoot() has no
+    # setting behind it). A fresh bind mount lands root-owned 755, which the
+    # analyzer cannot write without the same 777 treatment as the rest.
     for sub in voice voices archive jingles logs sessions sfx stems transitions; do
         state_prepare_dir "$dir/$sub"
     done
@@ -120,7 +114,6 @@ SECRETS=$STATE_ROOT/icecast-secrets.env
 TEMPLATE=/etc/icecast2/icecast.xml.template
 RENDERED=/etc/icecast2/icecast.xml
 
-# ---- Bootstrap shared state dirs --------------------------------------------
 bootstrap_state_dirs "$STATE_ROOT" "$STATE_DIR"
 
 # The compose logs bind mount lands owned by root on first boot; liquidsoap
@@ -175,8 +168,8 @@ export ICECAST_SOURCE_PASSWORD ICECAST_ADMIN_PASSWORD ICECAST_RELAY_PASSWORD
 export ICECAST_HOST=localhost
 
 # ---- Render icecast.xml -----------------------------------------------------
-# Plain sed with `|` delimiters — the secrets are hex and the caps numeric, so
-# there's no escaping risk.
+# Substitution is plain sed with `|` delimiters — the secrets are hex and every
+# other value numeric, so there's no escaping risk.
 
 # Concurrent-listener ceiling. A non-numeric value would render invalid XML and
 # fail icecast at boot, so fall back to 100 with a warning instead.
@@ -190,9 +183,9 @@ esac
 
 # Listener buffer depth (<burst-size>, #993/#1114). Sized in SECONDS and
 # converted per bitrate here, because burst-size is a byte count — a fixed one
-# means wildly different depths per mount (512 KB was ~22s at 192k but ~66s at
-# 64k). Sources: env override > settings files (written by the controller) >
-# default; read from state so a settings change applies on the next bounce.
+# means wildly different depths per mount (512 KB is ~22s at 192k, ~66s at
+# 64k). Env override > controller-written settings files > default; read from
+# state so a settings change applies on the next bounce.
 read_state_num() {
     # $1 = filename, $2 = fallback. Non-numeric or missing → fallback.
     _v=$(cat "$STATE_DIR/$1" 2>/dev/null || true)
@@ -276,14 +269,14 @@ emit_mount /stream.aac  "$AAC_BITRATE"
 # Trusted reverse proxies — real listener IPs in admin → Listeners instead of
 # the edge's container address. icecast-KH matches an EXACT IP only (a CIDR is
 # accepted and then silently never matches), so the address must be resolved.
-# Precedence: ICECAST_TRUSTED_PROXY_IPS (explicit, wins) > DNS for
+# ICECAST_TRUSTED_PROXY_IPS (explicit) wins over DNS for
 # ICECAST_TRUSTED_PROXY_HOSTS (default 'caddy', the bundled edge).
 #
-# The DNS path is deliberately best-effort: on a COLD `compose up` caddy can't
-# be running yet (it depends_on this container being healthy), so the name
-# doesn't resolve — every later restart picks it up. A miss degrades to the old
-# behaviour (proxy IP shown), never to a wrong IP. Operators who want first-boot
-# accuracy pin the edge and set ICECAST_TRUSTED_PROXY_IPS (docs/deployment.md).
+# The DNS path is deliberately best-effort and misses the first cold boot:
+# caddy depends_on this container being healthy, so the name cannot resolve
+# yet — every later restart picks it up. A miss degrades to the old behaviour
+# (proxy IP shown), never to a wrong IP. For first-boot accuracy, pin the edge
+# and set ICECAST_TRUSTED_PROXY_IPS (docs/deployment.md).
 TRUSTED_XML=/etc/icecast2/trusted-proxies.xml
 : > "$TRUSTED_XML"
 TRUSTED_LIST=""
@@ -335,7 +328,7 @@ sed \
     "$TEMPLATE" > "$RENDERED"
 chown icecast2 "$RENDERED" 2>/dev/null || true
 
-# ---- Launch icecast in the background --------------------------------------
+# ---- Launch the pair, then wait for either to die ---------------------------
 
 echo "broadcast: starting icecast2" >&2
 sudo -E -u icecast2 icecast2 -n -c "$RENDERED" &
@@ -351,8 +344,6 @@ for i in 1 2 3 4 5 6 7 8 9 10; do
     sleep 1
 done
 
-# ---- Launch liquidsoap in the background -----------------------------------
-
 echo "broadcast: starting liquidsoap" >&2
 # TEMPORARY (re-harden later): run liquidsoap as root instead of dropping to
 # the `liquidsoap` user. The savonet base bump 2.2.5 → 2.4.4 changed that
@@ -362,8 +353,6 @@ echo "broadcast: starting liquidsoap" >&2
 # (needs settings.init.allow_root reverted in radio.liq too).
 liquidsoap /etc/liquidsoap/radio.liq &
 LIQ_PID=$!
-
-# ---- Wait for either to die, then exit -------------------------------------
 
 trap 'kill -TERM "$ICECAST_PID" "$LIQ_PID" 2>/dev/null || true' INT TERM
 

--- a/docker/icecast.xml.template
+++ b/docker/icecast.xml.template
@@ -6,10 +6,9 @@
         <clients>${ICECAST_MAX_CLIENTS}</clients>
         <sources>4</sources>
         <!-- queue-size: per-client backlog before Icecast drops a lagging
-             listener. Computed by broadcast-entrypoint.sh as 4x burst-size
-             (floored at 2 MB) — it must comfortably exceed the burst or a
-             client is evicted the moment it falls behind its own primed
-             buffer (issue #993). -->
+             listener. 4x burst-size (floored at 2 MB) — it must comfortably
+             exceed the burst or a client is evicted the moment it falls
+             behind its own primed buffer (issue #993). -->
         <queue-size>${ICECAST_QUEUE_SIZE}</queue-size>
         <client-timeout>30</client-timeout>
         <header-timeout>15</header-timeout>
@@ -21,12 +20,11 @@
              /now-playing publishes stream.bufferSeconds and players shift
              their displays by it (issue #1114).
 
-             Computed by broadcast-entrypoint.sh from settings.stream.
-             bufferSeconds x the live bitrate, NOT hardcoded — it's a byte
-             count, so a fixed value drifts badly across bitrates.
-
-             These <limits> values are sized for the MP3 mount and act as the
-             default; every stream mount below carries its own burst/queue. -->
+             Both values are computed by broadcast-entrypoint.sh from
+             settings.stream.bufferSeconds x bitrate, never hardcoded — they
+             are byte counts, so a fixed value drifts badly across bitrates.
+             These <limits> are sized for MP3 and act as the default; every
+             stream mount below carries its own burst/queue. -->
         <burst-size>${ICECAST_BURST_SIZE}</burst-size>
     </limits>
 

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -72,11 +72,10 @@ log = logging.getLogger("tts-heavy")
 class TtsWorker:
     """Async wrapper around a long-lived stdio TTS worker subprocess.
 
-    One JSON object per line over stdin/stdout (the same protocol as the
-    controller's in-process TS clients); no multiplexing — one request in
-    flight per worker, gated by a lock. run() supervises the lifecycle:
-    start → wait-for-exit → respawn with a short backoff, so a crash (OOM,
-    fatal model error) recovers without bouncing the container.
+    Same line protocol as the controller's in-process TS clients; no
+    multiplexing — one request in flight per worker, gated by a lock. run()
+    supervises the lifecycle so a crash (OOM, fatal model error) recovers
+    without bouncing the container.
     """
 
     # START_BACKOFF applies when start() itself fails (model load error,


### PR DESCRIPTION
Comment-only pass over `docker/`. Net **−39 lines** (108 added, 147 removed) across all 12 files.

No behaviour change: I verified mechanically that every file's executable content is **byte-identical** after stripping comments — AST-based for the Python, so docstrings count as comments too, not just `#` lines.

## What changed

**De-duplicated the prose shared by `broadcast-entrypoint.sh` and `aio/supervisor.sh`.** Four blocks were near-verbatim in both: the state bootstrap header, the writability check, the stems/transitions rationale, and the liquidsoap-as-root note. The entrypoint now carries the full rationale and the supervisor points at it, keeping only what genuinely differs (`set -u` vs `set -eu`). This was the biggest source of bulk and the part most likely to drift — the same reason `state-bootstrap.test.ts` drives both scripts through one table.

**Dropped comments the code already says.** The `# ---- Bootstrap shared state dirs ----` banner sitting directly above `bootstrap_state_dirs(...)`; the "Launch liquidsoap" / "Wait for either to die" banners over three lines of code; `# British English voice` above an `en_GB-alan-medium` URL; and a re-render note that repeated `render_icecast()`'s own header.

**Tightened the long narrative blocks** — `ANALYZER_HEAVY`, the #1196 log-link story, the Cloudflare-tunnel warning, `capability_errors` — without losing an issue number, a measurement, or a "don't do X because Y". The load-bearing rationale this repo depends on is all still there, just shorter.

## Comment fixes

Two claims were actually wrong:

- `broadcast-entrypoint.sh` said its bootstrap block was kept "byte-for-byte in step" with the supervisor's. It never was — different indentation, and one warning message differs. Now states same functions/list/messages, which is true.
- `icecast.xml.template` credited the entrypoint with computing only `burst-size`; it computes `queue-size` too.

Also moved `Dockerfile.tts-heavy`'s orphaned "TTS-only" note into the header, where it's read before the venvs rather than stranded after them.

## Verification

- Comment-only proven by a strip-and-compare checker over all 12 files — not eyeballed
- `bash -n` clean on both shell scripts
- Both Caddyfiles pass `caddy validate`
- `icecast.xml.template` still parses as well-formed XML
- Tests that drive these files all pass: `state-bootstrap`, `aio-log-link`, `aio-analyzer-heavy`, `listener-auth` (they assert on runtime log strings, none of which moved)