### PR TITLE
feat: finish the zod form conversion — personas, blocklist, library, and the fieldErrors channel (#1337)

### DIFF
--- a/controller/scripts/library-schema.test.ts
+++ b/controller/scripts/library-schema.test.ts
@@ -1,0 +1,305 @@
+// The never-play blocklist and the manual tagger moved onto shared zod schemas
+// (controller/src/schemas/{blocklist,library}.ts), mirrored into
+// web/lib/schemas.generated.ts. These tests pin what the conversion promised:
+// the STORE's chokepoint (blocklist-rules.validateRulePatch) and the ROUTE
+// boundary now run one implementation, and every message stayed byte-identical.
+//
+// The message half is the sharp end here. Both schemas' messages already name
+// their own field ('rule.label is required'), so their routes mount
+// validateBody's `messages: 'verbatim'` posture — without it the operator reads
+// 'label: rule.label is required'. scripts/blocklist-rules.test.ts keeps the
+// MATCHING half; this file covers validation only.
+//
+// Run: npx tsx scripts/library-schema.test.ts (auto-discovered by npm test).
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+process.env.STATE_DIR = mkdtempSync(join(tmpdir(), 'subwave-library-schema-'));
+
+const {
+  BLOCK_TYPES,
+  RULE_FIELDS,
+  RULE_TEXT_MAX,
+  RULE_VALUES_MAX,
+  blockEntrySchema,
+  blockRuleSchema,
+  normText,
+} = await import('../src/schemas/blocklist.js');
+const {
+  MANUAL_TAG_ENERGIES,
+  MANUAL_TAG_MOODS_MAX,
+  manualTagSchema,
+} = await import('../src/schemas/library.js');
+const rules = await import('../src/music/blocklist-rules.js');
+const { validateBody } = await import('../src/middleware/validate.js');
+
+const rule = (o: Record<string, unknown> = {}) => ({
+  label: 'Christmas songs',
+  field: 'genre',
+  values: ['Christmas'],
+  ...o,
+});
+
+// --- the rule schema --------------------------------------------------------
+
+test('a minimal rule parses and defaults its optional halves', () => {
+  const r = blockRuleSchema.parse(rule());
+  assert.equal(r.label, 'Christmas songs');
+  assert.equal(r.field, 'genre');
+  assert.deepEqual(r.values, ['Christmas']);
+  assert.equal(r.season, null, 'no season = always blocking');
+  assert.deepEqual(r.showIds, [], 'no scope = station-wide');
+});
+
+test('label is required, trimmed and capped', () => {
+  assert.equal(blockRuleSchema.parse(rule({ label: '  Xmas  ' })).label, 'Xmas');
+  assert.equal(blockRuleSchema.safeParse(rule({ label: '' })).success, false);
+  assert.equal(blockRuleSchema.safeParse(rule({ label: '   ' })).success, false);
+  assert.equal(
+    blockRuleSchema.safeParse(rule({ label: 'x'.repeat(RULE_TEXT_MAX + 1) })).success,
+    false,
+  );
+});
+
+test('field must name a real attribute', () => {
+  for (const f of RULE_FIELDS) {
+    assert.equal(blockRuleSchema.safeParse(rule({ field: f })).success, true);
+  }
+  assert.equal(blockRuleSchema.safeParse(rule({ field: 'bpm' })).success, false);
+  assert.match(
+    blockRuleSchema.safeParse(rule({ field: 'bpm' })).error!.issues[0].message,
+    /^rule\.field must be one of: /,
+  );
+});
+
+test('values: blanks drop, duplicates collapse, non-strings REFUSE', () => {
+  // The asymmetry is deliberate. A blank or repeated value describes the same
+  // rule; a non-string means the operator typed something that is not a value,
+  // and silently discarding it would block LESS than the card shows.
+  const r = blockRuleSchema.parse(rule({ values: ['Christmas', '  ', 'christmas', 'Xmas'] }));
+  assert.deepEqual(r.values, ['Christmas', 'Xmas'], 'dedupe is case-insensitive, casing kept');
+  assert.equal(blockRuleSchema.safeParse(rule({ values: ['ok', 42] })).success, false);
+  assert.equal(blockRuleSchema.safeParse(rule({ values: [] })).success, false);
+  assert.equal(blockRuleSchema.safeParse(rule({ values: ['   '] })).success, false);
+  assert.equal(blockRuleSchema.safeParse(rule({ values: 'Christmas' })).success, false);
+  assert.equal(
+    blockRuleSchema.safeParse(rule({ values: ['x'.repeat(RULE_TEXT_MAX + 1)] })).success,
+    false,
+  );
+  assert.equal(
+    blockRuleSchema.safeParse(
+      rule({ values: Array.from({ length: RULE_VALUES_MAX + 1 }, (_, i) => `v${i}`) }),
+    ).success,
+    false,
+  );
+});
+
+test('normText is what dedupe compares on', () => {
+  assert.equal(normText('  Deep   House '), 'deep house');
+  assert.equal(normText(null), '');
+});
+
+test('a season window may WRAP the year end', () => {
+  // Unlike a show's era window, from > to is the feature (Dec 1 → Jan 6), not a
+  // backwards range to refuse.
+  const r = blockRuleSchema.parse(
+    rule({ season: { from: { month: 12, day: 1 }, to: { month: 1, day: 6 } } }),
+  );
+  assert.deepEqual(r.season, { from: { month: 12, day: 1 }, to: { month: 1, day: 6 } });
+});
+
+test('season months and days are range-checked, and numeric strings pass', () => {
+  const withSeason = (from: unknown, to: unknown) => blockRuleSchema.safeParse(rule({ season: { from, to } }));
+  // <input type=number> posts strings; Number() has always accepted them.
+  assert.equal(withSeason({ month: '12', day: '1' }, { month: '1', day: '6' }).success, true);
+  assert.equal(withSeason({ month: 13, day: 1 }, { month: 1, day: 6 }).success, false);
+  assert.equal(withSeason({ month: 0, day: 1 }, { month: 1, day: 6 }).success, false);
+  assert.equal(withSeason({ month: 1, day: 32 }, { month: 1, day: 6 }).success, false);
+  assert.equal(withSeason({ month: 1, day: 1.5 }, { month: 1, day: 6 }).success, false);
+  assert.match(
+    withSeason({ month: 13, day: 1 }, { month: 1, day: 6 }).error!.issues[0].message,
+    /^rule\.season\.from\.month must be 1-12$/,
+  );
+});
+
+test('showIds drops junk rather than refusing (stale ids are inert by design)', () => {
+  const r = blockRuleSchema.parse(rule({ showIds: ['s_a', '', 's_a', 42, null, 's_b'] }));
+  assert.deepEqual(r.showIds, ['s_a', 's_b']);
+  assert.deepEqual(blockRuleSchema.parse(rule({ showIds: null })).showIds, []);
+  assert.equal(blockRuleSchema.safeParse(rule({ showIds: 's_a' })).success, false);
+});
+
+test('a client-sent id or addedAt is STRIPPED, not honoured', () => {
+  // Both are store-owned. z.object drops them before the store ever sees them.
+  const r = blockRuleSchema.parse(rule({ id: 'r_forged', addedAt: '1999-01-01' })) as Record<string, unknown>;
+  assert.equal('id' in r, false);
+  assert.equal('addedAt' in r, false);
+});
+
+// --- the store chokepoint and the route agree -------------------------------
+
+test('validateRulePatch is the schema, and throws a readable single line', () => {
+  assert.deepEqual(rules.validateRulePatch(rule()), blockRuleSchema.parse(rule()));
+  assert.throws(() => rules.validateRulePatch(rule({ label: '' })), /^Error: rule\.label is required$/);
+  assert.throws(() => rules.validateRulePatch(null), /rule must be an object/);
+  assert.throws(() => rules.validateRulePatch('nope'), /rule must be an object/);
+  try {
+    rules.validateRulePatch(rule({ values: [] }));
+    assert.fail('expected a throw');
+  } catch (err) {
+    assert.equal((err as Error).message.includes('\n'), false);
+  }
+});
+
+test('blocklist-rules re-exports the schema constants rather than restating them', () => {
+  assert.equal(rules.RULE_TEXT_MAX, RULE_TEXT_MAX);
+  assert.equal(rules.RULE_VALUES_MAX, RULE_VALUES_MAX);
+  assert.equal(rules.normText, normText);
+  assert.deepEqual([...rules.RULE_FIELDS], [...RULE_FIELDS]);
+});
+
+// A minimal express-ish harness: run the middleware and capture what it wrote.
+function runMiddleware(mw: ReturnType<typeof validateBody>, body: unknown) {
+  let status = 0;
+  let payload: { error: string; fieldErrors: Record<string, string> } | null = null;
+  let nexted = false;
+  const req = { body } as never;
+  const res = {
+    status(code: number) {
+      status = code;
+      return this;
+    },
+    json(p: unknown) {
+      payload = p as typeof payload;
+      return this;
+    },
+  } as never;
+  mw(req, res, () => {
+    nexted = true;
+  });
+  return { status, payload, nexted, req: req as unknown as { body: unknown } };
+}
+
+test('the route reports the message VERBATIM, with no doubled location', () => {
+  const mw = validateBody(blockRuleSchema, { messages: 'verbatim' });
+  const { status, payload } = runMiddleware(mw, rule({ label: '' }));
+  assert.equal(status, 400);
+  assert.equal(payload!.error, 'rule.label is required', 'not "label: rule.label is required"');
+  // fieldErrors still carries the dotted path — that is where a form needs it.
+  assert.equal(payload!.fieldErrors.label, 'rule.label is required');
+});
+
+test('the default prefixed posture is unchanged for everyone else', () => {
+  const { payload } = runMiddleware(validateBody(blockRuleSchema), rule({ label: '' }));
+  assert.equal(payload!.error, 'label: rule.label is required');
+});
+
+test('the route and the store name the same failure for the same body', () => {
+  const bad = rule({ values: ['x'.repeat(RULE_TEXT_MAX + 1)] });
+  const { payload } = runMiddleware(validateBody(blockRuleSchema, { messages: 'verbatim' }), bad);
+  let storeError = '';
+  try {
+    rules.validateRulePatch(bad);
+  } catch (err) {
+    storeError = (err as Error).message;
+  }
+  assert.equal(payload!.error, storeError);
+});
+
+test('a valid body is normalised in place for the handler', () => {
+  const mw = validateBody(blockRuleSchema, { messages: 'verbatim' });
+  const { nexted, req } = runMiddleware(mw, rule({ label: '  Xmas  ', values: ['A', 'a'] }));
+  assert.equal(nexted, true);
+  assert.deepEqual(req.body, {
+    label: 'Xmas',
+    field: 'genre',
+    values: ['A'],
+    season: null,
+    showIds: [],
+  });
+});
+
+// --- the id-entry body ------------------------------------------------------
+
+test('the entry body accepts both accepted forms and pins the type vocabulary', () => {
+  for (const t of BLOCK_TYPES) {
+    assert.equal(blockEntrySchema.safeParse({ type: t, trackId: 't1' }).success, true);
+  }
+  assert.equal(blockEntrySchema.safeParse({ type: 'playlist', trackId: 't1' }).success, false);
+  assert.equal(
+    blockEntrySchema.safeParse({ type: 'nope' }).error!.issues[0].message,
+    "type must be 'track', 'album' or 'artist'",
+  );
+  // The pre-resolved form.
+  const direct = blockEntrySchema.parse({ type: 'artist', id: 'ar1', name: 'Nick Drake' });
+  assert.equal(direct.id, 'ar1');
+  assert.equal(direct.name, 'Nick Drake');
+  // A null snapshot is MEANINGFUL ("unknown") and survives.
+  assert.equal(blockEntrySchema.parse({ type: 'track', id: 't1', name: null }).name, null);
+  // Blank ids read as absent, so the handler's "trackId or id is required"
+  // check still owns that answer (it knows which form was intended).
+  assert.equal(blockEntrySchema.parse({ type: 'track', trackId: '' }).trackId, undefined);
+});
+
+// --- manual tagging ---------------------------------------------------------
+
+const MOODS = ['calm', 'upbeat', 'melancholy', 'driving'];
+const tagBody = (o: Record<string, unknown> = {}) => ({ id: 't1', moods: ['calm'], ...o });
+
+test('a manual tag needs a real id and at most three known moods', () => {
+  const schema = manualTagSchema({ moodNames: MOODS });
+  assert.equal(schema.parse(tagBody()).id, 't1');
+  assert.equal(schema.safeParse(tagBody({ id: '' })).success, false);
+  assert.equal(schema.safeParse(tagBody({ id: 42 })).success, false);
+  assert.match(schema.safeParse(tagBody({ id: '' })).error!.issues[0].message, /^id is required$/);
+  assert.equal(
+    schema.safeParse(tagBody({ moods: MOODS.slice(0, MANUAL_TAG_MOODS_MAX + 1) })).success,
+    false,
+  );
+  assert.equal(schema.safeParse(tagBody({ moods: ['nonsense'] })).success, false);
+  assert.match(
+    schema.safeParse(tagBody({ moods: ['nonsense'] })).error!.issues[0].message,
+    /^unknown mood\(s\): nonsense$/,
+  );
+  assert.equal(schema.safeParse(tagBody({ moods: 'calm' })).success, false);
+  assert.equal(schema.safeParse(tagBody({ moods: [1] })).success, false);
+});
+
+test('an EMPTY moods array is a legal request — it clears the track', () => {
+  const schema = manualTagSchema({ moodNames: MOODS });
+  assert.deepEqual(schema.parse(tagBody({ moods: [] })).moods, []);
+  // …but an OMITTED moods key is not the same request, and is refused.
+  assert.equal(schema.safeParse({ id: 't1' }).success, false);
+});
+
+test('moodNames: null validates SHAPE only — the browser posture', () => {
+  const shapeOnly = manualTagSchema({ moodNames: null });
+  assert.equal(shapeOnly.safeParse(tagBody({ moods: ['not-a-mood'] })).success, true);
+  // The caps and types still apply; only membership is skipped.
+  assert.equal(shapeOnly.safeParse(tagBody({ moods: ['a', 'b', 'c', 'd'] })).success, false);
+});
+
+test('energy accepts the three bands or null, and defaults to null', () => {
+  const schema = manualTagSchema({ moodNames: MOODS });
+  for (const e of MANUAL_TAG_ENERGIES) {
+    assert.equal(schema.parse(tagBody({ energy: e })).energy, e);
+  }
+  assert.equal(schema.parse(tagBody()).energy, null, 'omitted reads as null');
+  assert.equal(schema.parse(tagBody({ energy: null })).energy, null);
+  assert.equal(schema.safeParse(tagBody({ energy: 'blazing' })).success, false);
+  assert.match(
+    schema.safeParse(tagBody({ energy: 'blazing' })).error!.issues[0].message,
+    /^energy must be 'low', 'medium', 'high' or null$/,
+  );
+});
+
+test('applyToAlbum is === true, so a truthy non-boolean reads as off', () => {
+  const schema = manualTagSchema({ moodNames: MOODS });
+  assert.equal(schema.parse(tagBody({ applyToAlbum: true })).applyToAlbum, true);
+  assert.equal(schema.parse(tagBody({ applyToAlbum: 1 })).applyToAlbum, false);
+  assert.equal(schema.parse(tagBody({ applyToAlbum: 'yes' })).applyToAlbum, false);
+  assert.equal(schema.parse(tagBody()).applyToAlbum, false);
+});

--- a/controller/scripts/persona-schema.test.ts
+++ b/controller/scripts/persona-schema.test.ts
@@ -1,0 +1,574 @@
+// Personas + the DJ prompt library moved onto a shared zod schema
+// (controller/src/schemas/persona.ts), mirrored into
+// web/lib/schemas.generated.ts. These tests pin the three things that have to
+// agree afterwards: the schema itself, the strict update() chokepoint
+// (validatePersonasStrict / validateDjPromptsStrict / validateTtsBlock), and the
+// lenient load path (normalizePersonaArray / normalizeDjPrompts / normalizeTts).
+//
+// The conversion's stated contract is ZERO behaviour change, so most of what is
+// pinned here is accidental leniency the obvious conversion would have removed:
+// String() coercion on name/soul/tagline, an absent key reading as a default
+// rather than as a refusal, and a malformed skills entry being DROPPED while a
+// malformed language is REFUSED.
+//
+// Run: npx tsx scripts/persona-schema.test.ts (auto-discovered by npm test).
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+process.env.STATE_DIR = mkdtempSync(join(tmpdir(), 'subwave-persona-schema-'));
+
+const {
+  DJ_PROMPT_LIMIT,
+  DJ_PROMPT_NAME_MAX,
+  DJ_PROMPT_TEXT_MAX,
+  DJ_PROMPT_TEXT_MIN,
+  PERSONA_AVATAR_FILENAME_RE,
+  PERSONA_DIAL_NEUTRAL,
+  PERSONA_FREQUENCIES,
+  PERSONA_ID_RE,
+  PERSONA_LIMIT,
+  PERSONA_NAME_MAX,
+  PERSONA_SCRIPT_LENGTHS,
+  PERSONA_SKILLS_LIMIT,
+  PERSONA_SKILL_SLUG_RE,
+  PERSONA_SOUL_MAX,
+  TTS_CLOUD_PROVIDERS,
+  TTS_ENGINES,
+  clampPersonaDial,
+  clampTtsGain,
+  clampTtsSpeed,
+  djPromptsSchema,
+  personaSchema,
+  personasSchema,
+  repairPersonaForLoad,
+  repairTtsVoiceSlot,
+  ttsVoiceSlotSchema,
+} = await import('../src/schemas/persona.js');
+
+const { resolveDjPromptIds, resolvePersonaIds } = await import('../src/schemas/persona-server.js');
+const validate = await import('../src/settings/validate.js');
+const normalize = await import('../src/settings/normalize.js');
+const vocab = await import('../src/settings/vocab.js');
+
+// A minimal persona every test starts from — the shape the admin editor posts.
+const base = () => ({
+  name: 'Nova',
+  soul: 'warm and dry',
+  frequency: 'moderate',
+  tts: { engine: 'piper', cloudProvider: 'openai', voice: '' },
+});
+
+// ── the shared constants are one definition, not a hand-copied pair ──────────
+//
+// schemas/persona.ts may import nothing but zod, so two regexes it needs are
+// necessarily re-declared rather than imported (the flat mirror also forbids
+// reusing the ORIGINAL name). That duplication is structural; this is the guard
+// that stops it drifting — the same answer skill-schema.test.ts gives for
+// loader.SLUG_RE.
+
+test('PERSONA_ID_RE is the same pattern as the show schema owns', async () => {
+  const { SHOW_ID_RE } = await import('../src/schemas/show.js');
+  assert.equal(PERSONA_ID_RE.source, SHOW_ID_RE.source);
+  assert.equal(PERSONA_ID_RE.flags, SHOW_ID_RE.flags);
+});
+
+test('PERSONA_SKILL_SLUG_RE is the same pattern as the skill schema owns', async () => {
+  const { SKILL_SLUG_RE } = await import('../src/schemas/skill.js');
+  assert.equal(PERSONA_SKILL_SLUG_RE.source, SKILL_SLUG_RE.source);
+  assert.equal(PERSONA_SKILL_SLUG_RE.flags, SKILL_SLUG_RE.flags);
+});
+
+test('settings/vocab.ts ALIASES the schema constants rather than restating them', () => {
+  // Identity, not equality: a re-declared literal would still pass a value
+  // comparison on the day it was copied and fail silently a year later.
+  assert.equal(vocab.PERSONA_LIMIT, PERSONA_LIMIT);
+  assert.equal(vocab.SOUL_MAX, PERSONA_SOUL_MAX);
+  assert.equal(vocab.SKILLS_PER_PERSONA_LIMIT, PERSONA_SKILLS_LIMIT);
+  assert.equal(vocab.DIAL_NEUTRAL, PERSONA_DIAL_NEUTRAL);
+  assert.equal(vocab.DJ_PROMPT_LIMIT, DJ_PROMPT_LIMIT);
+  assert.equal(vocab.DJ_PROMPT_NAME_MAX, DJ_PROMPT_NAME_MAX);
+  assert.equal(vocab.DJ_PROMPT_TEXT_MIN, DJ_PROMPT_TEXT_MIN);
+  assert.equal(vocab.DJ_PROMPT_TEXT_MAX, DJ_PROMPT_TEXT_MAX);
+  assert.equal(vocab.AVATAR_FILENAME_RE, PERSONA_AVATAR_FILENAME_RE);
+  assert.equal(vocab.normalizeDial, clampPersonaDial);
+  assert.equal(vocab.clampTtsGain, clampTtsGain);
+  assert.equal(vocab.clampTtsSpeed, clampTtsSpeed);
+  assert.deepEqual([...vocab.FREQUENCIES], [...PERSONA_FREQUENCIES]);
+  assert.deepEqual([...vocab.SCRIPT_LENGTHS], [...PERSONA_SCRIPT_LENGTHS]);
+  assert.deepEqual([...vocab.TTS_ENGINES], [...TTS_ENGINES]);
+  assert.deepEqual([...vocab.TTS_CLOUD_PROVIDERS], [...TTS_CLOUD_PROVIDERS]);
+});
+
+// ── persona: the fields ──────────────────────────────────────────────────────
+
+test('a minimal persona parses and fills every default', () => {
+  const p = personaSchema.parse(base());
+  assert.equal(p.name, 'Nova');
+  assert.equal(p.tagline, '');
+  assert.equal(p.language, '');
+  assert.equal(p.scriptLength, 'concise');
+  assert.equal(p.djMode, false);
+  assert.equal(p.avatar, '');
+  assert.equal(p.skills, null);
+  assert.equal(p.humour, PERSONA_DIAL_NEUTRAL);
+  assert.equal(p.localColour, PERSONA_DIAL_NEUTRAL);
+  assert.equal(p.warmth, PERSONA_DIAL_NEUTRAL);
+  assert.equal(p.id, undefined, 'id is minted by the server-only sibling, not the schema');
+});
+
+test('name/soul/tagline COERCE rather than refuse a non-string (unchanged)', () => {
+  // String(x ?? '').trim() is what the hand-rolled validator did, so a persona
+  // named 123 has always saved. Refusing it now would be a tightening.
+  const p = personaSchema.parse({ ...base(), name: 123, tagline: 7 });
+  assert.equal(p.name, '123');
+  assert.equal(p.tagline, '7');
+});
+
+test('name/soul are trimmed and length-bounded', () => {
+  assert.equal(personaSchema.parse({ ...base(), name: '  Nova  ' }).name, 'Nova');
+  assert.equal(personaSchema.safeParse({ ...base(), name: '' }).success, false);
+  assert.equal(personaSchema.safeParse({ ...base(), name: '   ' }).success, false);
+  assert.equal(
+    personaSchema.safeParse({ ...base(), name: 'x'.repeat(PERSONA_NAME_MAX + 1) }).success,
+    false,
+  );
+  assert.equal(personaSchema.safeParse({ ...base(), soul: '' }).success, false);
+  assert.equal(
+    personaSchema.safeParse({ ...base(), soul: 'x'.repeat(PERSONA_SOUL_MAX + 1) }).success,
+    false,
+  );
+});
+
+test('an ABSENT optional key reads as its default, not as a refusal', () => {
+  // zod 4 treats a bare z.unknown() inside z.object as a REQUIRED key, so every
+  // coerced field carries .optional(). Without it a persona that merely omits
+  // `tagline` fails — which no persona ever written by this codebase has to do.
+  const { tagline: _t, ...noTagline } = { ...base(), tagline: 'x' };
+  assert.equal(personaSchema.parse(noTagline).tagline, '');
+  assert.equal(personaSchema.parse(base()).humour, PERSONA_DIAL_NEUTRAL);
+});
+
+test('explicit null reads as absent on every optional field', () => {
+  const p = personaSchema.parse({
+    ...base(),
+    tagline: null,
+    language: null,
+    scriptLength: null,
+    djMode: null,
+    avatar: null,
+    skills: null,
+  });
+  assert.equal(p.tagline, '');
+  assert.equal(p.language, '');
+  assert.equal(p.scriptLength, 'concise');
+  assert.equal(p.djMode, false);
+  assert.equal(p.avatar, '');
+  assert.equal(p.skills, null);
+});
+
+test('language REFUSES a non-string where name COERCES one', () => {
+  // Not an inconsistency to tidy up: the hand-rolled validator drew the line
+  // exactly here, and both directions are load-bearing behaviour.
+  assert.equal(personaSchema.safeParse({ ...base(), language: 42 }).success, false);
+  assert.equal(personaSchema.parse({ ...base(), language: '  Turkish  ' }).language, 'Turkish');
+});
+
+test('frequency must name a real frequency; scriptLength defaults but is checked', () => {
+  assert.equal(personaSchema.safeParse({ ...base(), frequency: 'loud' }).success, false);
+  assert.equal(personaSchema.safeParse({ ...base(), frequency: undefined }).success, false);
+  for (const f of PERSONA_FREQUENCIES) {
+    assert.equal(personaSchema.safeParse({ ...base(), frequency: f }).success, true);
+  }
+  assert.equal(personaSchema.safeParse({ ...base(), scriptLength: 'epic' }).success, false);
+});
+
+test('djMode REFUSES a truthy non-boolean (unchanged)', () => {
+  // Unlike a show's booleans — which both paths read as `=== true` — the strict
+  // persona validator has always refused a non-boolean here.
+  assert.equal(personaSchema.safeParse({ ...base(), djMode: 1 }).success, false);
+  assert.equal(personaSchema.safeParse({ ...base(), djMode: 'yes' }).success, false);
+  assert.equal(personaSchema.parse({ ...base(), djMode: true }).djMode, true);
+});
+
+test('dials clamp anything to 0-10 and never fail a save', () => {
+  const p = personaSchema.parse({ ...base(), humour: 99, localColour: -4, warmth: 'nonsense' });
+  assert.equal(p.humour, 10);
+  assert.equal(p.localColour, 0);
+  assert.equal(p.warmth, PERSONA_DIAL_NEUTRAL);
+  assert.equal(personaSchema.parse({ ...base(), humour: 6.6 }).humour, 7, 'rounds');
+});
+
+test('avatar must be a bare basename, and an empty one is not a refusal', () => {
+  assert.equal(personaSchema.parse({ ...base(), avatar: '' }).avatar, '');
+  assert.equal(personaSchema.parse({ ...base(), avatar: 'p_abc123.png' }).avatar, 'p_abc123.png');
+  for (const bad of ['../etc/passwd.png', '/abs/p_a.png', 'p_a.exe', 'p_a.png.exe', 'AB.png']) {
+    assert.equal(
+      personaSchema.safeParse({ ...base(), avatar: bad }).success,
+      false,
+      `avatar should refuse ${bad}`,
+    );
+  }
+});
+
+test('a malformed skills entry is DROPPED, but an over-cap list is REFUSED', () => {
+  // The asymmetry is deliberate (#917): an entry that cannot name a skill can
+  // never fire, so failing the whole roster over inert junk costs the operator
+  // everything and saves nothing. A list longer than the cap is a different
+  // claim about the data and stays a refusal.
+  const p = personaSchema.parse({
+    ...base(),
+    skills: ['news', '-bad', 'news', 'weather', 'A_B', null, { x: 1 }],
+  });
+  assert.deepEqual(p.skills, ['news', 'weather'], 'junk dropped, order kept, deduped');
+  // A numeric entry survives, because String(42) is '42' and a slug may be all
+  // digits — the hand-rolled validator coerced identically. Pinned so nobody
+  // "fixes" it into a z.string() and starts dropping a legal slug.
+  assert.deepEqual(personaSchema.parse({ ...base(), skills: [42] }).skills, ['42']);
+  assert.equal(personaSchema.safeParse({ ...base(), skills: 'news' }).success, false);
+  assert.equal(
+    personaSchema.safeParse({ ...base(), skills: new Array(PERSONA_SKILLS_LIMIT + 1).fill('news') })
+      .success,
+    false,
+  );
+  assert.deepEqual(personaSchema.parse({ ...base(), skills: [] }).skills, []);
+});
+
+test('a malformed id is re-minted, not refused', () => {
+  // Same call the shows conversion made, for a stronger reason: a persona id is
+  // what every show, guest list and activePersonaId points at.
+  assert.equal(personaSchema.parse({ ...base(), id: 'NOT VALID' }).id, undefined);
+  assert.equal(personaSchema.parse({ ...base(), id: 'p_abc123' }).id, 'p_abc123');
+});
+
+// ── the TTS voice slot ───────────────────────────────────────────────────────
+
+test('the voice slot bakes its own path into the message', () => {
+  // Both call sites read this as a flat toast string, so 'tts.fallback' has to
+  // survive in the text rather than being derived from a zod path.
+  const r = ttsVoiceSlotSchema('tts.fallback').safeParse({ engine: 'nope' });
+  assert.equal(r.success, false);
+  assert.match(r.error!.issues[0].message, /^tts\.fallback\.engine must be one of: /);
+});
+
+test('the voice slot reports engine BEFORE voice', () => {
+  // Engine decides which voice rule applies, so a voice complaint about a rule
+  // the operator never opted into is worse than useless.
+  const r = ttsVoiceSlotSchema('tts').safeParse({ engine: 'bogus', voice: 'also-bogus' });
+  assert.match(r.error!.issues[0].message, /\.engine must be one of/);
+});
+
+test('per-engine voice rules are unchanged', () => {
+  const ok = (raw: unknown) => ttsVoiceSlotSchema('tts').safeParse(raw).success;
+  const slot = (o: Record<string, unknown>) => ({ cloudProvider: 'openai', ...o });
+
+  // kokoro demands a <lang><gender>_<name> id — empty is NOT allowed.
+  assert.equal(ok(slot({ engine: 'kokoro', voice: 'bf_isabella' })), true);
+  assert.equal(ok(slot({ engine: 'kokoro', voice: '' })), false);
+  // chatterbox: empty = built-in default, else a bare .wav.
+  assert.equal(ok(slot({ engine: 'chatterbox', voice: '' })), true);
+  assert.equal(ok(slot({ engine: 'chatterbox', voice: 'ref.wav' })), true);
+  assert.equal(ok(slot({ engine: 'chatterbox', voice: 'a/b.wav' })), false);
+  // pocket-tts: empty becomes 'alba'; a built-in id or a .wav both pass.
+  assert.equal(
+    ttsVoiceSlotSchema('tts').parse(slot({ engine: 'pocket-tts', voice: '' })).voice,
+    'alba',
+  );
+  assert.equal(ok(slot({ engine: 'pocket-tts', voice: 'clone.wav' })), true);
+  // cloud: openai-compatible may be empty, the others may not.
+  assert.equal(ok({ engine: 'cloud', cloudProvider: 'openai-compatible', voice: '' }), true);
+  assert.equal(ok({ engine: 'cloud', cloudProvider: 'openai', voice: '' }), false);
+  assert.equal(ok({ engine: 'cloud', cloudProvider: 'openai', voice: 'alloy' }), true);
+  // remote: server-specific, empty is fine.
+  assert.equal(ok(slot({ engine: 'remote', voice: '' })), true);
+  // piper: empty, an .onnx, OR a kokoro-shaped id (#454 — the seed roster).
+  assert.equal(ok(slot({ engine: 'piper', voice: '' })), true);
+  assert.equal(ok(slot({ engine: 'piper', voice: 'en_GB-alba.onnx' })), true);
+  assert.equal(ok(slot({ engine: 'piper', voice: 'bf_isabella' })), true);
+  assert.equal(ok(slot({ engine: 'piper', voice: 'whatever' })), false);
+});
+
+test('gain and speed clamp rather than refuse, and treat unset differently', () => {
+  const p = ttsVoiceSlotSchema('tts').parse({
+    engine: 'piper',
+    cloudProvider: 'openai',
+    voice: '',
+    gainDb: 99,
+    speed: 99,
+  });
+  assert.equal(p.gainDb, 12);
+  assert.equal(p.speed, 2);
+  // Unset gain is 0 (unity); unset speed is 1.0 (unity) — NOT 0, which would
+  // clamp to the 0.5 floor and slow every voice down.
+  const q = ttsVoiceSlotSchema('tts').parse({ engine: 'piper', cloudProvider: 'openai' });
+  assert.equal(q.gainDb, 0);
+  assert.equal(q.speed, 1);
+  assert.equal(clampTtsSpeed(''), 1);
+  assert.equal(clampTtsGain('nonsense'), 0);
+});
+
+test('repairTtsVoiceSlot always produces something the strict slot accepts', () => {
+  const hostile: unknown[] = [
+    undefined,
+    null,
+    'not an object',
+    { engine: 'bogus' },
+    { engine: 'kokoro', voice: 'nope' },
+    { engine: 'cloud', cloudProvider: 'openai', voice: '' },
+    { engine: 'cloud', cloudProvider: 'openai-compatible', voice: '' },
+    { engine: 'pocket-tts', voice: '???' },
+    { engine: 'piper', voice: 'a/b.onnx' },
+    { engine: 'chatterbox', voice: 'x'.repeat(500) },
+    { engine: 'remote', voice: 'x'.repeat(500) },
+  ];
+  for (const raw of hostile) {
+    const repaired = repairTtsVoiceSlot(raw);
+    const r = ttsVoiceSlotSchema('tts').safeParse(repaired);
+    assert.equal(r.success, true, `repair of ${JSON.stringify(raw)} should be schema-valid`);
+  }
+});
+
+test('a kokoro-shaped voice under piper SURVIVES the repair (#454)', () => {
+  // The seed roster carries one per persona so switching to Kokoro yields
+  // distinct voices with no re-editing. Wiping it here broke that on the first
+  // reload after a save.
+  assert.equal(repairTtsVoiceSlot({ engine: 'piper', voice: 'bf_isabella' }).voice, 'bf_isabella');
+});
+
+// ── strict vs lenient ────────────────────────────────────────────────────────
+
+test('validatePersonasStrict throws a readable line, never a ZodError blob', () => {
+  try {
+    validate.validatePersonasStrict([{ ...base(), name: '' }]);
+    assert.fail('expected a throw');
+  } catch (err) {
+    const msg = (err as Error).message;
+    assert.equal(msg.includes('\n'), false, 'must be one line, not a JSON dump');
+    assert.match(msg, /^personas\.0\.name: /, 'names the row and the field');
+  }
+});
+
+test('validatePersonasStrict enforces the roster bounds', () => {
+  assert.throws(() => validate.validatePersonasStrict([]), /1-48/);
+  assert.throws(() => validate.validatePersonasStrict('nope'), /1-48/);
+  assert.throws(
+    () => validate.validatePersonasStrict(new Array(PERSONA_LIMIT + 1).fill(base())),
+    /1-48/,
+  );
+});
+
+test('validatePersonasStrict mints ids and de-duplicates them', () => {
+  const out = validate.validatePersonasStrict([
+    { ...base(), id: 'p_same' },
+    { ...base(), id: 'p_same' },
+    { ...base() },
+  ]);
+  assert.equal(out[0].id, 'p_same');
+  assert.notEqual(out[1].id, 'p_same', 'a collision is re-minted');
+  assert.match(out[2].id, /^p_/);
+  assert.equal(new Set(out.map((p) => p.id)).size, 3);
+});
+
+test('the LENIENT path drops a row where the strict one throws', () => {
+  const raw = [
+    { ...base(), name: '' }, // unsalvageable — no name
+    { ...base(), name: 'Kept', frequency: 'loud', tts: { engine: 'bogus' } }, // repairable
+  ];
+  assert.throws(() => validate.validatePersonasStrict(raw));
+  const out = normalize.normalizePersonaArray(raw)!;
+  assert.equal(out.length, 1);
+  assert.equal(out[0].name, 'Kept');
+  assert.equal(out[0].frequency, 'moderate', 'an unknown frequency is repaired, not fatal');
+  assert.equal(out[0].tts.engine, 'piper', 'an unknown engine is repaired, not fatal');
+});
+
+test('the lenient path truncates where the strict one refuses', () => {
+  const long = { ...base(), name: 'x'.repeat(PERSONA_NAME_MAX + 20) };
+  assert.throws(() => validate.validatePersonasStrict([long]));
+  assert.equal(normalize.normalizePersonaArray([long])![0].name.length, PERSONA_NAME_MAX);
+});
+
+test('the lenient path caps the roster instead of refusing it', () => {
+  const many = new Array(PERSONA_LIMIT + 5).fill(null).map((_, i) => ({ ...base(), name: `P${i}` }));
+  assert.throws(() => validate.validatePersonasStrict(many));
+  assert.equal(normalize.normalizePersonaArray(many)!.length, PERSONA_LIMIT);
+});
+
+test('an empty or non-array roster loads as null so the seed roster applies', () => {
+  assert.equal(normalize.normalizePersonaArray([]), null);
+  assert.equal(normalize.normalizePersonaArray('nope'), null);
+  assert.equal(normalize.normalizePersonaArray([{ name: '' }]), null);
+});
+
+test('the lenient path applies the skill RENAMES the strict path never did', () => {
+  // A rename is a migration of stored data, not a rule a submitted value has to
+  // satisfy — which is why it lives in the repair and not in the schema.
+  const out = normalize.normalizePersonaArray([{ ...base(), skills: ['random-facts'] }])!;
+  assert.deepEqual(out[0].skills, ['curiosity']);
+  assert.deepEqual(
+    validate.validatePersonasStrict([{ ...base(), skills: ['random-facts'] }])[0].skills,
+    ['random-facts'],
+  );
+});
+
+test('repairPersonaForLoad output always parses when name and soul survive', () => {
+  const hostile: Record<string, unknown>[] = [
+    { name: 'A', soul: 'B' },
+    { name: 'A', soul: 'B', frequency: 'nope', scriptLength: 'nope', djMode: 'yes' },
+    { name: 'A', soul: 'B', avatar: '../escape.png', language: 42, tagline: 99 },
+    { name: 'A', soul: 'B', skills: 'not-an-array', id: 'NOT VALID', humour: 'x' },
+    { name: '  A  ', soul: 'B', tts: { engine: 'bogus', voice: 'bogus' } },
+  ];
+  for (const raw of hostile) {
+    const r = personaSchema.safeParse(repairPersonaForLoad(raw, {}));
+    assert.equal(r.success, true, `repair of ${JSON.stringify(raw)} should be schema-valid`);
+  }
+});
+
+test('normalizeTts is the schema-backed repair, not a second implementation', () => {
+  assert.equal(normalize.normalizeTts, repairTtsVoiceSlot);
+});
+
+test('normalizeTtsFallback keeps enabled and drops the level trims', () => {
+  const f = normalize.normalizeTtsFallback({ engine: 'kokoro', voice: 'bf_isabella', gainDb: 6 });
+  assert.deepEqual(f, {
+    enabled: false,
+    engine: 'kokoro',
+    voice: 'bf_isabella',
+    cloudProvider: 'openai',
+  });
+  assert.equal(normalize.normalizeTtsFallback({ enabled: true }).enabled, true);
+  assert.equal(normalize.normalizeTtsFallback(undefined).enabled, false);
+});
+
+test('validateTtsBlock takes the message VERBATIM (no doubled path)', () => {
+  assert.throws(
+    () => validate.validateTtsBlock({ engine: 'nope' }, 'tts.fallback'),
+    (err: Error) => {
+      assert.match(err.message, /^tts\.fallback\.engine must be one of: /);
+      return true;
+    },
+  );
+});
+
+// ── the DJ prompt library ────────────────────────────────────────────────────
+
+const promptText = (extra = '') => `You are {name}, on air. ${'x'.repeat(DJ_PROMPT_TEXT_MIN)}${extra}`;
+
+test('a prompt needs a name, a bounded text, and the {name} placeholder', () => {
+  const ok = djPromptsSchema.parse([{ name: 'House', text: promptText() }]);
+  assert.equal(ok[0].name, 'House');
+  assert.equal(djPromptsSchema.safeParse([{ name: '', text: promptText() }]).success, false);
+  assert.equal(
+    djPromptsSchema.safeParse([{ name: 'x'.repeat(DJ_PROMPT_NAME_MAX + 1), text: promptText() }])
+      .success,
+    false,
+  );
+  assert.equal(djPromptsSchema.safeParse([{ name: 'H', text: 'too short' }]).success, false);
+  assert.equal(
+    djPromptsSchema.safeParse([{ name: 'H', text: 'x'.repeat(DJ_PROMPT_TEXT_MAX + 1) }]).success,
+    false,
+  );
+  assert.equal(
+    djPromptsSchema.safeParse([{ name: 'H', text: promptText().replace('{name}', 'Nova') }]).success,
+    false,
+    'a template without {name} would make dialogue anonymous',
+  );
+});
+
+test('the prompt library is bounded and an empty one is legal', () => {
+  assert.equal(djPromptsSchema.parse([]).length, 0);
+  assert.equal(
+    djPromptsSchema.safeParse(
+      new Array(DJ_PROMPT_LIMIT + 1).fill({ name: 'H', text: promptText() }),
+    ).success,
+    false,
+  );
+  assert.throws(() => validate.validateDjPromptsStrict('nope'), /0-20/);
+});
+
+test('validateDjPromptsStrict names the row and mints dp_ ids', () => {
+  try {
+    validate.validateDjPromptsStrict([{ name: 'H', text: 'short' }]);
+    assert.fail('expected a throw');
+  } catch (err) {
+    assert.match((err as Error).message, /^djPrompts\.0\.text: /);
+  }
+  const out = validate.validateDjPromptsStrict([
+    { name: 'A', text: promptText() },
+    { id: 'dp_dupe', name: 'B', text: promptText() },
+    { id: 'dp_dupe', name: 'C', text: promptText() },
+  ]);
+  assert.match(out[0].id, /^dp_/);
+  assert.equal(out[1].id, 'dp_dupe');
+  assert.notEqual(out[2].id, 'dp_dupe');
+});
+
+test('the lenient prompt path drops a bad text but INVENTS a missing name', () => {
+  // The text IS the entry; a name is recoverable, so losing the row over a
+  // missing one would throw away the only part the operator can't retype.
+  const out = normalize.normalizeDjPrompts([
+    { text: promptText() }, // no name
+    { name: 'Bad', text: 'too short' }, // unsalvageable
+    { name: '', text: promptText() }, // blank name
+  ]);
+  assert.equal(out.length, 2);
+  assert.equal(out[0].name, 'Prompt 1');
+  assert.equal(out[1].name, 'Prompt 2', 'the fallback numbers by SURVIVING row, not by input index');
+  assert.deepEqual(normalize.normalizeDjPrompts('nope'), []);
+});
+
+test('the lenient prompt path caps the library instead of refusing it', () => {
+  const many = new Array(DJ_PROMPT_LIMIT + 5).fill({ name: 'H', text: promptText() });
+  assert.throws(() => validate.validateDjPromptsStrict(many));
+  assert.equal(normalize.normalizeDjPrompts(many).length, DJ_PROMPT_LIMIT);
+});
+
+// ── the server-only sibling ──────────────────────────────────────────────────
+
+test('id resolution is shared by both paths and uses the right prefix', () => {
+  assert.match(resolvePersonaIds([{}])[0].id, /^p_/);
+  assert.match(resolveDjPromptIds([{}])[0].id, /^dp_/);
+  const kept = resolvePersonaIds([{ id: 'p_keep' }]);
+  assert.equal(kept[0].id, 'p_keep');
+});
+
+test('a roster that round-trips through the LOAD path keeps its ids', () => {
+  // The load path used to mint through a second hand-rolled copy of this rule.
+  // A persona whose id changes across a boot silently orphans its shows.
+  const stored = [
+    { ...base(), id: 'p_alpha', name: 'Alpha' },
+    { ...base(), id: 'p_beta', name: 'Beta' },
+  ];
+  assert.deepEqual(
+    normalize.normalizePersonaArray(stored)!.map((p) => p.id),
+    ['p_alpha', 'p_beta'],
+  );
+});
+
+// ── the strict and lenient paths agree about what is VALID ───────────────────
+
+test('anything the strict path accepts, the lenient path returns unchanged', () => {
+  const rich = {
+    id: 'p_rich',
+    name: 'Rich',
+    tagline: 'late nights',
+    frequency: 'chatty',
+    scriptLength: 'extended',
+    djMode: true,
+    humour: 8,
+    localColour: 2,
+    warmth: 7,
+    soul: 'dry and specific',
+    language: 'Turkish',
+    avatar: 'p_rich.webp',
+    tts: { engine: 'kokoro', cloudProvider: 'openai', voice: 'bf_isabella', gainDb: 1.5, speed: 1.1 },
+    skills: ['news', 'weather'],
+  };
+  const strict = validate.validatePersonasStrict([rich]);
+  const lenient = normalize.normalizePersonaArray([rich])!;
+  assert.deepEqual(strict, lenient);
+  assert.deepEqual(strict[0], rich, 'a fully-specified persona round-trips byte-for-byte');
+});

--- a/controller/scripts/settings-patch-schema.test.ts
+++ b/controller/scripts/settings-patch-schema.test.ts
@@ -23,6 +23,11 @@ const {
   BEDS_CROSS_SEC_BOUNDS,
   BEDS_THRESHOLD_SEC_BOUNDS,
   JINGLE_RATIO_BOUNDS,
+  activeDjPromptIdSchema,
+  djPromptTextSchema,
+  maxTrackSecondsSchema,
+  maxTrackSecondsValueSchema,
+  themePatchSchema,
   archivePatchSchema,
   audioPatchSchema,
   bedsPatchSchema,
@@ -597,12 +602,160 @@ test('the converted keys are exactly the ones with schemas', () => {
   // resists a stateless schema (clamps that fall back to the CURRENT value,
   // post-merge cross-field rules, write-throughs into another key).
   assert.deepEqual(Object.keys(SETTINGS_PATCH_SCHEMAS).sort(), [
-    'archive', 'audio', 'beds', 'crossfadeDuration', 'djHouseRules', 'festivals',
-    'jingleRatio', 'likes', 'locale', 'loudness', 'moodSchedule', 'moods',
-    'privacy', 'requests', 'scrobble', 'search', 'sfx', 'station',
-    'stationDescription', 'stream', 'timezone', 'transitions', 'ui', 'weather',
-    'weatherMoods', 'webhooksPolicy',
+    'activeDjPromptId', 'archive', 'audio', 'beds', 'crossfadeDuration',
+    'djHouseRules', 'djPrompt', 'djPrompts', 'festivals', 'jingleRatio', 'likes',
+    'locale', 'loudness', 'maxTrackSeconds', 'moodSchedule', 'moods', 'personas',
+    'privacy', 'requests', 'schedule', 'scheduleOverride', 'scrobble', 'search',
+    'sfx', 'shows', 'station', 'stationDescription', 'stream', 'theme',
+    'timezone', 'transitions', 'ui', 'weather', 'weatherMoods', 'webhooks',
+    'webhooksPolicy',
   ]);
+});
+
+test('the SIX unconverted keys are the ones CLAUDE.md documents as resistant', () => {
+  // Each resists for the same reason: the rule is a function of state the patch
+  // does not contain (a clamp that falls back to the CURRENT stored value, a
+  // cross-field rule read POST-merge, a write-through into another key, or an
+  // intentionally OPEN map). Plus two that are not "resistant" so much as
+  // deliberately left alone — see below.
+  const unconverted = SETTINGS_PATCH_KEYS.filter((k) => !(k in SETTINGS_PATCH_SCHEMAS));
+  assert.deepEqual([...unconverted].sort(), [
+    // No pure rule exists: the only check is membership in a roster the same
+    // patch may be replacing, so a schema would have nothing to say.
+    'activePersonaId',
+    'embedding',
+    'llm',
+    // The legacy alias, whose value is consulted ONLY when maxTrackSeconds is
+    // absent — a schema on it would refuse a body today's precedence ignores.
+    'maxTrackMinutes',
+    'skills',
+    'tts',
+  ]);
+});
+
+test('theme converts its SHAPE; the does-it-exist fallback stays in update()', () => {
+  assert.equal(themePatchSchema.parse({ active: '  midnight  ' }).active, 'midnight');
+  // A patch of {theme: {}} has always been a legal no-op, and a non-object
+  // block a silent one.
+  assert.equal(themePatchSchema.parse({}).active, undefined);
+  assert.equal(themePatchSchema.parse('nonsense').active, undefined);
+  assert.equal(themePatchSchema.safeParse({ active: '' }).success, false);
+  assert.equal(
+    themePatchSchema.safeParse({ active: '  ' }).error?.issues[0]?.message,
+    'theme.active must be a theme id',
+  );
+  // An unknown-but-non-empty id PASSES here: update() falls back to the default
+  // rather than refusing (#917), and that repair needs the theme registry.
+  assert.equal(themePatchSchema.safeParse({ active: 'retired-theme' }).success, true);
+});
+
+test('maxTrackSeconds: bounds convert, and the precedence handoff is preserved', () => {
+  const bounds = { min: 0, max: 36000 };
+  const registry = maxTrackSecondsSchema(bounds);
+  const value = maxTrackSecondsValueSchema(bounds);
+
+  // The resolved-value posture, which update() applies.
+  assert.equal(value.parse('600'), 600, 'parseInt, so a numeric string still saves');
+  assert.equal(value.parse(600.7), 600, 'and a float still truncates');
+  assert.equal(value.safeParse(-1).success, false);
+  assert.equal(value.safeParse(36001).success, false);
+  assert.equal(value.safeParse('nonsense').success, false);
+  assert.equal(
+    value.safeParse(-1).error?.issues[0]?.message,
+    'maxTrackSeconds must be int in [0, 36000]',
+  );
+
+  // The registry posture: one step looser, because an absent/empty seconds
+  // value hands off to the legacy maxTrackMinutes rather than failing.
+  assert.equal(registry.safeParse(undefined).success, true);
+  assert.equal(registry.safeParse(null).success, true);
+  assert.equal(registry.safeParse('').success, true);
+  assert.equal(registry.safeParse(-1).success, false);
+  // Both postures report the same string, because the bound is written once.
+  assert.equal(
+    registry.safeParse(99999).error?.issues[0]?.message,
+    value.safeParse(99999).error?.issues[0]?.message,
+  );
+  // maxTrackMinutes deliberately carries NO schema — a body where seconds wins
+  // ignores an unusable minutes value today, and must keep doing so.
+  assert.equal('maxTrackMinutes' in SETTINGS_PATCH_SCHEMAS, false);
+  assert.equal(validateSettingsPatch({ maxTrackSeconds: 600, maxTrackMinutes: 'junk' }), null);
+});
+
+test('the djPrompt trio: pure rules convert, cross-key ones stay in update()', () => {
+  const schema = djPromptTextSchema({ min: 50, max: 4000 });
+  const good = `You are {name}, on air tonight. ${'x'.repeat(50)}`;
+  assert.equal(schema.parse(good), good);
+  // '' is the "use the built-in default" selection, not an empty value.
+  assert.equal(schema.parse(''), '');
+  assert.equal(schema.parse(null), '');
+  assert.equal(schema.safeParse('too short').success, false);
+  assert.match(
+    schema.safeParse('too short').error!.issues[0].message,
+    /^djPrompt must be empty \(use the default\) or 50-4000 chars$/,
+  );
+  assert.equal(schema.safeParse(good.replace('{name}', 'Nova')).success, false);
+  assert.equal(
+    schema.safeParse(good.replace('{name}', 'Nova')).error?.issues[0]?.message,
+    'djPrompt must contain the {name} placeholder',
+  );
+  // activeDjPromptId is coercion only — whether the id RESOLVES is decided
+  // after djPrompts has been applied, and stays in update().
+  assert.equal(activeDjPromptIdSchema.parse('  dp_abc  '), 'dp_abc');
+  assert.equal(activeDjPromptIdSchema.parse(null), '');
+  assert.equal(activeDjPromptIdSchema.parse(undefined), '');
+  assert.equal(validateSettingsPatch({ activeDjPromptId: 'dp_nonexistent' }), null);
+});
+
+test('scheduleOverride validates SHAPE at the route, roster membership in update()', () => {
+  // Clearing the pin is how a takeover is cancelled, so null is legal.
+  assert.equal(validateSettingsPatch({ scheduleOverride: null }), null);
+  const bad = validateSettingsPatch({
+    scheduleOverride: { showId: '', startedAt: 1, expiresAt: 2 },
+  });
+  assert.equal(bad?.fieldErrors['scheduleOverride.showId'], 'must be a show id');
+  // A backwards window is a pure rule and IS caught at the route.
+  assert.equal(
+    validateSettingsPatch({ scheduleOverride: { showId: 's_a', startedAt: 9, expiresAt: 2 } })
+      ?.fieldErrors['scheduleOverride.expiresAt'] != null,
+    true,
+  );
+  // But "names a real show" is not — shows may ride in the same body.
+  assert.equal(
+    validateSettingsPatch({ scheduleOverride: { showId: 's_ghost', startedAt: 1, expiresAt: 2 } }),
+    null,
+  );
+});
+
+test('an ARRAY key roots its flat message; a block key still reports verbatim', () => {
+  // personas/djPrompts are registered but their branches deliberately stay on
+  // validatePersonasStrict / validateDjPromptsStrict, because both need a
+  // server-only id-minting step. What must NOT differ is the string the two
+  // report for the same body — hence SETTINGS_PATCH_ROOTED_KEYS.
+  const bad = validateSettingsPatch({ personas: [{ name: '', soul: 'x', frequency: 'moderate' }] });
+  assert.match(bad!.error, /^personas\.0\.name: /, 'the row is named, not just the field');
+  assert.equal(bad!.fieldErrors['personas.0.name'], 'name must be 1-40 chars');
+  // A block key is self-locating already and keeps its verbatim string.
+  const block = validateSettingsPatch({ beds: { crossSec: 999 } });
+  assert.equal(block!.error.startsWith('beds.'), true);
+  assert.equal(block!.error.includes(': '), false, 'no prefix doubling on a block key');
+});
+
+test('the route and update() name the SAME first failure for a persona roster', async () => {
+  const validate = await import('../src/settings/validate.js');
+  const roster = [
+    { name: 'Ok', soul: 'x', frequency: 'moderate', tts: { engine: 'piper', cloudProvider: 'openai' } },
+    { name: '', soul: 'x', frequency: 'moderate', tts: { engine: 'piper', cloudProvider: 'openai' } },
+  ];
+  const routeError = validateSettingsPatch({ personas: roster })!.error;
+  let updateError = '';
+  try {
+    validate.validatePersonasStrict(roster);
+  } catch (err) {
+    updateError = (err as Error).message;
+  }
+  assert.equal(routeError, updateError);
+  assert.match(routeError, /^personas\.1\.name: /);
 });
 
 // --- timezone / privacy / requests ------------------------------------------

--- a/controller/scripts/validate-wire-shape.test.ts
+++ b/controller/scripts/validate-wire-shape.test.ts
@@ -1,0 +1,174 @@
+// The route-boundary middleware's WIRE SHAPE — what an admin form actually
+// reads off a 400.
+//
+// scripts/validate-middleware.test.ts covers the two string helpers underneath
+// (firstMessage / flattenIssues) and scripts/settings-patch-schema.test.ts
+// covers the registry's decisions. This covers the ENVELOPE those arrive in,
+// because that envelope is a contract with the browser:
+// web/components/admin/SettingsPanel.tsx reads `j.fieldErrors` and hard-codes
+// the dotted paths its inline errors key off, and
+// web/components/admin/library/BlockRulesCard.tsx does the same for the
+// blocklist routes. A change that dropped `fieldErrors`, or rooted its paths
+// differently, would leave every one of those inputs silently blank — the
+// failure would look like "validation stopped working" and be invisible here
+// without this file.
+//
+// Run: npx tsx scripts/validate-wire-shape.test.ts (auto-discovered by npm test).
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+process.env.STATE_DIR = mkdtempSync(join(tmpdir(), 'subwave-validate-wire-'));
+
+const { validateBody, validateBodyAsync, validateSettingsBody } = await import(
+  '../src/middleware/validate.js'
+);
+const { blockRuleSchema } = await import('../src/schemas/blocklist.js');
+const { manualTagSchema } = await import('../src/schemas/library.js');
+
+interface Captured {
+  status: number;
+  body: { error?: string; fieldErrors?: Record<string, string>; message?: string } | null;
+  nexted: boolean;
+  reqBody: unknown;
+}
+
+async function run(
+  mw: (req: never, res: never, next: () => void) => unknown,
+  body: unknown,
+): Promise<Captured> {
+  const captured: Captured = { status: 200, body: null, nexted: false, reqBody: undefined };
+  const req = { body } as never;
+  const res = {
+    status(code: number) {
+      captured.status = code;
+      return this;
+    },
+    json(payload: unknown) {
+      captured.body = payload as Captured['body'];
+      return this;
+    },
+  } as never;
+  await mw(req, res, () => {
+    captured.nexted = true;
+  });
+  captured.reqBody = (req as { body: unknown }).body;
+  return captured;
+}
+
+// --- the envelope -----------------------------------------------------------
+
+test('a 400 always carries BOTH error and fieldErrors', async () => {
+  const r = await run(validateBody(blockRuleSchema), { label: '', field: 'genre', values: ['x'] });
+  assert.equal(r.status, 400);
+  assert.equal(typeof r.body?.error, 'string');
+  assert.ok(r.body!.error!.length > 0);
+  assert.equal(typeof r.body?.fieldErrors, 'object');
+  assert.equal(r.nexted, false, 'a rejected body must never reach the handler');
+});
+
+test('fieldErrors keys are DOTTED paths — react-hook-form setError syntax', async () => {
+  const r = await run(validateBody(blockRuleSchema), {
+    label: 'ok',
+    field: 'genre',
+    values: ['ok'],
+    season: { from: { month: 99, day: 1 }, to: { month: 1, day: 1 } },
+  });
+  assert.equal(r.status, 400);
+  assert.ok(
+    'season.from' in r.body!.fieldErrors!,
+    `expected a dotted season path, got ${JSON.stringify(r.body!.fieldErrors)}`,
+  );
+});
+
+test('a valid body is REPLACED with the parsed value before the handler', async () => {
+  const r = await run(validateBody(blockRuleSchema), {
+    label: '  Xmas  ',
+    field: 'genre',
+    values: ['A', 'a', '  '],
+  });
+  assert.equal(r.nexted, true);
+  assert.deepEqual(r.reqBody, {
+    label: 'Xmas',
+    field: 'genre',
+    values: ['A'],
+    season: null,
+    showIds: [],
+  });
+});
+
+test("the 'verbatim' posture changes only the flat string, never fieldErrors", async () => {
+  const body = { label: '', field: 'genre', values: ['x'] };
+  const prefixed = await run(validateBody(blockRuleSchema), body);
+  const verbatim = await run(validateBody(blockRuleSchema, { messages: 'verbatim' }), body);
+  assert.equal(verbatim.body!.error, 'rule.label is required');
+  assert.equal(prefixed.body!.error, 'label: rule.label is required');
+  assert.deepEqual(verbatim.body!.fieldErrors, prefixed.body!.fieldErrors);
+});
+
+// --- the async variant ------------------------------------------------------
+
+test('validateBodyAsync answers 400 for a bad body and 500 for a bad resolver', async () => {
+  const ok = validateBodyAsync(() => manualTagSchema({ moodNames: ['calm'] }), {
+    messages: 'verbatim',
+  });
+  const bad = await run(ok, { id: 't1', moods: ['nope'] });
+  assert.equal(bad.status, 400);
+  assert.equal(bad.body!.error, 'unknown mood(s): nope');
+
+  // A resolver that throws means the SERVER could not read its own context —
+  // that is not the operator's input being wrong, so it is a 500.
+  const broken = validateBodyAsync(() => {
+    throw new Error('mood cache unavailable');
+  });
+  const r = await run(broken, { id: 't1', moods: [] });
+  assert.equal(r.status, 500);
+  assert.equal(r.nexted, false);
+});
+
+// --- POST /settings ---------------------------------------------------------
+
+test('validateSettingsBody rejects an unknown top-level key, naming every one', async () => {
+  const r = await run(validateSettingsBody(), { nonsense: 1, alsoNonsense: 2, station: 'OK' });
+  assert.equal(r.status, 400);
+  assert.match(r.body!.error!, /unknown settings keys: /);
+  assert.equal(r.body!.fieldErrors!.nonsense, 'not a settings key');
+  assert.equal(r.body!.fieldErrors!.alsoNonsense, 'not a settings key');
+});
+
+test('a converted key reports at the path SettingsPanel keys its inputs off', async () => {
+  // These exact strings are hard-coded in the panel's JSX
+  // (<SettingsFieldError path="…" />), so a change here is a change to a
+  // contract with the browser — and one nothing else would catch.
+  const cases: Array<[Record<string, unknown>, string]> = [
+    [{ crossfadeDuration: 999 }, 'crossfadeDuration'],
+    [{ maxTrackSeconds: -5 }, 'maxTrackSeconds'],
+    [{ stream: { bitrate: 7 } }, 'stream.bitrate'],
+    [{ stream: { opusBitrate: 1 } }, 'stream.opusBitrate'],
+    [{ stream: { aacBitrate: 1 } }, 'stream.aacBitrate'],
+    [{ archive: { retentionDays: -1 } }, 'archive.retentionDays'],
+    [{ station: 'x'.repeat(500) }, 'station'],
+    [{ stationDescription: 'x'.repeat(5000) }, 'stationDescription'],
+    [{ personas: [{ name: '', soul: 'x', frequency: 'moderate' }] }, 'personas.0.name'],
+  ];
+  for (const [body, path] of cases) {
+    const r = await run(validateSettingsBody(), body);
+    assert.equal(r.status, 400, `${JSON.stringify(body)} should 400`);
+    assert.ok(
+      path in r.body!.fieldErrors!,
+      `expected fieldErrors["${path}"], got ${JSON.stringify(r.body!.fieldErrors)}`,
+    );
+  }
+});
+
+test('a valid patch passes THROUGH untouched — update() is still the chokepoint', async () => {
+  // Unlike validateBody, this middleware does not rewrite req.body: update()
+  // re-runs the same schemas as it applies each key, so there is exactly one
+  // place that decides what gets stored.
+  const body = { station: 'Night Loop' };
+  const r = await run(validateSettingsBody(), body);
+  assert.equal(r.nexted, true);
+  assert.equal(r.reqBody, body);
+});

--- a/controller/src/middleware/validate.ts
+++ b/controller/src/middleware/validate.ts
@@ -16,12 +16,42 @@ import type { ZodType } from 'zod';
 import { validateSettingsPatch } from '../settings/patch-registry.js';
 import { firstMessage, flattenIssues } from '../util/zod-error.js';
 
-export function validateBody(schema: ZodType) {
+export interface ValidateBodyOptions {
+  /**
+   * How the flat `error` string is built.
+   *
+   * `'prefixed'` (the default) puts the dotted path in front, because zod's
+   * built-in messages name a CONSTRAINT and never a location — 'expected array,
+   * received string' is useless without 'webhooks.1.url' ahead of it.
+   *
+   * `'verbatim'` takes the first issue's message as written. Use it ONLY for a
+   * schema whose every message already names its own field, where prefixing
+   * doubles the location: `POST /library/blocklist/rules` would otherwise
+   * answer 'label: rule.label is required'. This is the same narrow exception
+   * settings/patch-registry.ts documents, and for the same reason — these
+   * strings are what the store's own chokepoint throws, so the route and the
+   * chokepoint must not report the same body two different ways.
+   *
+   * `fieldErrors` is unaffected either way: it always carries the dotted path,
+   * which is where a form needs it.
+   */
+  messages?: 'prefixed' | 'verbatim';
+}
+
+function flatError(error: Parameters<typeof flattenIssues>[0], opts?: ValidateBodyOptions): string {
+  // firstMessage remains the fallback for an issue carrying no message at all,
+  // so a future schema cannot produce a bare 400.
+  return opts?.messages === 'verbatim'
+    ? error.issues[0]?.message || firstMessage(error)
+    : firstMessage(error);
+}
+
+export function validateBody(schema: ZodType, opts?: ValidateBodyOptions) {
   return (req: Request, res: Response, next: NextFunction) => {
     const r = schema.safeParse(req.body);
     if (!r.success) {
       return res.status(400).json({
-        error: firstMessage(r.error),
+        error: flatError(r.error, opts),
         fieldErrors: flattenIssues(r.error),
       });
     }
@@ -103,7 +133,10 @@ export function validateSettingsBody() {
   };
 }
 
-export function validateBodyAsync(resolve: (req: Request) => Promise<ZodType> | ZodType) {
+export function validateBodyAsync(
+  resolve: (req: Request) => Promise<ZodType> | ZodType,
+  opts?: ValidateBodyOptions,
+) {
   return async (req: Request, res: Response, next: NextFunction) => {
     let schema: ZodType;
     try {
@@ -114,7 +147,7 @@ export function validateBodyAsync(resolve: (req: Request) => Promise<ZodType> | 
     const r = schema.safeParse(req.body);
     if (!r.success) {
       return res.status(400).json({
-        error: firstMessage(r.error),
+        error: flatError(r.error, opts),
         fieldErrors: flattenIssues(r.error),
       });
     }

--- a/controller/src/music/blocklist-rules.ts
+++ b/controller/src/music/blocklist-rules.ts
@@ -16,19 +16,28 @@ import {
   trackMoods,
   type FilterTrack,
 } from './show-filter.js';
+// The rule's SHAPE — field vocabulary, caps, the season window and the
+// add/update validator — lives in the shared schema so the admin card runs the
+// same rules. Imported and re-exported here so no call site moved. This module
+// keeps the half a mirrored module cannot have: the MATCHING, which needs
+// show-filter's genre/tag normalisers.
+import {
+  RULES_MAX as RULES_MAX_VALUE,
+  RULE_FIELDS as RULE_FIELD_VALUES,
+  RULE_TEXT_MAX as RULE_TEXT_MAX_VALUE,
+  RULE_VALUES_MAX as RULE_VALUES_MAX_VALUE,
+  blockRuleSchema,
+  normText as normTextFn,
+  type RuleField,
+  type SeasonWindow,
+} from '../schemas/blocklist.js';
 
-export type RuleField = 'genre' | 'tag' | 'mood' | 'artist' | 'album' | 'title' | 'playlist';
-
-export const RULE_FIELDS: RuleField[] = ['genre', 'tag', 'mood', 'artist', 'album', 'title', 'playlist'];
-
-// Seasonal ALLOW-window: inclusive month/day bounds. from > to wraps the year
-// end (Dec 1 → Jan 6). While "in season" the rule does NOT block; a rule with
-// no season always blocks. Fixed month/day like settings.festivals — lunar
-// dates need per-year edits there too.
-export interface SeasonWindow {
-  from: { month: number; day: number };
-  to: { month: number; day: number };
-}
+export type { RuleField, SeasonWindow };
+export const RULE_FIELDS: readonly RuleField[] = RULE_FIELD_VALUES;
+export const RULES_MAX = RULES_MAX_VALUE;
+export const RULE_VALUES_MAX = RULE_VALUES_MAX_VALUE;
+export const RULE_TEXT_MAX = RULE_TEXT_MAX_VALUE;
+export const normText = normTextFn;
 
 export interface BlockRule {
   id: string;            // unique, generated server-side — logs and DELETE key
@@ -42,72 +51,23 @@ export interface BlockRule {
   addedAt: string;
 }
 
-export const RULES_MAX = 50;
-export const RULE_VALUES_MAX = 12;
-export const RULE_TEXT_MAX = 64;
-
-// Same normalisation as the blocklist's name fallback — trim, lowercase,
-// collapse whitespace — so a `tag`/`artist` rule value compares the way an
-// id entry's name snapshot does.
-export const normText = (s: unknown) => String(s ?? '').trim().toLowerCase().replace(/\s+/g, ' ');
-
 // ── Validation ───────────────────────────────────────────────────────────────
 
-function parseMonthDay(raw: unknown, where: string): { month: number; day: number } {
-  const o = (raw ?? {}) as Record<string, unknown>;
-  const month = Number(o.month);
-  const day = Number(o.day);
-  if (!Number.isInteger(month) || month < 1 || month > 12) throw new Error(`${where}.month must be 1-12`);
-  if (!Number.isInteger(day) || day < 1 || day > 31) throw new Error(`${where}.day must be 1-31`);
-  return { month, day };
-}
-
-// Validate an add/update payload into the persisted shape (minus id/addedAt,
-// which the store owns). Throws descriptive errors — the route surfaces the
-// message verbatim, same convention as validateShowsStrict.
+/**
+ * Validate an add/update payload into the persisted shape (minus id/addedAt,
+ * which the store owns).
+ *
+ * A thin wrapper over the shared schema — the store's chokepoint, reached by
+ * POST and PUT alike, so a rule that arrives any other way still meets the same
+ * rules the route middleware applied. Throws a plain Error with the message
+ * VERBATIM: every one already names its own `rule.<field>` path, so routing it
+ * through firstMessage would double the location.
+ */
 export function validateRulePatch(raw: unknown): Omit<BlockRule, 'id' | 'addedAt'> {
   if (!raw || typeof raw !== 'object') throw new Error('rule must be an object');
-  const o = raw as Record<string, unknown>;
-
-  const label = String(o.label ?? '').trim();
-  if (!label) throw new Error('rule.label is required');
-  if (label.length > RULE_TEXT_MAX) throw new Error(`rule.label must be at most ${RULE_TEXT_MAX} chars`);
-
-  const field = o.field as RuleField;
-  if (!RULE_FIELDS.includes(field)) throw new Error(`rule.field must be one of: ${RULE_FIELDS.join(', ')}`);
-
-  if (!Array.isArray(o.values)) throw new Error('rule.values must be an array');
-  const values: string[] = [];
-  const seen = new Set<string>();
-  for (const v of o.values) {
-    if (typeof v !== 'string') throw new Error('rule.values entries must be strings');
-    const t = v.trim();
-    if (!t) continue;
-    if (t.length > RULE_TEXT_MAX) throw new Error(`rule.values entries must be at most ${RULE_TEXT_MAX} chars`);
-    const key = normText(t);
-    if (seen.has(key)) continue; // silent dedupe — same value twice is one value
-    seen.add(key);
-    values.push(t);
-  }
-  if (!values.length) throw new Error('rule.values must have at least one entry');
-  if (values.length > RULE_VALUES_MAX) throw new Error(`rule.values must have at most ${RULE_VALUES_MAX} entries`);
-
-  let season: SeasonWindow | null = null;
-  if (o.season != null) {
-    const s = o.season as Record<string, unknown>;
-    season = {
-      from: parseMonthDay(s.from, 'rule.season.from'),
-      to: parseMonthDay(s.to, 'rule.season.to'),
-    };
-  }
-
-  let showIds: string[] = [];
-  if (o.showIds != null) {
-    if (!Array.isArray(o.showIds)) throw new Error('rule.showIds must be an array of strings');
-    showIds = [...new Set(o.showIds.filter((v): v is string => typeof v === 'string' && !!v.trim()))];
-  }
-
-  return { label, field, values, season, showIds };
+  const parsed = blockRuleSchema.safeParse(raw);
+  if (!parsed.success) throw new Error(parsed.error.issues[0]?.message || 'invalid rule');
+  return parsed.data;
 }
 
 // ── Season / scope activity ──────────────────────────────────────────────────

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -24,6 +24,12 @@ import { queue } from '../broadcast/queue.js';
 import { tagger, taggerView, startAnalyzer, startReconcile } from '../broadcast/tagger.js';
 import { refreshAutoPlaylist } from '../broadcast/scheduler.js';
 import * as mapProjection from '../music/map-projection.js';
+import { validateBody, validateBodyAsync } from '../middleware/validate.js';
+import { blockEntrySchema, blockRuleSchema } from '../schemas/blocklist.js';
+import { manualTagSchema } from '../schemas/library.js';
+import type { z } from 'zod';
+
+type ManualTagBody = z.output<ReturnType<typeof manualTagSchema>>;
 
 export const router = express.Router();
 
@@ -877,92 +883,88 @@ router.post('/library/retag', requireAdmin, async (req, res) => {
 // (settings.moodVocab()) so manual rows feed songsByMood()/MOOD_NEIGHBOURS
 // exactly like LLM-tagged ones.
 // ---------------------------------------------------------------------------
-router.post('/library/manual-tag', requireAdmin, async (req, res) => {
-  const id = req.body?.id;
-  if (!id || typeof id !== 'string') return res.status(400).json({ error: 'id is required' });
-  const moods = req.body?.moods;
-  if (!Array.isArray(moods) || moods.some((m) => typeof m !== 'string')) {
-    return res.status(400).json({ error: 'moods must be an array of strings' });
-  }
-  if (moods.length > 3) return res.status(400).json({ error: 'at most 3 moods per track' });
-  const unknown = moods.filter((m: string) => !settings.moodVocab().includes(m));
-  if (unknown.length) {
-    return res.status(400).json({ error: `unknown mood(s): ${unknown.join(', ')}` });
-  }
-  const energy = req.body?.energy ?? null;
-  if (energy !== null && !['low', 'medium', 'high'].includes(energy)) {
-    return res.status(400).json({ error: "energy must be 'low', 'medium', 'high' or null" });
-  }
-  const applyToAlbum = req.body?.applyToAlbum === true;
-  const clearing = moods.length === 0;
+router.post(
+  '/library/manual-tag',
+  requireAdmin,
+  // The mood vocabulary is operator-editable, so the schema cannot exist until
+  // the request does — hence validateBodyAsync, the same middleware POST /shows
+  // uses. Messages are verbatim: each already names its own field, and they are
+  // the exact strings this route has always answered with.
+  validateBodyAsync(() => manualTagSchema({ moodNames: settings.moodVocab() }), {
+    messages: 'verbatim',
+  }),
+  async (req, res) => {
+    const { id, moods, energy, applyToAlbum } = req.body as ManualTagBody;
+    const clearing = moods.length === 0;
 
-  try {
-    await library.load();
+    try {
+      await library.load();
 
-    // Resolve the seed track — Subsonic first (carries albumId), library-db
-    // row as fallback so already-indexed tracks work even if Navidrome misses.
-    let song: LibrarySong | null = null;
-    try { song = await subsonic.getSong(id); } catch {}
-    if (!song) {
-      const row = db.getTrack(id);
-      if (row) song = { id: row.id, title: row.title, artist: row.artist, album: row.album, year: row.year, genre: row.genre, duration: row.durationSec };
-    }
-    if (!song) return res.status(404).json({ error: 'track not found' });
-
-    let targets: LibrarySong[] = [song];
-    if (applyToAlbum) {
-      if (!song.albumId) return res.status(404).json({ error: 'album not resolvable for this track' });
-      targets = await subsonic.getAlbum(song.albumId);
-      if (!targets.length) return res.status(404).json({ error: 'album has no tracks' });
-    }
-
-    for (const t of targets) {
-      // Album siblings may be brand-new to library-db — make sure a row exists
-      // before tagging it.
-      db.upsertTrackMeta(t.id, {
-        title: t.title,
-        artist: t.artist,
-        album: t.album,
-        year: t.year ?? null,
-        genres: subsonic.songGenres(t),
-        duration: t.duration ?? null,
-      });
-      if (clearing) {
-        db.clearTrackTags(t.id);
-      } else {
-        db.upsertTrackTags(t.id, {
-          moods,
-          energy,
-          source: 'manual',
-          confidence: 1,
-        });
+      // Resolve the seed track — Subsonic first (carries albumId), library-db
+      // row as fallback so already-indexed tracks work even if Navidrome misses.
+      let song: LibrarySong | null = null;
+      try { song = await subsonic.getSong(id); } catch {}
+      if (!song) {
+        const row = db.getTrack(id);
+        if (row) song = { id: row.id, title: row.title, artist: row.artist, album: row.album, year: row.year, genre: row.genre, duration: row.durationSec };
       }
+      if (!song) return res.status(404).json({ error: 'track not found' });
+
+      let targets: LibrarySong[] = [song];
+      if (applyToAlbum) {
+        if (!song.albumId) return res.status(404).json({ error: 'album not resolvable for this track' });
+        targets = await subsonic.getAlbum(song.albumId);
+        if (!targets.length) return res.status(404).json({ error: 'album has no tracks' });
+      }
+
+      for (const t of targets) {
+        // Album siblings may be brand-new to library-db — make sure a row exists
+        // before tagging it.
+        db.upsertTrackMeta(t.id, {
+          title: t.title,
+          artist: t.artist,
+          album: t.album,
+          year: t.year ?? null,
+          genres: subsonic.songGenres(t),
+          duration: t.duration ?? null,
+        });
+        if (clearing) {
+          db.clearTrackTags(t.id);
+        } else {
+          db.upsertTrackTags(t.id, {
+            moods,
+            energy,
+            source: 'manual',
+            confidence: 1,
+          });
+        }
+      }
+      await library.save();
+
+      const scope = applyToAlbum ? `album "${song.album}" (${targets.length} tracks)` : `"${song.title}"`;
+      queue.log('info', clearing
+        ? `manual-tag: cleared tags on ${scope}`
+        : `manual-tag: ${scope} → [${moods.join(', ')}] energy=${energy ?? '—'}`);
+
+      res.json({
+        ok: true,
+        updated: targets.length,
+        cleared: clearing,
+        album: applyToAlbum ? (song.album ?? null) : null,
+        tracks: targets.map(t => ({
+          id: t.id,
+          title: t.title,
+          artist: t.artist,
+          moods: clearing ? [] : moods,
+          energy: clearing ? null : energy,
+        })),
+      });
+    } catch (err) {
+      queue.log('error', `/library/manual-tag failed: ${err.message}`);
+      res.status(500).json({ error: err.message });
     }
-    await library.save();
-
-    const scope = applyToAlbum ? `album "${song.album}" (${targets.length} tracks)` : `"${song.title}"`;
-    queue.log('info', clearing
-      ? `manual-tag: cleared tags on ${scope}`
-      : `manual-tag: ${scope} → [${moods.join(', ')}] energy=${energy ?? '—'}`);
-
-    res.json({
-      ok: true,
-      updated: targets.length,
-      cleared: clearing,
-      album: applyToAlbum ? (song.album ?? null) : null,
-      tracks: targets.map(t => ({
-        id: t.id,
-        title: t.title,
-        artist: t.artist,
-        moods: clearing ? [] : moods,
-        energy: clearing ? null : energy,
-      })),
-    });
-  } catch (err) {
-    queue.log('error', `/library/manual-tag failed: ${err.message}`);
-    res.status(500).json({ error: err.message });
-  }
-});
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Never-play blocklist — station-level "never let this air" entries at
@@ -989,7 +991,15 @@ router.get('/library/blocklist', requireAdmin, (_req, res) => {
 // Registered BEFORE the entry routes: DELETE /library/blocklist/:type/:id
 // would otherwise swallow /library/blocklist/rules/:id with type='rules'.
 
-router.post('/library/blocklist/rules', requireAdmin, async (req, res) => {
+// The route runs the SAME schema blocklist.addRule reaches through
+// validateRulePatch, so the card gets `fieldErrors` while the store stays the
+// authoritative chokepoint for anything arriving another way. Messages are
+// verbatim — each already names its own `rule.<field>` path.
+router.post(
+  '/library/blocklist/rules',
+  requireAdmin,
+  validateBody(blockRuleSchema, { messages: 'verbatim' }),
+  async (req, res) => {
   try {
     const rule = await blocklist.addRule(req.body);
     queue.log('blocked', `rule "${rule.label}" (${rule.field}: ${rule.values.join(', ')}) added to the never-play blocklist`);
@@ -1002,11 +1012,16 @@ router.post('/library/blocklist/rules', requireAdmin, async (req, res) => {
     // Validation errors are the operator's typo, not a server fault.
     res.status(400).json({ error: err.message });
   }
-});
+  },
+);
 
-router.put('/library/blocklist/rules/:id', requireAdmin, async (req, res) => {
+router.put(
+  '/library/blocklist/rules/:id',
+  requireAdmin,
+  validateBody(blockRuleSchema, { messages: 'verbatim' }),
+  async (req, res) => {
   try {
-    const rule = await blocklist.updateRule(req.params.id, req.body);
+    const rule = await blocklist.updateRule(String(req.params.id), req.body);
     if (!rule) return res.status(404).json({ error: 'no such rule' });
     queue.log('blocked', `rule "${rule.label}" updated on the never-play blocklist`);
     const purged = queue.purgeBlocked();
@@ -1015,7 +1030,8 @@ router.put('/library/blocklist/rules/:id', requireAdmin, async (req, res) => {
   } catch (err) {
     res.status(400).json({ error: err.message });
   }
-});
+  },
+);
 
 router.delete('/library/blocklist/rules/:id', requireAdmin, async (req, res) => {
   try {
@@ -1034,11 +1050,15 @@ router.delete('/library/blocklist/rules/:id', requireAdmin, async (req, res) => 
 // Body: { type: 'track'|'album'|'artist', trackId } — the UI flow: block from a
 // track row, server resolves the album/artist ids + display snapshots. OR a
 // pre-resolved { type, id, name?, artist?, album? } for direct entries.
-router.post('/library/blocklist', requireAdmin, async (req, res) => {
-  const type = req.body?.type;
-  if (!['track', 'album', 'artist'].includes(type)) {
-    return res.status(400).json({ error: "type must be 'track', 'album' or 'artist'" });
-  }
+router.post(
+  '/library/blocklist',
+  requireAdmin,
+  // Shape only — WHICH of the two accepted forms arrived is decided below,
+  // because resolving `{type, trackId}` needs Subsonic. Verbatim messages keep
+  // the existing "type must be 'track', 'album' or 'artist'" string exact.
+  validateBody(blockEntrySchema, { messages: 'verbatim' }),
+  async (req, res) => {
+  const type = req.body.type;
   try {
     let input: { type: blocklist.BlockType; id: string; name?: string | null; artist?: string | null; album?: string | null };
     const trackId = req.body?.trackId;
@@ -1082,7 +1102,8 @@ router.post('/library/blocklist', requireAdmin, async (req, res) => {
     queue.log('error', `/library/blocklist failed: ${err.message}`);
     res.status(500).json({ error: err.message });
   }
-});
+  },
+);
 
 router.delete('/library/blocklist/:type/:id', requireAdmin, async (req, res) => {
   const { type, id } = req.params;

--- a/controller/src/schemas/blocklist.ts
+++ b/controller/src/schemas/blocklist.ts
@@ -1,0 +1,205 @@
+// Shared never-play blocklist schema (#1300 FR 1) — the shape of a RULE entry
+// (attribute predicate + optional seasonal allow-window + optional show scope)
+// and of the id-entry create body, executed on BOTH sides. The controller runs
+// it in music/blocklist-rules.ts's validateRulePatch (the store's chokepoint,
+// reached by POST and PUT alike) and at the route boundary; the browser runs
+// the mirrored copy so BlockRulesCard can pre-flight a save.
+//
+// HARD RULE: this file may import ONLY from 'zod'. It is copied verbatim into
+// the web bundle, so a project import or a node builtin here breaks the mirror.
+// music/blocklist-rules.ts itself cannot be a schema module — it imports
+// show-filter's genre/tag normalisers for the MATCHING half — which is exactly
+// why the validation half moved here and is re-exported from there.
+//
+// WHAT DELIBERATELY DID NOT MOVE
+// ------------------------------
+// Rule ids and `addedAt` are minted by the store, not submitted, so they are
+// absent from the schema entirely (rather than optional): a client that sends
+// one is not describing a rule, and z.object strips it before the store sees it
+// — the same posture as a show's server-minted id, one step stricter because
+// nothing downstream points at a rule id the way a schedule slot points at a
+// show id.
+import { z } from 'zod';
+
+export const RULE_FIELDS = [
+  'genre',
+  'tag',
+  'mood',
+  'artist',
+  'album',
+  'title',
+  'playlist',
+] as const;
+
+export type RuleField = (typeof RULE_FIELDS)[number];
+
+export const RULES_MAX = 50;
+export const RULE_VALUES_MAX = 12;
+export const RULE_TEXT_MAX = 64;
+
+/** Id-entry granularity — a blocked track, its album, or its artist. */
+export const BLOCK_TYPES = ['track', 'album', 'artist'] as const;
+
+export interface SeasonWindow {
+  from: { month: number; day: number };
+  to: { month: number; day: number };
+}
+
+/**
+ * Trim, lowercase, collapse whitespace — the same normalisation the blocklist's
+ * name fallback uses, so a `tag`/`artist` rule value compares the way an id
+ * entry's name snapshot does. Used here only for DEDUPE; the stored value keeps
+ * its original casing.
+ */
+export const normText = (s: unknown) => String(s ?? '').trim().toLowerCase().replace(/\s+/g, ' ');
+
+// A month/day pair. Both halves are `Number(x)` + an integer/range test, not
+// z.number().int(), because the admin card posts them from <input type=number>
+// and a numeric STRING has always been accepted.
+function blocklistMonthDay(where: string) {
+  return z.unknown().optional().transform((raw, ctx) => {
+    const o = (raw ?? {}) as Record<string, unknown>;
+    const month = Number(o.month);
+    const day = Number(o.day);
+    if (!Number.isInteger(month) || month < 1 || month > 12) {
+      ctx.addIssue({ code: 'custom', message: `${where}.month must be 1-12` });
+      return z.NEVER;
+    }
+    if (!Number.isInteger(day) || day < 1 || day > 31) {
+      ctx.addIssue({ code: 'custom', message: `${where}.day must be 1-31` });
+      return z.NEVER;
+    }
+    return { month, day };
+  });
+}
+
+/**
+ * A seasonal ALLOW-window: inclusive month/day bounds, `from > to` wrapping the
+ * year end (Dec 1 → Jan 6). While in season the rule does NOT block.
+ *
+ * Deliberately NOT range-checked beyond each half: a wrapping window is the
+ * feature, so "from after to" is meaningful rather than backwards — unlike a
+ * show's era window, where the same shape IS an error.
+ */
+export const blockSeasonSchema = z.object({
+  from: blocklistMonthDay('rule.season.from'),
+  to: blocklistMonthDay('rule.season.to'),
+});
+
+/**
+ * The add/update payload for one rule, in the persisted shape minus the
+ * store-owned id/addedAt.
+ *
+ * Every message names `rule.<field>` because the route surfaces it verbatim,
+ * the same convention validateShowsStrict follows.
+ */
+export const blockRuleSchema = z.object({
+  label: z
+    .unknown()
+    .optional()
+    .transform((raw, ctx) => {
+      const v = String(raw ?? '').trim();
+      if (!v) {
+        ctx.addIssue({ code: 'custom', message: 'rule.label is required' });
+        return z.NEVER;
+      }
+      if (v.length > RULE_TEXT_MAX) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `rule.label must be at most ${RULE_TEXT_MAX} chars`,
+        });
+        return z.NEVER;
+      }
+      return v;
+    }),
+  field: z.enum(RULE_FIELDS, {
+    error: `rule.field must be one of: ${RULE_FIELDS.join(', ')}`,
+  }),
+  values: z
+    .array(z.unknown(), { error: 'rule.values must be an array' })
+    .transform((items, ctx) => {
+      // A blank entry is dropped and a duplicate is silently collapsed (same
+      // value twice is one value), but a NON-STRING entry and an over-long one
+      // are both refused — the operator typed something that isn't a value, and
+      // silently discarding it would block less than the card shows.
+      const out: string[] = [];
+      const seen = new Set<string>();
+      for (const v of items) {
+        if (typeof v !== 'string') {
+          ctx.addIssue({ code: 'custom', message: 'rule.values entries must be strings' });
+          return z.NEVER;
+        }
+        const t = v.trim();
+        if (!t) continue;
+        if (t.length > RULE_TEXT_MAX) {
+          ctx.addIssue({
+            code: 'custom',
+            message: `rule.values entries must be at most ${RULE_TEXT_MAX} chars`,
+          });
+          return z.NEVER;
+        }
+        const key = normText(t);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(t);
+      }
+      if (!out.length) {
+        ctx.addIssue({ code: 'custom', message: 'rule.values must have at least one entry' });
+        return z.NEVER;
+      }
+      if (out.length > RULE_VALUES_MAX) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `rule.values must have at most ${RULE_VALUES_MAX} entries`,
+        });
+        return z.NEVER;
+      }
+      return out;
+    }),
+  // Absent or null = no season, i.e. the rule always blocks.
+  season: z.preprocess((v) => (v == null ? undefined : v), blockSeasonSchema.nullable().default(null)),
+  // Empty = station-wide. Stale ids are inert by design (resolved against the
+  // live roster at evaluation time), so a non-string entry is DROPPED rather
+  // than refused — the same call persona.skills makes for the same reason.
+  showIds: z.preprocess(
+    (v) => (v == null ? undefined : v),
+    z
+      .array(z.unknown(), { error: 'rule.showIds must be an array of strings' })
+      .transform((items) => [
+        ...new Set(
+          items.filter((v): v is string => typeof v === 'string' && !!v.trim()),
+        ),
+      ])
+      .default([]),
+  ),
+});
+
+export type BlockRulePatch = z.output<typeof blockRuleSchema>;
+
+/**
+ * `POST /library/blocklist` — the id-entry create body.
+ *
+ * TWO accepted forms, which is why nothing but `type` is required: the UI flow
+ * posts `{type, trackId}` and the server resolves the album/artist ids and
+ * display snapshots from the track row, while a direct entry posts a
+ * pre-resolved `{type, id, …}`. Which of the two arrived is decided by the
+ * route (it needs Subsonic to resolve one of them), so the schema's job is only
+ * to pin the shape both share.
+ */
+export const blockEntrySchema = z.object({
+  type: z.enum(BLOCK_TYPES, { error: "type must be 'track', 'album' or 'artist'" }),
+  trackId: z.preprocess(
+    (v) => (v == null || v === '' ? undefined : v),
+    z.string({ error: 'trackId must be a string' }).optional(),
+  ),
+  id: z.preprocess(
+    (v) => (v == null || v === '' ? undefined : v),
+    z.string({ error: 'id must be a string' }).optional(),
+  ),
+  // Display snapshots — free text captured at block time so the Blocked tab can
+  // name a row whose source has since vanished. Null is meaningful ("unknown"),
+  // so it is preserved rather than folded to undefined.
+  name: z.string().nullable().optional(),
+  artist: z.string().nullable().optional(),
+  album: z.string().nullable().optional(),
+});

--- a/controller/src/schemas/library.ts
+++ b/controller/src/schemas/library.ts
@@ -1,0 +1,82 @@
+// Shared library-maintenance schemas — the operator-facing bodies under
+// /library that carry typed input rather than a bare id. Today that is
+// `POST /library/manual-tag`, the "tag this track (or its whole album) by hand,
+// no LLM involved" path behind the library row editor.
+//
+// HARD RULE: this file may import ONLY from 'zod'. It is copied verbatim into
+// the web bundle, so a project import or a node builtin here breaks the mirror.
+//
+// WHY A FACTORY
+// -------------
+// Moods are operator-editable (settings.moodVocab()), so a manual tag can only
+// be judged against the LIVE vocabulary — the same reason showSchema takes a
+// context. `moodNames: null` means "this caller cannot check that rule", which
+// is what lets the browser pre-flight the shape of a body whose vocabulary it
+// may not have fetched yet while the route still enforces membership.
+import { z } from 'zod';
+
+/** At most three moods per track — the tagger's own ceiling. */
+export const MANUAL_TAG_MOODS_MAX = 3;
+
+export const MANUAL_TAG_ENERGIES = ['low', 'medium', 'high'] as const;
+
+export interface ManualTagContext {
+  /** The live mood vocabulary, or null when the caller cannot know it. */
+  moodNames: string[] | null;
+}
+
+export const MANUAL_TAG_SHAPE_ONLY: ManualTagContext = { moodNames: null };
+
+export function manualTagSchema(ctx: ManualTagContext) {
+  return z.object({
+    // `!id || typeof id !== 'string'` — so a blank string is refused too, and
+    // with the same message, which is what the route has always answered.
+    id: z.unknown().optional().transform((raw, c) => {
+      if (typeof raw !== 'string' || !raw) {
+        c.addIssue({ code: 'custom', message: 'id is required' });
+        return z.NEVER;
+      }
+      return raw;
+    }),
+    // An EMPTY array is meaningful: it clears the track's tags entirely and
+    // returns it to the untagged pool. So this is required-but-may-be-empty,
+    // never defaulted — a missing key and an explicit [] must not be the same
+    // request.
+    moods: z
+      .array(z.unknown(), { error: 'moods must be an array of strings' })
+      .transform((items, c) => {
+        if (items.some((m) => typeof m !== 'string')) {
+          c.addIssue({ code: 'custom', message: 'moods must be an array of strings' });
+          return z.NEVER;
+        }
+        const values = items as string[];
+        if (values.length > MANUAL_TAG_MOODS_MAX) {
+          c.addIssue({
+            code: 'custom',
+            message: `at most ${MANUAL_TAG_MOODS_MAX} moods per track`,
+          });
+          return z.NEVER;
+        }
+        if (ctx.moodNames) {
+          const unknown = values.filter((m) => !ctx.moodNames!.includes(m));
+          if (unknown.length) {
+            c.addIssue({ code: 'custom', message: `unknown mood(s): ${unknown.join(', ')}` });
+            return z.NEVER;
+          }
+        }
+        return values;
+      }),
+    // null is the explicit "no energy", distinct from an omission only in that
+    // both land on null — matching `req.body?.energy ?? null`.
+    energy: z.preprocess(
+      (v) => (v === undefined ? null : v),
+      z
+        .enum(MANUAL_TAG_ENERGIES, {
+          error: "energy must be 'low', 'medium', 'high' or null",
+        })
+        .nullable(),
+    ),
+    // `=== true`, so anything else reads as off — unchanged.
+    applyToAlbum: z.unknown().optional().transform((v) => v === true),
+  });
+}

--- a/controller/src/schemas/persona-server.ts
+++ b/controller/src/schemas/persona-server.ts
@@ -1,0 +1,49 @@
+// Server-only persona rules — what schemas/persona.ts cannot express because
+// they are not pure functions of one submitted value:
+//
+//   1. id minting                    — a side effect (randomBytes)
+//   2. cross-row id de-duplication   — needs sibling awareness
+//
+// Same split, and the same two rules, as show-server.ts and webhook-server.ts.
+// Keeping them out of schemas/persona.ts is load-bearing: it is what lets that
+// file be copied byte-for-byte into the browser bundle.
+import { mintId } from '../settings/vocab.js';
+
+/**
+ * Give every persona an id, and make those ids unique.
+ *
+ * Shared by BOTH paths — the strict update() validator and the lenient
+ * load-time normaliser — because two hand-rolled copies of "mint if absent,
+ * re-mint on collision" is how load and save start disagreeing about which row
+ * owns which id. For a persona the stakes are higher than for a show: the id is
+ * what every show's `personaId`, every `guestPersonaIds` entry and
+ * `activePersonaId` point at, so a row that changes identity across a save
+ * silently orphans its shows — which update()'s post-patch integrity sweep then
+ * "repairs" by reassigning them to whoever is first in the roster.
+ */
+export function resolvePersonaIds<T extends { id?: string }>(items: T[]): (T & { id: string })[] {
+  const seen = new Set<string>();
+  return items.map((item) => {
+    let id = item.id ?? mintId('p_');
+    if (seen.has(id)) id = mintId('p_');
+    seen.add(id);
+    return { ...item, id };
+  });
+}
+
+/**
+ * The same rule for the prompt-template library.
+ *
+ * Separate from resolvePersonaIds only because the prefix differs ('dp_' vs
+ * 'p_'), and the prefix is what makes a stray id in a hand-edited settings.json
+ * legible to an operator.
+ */
+export function resolveDjPromptIds<T extends { id?: string }>(items: T[]): (T & { id: string })[] {
+  const seen = new Set<string>();
+  return items.map((item) => {
+    let id = item.id ?? mintId('dp_');
+    if (seen.has(id)) id = mintId('dp_');
+    seen.add(id);
+    return { ...item, id };
+  });
+}

--- a/controller/src/schemas/persona.ts
+++ b/controller/src/schemas/persona.ts
@@ -1,0 +1,662 @@
+// Shared persona + prompt-library schema — the single source of truth for a
+// DJ persona's shape and for the `{engine, voice, cloudProvider}` voice slot,
+// executed on BOTH sides. The controller runs it in
+// settings.validate.validatePersonasStrict (the update() chokepoint) and in
+// settings.normalize.normalizePersona (the lenient load path); the browser runs
+// the mirrored copy (web/lib/schemas.generated.ts) so the Personas editor can
+// pre-flight a save against the exact rules the controller enforces.
+//
+// HARD RULE: this file may import ONLY from 'zod'. It is copied verbatim into
+// the web bundle, so a project import or a node builtin here breaks the mirror.
+// That includes OTHER schema modules — the mirror is one flat concatenation, so
+// gen-schemas.ts rejects every specifier but 'zod', enforces unique top-level
+// names across every module, and each module has to stand alone.
+//
+// WHICH IS WHY TWO REGEXES ARE DECLARED HERE RATHER THAN IMPORTED
+// ---------------------------------------------------------------
+// `PERSONA_ID_RE` is the same pattern as schemas/show.ts's SHOW_ID_RE, and
+// `PERSONA_SKILL_SLUG_RE` the same as schemas/skill.ts's SKILL_SLUG_RE. Neither
+// can be imported (see above) and neither can reuse the other's NAME (the flat
+// mirror would carry two declarations of it). Re-declaring is therefore
+// structural, not sloppiness — and the drift it invites is pinned by
+// scripts/persona-schema.test.ts, which asserts `.source` equality against both
+// originals. That is the same answer skill-schema.test.ts gives for
+// loader.SLUG_RE and vocab's SKILL_SLUG_RE.
+//
+// WHY THERE IS NO FACTORY
+// -----------------------
+// Unlike a show, a persona CAN be validated against itself: every rule is a
+// pure function of the submitted value. `skills` names skill slugs, but a slug
+// that no longer resolves is dropped rather than refused (see the field), so
+// the live catalogue is not an input. Rules that are NOT pure — id minting and
+// cross-row de-duplication — live in persona-server.ts, which is NOT mirrored.
+//
+// SETTINGS/VOCAB.TS RE-EXPORTS EVERY CONSTANT BELOW
+// -------------------------------------------------
+// The "first feature converted owns the constant" rule. No call site moved when
+// this landed; vocab.ts aliases these under the names the controller already
+// used (PERSONA_FREQUENCIES as FREQUENCIES, and so on). The web side must read
+// them from the mirror rather than hand-copying — a hand-copied cap is exactly
+// the SKILL_SLUG_RE drift this whole mechanism exists to prevent.
+import { z } from 'zod';
+
+// ── Persona vocabulary ───────────────────────────────────────────────────────
+
+/** Entity id. Same pattern as SHOW_ID_RE — see the header. */
+export const PERSONA_ID_RE = /^[a-z0-9_]{3,32}$/;
+
+/** Same pattern as schemas/skill.ts's SKILL_SLUG_RE — see the header. */
+export const PERSONA_SKILL_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,48}$/;
+
+// An avatar is stored as a BARE BASENAME, never a path: the id half reuses
+// PERSONA_ID_RE's character class so the field can never reference a file
+// outside the avatar dir.
+export const PERSONA_AVATAR_FILENAME_RE = /^[a-z0-9_]{3,32}\.(png|jpe?g|webp)$/;
+
+export const PERSONA_LIMIT = 48;
+export const PERSONA_NAME_MAX = 40;
+export const PERSONA_TAGLINE_MAX = 80;
+export const PERSONA_LANGUAGE_MAX = 60;
+// Every persona's soul rides in the system prompt on every call, so this is a
+// recurring per-call token cost rather than a structural limit.
+export const PERSONA_SOUL_MAX = 2000;
+export const PERSONA_SKILLS_LIMIT = 64;
+
+export const PERSONA_FREQUENCIES = [
+  'silent',
+  'quiet',
+  'moderate',
+  'chatty',
+  'aggressive',
+] as const;
+
+export const PERSONA_SCRIPT_LENGTHS = [
+  'one-liner',
+  'concise',
+  'extended',
+  'storyteller',
+] as const;
+
+// Per-persona tone dials — 0-10 with 5 the neutral default.
+export const PERSONA_DIAL_MIN = 0;
+export const PERSONA_DIAL_MAX = 10;
+export const PERSONA_DIAL_NEUTRAL = 5;
+
+/**
+ * Clamp any input to an integer dial, defaulting to neutral when unparseable.
+ *
+ * Never throws, on EITHER path — the strict validator has always run the same
+ * coercion the lenient one does, so a garbage dial has never been able to fail
+ * a persona save. Reproduced verbatim rather than tightened.
+ */
+export function clampPersonaDial(v: unknown): number {
+  const n = Math.round(Number(v));
+  return Number.isFinite(n)
+    ? Math.min(PERSONA_DIAL_MAX, Math.max(PERSONA_DIAL_MIN, n))
+    : PERSONA_DIAL_NEUTRAL;
+}
+
+// ── TTS voice slot ───────────────────────────────────────────────────────────
+//
+// The `{engine, voice, cloudProvider, gainDb, speed}` block. Shared by every
+// persona's `tts` AND by the station-wide rescue slot (`settings.tts.fallback`)
+// — the two carry the same shape by design, because a fallback slot is handed
+// to speakWith() as a synthetic persona. One implementation is what stops the
+// per-engine voice rules drifting between them.
+
+export const TTS_ENGINES = [
+  'piper',
+  'kokoro',
+  'chatterbox',
+  'pocket-tts',
+  'cloud',
+  'remote',
+] as const;
+
+export const TTS_CLOUD_PROVIDERS = [
+  'openai',
+  'elevenlabs',
+  'fish-audio',
+  'openai-compatible',
+] as const;
+
+// Kokoro voice ids are `<lang><gender>_<name>`, e.g. bf_isabella.
+export const TTS_KOKORO_VOICE_RE = /^[a-z]{2}_[a-z0-9]+$/;
+// Chatterbox (and pocket-tts zero-shot cloning) voices are reference-WAV
+// filenames in the shared voice folder — no path separators.
+export const TTS_CHATTERBOX_VOICE_RE = /^[A-Za-z0-9_.-]{1,80}\.wav$/;
+// PocketTTS built-in voice ids (alba, anna, charles, …).
+export const TTS_POCKET_VOICE_RE = /^[a-z][a-z0-9_-]{0,39}$/;
+// Piper voices are `.onnx` filenames in the shared voice folder.
+export const TTS_PIPER_VOICE_RE = /^[A-Za-z0-9_.-]{1,100}\.onnx$/;
+
+export const TTS_VOICE_MAX = 100;
+
+export const TTS_GAIN_CLAMP_DB = 12;
+export const TTS_SPEED_MIN = 0.5;
+export const TTS_SPEED_MAX = 2.0;
+export const TTS_SPEED_DEFAULT = 1.0;
+
+/**
+ * Coerce any value to a clean gain: finite, clamped to ±TTS_GAIN_CLAMP_DB,
+ * rounded to 0.1 dB. Garbage / non-finite → 0 (unity).
+ */
+export function clampTtsGain(v: unknown): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 0;
+  const c = Math.max(-TTS_GAIN_CLAMP_DB, Math.min(TTS_GAIN_CLAMP_DB, n));
+  return Math.round(c * 10) / 10;
+}
+
+/**
+ * Coerce any value to a clean speech-rate multiplier.
+ *
+ * Unset (null/undefined/'') is unity, NOT 0 — unlike gain, 0 is not this dial's
+ * default and would clamp to the 0.5 floor instead of no-change.
+ */
+export function clampTtsSpeed(v: unknown): number {
+  if (v === null || v === undefined || v === '') return TTS_SPEED_DEFAULT;
+  const n = Number(v);
+  if (!Number.isFinite(n)) return TTS_SPEED_DEFAULT;
+  const c = Math.max(TTS_SPEED_MIN, Math.min(TTS_SPEED_MAX, n));
+  return Math.round(c * 20) / 20;
+}
+
+export interface TtsVoiceSlot {
+  engine: string;
+  cloudProvider: string;
+  voice: string;
+  gainDb: number;
+  speed: number;
+}
+
+/**
+ * The strict voice slot, as a factory over the settings path prefix.
+ *
+ * `where` is a FACTORY PARAMETER rather than a path zod derives, because these
+ * messages have always embedded the location in the text ("tts.fallback.voice
+ * must …") and both call sites read them as a flat toast string. The persona
+ * array passes `personas[].tts` and the station slot passes `tts.fallback`, so
+ * an operator reading a 400 still learns which of the two failed.
+ *
+ * Implemented as one transform rather than a z.object because the rules are
+ * SEQUENTIAL and cross-field: engine decides which voice rule applies, so
+ * reporting a voice issue before an engine issue would name a rule the operator
+ * never opted into. A transform reports exactly the first failure the
+ * hand-rolled validator reported, in the same order.
+ */
+export function ttsVoiceSlotSchema(where: string) {
+  // `.optional()` so an ABSENT block reaches the transform and is refused by the
+  // engine rule below ("tts.engine must be one of: …") rather than by zod's
+  // generic 'expected nonoptional' — the hand-rolled validator's `raw || {}`
+  // gave the operator the useful message, and that is the one worth keeping.
+  return z.unknown().optional().transform((raw, ctx): TtsVoiceSlot => {
+    // `raw || {}` — an absent or non-object block reads as "all defaults", which
+    // is how a persona written before this block existed still validates.
+    const t = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+
+    const engine = t.engine as string;
+    if (!(TTS_ENGINES as readonly string[]).includes(engine)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `${where}.engine must be one of: ${TTS_ENGINES.join(', ')}`,
+      });
+      return z.NEVER;
+    }
+    const cloudProvider = t.cloudProvider as string;
+    if (!(TTS_CLOUD_PROVIDERS as readonly string[]).includes(cloudProvider)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `${where}.cloudProvider must be one of: ${TTS_CLOUD_PROVIDERS.join(', ')}`,
+      });
+      return z.NEVER;
+    }
+
+    // String(x ?? '') and not z.string(): a numeric voice id posted by an older
+    // admin build has always coerced, and refusing it now would be a tightening.
+    let voice = String(t.voice ?? '').trim();
+    const fail = (message: string) => {
+      ctx.addIssue({ code: 'custom', message });
+      return z.NEVER;
+    };
+
+    if (engine === 'kokoro') {
+      if (!TTS_KOKORO_VOICE_RE.test(voice)) {
+        return fail(
+          `${where}.voice must match <lang><gender>_<name> for kokoro, e.g. bf_isabella`,
+        );
+      }
+    } else if (engine === 'chatterbox') {
+      // Empty = built-in default voice.
+      if (voice && !TTS_CHATTERBOX_VOICE_RE.test(voice)) {
+        return fail(
+          `${where}.voice for chatterbox must be a .wav filename (no path), or empty for the default voice`,
+        );
+      }
+    } else if (engine === 'pocket-tts') {
+      // A built-in voice id OR a .wav filename for zero-shot cloning (#213).
+      if (!voice) voice = 'alba';
+      if (!TTS_POCKET_VOICE_RE.test(voice) && !TTS_CHATTERBOX_VOICE_RE.test(voice)) {
+        return fail(
+          `${where}.voice for pocket-tts must be a built-in voice id (e.g. alba) or a .wav filename`,
+        );
+      }
+    } else if (engine === 'cloud') {
+      // openai-compatible voices are server-specific; empty lets the server use
+      // its own default. openai/elevenlabs both require a voice id.
+      if (cloudProvider === 'openai-compatible') {
+        if (voice.length > TTS_VOICE_MAX) {
+          return fail(`${where}.voice must be 0-${TTS_VOICE_MAX} chars`);
+        }
+      } else if (voice.length < 1 || voice.length > TTS_VOICE_MAX) {
+        return fail(`${where}.voice must be 1-${TTS_VOICE_MAX} chars`);
+      }
+    } else if (engine === 'remote') {
+      // Server-specific — the sidecar interprets them. Empty is valid.
+      if (voice.length > TTS_VOICE_MAX) {
+        return fail(`${where}.voice must be 0-${TTS_VOICE_MAX} chars`);
+      }
+    } else {
+      // piper: empty = the baked-in default. A Kokoro-shaped id is also
+      // accepted — the seed roster carries one per persona under piper so
+      // switching to Kokoro yields distinct voices with no extra editing, and
+      // resolvePiperVoice() falls back gracefully for it (#454).
+      if (
+        voice &&
+        !TTS_PIPER_VOICE_RE.test(voice) &&
+        !TTS_KOKORO_VOICE_RE.test(voice)
+      ) {
+        return fail(
+          `${where}.voice for piper must be an .onnx filename (no path), or empty for the default voice`,
+        );
+      }
+    }
+
+    return {
+      engine,
+      cloudProvider,
+      voice,
+      gainDb: clampTtsGain(t.gainDb),
+      speed: clampTtsSpeed(t.speed),
+    };
+  });
+}
+
+/**
+ * The lenient twin of ttsVoiceSlotSchema — the LOAD path.
+ *
+ * Where the schema refuses, this resets to a value the schema accepts. The
+ * output is therefore always schema-valid, which is what lets the load path run
+ * the real schema after repairing rather than maintaining a second set of rules.
+ */
+export function repairTtsVoiceSlot(raw: unknown): TtsVoiceSlot {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  const engine = (TTS_ENGINES as readonly string[]).includes(r.engine as string)
+    ? (r.engine as string)
+    : 'piper';
+  const cloudProvider = (TTS_CLOUD_PROVIDERS as readonly string[]).includes(
+    r.cloudProvider as string,
+  )
+    ? (r.cloudProvider as string)
+    : 'openai';
+  let voice =
+    typeof r.voice === 'string' && r.voice.trim()
+      ? r.voice.trim().slice(0, TTS_VOICE_MAX)
+      : '';
+
+  if (engine === 'kokoro' && !TTS_KOKORO_VOICE_RE.test(voice)) voice = 'bf_isabella';
+  // Invalid chatterbox filenames reset to empty rather than being rewritten to
+  // a Kokoro id.
+  if (engine === 'chatterbox' && voice && !TTS_CHATTERBOX_VOICE_RE.test(voice)) voice = '';
+  if (
+    engine === 'pocket-tts' &&
+    (!voice ||
+      (!TTS_POCKET_VOICE_RE.test(voice) && !TTS_CHATTERBOX_VOICE_RE.test(voice)))
+  ) {
+    voice = 'alba';
+  }
+  // A Kokoro-shaped id under piper is PRESERVED, not wiped — see the schema.
+  if (
+    engine === 'piper' &&
+    voice &&
+    !TTS_PIPER_VOICE_RE.test(voice) &&
+    !TTS_KOKORO_VOICE_RE.test(voice)
+  ) {
+    voice = '';
+  }
+  if (!voice && engine === 'cloud' && cloudProvider !== 'openai-compatible') voice = 'alloy';
+  if (
+    !voice &&
+    engine !== 'cloud' &&
+    engine !== 'chatterbox' &&
+    engine !== 'piper' &&
+    engine !== 'remote'
+  ) {
+    voice = 'bf_isabella';
+  }
+  return {
+    engine,
+    cloudProvider,
+    voice,
+    gainDb: clampTtsGain(r.gainDb),
+    speed: clampTtsSpeed(r.speed),
+  };
+}
+
+// ── Persona ──────────────────────────────────────────────────────────────────
+
+// Explicit null reads as "absent" on every OPTIONAL field. The pre-schema
+// validator accepted null everywhere it accepted an omission (`String(x ?? '')`,
+// `!== undefined && !== null` guards), and clients that write null for an empty
+// field relied on it. zod's `.default()` fires only on undefined.
+const personaNullToUndefined = (v: unknown) => (v == null ? undefined : v);
+
+/**
+ * `String(x ?? '').trim()` then a length check — the exact coercion the
+ * hand-rolled validator applied to name/soul/tagline.
+ *
+ * Deliberately NOT `z.string()`: a numeric or boolean value stringifies today
+ * (a persona named `123` saves), and refusing it would be a tightening. The
+ * message names its own field because it is also the flat `error` a 400 carries.
+ */
+// The `.optional()` is load-bearing on every z.unknown() field in this module,
+// and is NOT the same statement as "this field may be omitted". zod 4 treats a
+// bare z.unknown() inside z.object as a REQUIRED key and refuses an absent one
+// with 'expected nonoptional' before the transform ever runs — so without it a
+// persona that simply omits `tagline` (or a dial) fails, where the hand-rolled
+// validator read the omission as '' and 5 respectively. Optionality here restores
+// that: the transform still runs, and `String(undefined ?? '')` is what decides
+// the outcome — '' passes a min of 0 and fails a min of 1, exactly as before.
+function personaCoercedText(field: string, min: number, max: number) {
+  return z.unknown().optional().transform((raw, ctx) => {
+    const v = String(raw ?? '').trim();
+    if (v.length < min || v.length > max) {
+      ctx.addIssue({ code: 'custom', message: `${field} must be ${min}-${max} chars` });
+      return z.NEVER;
+    }
+    return v;
+  });
+}
+
+export interface PersonaParsed {
+  id?: string;
+  name: string;
+  tagline: string;
+  frequency: string;
+  scriptLength: string;
+  djMode: boolean;
+  humour: number;
+  localColour: number;
+  warmth: number;
+  soul: string;
+  language: string;
+  avatar: string;
+  tts: TtsVoiceSlot;
+  skills: string[] | null;
+}
+
+/**
+ * One persona.
+ *
+ * `id` is OPTIONAL and a malformed one is DROPPED rather than refused — the
+ * same call the shows conversion made, and for a stronger reason: a persona id
+ * is what every show's `personaId`, every guest list and `activePersonaId` point
+ * at, so refusing one bad id in a backup would refuse the whole roster.
+ * persona-server.ts's resolvePersonaIds mints the replacement.
+ *
+ * Field ORDER matters — zod reports issues in declaration order, and the
+ * hand-rolled validator checked name → soul → tagline → language → frequency →
+ * scriptLength → djMode → tts → skills → avatar. An operator with two bad
+ * fields must still be told about the same one first.
+ */
+export const personaSchema = z
+  .object({
+    name: personaCoercedText('name', 1, PERSONA_NAME_MAX),
+    soul: personaCoercedText('soul', 1, PERSONA_SOUL_MAX),
+    tagline: personaCoercedText('tagline', 0, PERSONA_TAGLINE_MAX),
+    // language — optional free text ("Turkish", "Türkçe", …). Absent/empty → ''
+    // (English, no directive injected). Unlike name/soul this one REFUSES a
+    // non-string instead of coercing, which is what the validator did.
+    language: z.preprocess(
+      personaNullToUndefined,
+      z
+        .string({ error: 'language must be a string' })
+        .trim()
+        .max(PERSONA_LANGUAGE_MAX, `language must be 0-${PERSONA_LANGUAGE_MAX} chars`)
+        .default(''),
+    ),
+    frequency: z.enum(PERSONA_FREQUENCIES, {
+      error: `frequency must be one of: ${PERSONA_FREQUENCIES.join(', ')}`,
+    }),
+    // Absent → 'concise' (the default and the historical behaviour).
+    scriptLength: z.preprocess(
+      personaNullToUndefined,
+      z
+        .enum(PERSONA_SCRIPT_LENGTHS, {
+          error: `scriptLength must be one of: ${PERSONA_SCRIPT_LENGTHS.join(', ')}`,
+        })
+        .default('concise'),
+    ),
+    // Absent → false (a plain narrator persona). Present must be a real boolean:
+    // unlike the `=== true` booleans on a show, BOTH paths never agreed here —
+    // the strict validator refused a non-boolean — so the refusal is preserved.
+    djMode: z.preprocess(
+      personaNullToUndefined,
+      z.boolean({ error: 'djMode must be a boolean' }).default(false),
+    ),
+    // An absent dial reads as neutral, which is what clampPersonaDial returns
+    // for undefined — see the note on personaCoercedText for the .optional().
+    humour: z.unknown().optional().transform(clampPersonaDial),
+    localColour: z.unknown().optional().transform(clampPersonaDial),
+    warmth: z.unknown().optional().transform(clampPersonaDial),
+    // A bare basename, never a path. The dedicated upload route is the only
+    // writer that creates the file; this just checks the persisted string.
+    avatar: z.preprocess(
+      (v) => (v == null || v === '' ? undefined : v),
+      z
+        .unknown()
+        .transform((raw, ctx) => {
+          const a = String(raw).trim();
+          if (!PERSONA_AVATAR_FILENAME_RE.test(a)) {
+            ctx.addIssue({
+              code: 'custom',
+              message: 'avatar must be a basename like <id>.png|jpg|jpeg|webp',
+            });
+            return z.NEVER;
+          }
+          return a;
+        })
+        .optional()
+        .transform((v) => v ?? ''),
+    ),
+    tts: ttsVoiceSlotSchema('tts'),
+    // skills — absent → null ("all skills", the legacy default). Present → an
+    // explicit slug array.
+    skills: z.preprocess(
+      personaNullToUndefined,
+      z
+        .array(z.unknown(), { error: 'skills must be an array of skill names' })
+        .max(PERSONA_SKILLS_LIMIT, `skills must be at most ${PERSONA_SKILLS_LIMIT} entries`)
+        .transform((items) => {
+          // A malformed entry is DROPPED, not refused. persona.skills is a
+          // subscription list resolved against the live skill catalogue at fire
+          // time, so an entry that can't name a skill can never fire — and the
+          // OLD shape check accepted forms the slug rule refuses (a leading
+          // hyphen), so a backup can legitimately carry one. Failing the whole
+          // roster over inert junk is the themeId lesson (#917) again.
+          const seen = new Set<string>();
+          const out: string[] = [];
+          for (const s of items) {
+            const v = String(s ?? '').trim();
+            if (!PERSONA_SKILL_SLUG_RE.test(v)) continue;
+            if (seen.has(v)) continue;
+            seen.add(v);
+            out.push(v);
+          }
+          return out;
+        })
+        .nullable()
+        .default(null),
+    ),
+    id: z.preprocess(
+      // A malformed id reads as absent so resolvePersonaIds mints one.
+      (v) => (typeof v === 'string' && PERSONA_ID_RE.test(v) ? v : undefined),
+      z.string().optional(),
+    ),
+  })
+  // The persisted key order, which several fixtures and the backup diff rely on.
+  .transform(
+    (p): PersonaParsed => ({
+      id: p.id,
+      name: p.name,
+      tagline: p.tagline,
+      frequency: p.frequency,
+      scriptLength: p.scriptLength,
+      djMode: p.djMode,
+      humour: p.humour,
+      localColour: p.localColour,
+      warmth: p.warmth,
+      soul: p.soul,
+      language: p.language,
+      avatar: p.avatar,
+      tts: p.tts,
+      skills: p.skills,
+    }),
+  );
+
+/**
+ * The whole roster.
+ *
+ * A station with NO persona has no one to speak, which is why the floor is 1
+ * rather than 0 — settings.load() falls back to the seeded roster instead.
+ */
+export const personasSchema = z
+  .array(personaSchema, { error: `personas must be an array of 1-${PERSONA_LIMIT} entries` })
+  .min(1, `personas must be an array of 1-${PERSONA_LIMIT} entries`)
+  .max(PERSONA_LIMIT, `personas must be an array of 1-${PERSONA_LIMIT} entries`);
+
+/**
+ * Every per-field repair the LOAD path applies before parsing.
+ *
+ * `undefined` lets the schema's own default apply. Each repair lands on a value
+ * the strict path accepts, so load and save still agree about what a valid
+ * persona is — the schema itself is still run on the result. A row that cannot
+ * be repaired into validity (no name, no soul) fails the parse and the caller
+ * drops it, exactly as normalizePersona returned null.
+ *
+ * `skillRenames` travels as plain DATA rather than being imported, because this
+ * module may import nothing but zod. The browser passes `{}`.
+ */
+export function repairPersonaForLoad(
+  raw: Record<string, unknown>,
+  skillRenames: Record<string, string> = {},
+): Record<string, unknown> {
+  return {
+    ...raw,
+    id: typeof raw.id === 'string' && PERSONA_ID_RE.test(raw.id) ? raw.id : undefined,
+    name: typeof raw.name === 'string' ? raw.name.trim().slice(0, PERSONA_NAME_MAX) : undefined,
+    soul: typeof raw.soul === 'string' ? raw.soul.trim().slice(0, PERSONA_SOUL_MAX) : undefined,
+    tagline:
+      typeof raw.tagline === 'string' ? raw.tagline.trim().slice(0, PERSONA_TAGLINE_MAX) : '',
+    language:
+      typeof raw.language === 'string'
+        ? raw.language.trim().slice(0, PERSONA_LANGUAGE_MAX)
+        : undefined,
+    frequency: (PERSONA_FREQUENCIES as readonly string[]).includes(raw.frequency as string)
+      ? raw.frequency
+      : 'moderate',
+    scriptLength: (PERSONA_SCRIPT_LENGTHS as readonly string[]).includes(
+      raw.scriptLength as string,
+    )
+      ? raw.scriptLength
+      : undefined,
+    djMode: raw.djMode === true ? true : undefined,
+    avatar:
+      typeof raw.avatar === 'string' && PERSONA_AVATAR_FILENAME_RE.test(raw.avatar.trim())
+        ? raw.avatar.trim()
+        : undefined,
+    tts: repairTtsVoiceSlot(raw.tts),
+    // Non-array → undefined → the schema's null default ("all skills"), which is
+    // what normalizeSkills returned. Renames are applied HERE and not in the
+    // schema: a rename is a migration of stored data, not a rule a submitted
+    // value has to satisfy, and the strict path has never applied them.
+    skills: Array.isArray(raw.skills)
+      ? raw.skills
+          .filter((s): s is string => typeof s === 'string')
+          .map((s) => skillRenames[s.trim()] || s.trim())
+          .filter((s) => PERSONA_SKILL_SLUG_RE.test(s))
+          .slice(0, PERSONA_SKILLS_LIMIT)
+      : undefined,
+  };
+}
+
+// ── DJ prompt library ────────────────────────────────────────────────────────
+
+export const DJ_PROMPT_LIMIT = 20;
+export const DJ_PROMPT_NAME_MAX = 60;
+export const DJ_PROMPT_TEXT_MIN = 50;
+export const DJ_PROMPT_TEXT_MAX = 4000;
+/** Every prompt template must address the persona by name. */
+export const DJ_PROMPT_PLACEHOLDER = '{name}';
+
+export interface DjPromptParsed {
+  id?: string;
+  name: string;
+  text: string;
+}
+
+export const djPromptSchema = z
+  .object({
+    name: personaCoercedText('name', 1, DJ_PROMPT_NAME_MAX),
+    text: z.unknown().optional().transform((raw, ctx) => {
+      const v = String(raw ?? '').trim();
+      if (v.length < DJ_PROMPT_TEXT_MIN || v.length > DJ_PROMPT_TEXT_MAX) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `text must be ${DJ_PROMPT_TEXT_MIN}-${DJ_PROMPT_TEXT_MAX} chars`,
+        });
+        return z.NEVER;
+      }
+      if (!v.includes(DJ_PROMPT_PLACEHOLDER)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `text must contain the ${DJ_PROMPT_PLACEHOLDER} placeholder`,
+        });
+        return z.NEVER;
+      }
+      return v;
+    }),
+    id: z.preprocess(
+      (v) => (typeof v === 'string' && PERSONA_ID_RE.test(v) ? v : undefined),
+      z.string().optional(),
+    ),
+  })
+  .transform((p): DjPromptParsed => ({ id: p.id, name: p.name, text: p.text }));
+
+export const djPromptsSchema = z
+  .array(djPromptSchema, {
+    error: `djPrompts must be an array of 0-${DJ_PROMPT_LIMIT} entries`,
+  })
+  .max(DJ_PROMPT_LIMIT, `djPrompts must be an array of 0-${DJ_PROMPT_LIMIT} entries`);
+
+/**
+ * The LOAD path's per-field repair for one prompt entry.
+ *
+ * Only `name` is repairable — the text IS the entry, so a text that can't render
+ * drops the row rather than being invented. `fallbackName` is supplied by the
+ * caller because the historical fallback ("Prompt 3") numbers by SURVIVING row,
+ * which this module cannot know.
+ */
+export function repairDjPromptForLoad(
+  raw: Record<string, unknown>,
+  fallbackName: string,
+): Record<string, unknown> {
+  const name =
+    (typeof raw.name === 'string' ? raw.name.trim().slice(0, DJ_PROMPT_NAME_MAX) : '') ||
+    fallbackName;
+  return {
+    ...raw,
+    id: typeof raw.id === 'string' && PERSONA_ID_RE.test(raw.id) ? raw.id : undefined,
+    name,
+  };
+}

--- a/controller/src/schemas/schedule.ts
+++ b/controller/src/schemas/schedule.ts
@@ -248,11 +248,18 @@ export interface ScheduleOverrideContext {
 
 export function scheduleOverrideSchema(ctx: ScheduleOverrideContext) {
   return z
-    .object({
-      showId: z.string({ error: 'must be a show id' }).min(1, 'must be a show id'),
-      startedAt: z.number({ error: 'must be an epoch-ms number' }).finite('must be an epoch-ms number'),
-      expiresAt: z.number({ error: 'must be an epoch-ms number' }).finite('must be an epoch-ms number'),
-    })
+    .object(
+      {
+        showId: z.string({ error: 'must be a show id' }).min(1, 'must be a show id'),
+        startedAt: z.number({ error: 'must be an epoch-ms number' }).finite('must be an epoch-ms number'),
+        expiresAt: z.number({ error: 'must be an epoch-ms number' }).finite('must be an epoch-ms number'),
+      },
+      // Explicit, so a non-object never reaches an operator as zod's own
+      // 'Invalid input: expected object, received number'. Phrased WITHOUT the
+      // key, like the field messages above, because every caller roots this
+      // schema at 'scheduleOverride' — self-naming here would double it.
+      { error: 'must be an object' },
+    )
     .check((c) => {
       const { showId, startedAt, expiresAt } = c.value;
       if (ctx.showIds && !ctx.showIds.includes(showId)) {

--- a/controller/src/schemas/settings.ts
+++ b/controller/src/schemas/settings.ts
@@ -939,3 +939,135 @@ export function festivalsSchema(ctx: SettingsMoodContext) {
       })),
     );
 }
+
+
+// ── theme ────────────────────────────────────────────────────────────────────
+
+/**
+ * `theme` — only `active` is a settings value; everything else in the block is
+ * derived at serve time.
+ *
+ * A NON-OBJECT block is a silent no-op (`patch.theme || {}`), so it is coerced
+ * rather than refused — the settingsBlockOf posture. And `active` is optional
+ * BECAUSE the branch acts only `if (t.active !== undefined)`: a patch of
+ * `{theme: {}}` has always been a legal no-op.
+ *
+ * What stays in update(): the "is this a theme id that actually exists" check.
+ * It is async (the registry reads the themes dir) and it FALLS BACK to the
+ * built-in default rather than refusing (#917 — throwing there aborted the whole
+ * restore for any install whose active theme id had since been retired), which
+ * is a repair only the server can make.
+ */
+export const themePatchSchema = z.preprocess(
+  (v) => (v && typeof v === 'object' && !Array.isArray(v) ? v : {}),
+  z.object({
+    active: z
+      .unknown()
+      .optional()
+      .transform((raw, ctx) => {
+        if (raw === undefined) return undefined;
+        const v = String(raw ?? '').trim();
+        if (!v) {
+          ctx.addIssue({ code: 'custom', message: 'theme.active must be a theme id' });
+          return z.NEVER;
+        }
+        return v;
+      }),
+  }),
+);
+
+// ── maxTrackSeconds ──────────────────────────────────────────────────────────
+
+/**
+ * The station-wide track-length cap. 0 = unlimited.
+ *
+ * BOUNDS ONLY. The crossfade-derived FLOOR ("a non-zero cap must leave solo
+ * airtime") stays in update(), for the reason ShowSchemaContext's
+ * `minTrackSeconds: null` documents: the floor is a function of the crossfade,
+ * which the SAME patch may be changing, so only update() — which applies the
+ * crossfade first — can judge it.
+ *
+ * The legacy `maxTrackMinutes` alias is deliberately NOT registered beside this.
+ * One branch serves both keys through `rawMaxTrackSec`, whose precedence rule is
+ * "seconds wins whenever it is present and non-empty" — so when both ride along,
+ * an unusable minutes value is IGNORED today, and a schema on that key would
+ * refuse a body that currently saves. An empty/absent seconds value passes here
+ * for the same reason: precedence hands off to minutes, and update() is still
+ * the authoritative chokepoint for whatever it resolves.
+ */
+export function maxTrackSecondsValueSchema(bounds: SettingsNumericBound) {
+  return settingsIntLike(
+    bounds,
+    `maxTrackSeconds must be int in [${bounds.min}, ${bounds.max}]`,
+  );
+}
+
+/**
+ * The REGISTRY entry — the same rule, one posture looser.
+ *
+ * `rawMaxTrackSec`'s precedence is "seconds wins whenever it is present and
+ * non-empty", so an absent or empty `maxTrackSeconds` beside a `maxTrackMinutes`
+ * is a legal body that hands off rather than a failure. update() validates the
+ * RESOLVED value with maxTrackSecondsValueSchema above, which is why the bound
+ * itself is written once.
+ *
+ * The legacy `maxTrackMinutes` alias is deliberately NOT registered: when both
+ * ride along, an unusable minutes value is IGNORED today, and a schema on that
+ * key would refuse a body that currently saves.
+ */
+export function maxTrackSecondsSchema(bounds: SettingsNumericBound) {
+  const value = maxTrackSecondsValueSchema(bounds);
+  return z.unknown().superRefine((raw, ctx) => {
+    if (raw == null || raw === '') return;
+    const r = value.safeParse(raw);
+    if (!r.success) {
+      for (const issue of r.error.issues) ctx.addIssue({ code: 'custom', message: issue.message });
+    }
+  });
+}
+
+// ── the DJ prompt selection ──────────────────────────────────────────────────
+
+/**
+ * `activeDjPromptId` — '' selects the built-in default, otherwise the id of a
+ * djPrompts entry.
+ *
+ * Coercion ONLY: `String(x ?? '').trim()` is the whole of what the branch does
+ * to this value. Whether the id resolves is a cross-key question answered after
+ * `djPrompts` has been applied, and it stays in update() — the same patch may be
+ * replacing the library the id has to name.
+ */
+export const activeDjPromptIdSchema = z
+  .unknown()
+  .optional()
+  .transform((raw) => String(raw ?? '').trim());
+
+/**
+ * `djPrompt` — the legacy single-field prompt (onboarding, older clients).
+ *
+ * Its two rules are pure and convert; what stays in update() is the MAPPING onto
+ * the library — '' selects the default, and custom text reuses the entry with
+ * identical text or appends a new "Custom prompt" — which reads and writes
+ * `next.djPrompts` and can hit the library cap.
+ */
+export function djPromptTextSchema(bounds: { min: number; max: number }) {
+  return z
+    .unknown()
+    .optional()
+    .transform((raw, ctx) => {
+      const v = String(raw ?? '').trim();
+      if (v === '') return v;
+      if (v.length < bounds.min || v.length > bounds.max) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `djPrompt must be empty (use the default) or ${bounds.min}-${bounds.max} chars`,
+        });
+        return z.NEVER;
+      }
+      if (!v.includes('{name}')) {
+        ctx.addIssue({ code: 'custom', message: 'djPrompt must contain the {name} placeholder' });
+        return z.NEVER;
+      }
+      return v;
+    });
+}

--- a/controller/src/schemas/settings.ts
+++ b/controller/src/schemas/settings.ts
@@ -860,6 +860,17 @@ export function weatherMoodsSchema(ctx: SettingsMoodContext) {
   return settingsMoodMap(SETTINGS_WEATHER_CONDITIONS, 'weatherMoods', true, ctx);
 }
 
+// Festival field bounds. Named rather than left as literals inside the schema
+// because the admin editor needs the same numbers for its maxLength / min / max
+// attributes, and it was hard-coding them — the drift that had already bitten
+// the persona editor.
+export const SETTINGS_FESTIVAL_NAME_MAX = 80;
+export const SETTINGS_FESTIVAL_DESCRIPTION_MAX = 200;
+// Days either side of the date on which the festival's mood applies. The
+// ceiling is deliberately low: past a fortnight a "festival window" is just a
+// season, which is what moodSchedule is for.
+export const SETTINGS_FESTIVAL_WINDOW_DAYS_MAX = 14;
+
 export function festivalsSchema(ctx: SettingsMoodContext) {
   const names = ctx.moodNames ? new Set(ctx.moodNames) : null;
   const list = ctx.moodNames ? ctx.moodNames.join(', ') : '';
@@ -890,8 +901,8 @@ export function festivalsSchema(ctx: SettingsMoodContext) {
         }
         const f = item as Record<string, unknown>;
         const name = String(f.name ?? '').trim();
-        if (name.length < 1 || name.length > 80) {
-          add(`festivals[${i}].name must be 1-80 chars`, 'name');
+        if (name.length < 1 || name.length > SETTINGS_FESTIVAL_NAME_MAX) {
+          add(`festivals[${i}].name must be 1-${SETTINGS_FESTIVAL_NAME_MAX} chars`, 'name');
           return;
         }
         const month = Number(f.month);
@@ -922,8 +933,15 @@ export function festivalsSchema(ctx: SettingsMoodContext) {
           return;
         }
         const windowDays = Number(f.windowDays ?? 0);
-        if (!Number.isInteger(windowDays) || windowDays < 0 || windowDays > 14) {
-          add(`festivals[${i}].windowDays must be an integer 0-14`, 'windowDays');
+        if (
+          !Number.isInteger(windowDays)
+          || windowDays < 0
+          || windowDays > SETTINGS_FESTIVAL_WINDOW_DAYS_MAX
+        ) {
+          add(
+            `festivals[${i}].windowDays must be an integer 0-${SETTINGS_FESTIVAL_WINDOW_DAYS_MAX}`,
+            'windowDays',
+          );
         }
       });
     })
@@ -934,7 +952,9 @@ export function festivalsSchema(ctx: SettingsMoodContext) {
         name: String(f.name ?? '').trim(),
         mood: String(f.mood ?? '').trim(),
         description:
-          typeof f.description === 'string' ? f.description.trim().slice(0, 200) : '',
+          typeof f.description === 'string'
+            ? f.description.trim().slice(0, SETTINGS_FESTIVAL_DESCRIPTION_MAX)
+            : '',
         windowDays: Number(f.windowDays ?? 0),
       })),
     );

--- a/controller/src/schemas/show.ts
+++ b/controller/src/schemas/show.ts
@@ -399,7 +399,13 @@ export type ShowParsed = z.output<ReturnType<typeof showSchema>>;
 export type Show = ShowParsed & { id: string };
 
 export function showsSchema(ctx: ShowSchemaContext) {
-  return z.array(showSchema(ctx)).max(SHOWS_LIMIT, `must be at most ${SHOWS_LIMIT} entries`);
+  // The array-level error is explicit so a non-array never reaches an operator
+  // as zod's own 'Invalid input: expected array, received number'. Phrased
+  // WITHOUT the key, like every other message here, because both callers root
+  // this schema at 'shows'.
+  return z
+    .array(showSchema(ctx), { error: 'must be an array' })
+    .max(SHOWS_LIMIT, `must be at most ${SHOWS_LIMIT} entries`);
 }
 
 // POST /shows submits ONE show under a `show` key and merges it server-side.

--- a/controller/src/schemas/webhook.ts
+++ b/controller/src/schemas/webhook.ts
@@ -66,7 +66,10 @@ export type WebhookParsed = z.output<typeof webhookSchema>;
 export type Webhook = WebhookParsed & { id: string };
 
 export const webhooksSchema = z
-  .array(webhookSchema)
+  // Explicit, so a non-array reads as something an operator can act on rather
+  // than zod's 'Invalid input: expected array, received number'. Both callers
+  // root this schema at 'webhooks'.
+  .array(webhookSchema, { error: 'must be an array' })
   .max(WEBHOOKS_LIMIT, `At most ${WEBHOOKS_LIMIT} webhooks`);
 
 // Both fields optional: the route lets the listener gate save on its own

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -34,8 +34,6 @@ import {
   DEFAULT_DJ_PROMPT_TEMPLATE,
   DJ_HOUSE_RULES_MAX,
   DJ_PROMPT_LIMIT,
-  DJ_PROMPT_TEXT_MAX,
-  DJ_PROMPT_TEXT_MIN,
   DjPromptEntry,
   FESTIVAL_DEFAULTS,
   KOKORO_LANGS,
@@ -88,6 +86,7 @@ import {
 } from './settings/defaults.js';
 import { validateCompatParams } from './settings/compat-params.js';
 import { parseSettingsPatchKey } from './settings/patch-registry.js';
+import { maxTrackSecondsValueSchema } from './schemas/settings.js';
 import { minTrackSeconds, peek, setCache } from './settings/store.js';
 import {
   SKILL_RENAMES,
@@ -1045,12 +1044,14 @@ export async function update(patch) {
     }
   }
   if ('maxTrackSeconds' in patch || 'maxTrackMinutes' in patch) {
-    const v = parseInt(rawMaxTrackSec(patch) as string, 10);
-    if (!Number.isFinite(v) || v < BOUNDS.maxTrackSeconds.min || v > BOUNDS.maxTrackSeconds.max) {
-      throw new Error(
-        `maxTrackSeconds must be int in [${BOUNDS.maxTrackSeconds.min}, ${BOUNDS.maxTrackSeconds.max}]`,
-      );
-    }
+    // The bound lives once, in the shared schema — this applies it to the
+    // RESOLVED value (seconds, or the legacy minutes alias × 60), which is the
+    // figure the precedence rule actually selected.
+    const parsedCap = maxTrackSecondsValueSchema(BOUNDS.maxTrackSeconds).safeParse(
+      rawMaxTrackSec(patch),
+    );
+    if (!parsedCap.success) throw new Error(parsedCap.error.issues[0].message);
+    const v = parsedCap.data;
     // Non-zero caps must clear the crossfade-relative floor (0 = unlimited stays
     // allowed): the track crossfades out starting crossfadeDuration before the
     // cap, so a shorter cap is degenerate / leaves no solo airtime. Uses next's
@@ -1182,10 +1183,9 @@ export async function update(patch) {
     next.locale = parseSettingsPatchKey<string>('locale', patch.locale);
   }
   if ('theme' in patch) {
-    const t = patch.theme || {};
+    const t = parseSettingsPatchKey<{ active?: string }>('theme', patch.theme);
     if (t.active !== undefined) {
-      const v = String(t.active ?? '').trim();
-      if (!v) throw new Error('theme.active must be a theme id');
+      const v = t.active;
       // A stale active theme (a retired built-in renamed in 58c3782b, or a
       // custom theme that isn't on disk) falls back to the built-in default
       // rather than failing the save — same tolerance as shows[].themeId above
@@ -1209,7 +1209,9 @@ export async function update(patch) {
   // Captured ONCE so the maps, festivals and shows below all judge against the
   // same list; re-deriving per branch is a latent divergence.
   const moodNames = (next.moods || []).map((m: any) => m.name);
-  const moodCtx = { moodNames };
+  // The mood family needs only the vocabulary; `showIds: null` says this branch
+  // is not in a position to check roster membership — shows are validated below.
+  const moodCtx = { moodNames, showIds: null };
   if ('moodSchedule' in patch) {
     next.moodSchedule = parseSettingsPatchKey('moodSchedule', patch.moodSchedule, moodCtx);
   }
@@ -1228,21 +1230,18 @@ export async function update(patch) {
     next.djPrompts = validateDjPromptsStrict(patch.djPrompts);
   }
   if ('activeDjPromptId' in patch) {
-    next.activeDjPromptId = String(patch.activeDjPromptId ?? '').trim();
+    next.activeDjPromptId = parseSettingsPatchKey<string>(
+      'activeDjPromptId',
+      patch.activeDjPromptId,
+    );
   }
   if ('djPrompt' in patch) {
-    const v = String(patch.djPrompt ?? '').trim();
+    // The length + placeholder rules come from the shared schema; what stays
+    // here is the MAPPING onto the library, which reads and writes next.djPrompts.
+    const v = parseSettingsPatchKey<string>('djPrompt', patch.djPrompt);
     if (v === '') {
       next.activeDjPromptId = '';
     } else {
-      if (v.length < DJ_PROMPT_TEXT_MIN || v.length > DJ_PROMPT_TEXT_MAX) {
-        throw new Error(
-          `djPrompt must be empty (use the default) or ${DJ_PROMPT_TEXT_MIN}-${DJ_PROMPT_TEXT_MAX} chars`,
-        );
-      }
-      if (!v.includes('{name}')) {
-        throw new Error('djPrompt must contain the {name} placeholder');
-      }
       let entry = next.djPrompts.find((p: DjPromptEntry) => p.text === v);
       if (!entry) {
         if (next.djPrompts.length >= DJ_PROMPT_LIMIT) {

--- a/controller/src/settings/normalize.ts
+++ b/controller/src/settings/normalize.ts
@@ -5,35 +5,15 @@
 // Part of the settings/ split — see ../settings.ts for the public barrel.
 
 import {
-  AVATAR_FILENAME_RE,
-  CHATTERBOX_VOICE_RE,
   DJ_PROMPT_LIMIT,
-  DJ_PROMPT_NAME_MAX,
-  DJ_PROMPT_TEXT_MAX,
-  DJ_PROMPT_TEXT_MIN,
   DjPromptEntry,
-  FREQUENCIES,
-  ID_RE,
-  KOKORO_VOICE_RE,
   NormalizedShow,
   PERSONA_LIMIT,
-  PIPER_VOICE_RE,
-  POCKET_TTS_VOICE_RE,
-  SCRIPT_LENGTHS,
-  SKILLS_PER_PERSONA_LIMIT,
-  SKILL_SLUG_RE,
-  SOUL_MAX,
   ScheduleOverride,
-  TTS_CLOUD_PROVIDERS,
-  TTS_ENGINES,
   WEBHOOKS_LIMIT,
   WEBHOOK_EVENTS,
   Webhook,
-  clampTtsGain,
-  clampTtsSpeed,
   emptyWeek,
-  mintId,
-  normalizeDial,
 } from './vocab.js';
 import { DEFAULTS, coerceMaxTrackSeconds } from './defaults.js';
 // The webhook rules themselves, so this lenient path and update()'s strict one
@@ -49,6 +29,16 @@ import {
   type ShowSchemaContext,
 } from '../schemas/show.js';
 import { resolveShowIds } from '../schemas/show-server.js';
+// The persona + prompt-library rules themselves, so this lenient path and
+// update()'s strict one cannot restate them differently.
+import {
+  djPromptSchema,
+  personaSchema,
+  repairDjPromptForLoad,
+  repairPersonaForLoad,
+  repairTtsVoiceSlot,
+} from '../schemas/persona.js';
+import { resolveDjPromptIds, resolvePersonaIds } from '../schemas/persona-server.js';
 import {
   repairScheduleForLoad,
   scheduleSchema,
@@ -85,69 +75,17 @@ export function normalizeArchiveRetentionDays(archive: any): number {
 export const SKILL_RENAMES: Record<string, string> = {
   'random-facts': 'curiosity',
 };
-function normalizeSkills(raw: unknown) {
-  if (!Array.isArray(raw)) return null;
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const item of raw) {
-    if (typeof item !== 'string') continue;
-    const v = SKILL_RENAMES[item.trim()] || item.trim();
-    if (!SKILL_SLUG_RE.test(v) || seen.has(v)) continue;
-    seen.add(v);
-    out.push(v);
-    if (out.length >= SKILLS_PER_PERSONA_LIMIT) break;
-  }
-  return out;
-}
-
-// Lenient normaliser for a `{engine, voice, cloudProvider}` voice slot. Shared
-// by every persona's `tts` block AND the station-wide TTS fallback slot
-// (`settings.tts.fallback`) — the two carry the same shape by design, because a
-// fallback slot is handed to speakWith() as a synthetic persona (the same trick
-// synthesizeSample() uses for previews). Keeping one normaliser is what stops
-// the per-engine voice rules drifting between the two.
-export function normalizeTts(raw: unknown) {
-  const r = (raw ?? {}) as Record<string, unknown>;
-  const engine = TTS_ENGINES.includes(r.engine as string) ? (r.engine as string) : 'piper';
-  const cloudProvider = TTS_CLOUD_PROVIDERS.includes(r.cloudProvider as string)
-    ? (r.cloudProvider as string)
-    : 'openai';
-  let voice =
-    typeof r.voice === 'string' && r.voice.trim() ? r.voice.trim().slice(0, 100) : '';
-  if (engine === 'kokoro' && !KOKORO_VOICE_RE.test(voice)) voice = 'bf_isabella';
-  // Chatterbox voices are reference-WAV filenames in config.chatterbox.voiceDir.
-  // Empty is legitimate ("use built-in default"), invalid filenames get reset
-  // to empty rather than rewritten to a Kokoro id.
-  if (engine === 'chatterbox' && voice && !CHATTERBOX_VOICE_RE.test(voice)) voice = '';
-  // PocketTTS accepts a built-in voice id (alba, anna, …) OR a .wav filename
-  // in the shared voice folder for zero-shot cloning (issue #213). Anything
-  // that matches neither shape resets to the default; the worker also guards
-  // against unknown ids, but normalising here keeps the persisted form clean.
-  if (
-    engine === 'pocket-tts'
-    && (!voice
-      || (!POCKET_TTS_VOICE_RE.test(voice) && !CHATTERBOX_VOICE_RE.test(voice)))
-  ) {
-    voice = 'alba';
-  }
-  // Piper voices are `.onnx` filenames in the shared voice folder (issue #230).
-  // Empty is legitimate ("use the baked-in default voice"); invalid filenames
-  // reset to empty. A Kokoro-shaped id is preserved, not wiped: the seed roster
-  // carries one per persona under piper so switching to Kokoro yields distinct
-  // voices without re-editing, and resolvePiperVoice() falls back gracefully for
-  // it at render time. Wiping it here would silently break that on first reload
-  // after a save (issue #454).
-  if (engine === 'piper' && voice && !PIPER_VOICE_RE.test(voice) && !KOKORO_VOICE_RE.test(voice))
-    voice = '';
-  // openai-compatible voices are server-specific (often arbitrary cloning ref
-  // names) — no canonical default; leave empty so generateSpeech omits the
-  // field and the server picks its own. Remote engine voices likewise:
-  // server-specific (id, reference-wav filename, or VoiceDesign prompt), no
-  // Subwave-side default.
-  if (!voice && engine === 'cloud' && cloudProvider !== 'openai-compatible') voice = 'alloy';
-  if (!voice && engine !== 'cloud' && engine !== 'chatterbox' && engine !== 'piper' && engine !== 'remote') voice = 'bf_isabella';
-  return { engine, cloudProvider, voice, gainDb: clampTtsGain(r.gainDb), speed: clampTtsSpeed(r.speed) };
-}
+/**
+ * Lenient normaliser for a `{engine, voice, cloudProvider}` voice slot.
+ *
+ * Shared by every persona's `tts` block AND the station-wide TTS fallback slot
+ * (`settings.tts.fallback`) — the two carry the same shape by design, because a
+ * fallback slot is handed to speakWith() as a synthetic persona. The rules now
+ * live once, in schemas/persona.ts's repairTtsVoiceSlot, beside the strict ones
+ * they repair against — a repair restated at the call site is a repair that can
+ * drift from the schema.
+ */
+export const normalizeTts = repairTtsVoiceSlot;
 
 // Load-time shape for `settings.tts.fallback` — the station's operator-chosen
 // rescue voice. The voice slot itself goes through normalizeTts() (one set of
@@ -163,73 +101,64 @@ export function normalizeTtsFallback(raw: unknown) {
   return { enabled: typeof r.enabled === 'boolean' ? r.enabled : false, engine, voice, cloudProvider };
 }
 
+/**
+ * One persona, repaired then validated by the SAME schema update() enforces.
+ *
+ * repairPersonaForLoad lands every field on a value the strict path accepts, so
+ * load and save cannot disagree about what a valid persona is. What stays here
+ * is only the LENIENCY: a row that cannot be repaired into validity (no name,
+ * no soul) returns null and the caller drops it, where update() would throw.
+ *
+ * SKILL_RENAMES travels as an argument because schemas/persona.ts may import
+ * nothing but zod — and because a rename is a migration of stored data, not a
+ * rule a submitted value has to satisfy, which is why the strict path has never
+ * applied one.
+ */
 export function normalizePersona(raw: unknown) {
   if (!raw || typeof raw !== 'object') return null;
-  const r = raw as Record<string, unknown>;
-  const name = typeof r.name === 'string' ? r.name.trim().slice(0, 40) : '';
-  const soul = typeof r.soul === 'string' ? r.soul.trim().slice(0, SOUL_MAX) : '';
-  if (!name || !soul) return null;
-  // Avatar — stored as a bare basename. Reset to '' if the persisted value
-  // doesn't match the strict basename shape, so a hand-edited settings.json
-  // can never point /persona-avatar/:id at an arbitrary path.
-  const rawAvatar = typeof r.avatar === 'string' ? r.avatar.trim() : '';
-  const avatar = rawAvatar && AVATAR_FILENAME_RE.test(rawAvatar) ? rawAvatar : '';
-  return {
-    id: typeof r.id === 'string' && ID_RE.test(r.id) ? r.id : mintId('p_'),
-    name,
-    tagline: typeof r.tagline === 'string' ? r.tagline.trim().slice(0, 80) : '',
-    frequency: FREQUENCIES.includes(r.frequency as string) ? (r.frequency as string) : 'moderate',
-    scriptLength: SCRIPT_LENGTHS.includes(r.scriptLength as string) ? (r.scriptLength as string) : 'concise',
-    djMode: r.djMode === true,
-    humour: normalizeDial(r.humour),
-    localColour: normalizeDial(r.localColour),
-    warmth: normalizeDial(r.warmth),
-    soul,
-    language: typeof r.language === 'string' ? r.language.trim().slice(0, 60) : '',
-    avatar,
-    tts: normalizeTts(r.tts),
-    skills: normalizeSkills(r.skills),
-  };
+  const repaired = repairPersonaForLoad(raw as Record<string, unknown>, SKILL_RENAMES);
+  const parsed = personaSchema.safeParse(repaired);
+  return parsed.success ? parsed.data : null;
 }
 
 export function normalizePersonaArray(raw: unknown) {
   if (!Array.isArray(raw)) return null;
-  const seen = new Set<string>();
   const out: NonNullable<ReturnType<typeof normalizePersona>>[] = [];
   for (const item of raw) {
     const p = normalizePersona(item);
     if (!p) continue;
-    if (seen.has(p.id)) p.id = mintId('p_');
-    seen.add(p.id);
     out.push(p);
     if (out.length >= PERSONA_LIMIT) break;
   }
-  return out.length ? out : null;
+  // Ids are minted and de-duplicated by the same server-only helper the strict
+  // path uses, so a roster that round-trips through load never renumbers.
+  return out.length ? resolvePersonaIds(out) : null;
 }
 
-// Lenient load-time path for the prompt-template library: drop entries that
-// can't render (bad text) rather than failing the whole settings load. A
-// missing/duplicate name degrades to "Prompt N" instead of dropping the entry —
-// the text is the part the operator can't afford to lose.
+/**
+ * Lenient load-time path for the prompt-template library: drop entries that
+ * can't render (bad text) rather than failing the whole settings load.
+ *
+ * A missing/duplicate name degrades to "Prompt N" instead of dropping the
+ * entry — the text is the part the operator can't afford to lose. That fallback
+ * numbers by SURVIVING row, which is why it is computed here and handed to the
+ * repair rather than derived inside it.
+ */
 export function normalizeDjPrompts(raw: unknown): DjPromptEntry[] {
   if (!Array.isArray(raw)) return [];
-  const seen = new Set<string>();
   const out: DjPromptEntry[] = [];
   for (const item of raw) {
     if (!item || typeof item !== 'object') continue;
-    const text = typeof item.text === 'string' ? item.text.trim() : '';
-    if (text.length < DJ_PROMPT_TEXT_MIN || text.length > DJ_PROMPT_TEXT_MAX) continue;
-    if (!text.includes('{name}')) continue;
-    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('dp_');
-    if (seen.has(id)) id = mintId('dp_');
-    seen.add(id);
-    const name =
-      (typeof item.name === 'string' ? item.name.trim().slice(0, DJ_PROMPT_NAME_MAX) : '') ||
-      `Prompt ${out.length + 1}`;
-    out.push({ id, name, text });
+    const repaired = repairDjPromptForLoad(
+      item as Record<string, unknown>,
+      `Prompt ${out.length + 1}`,
+    );
+    const parsed = djPromptSchema.safeParse(repaired);
+    if (!parsed.success) continue;
+    out.push(parsed.data as DjPromptEntry);
     if (out.length >= DJ_PROMPT_LIMIT) break;
   }
-  return out;
+  return resolveDjPromptIds(out) as DjPromptEntry[];
 }
 
 export function normalizeShows(raw: unknown, personaIds: string[]): NormalizedShow[] {

--- a/controller/src/settings/patch-registry.ts
+++ b/controller/src/settings/patch-registry.ts
@@ -59,6 +59,26 @@ import {
   weatherPatchSchema,
   webhooksPolicyPatchSchema,
 } from '../schemas/settings.js';
+import {
+  activeDjPromptIdSchema,
+  djPromptTextSchema,
+  maxTrackSecondsSchema,
+  themePatchSchema,
+} from '../schemas/settings.js';
+import {
+  DJ_PROMPT_TEXT_MAX,
+  DJ_PROMPT_TEXT_MIN,
+  djPromptsSchema,
+  personasSchema,
+} from '../schemas/persona.js';
+import { scheduleOverrideSchema, scheduleSchema } from '../schemas/schedule.js';
+import { SHOW_MAX_TRACK_SECONDS, showsSchema } from '../schemas/show.js';
+import { webhooksSchema } from '../schemas/webhook.js';
+
+// Mirrors settings/defaults.ts's BOUNDS.maxTrackSeconds, which reads its ceiling
+// from the same SHOW_MAX_TRACK_SECONDS — a mirrored module may not import a
+// non-mirrored one, so the bound is composed here rather than imported.
+const MAX_TRACK_SECONDS_BOUNDS = { min: 0, max: SHOW_MAX_TRACK_SECONDS };
 import { firstMessage, flattenIssues } from '../util/zod-error.js';
 
 /**
@@ -140,9 +160,16 @@ export interface SettingsPatchContext {
    *  body. The route cannot know it (that is update()'s ordering to resolve),
    *  so it passes null and checks shape only. */
   moodNames: string[] | null;
+  /** The EFFECTIVE show roster, for `scheduleOverride`'s "must name a real
+   *  show" rule. Null for the same reason as moodNames: `shows` may ride in the
+   *  same body, and only update() has applied it by the time this is judged. */
+  showIds: string[] | null;
 }
 
-export const SETTINGS_PATCH_SHAPE_ONLY: SettingsPatchContext = { moodNames: null };
+export const SETTINGS_PATCH_SHAPE_ONLY: SettingsPatchContext = {
+  moodNames: null,
+  showIds: null,
+};
 
 type SettingsPatchEntry = ZodType | ((ctx: SettingsPatchContext) => ZodType);
 
@@ -183,6 +210,53 @@ export const SETTINGS_PATCH_SCHEMAS: Readonly<Partial<Record<SettingsPatchKey, S
   timezone: timezoneSchema,
   privacy: privacyPatchSchema,
   requests: requestsPatchSchema,
+  // Both are validated by the SAME schema update() reaches through
+  // validatePersonasStrict / validateDjPromptsStrict. Their branches are NOT
+  // switched to parseSettingsPatchKey, because both need a server-only step the
+  // schema deliberately cannot do — resolvePersonaIds / resolveDjPromptIds mint
+  // and de-duplicate ids, which is a side effect. Registering them here is what
+  // gives the Personas panel its `fieldErrors` channel; the strict validators
+  // stay the authoritative chokepoint, and both run one implementation.
+  personas: personasSchema,
+  djPrompts: djPromptsSchema,
+  // Shape and bounds only — each of these keeps a genuinely stateful half in
+  // update(), named on its schema: theme's async "does this id exist" fallback,
+  // maxTrackSeconds' crossfade-derived floor, activeDjPromptId's membership in a
+  // library the same patch may be replacing, and djPrompt's mapping onto that
+  // library. Registering the pure half is still worth it: it is what gives these
+  // inputs a `fieldErrors` key, and it moves the refusal to the boundary.
+  theme: themePatchSchema,
+  maxTrackSeconds: maxTrackSecondsSchema(MAX_TRACK_SECONDS_BOUNDS),
+  activeDjPromptId: activeDjPromptIdSchema,
+  djPrompt: djPromptTextSchema({ min: DJ_PROMPT_TEXT_MIN, max: DJ_PROMPT_TEXT_MAX }),
+  // A FACTORY over the show roster — null at the route (shows may ride in the
+  // same body), the real list inside update(). Nullable because clearing the
+  // pin is how a takeover is cancelled.
+  scheduleOverride: (ctx) =>
+    scheduleOverrideSchema({ showIds: ctx.showIds, now: null }).nullable(),
+  // These three were already on a shared schema before this registry existed —
+  // update() reaches them through validateShowsStrict / validateScheduleStrict /
+  // validateWebhooksStrict, which is where their server-only halves live (id
+  // resolution, the redacted-secret merge, the drop-and-count posture). What
+  // they lacked was a ROUTE, so a panel posting them to /settings got a flat
+  // 400 and no `fieldErrors`. Registering the pure half closes that without
+  // touching their branches.
+  //
+  // Every context field is null: the route cannot know the roster, the mood
+  // vocabulary, the theme registry or the crossfade-derived floor, any of which
+  // the same body may be changing. Shape and per-field rules still apply.
+  shows: (ctx) =>
+    showsSchema({
+      // personaIds is NOT nullable on ShowSchemaContext — a show with no owner
+      // has none on either path — so the route passes the empty roster, which
+      // makes host membership unresolvable and therefore unchecked here.
+      personaIds: [],
+      moodNames: ctx.moodNames,
+      themeIds: null,
+      minTrackSeconds: null,
+    }),
+  schedule: (ctx) => scheduleSchema({ showIds: ctx.showIds }),
+  webhooks: webhooksSchema,
 };
 
 /** Resolve an entry against a context — a plain schema ignores it. */
@@ -240,6 +314,42 @@ function flatten(err: ZodError): string {
 }
 
 /**
+ * The keys whose messages are NOT self-locating, and therefore need the path
+ * prefixed after all.
+ *
+ * The verbatim rule above holds for a BLOCK ('beds.thresholdSec must be …') and
+ * for a scalar, because there is exactly one place the failure can be. It
+ * breaks for an ARRAY: the persona schema's message is 'name must be 1-40
+ * chars', and on a 20-persona roster that names no row at all — which is the
+ * precise failure `firstMessage` was written to fix, and which
+ * validatePersonasStrict already avoids by rooting at its settings key. Rooting
+ * these here is what keeps the route's flat string identical to the one
+ * update() throws for the same body, rather than a less useful second opinion.
+ *
+ * A key belongs here when its schema is an array (or otherwise reports issues
+ * at a path), NOT when its messages merely happen to omit the key name.
+ */
+const SETTINGS_PATCH_ROOTED_KEYS: ReadonlySet<string> = new Set<SettingsPatchKey>([
+  'personas',
+  'djPrompts',
+  // A nested object rather than an array, but the same reason: its messages
+  // ('must be a show id', 'must be an object') are phrased WITHOUT the key,
+  // because validateScheduleOverrideStrict has always rooted them here. Adding
+  // the key to the text instead would double it on that path.
+  'scheduleOverride',
+  // The same three validate*Strict functions already root at their settings
+  // key, so the route must too or the two disagree about the same body.
+  'shows',
+  'schedule',
+  'webhooks',
+]);
+
+/** Root the flat message at its settings key when that key needs it. */
+function flattenFor(key: SettingsPatchKey, err: ZodError): string {
+  return SETTINGS_PATCH_ROOTED_KEYS.has(key) ? firstMessage(err, key) : flatten(err);
+}
+
+/**
  * Strict posture — parse ONE key's value, or throw a plain Error.
  *
  * Used inside update(), which answers `{ error: err.message }`. A raw ZodError
@@ -258,7 +368,7 @@ export function parseSettingsPatchKey<T = unknown>(
   const schema = schemaFor(key, ctx);
   if (!schema) return value as T;
   const r = schema.safeParse(value);
-  if (!r.success) throw new Error(flatten(r.error));
+  if (!r.success) throw new Error(flattenFor(key, r.error));
   return r.data as T;
 }
 
@@ -308,7 +418,7 @@ export function validateSettingsPatch(patch: unknown): SettingsPatchFailure | nu
     if (r.success) continue;
     // First failure in BRANCH order owns the flat string, so the route and
     // update() agree on which problem to name.
-    if (!error) error = flatten(r.error);
+    if (!error) error = flattenFor(key, r.error);
     fieldErrors = { ...fieldErrors, ...prefixed(key, flattenIssues(r.error)) };
   }
   return error ? { error, fieldErrors } : null;

--- a/controller/src/settings/validate.ts
+++ b/controller/src/settings/validate.ts
@@ -4,39 +4,15 @@
 //
 // Part of the settings/ split — see ../settings.ts for the public barrel.
 
-import {
-  AVATAR_FILENAME_RE,
-  CHATTERBOX_VOICE_RE,
-  DJ_PROMPT_LIMIT,
-  DJ_PROMPT_NAME_MAX,
-  DJ_PROMPT_TEXT_MAX,
-  DJ_PROMPT_TEXT_MIN,
-  FREQUENCIES,
-  ID_RE,
-  KOKORO_VOICE_RE,
-  PERSONA_LIMIT,
-  PIPER_VOICE_RE,
-  POCKET_TTS_VOICE_RE,
-  SCRIPT_LENGTHS,
-  SHOW_MOODS,
-  SKILLS_PER_PERSONA_LIMIT,
-  SKILL_SLUG_RE,
-  SOUL_MAX,
-  ScheduleOverride,
-  TTS_CLOUD_PROVIDERS,
-  TTS_ENGINES,
-  Webhook,
-  clampTtsGain,
-  clampTtsSpeed,
-  mintId,
-  normalizeDial,
-} from './vocab.js';
+import { SHOW_MOODS, ScheduleOverride, Webhook } from './vocab.js';
 
 import { minTrackSeconds } from './store.js';
 import { webhooksSchema } from '../schemas/webhook.js';
 import { mergeWebhookSecrets } from '../schemas/webhook-server.js';
 import { showsSchema, type ShowSchemaContext } from '../schemas/show.js';
 import { resolveShowIds } from '../schemas/show-server.js';
+import { djPromptsSchema, personasSchema, ttsVoiceSlotSchema } from '../schemas/persona.js';
+import { resolveDjPromptIds, resolvePersonaIds } from '../schemas/persona-server.js';
 import { scheduleSchema, scheduleOverrideSchema } from '../schemas/schedule.js';
 import {
   festivalsSchema,
@@ -67,231 +43,54 @@ function runMoodSchema<T>(schema: { safeParse: (v: unknown) => { success: boolea
   return r.data as T;
 }
 
-// Strict validator for a `{engine, voice, cloudProvider}` voice slot. Shared by
-// every persona's `tts` block AND the station-wide TTS fallback slot
-// (`settings.tts.fallback`) — same shape, same per-engine voice rules, one
-// implementation. `where` is the settings path prefix used in error messages,
-// so a bad fallback voice reads `tts.fallback.voice must ...`.
+/**
+ * Strict validator for a `{engine, voice, cloudProvider}` voice slot.
+ *
+ * A thin wrapper over schemas/persona.ts's ttsVoiceSlotSchema — shared by every
+ * persona's `tts` block AND the station-wide TTS fallback slot
+ * (`settings.tts.fallback`), same shape, same per-engine voice rules, one
+ * implementation. `where` is the settings path prefix baked into the messages,
+ * so a bad fallback voice still reads `tts.fallback.voice must ...`.
+ *
+ * The message is taken VERBATIM rather than through `firstMessage`: the schema
+ * already names its own full path in the text, so prefixing would double it.
+ */
 export function validateTtsBlock(raw, where) {
-  const t = raw || {};
-  if (!TTS_ENGINES.includes(t.engine)) {
-    throw new Error(`${where}.engine must be one of: ${TTS_ENGINES.join(', ')}`);
-  }
-  if (!TTS_CLOUD_PROVIDERS.includes(t.cloudProvider)) {
-    throw new Error(`${where}.cloudProvider must be one of: ${TTS_CLOUD_PROVIDERS.join(', ')}`);
-  }
-  let voice = String(t.voice ?? '').trim();
-  if (t.engine === 'kokoro') {
-    if (!KOKORO_VOICE_RE.test(voice)) {
-      throw new Error(
-        `${where}.voice must match <lang><gender>_<name> for kokoro, e.g. bf_isabella`,
-      );
-    }
-  } else if (t.engine === 'chatterbox') {
-    // Empty = use built-in default voice. Otherwise the value must be a plain
-    // .wav filename — no path separators — referencing a file the operator has
-    // uploaded into config.chatterbox.voiceDir.
-    if (voice && !CHATTERBOX_VOICE_RE.test(voice)) {
-      throw new Error(
-        `${where}.voice for chatterbox must be a .wav filename (no path), or empty for the default voice`,
-      );
-    }
-  } else if (t.engine === 'pocket-tts') {
-    // Two accepted forms (issue #213):
-    //   - A built-in voice id (alba, anna, charles, …). Curated set lives in
-    //     POCKET_TTS_VOICES; anything passing POCKET_TTS_VOICE_RE is also
-    //     accepted (the worker falls back to the default for unknown ids).
-    //   - A `.wav` filename in the shared voice folder → zero-shot cloning.
-    //     Same shape as the chatterbox value.
-    if (!voice) voice = 'alba';
-    if (!POCKET_TTS_VOICE_RE.test(voice) && !CHATTERBOX_VOICE_RE.test(voice)) {
-      throw new Error(
-        `${where}.voice for pocket-tts must be a built-in voice id (e.g. alba) or a .wav filename`,
-      );
-    }
-  } else if (t.engine === 'cloud') {
-    // openai-compatible voices are server-specific; an empty voice lets the
-    // server use its own default. openai/elevenlabs both require a voice id.
-    if (t.cloudProvider === 'openai-compatible') {
-      if (voice.length > 100) throw new Error(`${where}.voice must be 0-100 chars`);
-    } else if (voice.length < 1 || voice.length > 100) {
-      throw new Error(`${where}.voice must be 1-100 chars`);
-    }
-  } else if (t.engine === 'remote') {
-    // Remote engine voices are server-specific — the sidecar interprets them
-    // (built-in id, reference-wav filename, or VoiceDesign prompt). Empty is
-    // valid: the sidecar picks its own default.
-    if (voice.length > 100) throw new Error(`${where}.voice must be 0-100 chars`);
-  } else {
-    // piper: empty = use the baked-in default voice. Otherwise the value must
-    // be an .onnx filename (no path separators) referencing a model the operator
-    // dropped into the shared voice folder (issue #230). A Kokoro-shaped id is
-    // also accepted: the seed roster carries a distinct Kokoro voice per persona
-    // under the piper engine so switching to Kokoro yields different-sounding
-    // DJs with no extra editing (see SEED_PERSONAS). resolvePiperVoice() falls
-    // back to the default for it at render time, so it is harmless under piper
-    // and must not block saving the shipped roster (issue #454).
-    if (voice && !PIPER_VOICE_RE.test(voice) && !KOKORO_VOICE_RE.test(voice)) {
-      throw new Error(
-        `${where}.voice for piper must be an .onnx filename (no path), or empty for the default voice`,
-      );
-    }
-  }
-  return { engine: t.engine, cloudProvider: t.cloudProvider, voice, gainDb: clampTtsGain(t.gainDb), speed: clampTtsSpeed(t.speed) };
+  const parsed = ttsVoiceSlotSchema(where).safeParse(raw);
+  if (!parsed.success) throw new Error(parsed.error.issues[0]?.message || `${where} is invalid`);
+  return parsed.data;
 }
 
-// Strict update-time path for the prompt-template library — any bad entry
-// rejects the whole patch so the operator sees the error instead of silently
-// losing a prompt.
+/**
+ * Strict update-time path for the prompt-template library.
+ *
+ * Any bad entry rejects the whole patch so the operator sees the error instead
+ * of silently losing a prompt. Ids are minted/de-duplicated by the server-only
+ * sibling, shared with the lenient load path.
+ */
 export function validateDjPromptsStrict(raw) {
-  if (!Array.isArray(raw) || raw.length > DJ_PROMPT_LIMIT) {
-    throw new Error(`djPrompts must be an array of 0-${DJ_PROMPT_LIMIT} entries`);
-  }
-  const seen = new Set();
-  return raw.map((item, i) => {
-    if (!item || typeof item !== 'object') throw new Error(`djPrompts[${i}] must be an object`);
-    const name = String(item.name ?? '').trim();
-    if (name.length < 1 || name.length > DJ_PROMPT_NAME_MAX) {
-      throw new Error(`djPrompts[${i}].name must be 1-${DJ_PROMPT_NAME_MAX} chars`);
-    }
-    const text = String(item.text ?? '').trim();
-    if (text.length < DJ_PROMPT_TEXT_MIN || text.length > DJ_PROMPT_TEXT_MAX) {
-      throw new Error(
-        `djPrompts[${i}].text must be ${DJ_PROMPT_TEXT_MIN}-${DJ_PROMPT_TEXT_MAX} chars`,
-      );
-    }
-    if (!text.includes('{name}')) {
-      throw new Error(`djPrompts[${i}].text must contain the {name} placeholder`);
-    }
-    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('dp_');
-    if (seen.has(id)) id = mintId('dp_');
-    seen.add(id);
-    return { id, name, text };
-  });
+  const parsed = djPromptsSchema.safeParse(raw);
+  if (!parsed.success) throw new Error(firstMessage(parsed.error, 'djPrompts'));
+  return resolveDjPromptIds(parsed.data);
 }
 
+/**
+ * Strict update-time path for the persona roster.
+ *
+ * The SAME schema settings/normalize.ts runs on load and the browser runs in the
+ * Personas editor — what differs is only the consequence: this throws, the load
+ * path repairs-or-drops. Id minting and cross-row de-duplication live in
+ * persona-server.ts because neither is a pure function of one submitted value.
+ */
 export function validatePersonasStrict(raw) {
-  if (!Array.isArray(raw) || raw.length < 1 || raw.length > PERSONA_LIMIT) {
-    throw new Error(`personas must be an array of 1-${PERSONA_LIMIT} entries`);
-  }
-  const seen = new Set();
-  return raw.map((item, i) => {
-    if (!item || typeof item !== 'object') throw new Error(`personas[${i}] must be an object`);
-    const name = String(item.name ?? '').trim();
-    if (name.length < 1 || name.length > 40)
-      throw new Error(`personas[${i}].name must be 1-40 chars`);
-    const soul = String(item.soul ?? '').trim();
-    if (soul.length < 1 || soul.length > SOUL_MAX)
-      throw new Error(`personas[${i}].soul must be 1-${SOUL_MAX} chars`);
-    const tagline = String(item.tagline ?? '').trim();
-    if (tagline.length > 80) throw new Error(`personas[${i}].tagline must be 0-80 chars`);
-    // language — optional free text ("Turkish", "Türkçe", …). Absent/empty →
-    // '' (English, no directive injected — the historical behaviour).
-    let language = '';
-    if (item.language !== undefined && item.language !== null) {
-      if (typeof item.language !== 'string') {
-        throw new Error(`personas[${i}].language must be a string`);
-      }
-      language = item.language.trim();
-      if (language.length > 60) throw new Error(`personas[${i}].language must be 0-60 chars`);
-    }
-    if (!FREQUENCIES.includes(item.frequency)) {
-      throw new Error(`personas[${i}].frequency must be one of: ${FREQUENCIES.join(', ')}`);
-    }
-    // scriptLength — optional. Absent → 'concise' (the default and the
-    // historical behaviour); present must be a known value.
-    let scriptLength = 'concise';
-    if (item.scriptLength !== undefined && item.scriptLength !== null) {
-      if (!SCRIPT_LENGTHS.includes(item.scriptLength)) {
-        throw new Error(`personas[${i}].scriptLength must be one of: ${SCRIPT_LENGTHS.join(', ')}`);
-      }
-      scriptLength = item.scriptLength;
-    }
-    // djMode — optional boolean. Absent → false (a plain narrator persona, the
-    // historical behaviour). When true the persona behaves like a working DJ
-    // (forward-tease, callbacks, more presence) — see effectiveFrequency above.
-    let djMode = false;
-    if (item.djMode !== undefined && item.djMode !== null) {
-      if (typeof item.djMode !== 'boolean') {
-        throw new Error(`personas[${i}].djMode must be a boolean`);
-      }
-      djMode = item.djMode;
-    }
-    const tts = validateTtsBlock(item.tts, `personas[${i}].tts`);
-    // skills — optional. Absent → null ("all skills", legacy/default). Present
-    // → an explicit slug array (the UI always sends one once edited).
-    let skills: string[] | null = null;
-    if (item.skills !== undefined && item.skills !== null) {
-      if (!Array.isArray(item.skills)) {
-        throw new Error(`personas[${i}].skills must be an array of skill names`);
-      }
-      if (item.skills.length > SKILLS_PER_PERSONA_LIMIT) {
-        throw new Error(
-          `personas[${i}].skills must be at most ${SKILLS_PER_PERSONA_LIMIT} entries`,
-        );
-      }
-      const seenSk = new Set<string>();
-      skills = [];
-      for (const s of item.skills) {
-        const v = String(s ?? '').trim();
-        // A malformed entry is DROPPED, not thrown. persona.skills is a
-        // subscription list resolved against the live skill catalog at fire
-        // time, so an entry that can't name a skill can never fire — and the
-        // OLD shape check here (/^[a-z0-9-]{1,40}$/) accepted forms the slug
-        // rule refuses (a leading hyphen), so a backup or older settings.json
-        // can legitimately carry one. Failing the whole personas save over
-        // inert junk is the themeId lesson (#917) again: all cost, no benefit.
-        if (!SKILL_SLUG_RE.test(v)) {
-          console.warn(
-            `[personas] dropping unrecognisable skills entry ${JSON.stringify(v)} from personas[${i}]`,
-          );
-          continue;
-        }
-        if (!seenSk.has(v)) {
-          seenSk.add(v);
-          skills.push(v);
-        }
-      }
-    }
-    let id = typeof item.id === 'string' && ID_RE.test(item.id) ? item.id : mintId('p_');
-    if (seen.has(id)) id = mintId('p_');
-    seen.add(id);
-    // Avatar — optional. Absent/empty → '' (no avatar). Present must be a
-    // bare basename matching AVATAR_FILENAME_RE. The dedicated upload route
-    // is the only writer that creates the file on disk; this validator just
-    // checks the persisted string. The post-patch sweep below garbage-
-    // collects orphaned files when the persona itself is removed.
-    let avatar = '';
-    if (item.avatar !== undefined && item.avatar !== null && item.avatar !== '') {
-      const a = String(item.avatar).trim();
-      if (!AVATAR_FILENAME_RE.test(a)) {
-        throw new Error(
-          `personas[${i}].avatar must be a basename like <id>.png|jpg|jpeg|webp`,
-        );
-      }
-      avatar = a;
-    }
-    return {
-      id,
-      name,
-      tagline,
-      frequency: item.frequency,
-      scriptLength,
-      djMode,
-      humour: normalizeDial(item.humour),
-      localColour: normalizeDial(item.localColour),
-      warmth: normalizeDial(item.warmth),
-      soul,
-      language,
-      avatar,
-      tts,
-      skills,
-    };
-  });
+  const parsed = personasSchema.safeParse(raw);
+  if (!parsed.success) throw new Error(firstMessage(parsed.error, 'personas'));
+  return resolvePersonaIds(parsed.data);
 }
 
 export function validateShowsStrict(raw, personas, allowedThemeIds: Set<string>, moodNames: string[] = SHOW_MOODS) {
-  if (!Array.isArray(raw)) throw new Error('shows must be an array');
+  // The non-array refusal is the SCHEMA's now, not a pre-check here — so this
+  // path and the route report the same string for the same body.
   // Note the legacy singular fields #929 replaced (mood / genre / …) are
   // migrated by the SCHEMA itself (a preprocess, so z.object can't strip them
   // first), so POST /shows, a backup restore and the lenient load path all

--- a/controller/src/settings/vocab.ts
+++ b/controller/src/settings/vocab.ts
@@ -23,6 +23,36 @@ import {
   type EraWindow,
 } from '../schemas/show.js';
 import { SKILL_SLUG_RE as SKILL_SLUG_PATTERN } from '../schemas/skill.js';
+// The persona shape's rules — and the TTS voice slot's, which the station-wide
+// rescue slot shares — now live in the shared schema the admin form runs too.
+// Aliased below under the names the controller already used, so no call site
+// moved when this landed.
+import {
+  DJ_PROMPT_LIMIT as DJ_PROMPT_LIMIT_VALUE,
+  DJ_PROMPT_NAME_MAX as DJ_PROMPT_NAME_MAX_VALUE,
+  DJ_PROMPT_TEXT_MAX as DJ_PROMPT_TEXT_MAX_VALUE,
+  DJ_PROMPT_TEXT_MIN as DJ_PROMPT_TEXT_MIN_VALUE,
+  PERSONA_AVATAR_FILENAME_RE,
+  PERSONA_DIAL_NEUTRAL,
+  PERSONA_FREQUENCIES,
+  PERSONA_LIMIT as PERSONA_LIMIT_VALUE,
+  PERSONA_SCRIPT_LENGTHS,
+  PERSONA_SKILLS_LIMIT,
+  PERSONA_SOUL_MAX,
+  TTS_CHATTERBOX_VOICE_RE,
+  TTS_CLOUD_PROVIDERS as TTS_CLOUD_PROVIDER_VALUES,
+  TTS_ENGINES as TTS_ENGINE_VALUES,
+  TTS_GAIN_CLAMP_DB as TTS_GAIN_CLAMP_DB_VALUE,
+  TTS_KOKORO_VOICE_RE,
+  TTS_PIPER_VOICE_RE,
+  TTS_POCKET_VOICE_RE,
+  TTS_SPEED_DEFAULT as TTS_SPEED_DEFAULT_VALUE,
+  TTS_SPEED_MAX as TTS_SPEED_MAX_VALUE,
+  TTS_SPEED_MIN as TTS_SPEED_MIN_VALUE,
+  clampPersonaDial,
+  clampTtsGain as clampTtsGainFn,
+  clampTtsSpeed as clampTtsSpeedFn,
+} from '../schemas/persona.js';
 import {
   SETTINGS_AAC_BITRATES,
   SETTINGS_LOUDNESS_SOURCES,
@@ -61,13 +91,13 @@ export const DJ_SOULS = [
 // hourlies, banter or segments) — only manual /dj/segment triggers, listener
 // requests and programme beats still speak. 'chatty' sits between the
 // historical moderate and aggressive.
-export const FREQUENCIES = ['silent', 'quiet', 'moderate', 'chatty', 'aggressive'];
+export const FREQUENCIES: readonly string[] = PERSONA_FREQUENCIES;
 
 // Per-persona verbosity, ascending. 'concise' is the historical default;
 // 'one-liner' cuts every segment to a single quick line, 'extended' roughly
 // doubles, 'storyteller' roughly triples for long-form monologues.
 // See llm/internal/prompts/system.ts LENGTH_PHRASES for the actual directives.
-export const SCRIPT_LENGTHS = ['one-liner', 'concise', 'extended', 'storyteller'];
+export const SCRIPT_LENGTHS: readonly string[] = PERSONA_SCRIPT_LENGTHS;
 
 // Per-persona tone dials. Each is 0-10 with 5 (DIAL_NEUTRAL) the default. A
 // model can't distinguish humour=6 from 7, so rather than inject a raw "7/10"
@@ -75,7 +105,7 @@ export const SCRIPT_LENGTHS = ['one-liner', 'concise', 'extended', 'storyteller'
 // away from neutral appends a style directive (personaToneDirectives below), so
 // a persona left at the defaults renders a byte-identical prompt to before.
 export const TONE_DIALS = ['humour', 'localColour', 'warmth'] as const;
-export const DIAL_NEUTRAL = 5;
+export const DIAL_NEUTRAL = PERSONA_DIAL_NEUTRAL;
 
 const TONE_DIAL_PHRASES: Record<string, { low: string; high: string }> = {
   humour: {
@@ -93,11 +123,9 @@ const TONE_DIAL_PHRASES: Record<string, { low: string; high: string }> = {
 };
 
 // Clamp any input to an integer 0-10, defaulting to neutral when unparseable.
-// The single chokepoint used by both normalizePersona and the seed roster.
-export function normalizeDial(v: unknown): number {
-  const n = Math.round(Number(v));
-  return Number.isFinite(n) ? Math.min(10, Math.max(0, n)) : DIAL_NEUTRAL;
-}
+// The single chokepoint used by both normalizePersona and the seed roster —
+// now defined in the shared schema, so the admin form clamps identically.
+export const normalizeDial = clampPersonaDial;
 
 // Pure: persona in, prompt fragment out. Returns '' when every dial sits in the
 // neutral band, so renderDjPrompt appends nothing and the default prompt is
@@ -131,7 +159,7 @@ export function personaToneDirectives(persona: unknown): string {
 // docker/Dockerfile.controller) to include the runtime. The dispatcher gates
 // each engine on isAvailable() so settings can reference it safely even when
 // the runtime is absent (the engine just falls back to Piper).
-export const TTS_ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'cloud', 'remote'];
+export const TTS_ENGINES: readonly string[] = TTS_ENGINE_VALUES;
 
 // DJ-voice level trim, in dB. A per-engine gain levels the loudness gap between
 // TTS engines (only PocketTTS self-normalises today, so it sits quieter than
@@ -140,17 +168,12 @@ export const TTS_ENGINES = ['piper', 'kokoro', 'chatterbox', 'pocket-tts', 'clou
 // annotation on say.txt/intro.txt (see audio/tts.ts:voiceGainDb +
 // broadcast/queue.ts) — the same mechanism the music loudness path uses. A
 // manual dial, not auto-normalisation, so the range is generous (±12 dB).
-export const TTS_GAIN_CLAMP_DB = 12;
+export const TTS_GAIN_CLAMP_DB = TTS_GAIN_CLAMP_DB_VALUE;
 
 // Coerce any value to a clean gain: finite number, clamped to ±TTS_GAIN_CLAMP_DB,
 // rounded to 0.1 dB (finer is inaudible and just bloats the annotate string).
 // Garbage / non-finite → 0 (unity, i.e. today's behaviour).
-export function clampTtsGain(v: unknown): number {
-  const n = Number(v);
-  if (!Number.isFinite(n)) return 0;
-  const c = Math.max(-TTS_GAIN_CLAMP_DB, Math.min(TTS_GAIN_CLAMP_DB, n));
-  return Math.round(c * 10) / 10;
-}
+export const clampTtsGain = clampTtsGainFn;
 
 // Normalise a per-engine gain map to exactly one clean gain per known engine
 // (default 0). Drops unknown keys so a hand-edited settings.json can't smuggle
@@ -171,22 +194,14 @@ export function normalizeTtsGainMap(raw: unknown): Record<string, number> {
 // MULTIPLIER where 1.0 = no change (today's behaviour); lower = slower. Only
 // Piper/Kokoro/cloud honour it — chatterbox/pocket-tts workers ignore speed,
 // so their map entries are inert (kept for symmetry with the gain map).
-export const TTS_SPEED_MIN = 0.5;
-export const TTS_SPEED_MAX = 2.0;
-export const TTS_SPEED_DEFAULT = 1.0;
+export const TTS_SPEED_MIN = TTS_SPEED_MIN_VALUE;
+export const TTS_SPEED_MAX = TTS_SPEED_MAX_VALUE;
+export const TTS_SPEED_DEFAULT = TTS_SPEED_DEFAULT_VALUE;
 
 // Coerce any value to a clean speed multiplier: finite number, clamped to
 // [TTS_SPEED_MIN, TTS_SPEED_MAX], rounded to 0.05. Garbage / non-finite →
 // 1.0 (unity, i.e. today's behaviour).
-export function clampTtsSpeed(v: unknown): number {
-  // Treat unset (null/undefined/'') as unity, NOT as 0 — unlike gain, 0 is not
-  // this dial's default and would clamp to the 0.5 floor instead of no-change.
-  if (v === null || v === undefined || v === '') return TTS_SPEED_DEFAULT;
-  const n = Number(v);
-  if (!Number.isFinite(n)) return TTS_SPEED_DEFAULT;
-  const c = Math.max(TTS_SPEED_MIN, Math.min(TTS_SPEED_MAX, n));
-  return Math.round(c * 20) / 20;
-}
+export const clampTtsSpeed = clampTtsSpeedFn;
 
 // Normalise a per-engine speed map to exactly one clean multiplier per known
 // engine (default 1.0). Drops unknown keys, mirroring normalizeTtsGainMap.
@@ -571,7 +586,7 @@ export function normalizeLlmProviderBaseUrls(
 // any self-hosted OpenAI-compatible speech server (Chatterbox, Qwen3 TTS,
 // VibeVoice, etc.) via the operator-supplied `tts.cloud.baseUrl` — mirrors the
 // LLM provider of the same name.
-export const TTS_CLOUD_PROVIDERS = ['openai', 'elevenlabs', 'fish-audio', 'openai-compatible'];
+export const TTS_CLOUD_PROVIDERS: readonly string[] = TTS_CLOUD_PROVIDER_VALUES;
 
 // Web-search backends for the segment director's `web-search` capability.
 // `duckduckgo` is the homelab default — DuckDuckGo's Instant Answer API is free
@@ -761,7 +776,7 @@ export const KOKORO_VOICE_LANGUAGES: Record<string, string> = {
   'z': 'Mandarin Chinese',
 };
 
-export const KOKORO_VOICE_RE = /^[a-z]{2}_[a-z0-9]+$/;
+export const KOKORO_VOICE_RE = TTS_KOKORO_VOICE_RE;
 
 // Kokoro language override — the set of phonemizer languages the worker accepts.
 // The worker builds an espeak.EspeakG2P for the chosen language (see _phonemize
@@ -805,18 +820,18 @@ export const POCKET_TTS_VOICES = [
   { id: 'lola', label: 'Lola (ES, F)' },
   { id: 'rafael', label: 'Rafael (PT, M)' },
 ];
-export const POCKET_TTS_VOICE_RE = /^[a-z][a-z0-9_-]{0,39}$/;
+export const POCKET_TTS_VOICE_RE = TTS_POCKET_VOICE_RE;
 // Reference-WAV filenames live in the shared voice folder (config.voices.dir,
 // formerly config.chatterbox.voiceDir). Loose check — basename only, no path
 // separators, conservative character set, ends in .wav. Empty is also valid
 // (means "use the built-in default voice"). Used by both chatterbox and
 // pocket-tts since issue #213.
-export const CHATTERBOX_VOICE_RE = /^[A-Za-z0-9_.-]{1,80}\.wav$/;
+export const CHATTERBOX_VOICE_RE = TTS_CHATTERBOX_VOICE_RE;
 // Per-persona Piper voice — an `.onnx` model filename in the shared voice folder
 // (config.voices.dir), e.g. `en_US-amy-medium.onnx`, dropped alongside its
 // `.onnx.json` manifest. Basename only, no path separators. Empty is valid and
 // means "use the baked-in default voice" (issue #230).
-export const PIPER_VOICE_RE = /^[A-Za-z0-9_.-]{1,100}\.onnx$/;
+export const PIPER_VOICE_RE = TTS_PIPER_VOICE_RE;
 // The entity-id pattern shows, personas and skill assignments all share. Its
 // one definition is SHOW_ID_RE in the shared show schema — a mirrored module
 // cannot import a common one (gen-schemas.ts rejects every specifier but
@@ -826,7 +841,7 @@ export const ID_RE = SHOW_ID_RE;
 // Persona avatar filename — `<personaId>.(png|jpg|jpeg|webp)`. The id segment
 // reuses ID_RE's shape so an avatar field can never reference a basename
 // outside the persona-avatars directory. Empty is also valid (no avatar set).
-export const AVATAR_FILENAME_RE = /^[a-z0-9_]{3,32}\.(png|jpe?g|webp)$/;
+export const AVATAR_FILENAME_RE = PERSONA_AVATAR_FILENAME_RE;
 // Skill slugs (e.g. 'weather', 'random-facts'). The skills registry is the
 // source of truth for which slugs exist; settings only checks the shape — and
 // now checks the SAME shape, aliasing the pattern in the shared skill schema
@@ -839,7 +854,7 @@ export const SKILL_SLUG_RE = SKILL_SLUG_PATTERN;
 
 // Exported for the community-persona install route (routes/personas.ts), which
 // gives a friendly 409 before settings.update() would throw on an oversize roster.
-export const PERSONA_LIMIT = 48;
+export const PERSONA_LIMIT = PERSONA_LIMIT_VALUE;
 // Persona `soul` — the character sketch injected into EVERY free-text DJ
 // generation call, so each char is a recurring per-call token cost. Bounded
 // rather than unbounded for that reason alone; nothing structural depends on
@@ -849,7 +864,7 @@ export const PERSONA_LIMIT = 48;
 // is NOT the speaking seat (the multi-voice cast blocks, the cloud-TTS
 // delivery hint) clamp it further at their own boundary — see soulBrief() in
 // llm/internal/core/pure.ts.
-export const SOUL_MAX = 2000;
+export const SOUL_MAX = PERSONA_SOUL_MAX;
 export { SHOWS_LIMIT } from '../schemas/show.js';
 // Show `topic` — the standing brief the DJ works from while the show is on air.
 // Injected into the pick prompts (picker.ts / dj-agent schemas) and the
@@ -886,14 +901,14 @@ export { SHOW_FILTER_VALUES_MAX };
 // Must comfortably exceed a realistic skill library: unticking one skill on an
 // "all skills" (null) persona materialises the FULL catalog minus one, so a cap
 // near the library size would make that first untick fail (#skill-organization).
-export const SKILLS_PER_PERSONA_LIMIT = 64;
+export const SKILLS_PER_PERSONA_LIMIT = PERSONA_SKILLS_LIMIT;
 // Prompt-template library (djPrompts). Text bounds match the historical
 // single-djPrompt rule — keep them in lockstep with PROMPT_MIN/PROMPT_MAX in
 // web/components/admin/personas/constants.ts.
-export const DJ_PROMPT_LIMIT = 20;
-export const DJ_PROMPT_NAME_MAX = 60;
-export const DJ_PROMPT_TEXT_MIN = 50;
-export const DJ_PROMPT_TEXT_MAX = 4000;
+export const DJ_PROMPT_LIMIT = DJ_PROMPT_LIMIT_VALUE;
+export const DJ_PROMPT_NAME_MAX = DJ_PROMPT_NAME_MAX_VALUE;
+export const DJ_PROMPT_TEXT_MIN = DJ_PROMPT_TEXT_MIN_VALUE;
+export const DJ_PROMPT_TEXT_MAX = DJ_PROMPT_TEXT_MAX_VALUE;
 // Station house rules (djHouseRules) — operator rules appended to BOTH prompt
 // paths (renderDjPrompt and agentPersonaPreamble), unlike the djPrompt
 // template which only the scripted-talk path renders (issue #1182). No

--- a/web/components/admin/FestivalsSection.tsx
+++ b/web/components/admin/FestivalsSection.tsx
@@ -15,6 +15,13 @@ import { V3AlertDialog } from '../ui/alert-dialog';
 import { SkeletonRows } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ErrorState } from '@/components/ui/error-state';
+// Bounds from the mirror rather than re-typed literals — the festival window
+// in particular was hard-coded as a bare 14 in two places here.
+import {
+  SETTINGS_FESTIVAL_DESCRIPTION_MAX,
+  SETTINGS_FESTIVAL_NAME_MAX,
+  SETTINGS_FESTIVAL_WINDOW_DAYS_MAX,
+} from '@/lib/schemas.generated';
 
 interface Festival {
   month: number;
@@ -308,7 +315,7 @@ export default function FestivalsSection() {
                 value={editing.name}
                 onChange={e => updateField('name', e.target.value)}
                 placeholder="e.g. New Year's Day"
-                maxLength={80}
+                maxLength={SETTINGS_FESTIVAL_NAME_MAX}
               />
             </div>
 
@@ -364,7 +371,7 @@ export default function FestivalsSection() {
                 value={editing.description || ''}
                 onChange={e => updateField('description', e.target.value)}
                 placeholder="Short note about the festival"
-                maxLength={200}
+                maxLength={SETTINGS_FESTIVAL_DESCRIPTION_MAX}
               />
               <div className="field-hint mt-1">
                 A short note your DJ can weave into its chat while the festival is on.
@@ -395,9 +402,12 @@ export default function FestivalsSection() {
                   id={`${fieldId}-window`}
                   type="number"
                   min={0}
-                  max={14}
+                  max={SETTINGS_FESTIVAL_WINDOW_DAYS_MAX}
                   value={String(editing.windowDays ?? 0)}
-                  onChange={e => updateField('windowDays', Math.max(0, Math.min(14, Number(e.target.value) || 0)))}
+                  onChange={e => updateField(
+                    'windowDays',
+                    Math.max(0, Math.min(SETTINGS_FESTIVAL_WINDOW_DAYS_MAX, Number(e.target.value) || 0)),
+                  )}
                 />
               </div>
             </div>

--- a/web/components/admin/MoodsPanel.tsx
+++ b/web/components/admin/MoodsPanel.tsx
@@ -15,6 +15,11 @@ import {
 import { SkeletonCards } from '@/components/ui/skeleton';
 import { ErrorState } from '@/components/ui/error-state';
 import FestivalsSection from './FestivalsSection';
+import {
+  SETTINGS_MOODS_LIMIT,
+  SETTINGS_MOOD_NAME_MAX,
+  SETTINGS_MOOD_PROMPT_MAX,
+} from '@/lib/schemas.generated';
 
 interface MoodEntry {
   name: string;
@@ -52,7 +57,9 @@ const CONDITIONS: Array<{ id: string; label: string }> = [
 // option rides a sentinel that maps back to '' on save.
 const NONE = '__none__';
 
-const MOODS_LIMIT = 40; // mirrors the server MOODS_LIMIT
+// From the mirror, not re-typed: a bare literal beside a "mirrors the
+// server" comment is exactly what had already drifted in the persona editor.
+const MOODS_LIMIT = SETTINGS_MOODS_LIMIT;
 
 type TabId = 'vocab' | 'moments' | 'festivals' | 'speech';
 const TAB_IDS: TabId[] = ['vocab', 'moments', 'festivals', 'speech'];
@@ -240,7 +247,7 @@ export default function MoodsPanel() {
                       onChange={e => setMoods(list =>
                         (list ?? []).map((row, i) => i === idx ? { ...row, name: e.target.value } : row))}
                       placeholder="id (e.g. mellow)"
-                      maxLength={40}
+                      maxLength={SETTINGS_MOOD_NAME_MAX}
                       className="col-start-1 row-start-1 min-w-0"
                     />
                     <Input
@@ -249,7 +256,7 @@ export default function MoodsPanel() {
                       onChange={e => setMoods(list =>
                         (list ?? []).map((row, i) => i === idx ? { ...row, clapPrompt: e.target.value } : row))}
                       placeholder="sound description for audio tagging (optional)"
-                      maxLength={200}
+                      maxLength={SETTINGS_MOOD_PROMPT_MAX}
                       className="col-span-2 col-start-1 row-start-2 min-w-0 sm:col-span-1 sm:col-start-2 sm:row-start-1"
                     />
                     <Btn

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -19,6 +19,11 @@ import { cn } from '../../lib/cn';
 import ArchivesPanel from './ArchivesPanel';
 import BackupPanel from './BackupPanel';
 import {
+  SETTINGS_AAC_BITRATES,
+  SETTINGS_MP3_BITRATES,
+  SETTINGS_OPUS_BITRATES,
+} from '@/lib/schemas.generated';
+import {
   Radio, Palette, Cpu, Mic, Library, Search,
   Activity, Archive, Save, AlertTriangle, Heart, Music2,
 } from 'lucide-react';
@@ -54,12 +59,14 @@ const SECTIONS = [
 
 type SectionId = (typeof SECTIONS)[number]['id'];
 
-// Keep in sync with MP3_BITRATES in controller/src/settings.ts — radio.liq
-// has a literal `%mp3(bitrate=…)` branch per value, so this set is fixed.
-const MP3_BITRATES = [64, 96, 128, 160, 192, 320] as const;
-// Keep in sync with OPUS_BITRATES / AAC_BITRATES in controller/src/settings.ts.
-const OPUS_BITRATES = [96, 128, 192, 256, 320] as const;
-const AAC_BITRATES = [128, 192, 256] as const;
+// The three encoder vocabularies, from the mirror rather than re-typed. radio.liq
+// has a literal `%mp3(bitrate=…)` branch per value, so each set is genuinely
+// fixed — but "fixed" is why a hand-copied list is dangerous rather than safe:
+// it drifts silently the one time a value IS added, offering the operator a
+// bitrate the schema then refuses (or hiding one it would have accepted).
+const MP3_BITRATES = SETTINGS_MP3_BITRATES;
+const OPUS_BITRATES = SETTINGS_OPUS_BITRATES;
+const AAC_BITRATES = SETTINGS_AAC_BITRATES;
 
 /**
  * Replace exactly the errors belonging to the keys this patch carried.

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -23,7 +23,7 @@ import {
   Activity, Archive, Save, AlertTriangle, Heart, Music2,
 } from 'lucide-react';
 import {
-  SectionHeader, ELEVENLABS_VS_DEFAULTS, FISH_TTS_DEFAULTS,
+  SectionHeader, SettingsFieldError, ELEVENLABS_VS_DEFAULTS, FISH_TTS_DEFAULTS,
   type FormState, type FormUpdater, type SettingsData, type SaveSettings,
   type LoudnessSource, type LlmForm, type LlmFallbackForm,
 } from './settings/shared';
@@ -61,6 +61,31 @@ const MP3_BITRATES = [64, 96, 128, 160, 192, 320] as const;
 const OPUS_BITRATES = [96, 128, 192, 256, 320] as const;
 const AAC_BITRATES = [128, 192, 256] as const;
 
+/**
+ * Replace exactly the errors belonging to the keys this patch carried.
+ *
+ * Scoped by TOP-LEVEL key, because that is the unit a save button posts and the
+ * unit the controller reports against: a `{beds: …}` save owns every
+ * `beds.*` error and nothing else. Merging blindly would let a fixed field keep
+ * showing its old message; clearing everything would wipe an unrelated
+ * section's unresolved error the moment any other control saved.
+ */
+function mergePatchErrors(
+  prev: Record<string, string>,
+  patch: Record<string, unknown>,
+  next: Record<string, string> | undefined,
+): Record<string, string> {
+  const owned = Object.keys(patch);
+  const isOwned = (path: string) =>
+    owned.some((key) => path === key || path.startsWith(`${key}.`));
+  const out: Record<string, string> = {};
+  for (const [path, message] of Object.entries(prev)) {
+    if (!isOwned(path)) out[path] = message;
+  }
+  for (const [path, message] of Object.entries(next || {})) out[path] = message;
+  return out;
+}
+
 export default function SettingsPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
   const [data, setData] = useState<SettingsData | null>(null);
@@ -71,6 +96,7 @@ export default function SettingsPanel() {
   const [confirmRestart, setConfirmRestart] = useState(false);
   const [confirmStop, setConfirmStop] = useState(false);
   const [activeSection, setActiveSection] = useState<SectionId>('station');
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   const router = useRouter();
 
   const refresh = async () => {
@@ -345,8 +371,24 @@ export default function SettingsPanel() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(patch),
       });
-      const j = (await r.json().catch(() => ({}))) as { error?: string; requiresRestart?: boolean };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      const j = (await r.json().catch(() => ({}))) as {
+        error?: string;
+        requiresRestart?: boolean;
+        fieldErrors?: Record<string, string>;
+      };
+      if (!r.ok) {
+        // Land the failure on the inputs it belongs to. The toast still fires —
+        // a save button can be off-screen from the control that failed — but
+        // the operator now also sees WHICH field, without decoding a dotted
+        // path out of a sentence.
+        //
+        // Only the keys THIS patch carried are replaced, so a stale error from
+        // an unrelated section can't linger and a section that saved cleanly
+        // can't be blamed for another's failure.
+        setFieldErrors((prev) => mergePatchErrors(prev, patch, j.fieldErrors));
+        throw new Error(j.error || `failed (${r.status})`);
+      }
+      setFieldErrors((prev) => mergePatchErrors(prev, patch, undefined));
       if (j.requiresRestart) setPendingRestart(true);
       notify.ok(j.requiresRestart ? 'saved, restart the mixer to apply' : 'saved');
       await refresh();
@@ -460,31 +502,31 @@ export default function SettingsPanel() {
             {activeSection === 'tts' && data.tts && (
               <TtsSection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings} adminFetch={adminFetch} refresh={refresh}
+                saveSettings={saveSettings} fieldErrors={fieldErrors} adminFetch={adminFetch} refresh={refresh}
               />
             )}
             {activeSection === 'llm' && data.llm && (
               <LlmSection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings} adminFetch={adminFetch} refresh={refresh}
+                saveSettings={saveSettings} fieldErrors={fieldErrors} adminFetch={adminFetch} refresh={refresh}
               />
             )}
             {activeSection === 'search' && (
               <SearchSection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings} adminFetch={adminFetch}
+                saveSettings={saveSettings} fieldErrors={fieldErrors} adminFetch={adminFetch}
               />
             )}
             {activeSection === 'library' && (
               <LibrarySection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings} adminFetch={adminFetch} refresh={refresh}
+                saveSettings={saveSettings} fieldErrors={fieldErrors} adminFetch={adminFetch} refresh={refresh}
               />
             )}
             {activeSection === 'station' && (
               <StationSection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings}
+                saveSettings={saveSettings} fieldErrors={fieldErrors}
               />
             )}
             {activeSection === 'music' && (
@@ -492,20 +534,20 @@ export default function SettingsPanel() {
             )}
             {activeSection === 'theme' && (
               <ThemeSection
-                data={data} busy={busy} saveSettings={saveSettings}
+                data={data} busy={busy} saveSettings={saveSettings} fieldErrors={fieldErrors}
                 adminFetch={adminFetch}
               />
             )}
             {activeSection === 'scrobble' && (
               <ScrobbleSection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings} adminFetch={adminFetch} refresh={refresh}
+                saveSettings={saveSettings} fieldErrors={fieldErrors} adminFetch={adminFetch} refresh={refresh}
               />
             )}
             {activeSection === 'likes' && (
               <LikesSection
                 data={data} form={form} setForm={updateForm} busy={busy}
-                saveSettings={saveSettings}
+                saveSettings={saveSettings} fieldErrors={fieldErrors}
               />
             )}
           </>
@@ -547,6 +589,7 @@ export default function SettingsPanel() {
                         Save
                       </Btn>
                     </div>
+                    <SettingsFieldError path="archive.enabled" errors={fieldErrors} />
                     <div className="field-hint">
                       The archive runs a second MP3 encoder 24/7 and is the biggest constant
                       CPU cost in the broadcast container. Turn it off if you don't replay
@@ -769,6 +812,7 @@ export default function SettingsPanel() {
                       Save crossfade
                     </Btn>
                   </div>
+                  <SettingsFieldError path="crossfadeDuration" errors={fieldErrors} />
                   <div className="field-hint">
                     Seconds of overlap between tracks (current: {data?.values?.crossfadeDuration}s).
                     Saving flags a pending restart. Apply it with the Mixer card below.
@@ -959,6 +1003,7 @@ export default function SettingsPanel() {
                       Save limit
                     </Btn>
                   </div>
+                  <SettingsFieldError path="maxTrackSeconds" errors={fieldErrors} />
                   <div className="field-hint">
                     The DJ won&rsquo;t auto-pick tracks longer than this, handy for hour-long
                     album mixes or DJ sets that keep landing in rotation. Listener requests still
@@ -1110,6 +1155,7 @@ export default function SettingsPanel() {
                         Save
                       </Btn>
                     </div>
+                    <SettingsFieldError path="stream.opusEnabled" errors={fieldErrors} />
                     <div className="field-hint">
                       Off by default. Only Chrome/Edge listeners ever pick Opus (Safari, iOS and
                       Firefox stay on the universal MP3 mount); for them it&apos;s equal-or-better
@@ -1154,6 +1200,7 @@ export default function SettingsPanel() {
                         Save bitrate
                       </Btn>
                     </div>
+                    <SettingsFieldError path="stream.opusBitrate" errors={fieldErrors} />
                     <div className="field-hint">
                       96 kbps is transparent for most music; 256/320 suits hifi listeners
                       (current: {data?.values?.stream?.opusBitrate ?? '—'} kbps). Raising it
@@ -1195,6 +1242,7 @@ export default function SettingsPanel() {
                       Save
                     </Btn>
                   </div>
+                  <SettingsFieldError path="stream.flacEnabled" errors={fieldErrors} />
                   {form.stream.flacEnabled && (
                     <div className="field-hint">
                       Point a player at{' '}
@@ -1248,6 +1296,7 @@ export default function SettingsPanel() {
                       Save
                     </Btn>
                   </div>
+                  <SettingsFieldError path="stream.oggIcyMetadata" errors={fieldErrors} />
                   <div className="field-hint">
                     On by default. Sends each track&apos;s title out-of-band (ICY) on the Opus and
                     FLAC mounts, which most internet-radio players and Cast receivers need: they
@@ -1292,6 +1341,7 @@ export default function SettingsPanel() {
                         Save
                       </Btn>
                     </div>
+                    <SettingsFieldError path="stream.aacEnabled" errors={fieldErrors} />
                     {form.stream.aacEnabled && (
                       <div className="field-hint">
                         Point a player at{' '}
@@ -1343,6 +1393,7 @@ export default function SettingsPanel() {
                         Save bitrate
                       </Btn>
                     </div>
+                    <SettingsFieldError path="stream.aacBitrate" errors={fieldErrors} />
                     <div className="field-hint">
                       AAC-LC is transparent around 256 kbps (current:{' '}
                       {data?.values?.stream?.aacBitrate ?? '—'} kbps).
@@ -1389,6 +1440,7 @@ export default function SettingsPanel() {
                       Save bitrate
                     </Btn>
                   </div>
+                  <SettingsFieldError path="stream.bitrate" errors={fieldErrors} />
                   <div className="field-hint">
                     Higher bitrate = better quality, more listener bandwidth
                     (current: {data?.values?.stream?.bitrate ?? '—'} kbps). 192 kbps is the

--- a/web/components/admin/library/BlockRulesCard.tsx
+++ b/web/components/admin/library/BlockRulesCard.tsx
@@ -22,7 +22,27 @@ import { V3AlertDialog } from '../../ui/alert-dialog';
 import { SkeletonRows } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/ui/empty-state';
 import { cn } from '../../../lib/cn';
+import { FieldError } from '../../ui/field';
+import { RULE_TEXT_MAX, blockRuleSchema } from '@/lib/schemas.generated';
+import type { ZodError } from 'zod';
 import type { BlockRuleStat, RuleField, SeasonWindow } from './types';
+
+/**
+ * Flatten a client-side parse into the same dotted-path map the controller
+ * sends, so one piece of rendering serves both sources.
+ *
+ * Mirrors util/zod-error.ts's flattenIssues, including the null-prototype
+ * accumulator: a rule value is operator data, and on a `{}` literal a path of
+ * `__proto__` would be dropped outright rather than stored.
+ */
+function schemaFieldErrors(error: ZodError): Record<string, string> {
+  const out: Record<string, string> = Object.create(null);
+  for (const issue of error.issues) {
+    const key = issue.path.join('.');
+    if (!(key in out)) out[key] = issue.message;
+  }
+  return out;
+}
 
 const MONTH_NAMES = [
   'January', 'February', 'March', 'April', 'May', 'June',
@@ -133,6 +153,9 @@ export function BlockRulesCard({ onChanged }: { onChanged?: () => void }) {
   const [editing, setEditing] = useState<RuleForm | null>(null);
   const [editId, setEditId] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  // Keyed by the schema's own dotted path ('label', 'values'), which is what
+  // both the pre-flight and the controller's fieldErrors produce.
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
   // Picker vocab, loaded once alongside the rules. Failures degrade to free
   // text (genres) / an empty list with a hint (shows, playlists).
   const [genres, setGenres] = useState<string[]>([]);
@@ -183,15 +206,40 @@ export function BlockRulesCard({ onChanged }: { onChanged?: () => void }) {
 
   const save = async () => {
     if (!editing) return;
+    // Pre-flight against the SAME schema the route and the store run, so a
+    // missing label or an empty value list is refused here rather than after a
+    // round trip. The card keeps its own state machine — the chip input and the
+    // two month/day pickers are not react-hook-form shaped — but the rules it
+    // gates on are no longer its own.
+    const preflight = blockRuleSchema.safeParse(editing);
+    if (!preflight.success) {
+      setFieldErrors(schemaFieldErrors(preflight.error));
+      return;
+    }
+    setFieldErrors({});
     setBusy(true);
     try {
       const r = await adminFetch(editId ? `/library/blocklist/rules/${encodeURIComponent(editId)}` : '/library/blocklist/rules', {
         method: editId ? 'PUT' : 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(editing),
+        // The PARSED value, not the raw form: trimmed label, blank values
+        // dropped, duplicates collapsed — so what the operator sees accepted is
+        // what gets stored.
+        body: JSON.stringify(preflight.data),
       });
-      const j = await r.json().catch(() => ({})) as { rule?: BlockRuleStat; purged?: number; error?: string };
-      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      const j = await r.json().catch(() => ({})) as {
+        rule?: BlockRuleStat;
+        purged?: number;
+        error?: string;
+        fieldErrors?: Record<string, string>;
+      };
+      if (!r.ok) {
+        // Both sides run one schema, so this should be unreachable for a body
+        // the pre-flight accepted — but the server stays authoritative, and a
+        // controller a version ahead can refuse something this build allows.
+        if (j.fieldErrors) setFieldErrors(j.fieldErrors);
+        throw new Error(j.error || `failed (${r.status})`);
+      }
       setEditing(null);
       setEditId(null);
       notify.ok(`Rule ${editId ? 'updated' : 'added'}${j.purged ? ` — ${j.purged} queued track${j.purged === 1 ? '' : 's'} dropped` : ''}`);
@@ -250,11 +298,11 @@ export function BlockRulesCard({ onChanged }: { onChanged?: () => void }) {
         right={
           <div className="flex items-center gap-2">
             {rows.length === 0 && rules !== null && (
-              <Btn sm onClick={() => { setEditing({ ...XMAS_PRESET }); setEditId(null); }} title="Prefill: tracks tagged christmas only air Dec 1–26">
+              <Btn sm onClick={() => { setEditing({ ...XMAS_PRESET }); setEditId(null); setFieldErrors({}); }} title="Prefill: tracks tagged christmas only air Dec 1–26">
                 <Snowflake size={11} /> Seasonal preset
               </Btn>
             )}
-            <Btn sm tone="accent" onClick={() => { setEditing({ ...EMPTY_RULE }); setEditId(null); }} disabled={rules === null}>
+            <Btn sm tone="accent" onClick={() => { setEditing({ ...EMPTY_RULE }); setEditId(null); setFieldErrors({}); }} disabled={rules === null}>
               <Plus size={11} /> Add rule
             </Btn>
           </div>
@@ -318,7 +366,7 @@ export function BlockRulesCard({ onChanged }: { onChanged?: () => void }) {
 
       <Modal
         open={editing !== null}
-        onOpenChange={o => { if (!o) { setEditing(null); setEditId(null); } }}
+        onOpenChange={o => { if (!o) { setEditing(null); setEditId(null); setFieldErrors({}); } }}
         title={editId ? 'edit rule' : 'new rule'}
         sub={editId && editing ? editing.label : undefined}
         width={560}
@@ -330,7 +378,7 @@ export function BlockRulesCard({ onChanged }: { onChanged?: () => void }) {
               </Btn>
             ) : <span />}
             <div className="flex items-center gap-2">
-              <Btn sm className="min-h-9 sm:min-h-0" onClick={() => { setEditing(null); setEditId(null); }} disabled={busy}>Cancel</Btn>
+              <Btn sm className="min-h-9 sm:min-h-0" onClick={() => { setEditing(null); setEditId(null); setFieldErrors({}); }} disabled={busy}>Cancel</Btn>
               <Btn
                 sm
                 tone="accent"
@@ -353,8 +401,13 @@ export function BlockRulesCard({ onChanged }: { onChanged?: () => void }) {
                 value={editing.label}
                 onChange={e => patch({ label: e.target.value })}
                 placeholder="e.g. Christmas songs"
-                maxLength={64}
+                maxLength={RULE_TEXT_MAX}
+                aria-invalid={!!fieldErrors.label || undefined}
+                aria-describedby={fieldErrors.label ? `${fieldId}-label-error` : undefined}
               />
+              {fieldErrors.label && (
+                <FieldError id={`${fieldId}-label-error`} errors={[{ message: fieldErrors.label }]} />
+              )}
             </div>
 
             <div className="field">
@@ -410,6 +463,12 @@ export function BlockRulesCard({ onChanged }: { onChanged?: () => void }) {
                   placeholder={editing.field === 'genre' ? 'e.g. Death Metal' : editing.field === 'tag' ? 'e.g. christmas' : 'add a value…'}
                   suggestions={editing.field === 'genre' || editing.field === 'tag' ? genres : undefined}
                 />
+                {fieldErrors.values && (
+                  <FieldError
+                    id={`${fieldId}-values-error`}
+                    errors={[{ message: fieldErrors.values }]}
+                  />
+                )}
               </div>
             )}
 

--- a/web/components/admin/library/types.ts
+++ b/web/components/admin/library/types.ts
@@ -73,15 +73,17 @@ export interface BlockEntry {
 }
 
 // Rule entries — attribute/tag predicates beside the id entries, with an
-// optional seasonal allow-window and show scope. Server shape from
-// music/blocklist-rules.ts; `active`/`matchCount` are the listing stats
-// GET /library/blocklist stamps per rule.
-export type RuleField = 'genre' | 'tag' | 'mood' | 'artist' | 'album' | 'title' | 'playlist';
+// optional seasonal allow-window and show scope. `active`/`matchCount` are the
+// listing stats GET /library/blocklist stamps per rule.
+//
+// The SHAPE comes from the mirrored schema rather than being re-declared here.
+// Both of these were hand-copied from the controller, which is the drift the
+// mirror exists to prevent: the field vocabulary in particular is enumerated in
+// FIELD_OPTIONS on the card too, and a field added server-side would otherwise
+// typecheck cleanly here while being unreachable in the UI.
+export type { RuleField, SeasonWindow } from '@/lib/schemas.generated';
 
-export interface SeasonWindow {
-  from: { month: number; day: number };
-  to: { month: number; day: number };
-}
+import type { RuleField, SeasonWindow } from '@/lib/schemas.generated';
 
 export interface BlockRule {
   id: string;

--- a/web/components/admin/personas/constants.ts
+++ b/web/components/admin/personas/constants.ts
@@ -58,30 +58,51 @@ export const FADER_FILL_WIDTH: Record<number, readonly string[]> = {
 // Engine descriptors live in components/admin/tts/engineMeta.ts (shared with the
 // Settings voice tab) — import ENGINES from there, not here.
 
-// Chatterbox reference voice files are validated against this in audio/chatterbox.ts
-// — basename only, no path separators, .wav extension, conservative chars.
-export const CHATTERBOX_VOICE_RE = /^[A-Za-z0-9_.-]{1,80}\.wav$/;
-// Sentinel for the empty-string "use the built-in voice" choice — Radix Select
-// rejects an empty-string SelectItem value.
-export const CB_DEFAULT_VOICE = '__cb_default__';
-// PocketTTS voice ids — lowercase, allow underscores/hyphens (matches the
-// settings-side POCKET_TTS_VOICE_RE).
-export const POCKET_TTS_VOICE_RE = /^[a-z][a-z0-9_-]{0,39}$/;
-export const KOKORO_RE = /^[a-z]{2}_[a-z0-9]+$/;
+// Every cap and voice pattern below comes from the MIRROR
+// (controller/src/schemas/persona.ts via lib/schemas.generated.ts) rather than
+// being re-typed here. They used to be hand-copied with "keep in lockstep with
+// …" comments, which is the surest sign of a constant about to drift — and one
+// already had: personaValid required a `cloud` voice unconditionally while the
+// controller allows an empty one for openai-compatible, so an operator on a
+// self-hosted TTS server could not save their roster at all.
+//
+// These are re-exported under the names this editor already used, so no call
+// site moved.
+import {
+  DJ_PROMPT_LIMIT,
+  DJ_PROMPT_NAME_MAX,
+  DJ_PROMPT_TEXT_MAX,
+  DJ_PROMPT_TEXT_MIN,
+  PERSONA_LANGUAGE_MAX,
+  PERSONA_LIMIT,
+  PERSONA_NAME_MAX,
+  PERSONA_SOUL_MAX,
+  PERSONA_TAGLINE_MAX,
+  TTS_CHATTERBOX_VOICE_RE,
+  TTS_KOKORO_VOICE_RE,
+  TTS_POCKET_VOICE_RE,
+} from '@/lib/schemas.generated';
 
-export const NAME_MAX = 40;
-export const TAGLINE_MAX = 80;
-export const SOUL_MAX = 2000;
-export const LANGUAGE_MAX = 60;
-export const PROMPT_MIN = 50;
-export const PROMPT_MAX = 4000;
-// Prompt-template library caps — keep in lockstep with the controller's
-// DJ_PROMPT_LIMIT / DJ_PROMPT_NAME_MAX (settings.ts).
-export const PROMPT_PRESET_MAX = 20;
-export const PROMPT_NAME_MAX = 60;
+export const CHATTERBOX_VOICE_RE = TTS_CHATTERBOX_VOICE_RE;
+// Sentinel for the empty-string "use the built-in voice" choice — Radix Select
+// rejects an empty-string SelectItem value. Purely a UI concern, so it stays.
+export const CB_DEFAULT_VOICE = '__cb_default__';
+export const POCKET_TTS_VOICE_RE = TTS_POCKET_VOICE_RE;
+export const KOKORO_RE = TTS_KOKORO_VOICE_RE;
+
+export const NAME_MAX = PERSONA_NAME_MAX;
+export const TAGLINE_MAX = PERSONA_TAGLINE_MAX;
+export const SOUL_MAX = PERSONA_SOUL_MAX;
+export const LANGUAGE_MAX = PERSONA_LANGUAGE_MAX;
+export const PROMPT_MIN = DJ_PROMPT_TEXT_MIN;
+export const PROMPT_MAX = DJ_PROMPT_TEXT_MAX;
+export const PROMPT_PRESET_MAX = DJ_PROMPT_LIMIT;
+export const PROMPT_NAME_MAX = DJ_PROMPT_NAME_MAX;
 // Station house rules cap — lockstep with DJ_HOUSE_RULES_MAX (settings/vocab.ts).
+// Not yet on the mirror: djHouseRules converted as a scalar settings key, whose
+// schema owns the bound but does not export it as a named constant.
 export const HOUSE_RULES_MAX = 2000;
-export const PERSONA_MAX = 48;
+export const PERSONA_MAX = PERSONA_LIMIT;
 
 // 512×512 output target. The controller hard-caps the decoded image at 300 KB
 // and the JSON body at 600 KB; a center-cropped 512×512 WebP from a typical

--- a/web/components/admin/personas/helpers.ts
+++ b/web/components/admin/personas/helpers.ts
@@ -1,10 +1,11 @@
 import type { DjPromptPreset, FormState, Persona, SettingsResponse } from './types';
 import {
   AVATAR_TARGET_PX, DICEBEAR_STYLES, DIAL_NEUTRAL,
-  NAME_MAX, TAGLINE_MAX, SOUL_MAX, LANGUAGE_MAX,
-  PROMPT_NAME_MAX, PROMPT_MIN, PROMPT_MAX,
-  KOKORO_RE, CHATTERBOX_VOICE_RE, POCKET_TTS_VOICE_RE,
+  CHATTERBOX_VOICE_RE, POCKET_TTS_VOICE_RE,
 } from './constants';
+// The validity RULES themselves, so this editor and the controller cannot
+// disagree about whether a persona is saveable — see personaValid.
+import { djPromptSchema, personaSchema } from '@/lib/schemas.generated';
 import { CLOUD_PROVIDER_ENV_KEY, cloudProviderLabel } from '../tts/cloudProviderMeta';
 
 // Client-minted opaque id ('p_' personas, 'dp_' prompt presets). The server
@@ -17,14 +18,12 @@ export function clientMintId(prefix: string = 'p_') {
 
 // Client-side mirror of the controller's per-preset validation
 // (settings.ts:validateDjPromptsStrict) — used to gate Save.
+/**
+ * Same treatment as personaValid: the SHARED djPromptSchema, not a local copy
+ * of its three rules (name cap, text bounds, the mandatory {name} placeholder).
+ */
 export function promptPresetValid(p: { name: string; text: string }): boolean {
-  const name = p.name.trim();
-  const text = p.text.trim();
-  return (
-    name.length >= 1 && name.length <= PROMPT_NAME_MAX &&
-    text.length >= PROMPT_MIN && text.length <= PROMPT_MAX &&
-    text.includes('{name}')
-  );
+  return djPromptSchema.safeParse(p).success;
 }
 
 // The single defaulting path — used by the initial load, community install and
@@ -167,33 +166,42 @@ export async function fileToAvatarDataUrl(file: File): Promise<string> {
   }
 }
 
+/**
+ * Is this persona one the controller would accept?
+ *
+ * Runs the SHARED schema (personaSchema, mirrored from
+ * controller/src/schemas/persona.ts), not a local reimplementation of it. This
+ * predicate gates the Save button and paints the roster's per-row validity dot,
+ * so it deciding differently from the server means either a save that is
+ * refused after the fact or — worse, and what happened here — a valid roster
+ * the operator is simply not allowed to save.
+ *
+ * The version this replaces had already drifted: it required a `cloud` voice
+ * unconditionally, while the controller has always allowed an EMPTY voice for
+ * the `openai-compatible` provider (a self-hosted server picks its own default,
+ * and there is no canonical voice id to type). An operator on such a server saw
+ * their persona marked invalid and the Save button disabled, with nothing
+ * naming the field.
+ */
 export function personaValid(p: Persona): boolean {
-  if (p.name.trim().length < 1 || p.name.trim().length > NAME_MAX) return false;
-  if (p.tagline.trim().length > TAGLINE_MAX) return false;
-  if (p.soul.trim().length < 1 || p.soul.trim().length > SOUL_MAX) return false;
-  if (p.language.trim().length > LANGUAGE_MAX) return false;
-  const e = p.tts.engine;
-  if (e === 'kokoro') return KOKORO_RE.test(p.tts.voice.trim());
-  if (e === 'chatterbox') {
-    // Empty = use built-in default voice; otherwise must be a plain .wav filename.
-    const v = p.tts.voice.trim();
-    return v === '' || CHATTERBOX_VOICE_RE.test(v);
+  return personaSchema.safeParse(p).success;
+}
+
+/**
+ * The same answer, but keyed by field, for surfacing WHICH rule failed.
+ *
+ * Dotted paths, matching the controller's own `fieldErrors` payload, so one
+ * rendering serves a local parse and a server refusal alike.
+ */
+export function personaFieldErrors(p: Persona): Record<string, string> {
+  const r = personaSchema.safeParse(p);
+  if (r.success) return {};
+  const out: Record<string, string> = Object.create(null);
+  for (const issue of r.error.issues) {
+    const key = issue.path.join('.');
+    if (!(key in out)) out[key] = issue.message;
   }
-  if (e === 'pocket-tts') {
-    // Built-in voice id, OR a .wav filename for zero-shot cloning (issue #213),
-    // OR empty for the default — matches the server-side validator in settings.ts.
-    const v = p.tts.voice.trim();
-    return v === '' || POCKET_TTS_VOICE_RE.test(v) || CHATTERBOX_VOICE_RE.test(v);
-  }
-  if (e === 'cloud') {
-    const v = p.tts.voice.trim();
-    return v.length >= 1 && v.length <= 100;
-  }
-  if (e === 'remote') {
-    const v = p.tts.voice.trim();
-    return v.length <= 100;
-  }
-  return true; // piper — voice ignored
+  return out;
 }
 
 // `voice` is shared across engines, so switching engines can leave an incompatible

--- a/web/components/admin/settings/LibrarySection.tsx
+++ b/web/components/admin/settings/LibrarySection.tsx
@@ -51,7 +51,7 @@ interface LibrarySectionProps extends SectionProps {
   refresh: () => void;
 }
 
-export function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, refresh }: LibrarySectionProps) {
+export function LibrarySection({ data, form, setForm, busy, saveSettings, adminFetch, refresh, fieldErrors }: LibrarySectionProps) {
   const e = form.embedding;
   const [embeddingKeyInput, setEmbeddingKeyInput] = useState('');
   const [compatEmbedKeyInput, setCompatEmbedKeyInput] = useState('');
@@ -857,6 +857,8 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
         busy={busy}
         onSave={save}
         saveLabel="Save library tagger"
+        errors={fieldErrors}
+        ownedKeys={['embedding', 'audio']}
       />
     </>
   );

--- a/web/components/admin/settings/LikesSection.tsx
+++ b/web/components/admin/settings/LikesSection.tsx
@@ -9,7 +9,7 @@ import { Label } from '../../ui/label';
 import { Card, Pill, Seg } from '../ui';
 import { SectionHeader, SaveBar, type SectionProps, type LikesForm } from './shared';
 
-export function LikesSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
+export function LikesSection({ data, form, setForm, busy, saveSettings, fieldErrors }: SectionProps) {
   const lk = form.likes;
   const saved = data.values?.likes || {};
 
@@ -145,6 +145,8 @@ export function LikesSection({ data, form, setForm, busy, saveSettings }: Sectio
           busy={busy}
           onSave={save}
           saveLabel="Save likes"
+          errors={fieldErrors}
+          ownedKeys={['likes']}
         />
       </Card>
     </>

--- a/web/components/admin/settings/LlmSection.tsx
+++ b/web/components/admin/settings/LlmSection.tsx
@@ -33,7 +33,7 @@ interface LlmSectionProps extends SectionProps {
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
   refresh: () => void;
 }
-export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refresh }: LlmSectionProps) {
+export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch, refresh, fieldErrors }: LlmSectionProps) {
   const [primaryKeyInput, setPrimaryKeyInput] = useState('');
   const [fallbackKeyInput, setFallbackKeyInput] = useState('');
   const [primaryKeyTest, setPrimaryKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
@@ -1198,6 +1198,8 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
         busy={busy}
         onSave={save}
         saveLabel="Save LLM provider"
+        errors={fieldErrors}
+        ownedKeys={['llm']}
       />
 
       {/* The SAFE outcome (keep the embedding pin) is the default; only the explicit

--- a/web/components/admin/settings/SearchSection.tsx
+++ b/web/components/admin/settings/SearchSection.tsx
@@ -34,7 +34,7 @@ const searchProviderLabel = (id: string | undefined): string =>
 interface SearchSectionProps extends SectionProps {
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
 }
-export function SearchSection({ data, form, setForm, busy, saveSettings, adminFetch }: SearchSectionProps) {
+export function SearchSection({ data, form, setForm, busy, saveSettings, adminFetch, fieldErrors }: SearchSectionProps) {
   const [keyTest, setKeyTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
   const [keyTesting, setKeyTesting] = useState(false);
   const [testingSearxng, setTestingSearxng] = useState(false);
@@ -250,6 +250,8 @@ export function SearchSection({ data, form, setForm, busy, saveSettings, adminFe
         busy={busy}
         onSave={save}
         saveLabel="Save web search"
+        errors={fieldErrors}
+        ownedKeys={['search']}
       />
     </>
   );

--- a/web/components/admin/settings/StationSection.tsx
+++ b/web/components/admin/settings/StationSection.tsx
@@ -11,7 +11,7 @@ import {
 import { Card, Btn, Pill, Seg } from '../ui';
 import { LocationPicker, type GeocodeResult } from '../../LocationPicker';
 import {
-  SectionHeader, SaveBar,
+  SectionHeader, SaveBar, SettingsFieldError,
   type SectionProps,
 } from './shared';
 
@@ -41,7 +41,7 @@ const ON_OFF = [
   { id: 'off', label: 'Off' },
 ] as const;
 
-export function StationSection({ data, form, setForm, busy, saveSettings }: SectionProps) {
+export function StationSection({ data, form, setForm, busy, saveSettings, fieldErrors }: SectionProps) {
   // Persisted state, for the "restart required" pill and the password placeholder.
   const authOnFile = data.values?.privacy?.listenerAuth === true;
   const passwordOnFile = data.values?.privacy?.password === 'set';
@@ -123,6 +123,7 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
             className="w-[260px] max-w-full"
             maxLength={80}
           />
+          <SettingsFieldError path="station" errors={fieldErrors} />
           <div className="field-hint">
             Substituted into the DJ prompt’s {'{station}'} placeholder (current: {data.values?.station || 'SUB/WAVE'}). Applies live.
           </div>
@@ -139,6 +140,7 @@ export function StationSection({ data, form, setForm, busy, saveSettings }: Sect
             className="w-full"
             maxLength={200}
           />
+          <SettingsFieldError path="stationDescription" errors={fieldErrors} />
           <div className="field-hint">
             The blurb shown when someone shares a link to this station on social
             media or chat. Stays the same whoever is on air; leave it empty and

--- a/web/components/admin/settings/StationSection.tsx
+++ b/web/components/admin/settings/StationSection.tsx
@@ -543,6 +543,8 @@ export function StationSection({ data, form, setForm, busy, saveSettings, fieldE
         busy={busy}
         onSave={save}
         saveLabel="Save station settings"
+        errors={fieldErrors}
+        ownedKeys={['station', 'stationDescription', 'timezone', 'locale', 'weather', 'privacy', 'requests']}
       />
     </>
   );

--- a/web/components/admin/settings/ThemeSection.tsx
+++ b/web/components/admin/settings/ThemeSection.tsx
@@ -19,7 +19,7 @@ import { DEFAULT_SKIN_ID, SKINS } from '../../skins';
 import { THEME_TOKENS, THEME_TOKEN_KEYS, SWATCH_KEYS, DISPLAY_FONT_IDS, MONO_FONT_IDS } from '../../../lib/theme-tokens.generated';
 import {
   SectionHeader,
-  type SettingsData, type SaveSettings,
+  type SettingsData, type SaveSettings, type SettingsFieldErrors,
 } from './shared';
 
 interface ThemeSectionProps {
@@ -27,6 +27,8 @@ interface ThemeSectionProps {
   busy: boolean;
   saveSettings: SaveSettings;
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  /** Server-side errors from the last save, keyed by dotted path. */
+  fieldErrors: SettingsFieldErrors;
 }
 
 interface ThemeDef {

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -10,6 +10,7 @@ import type { EngineAvailability } from '../tts/engineMeta';
 import { Play } from 'lucide-react';
 import { Btn, Eyebrow, Metric } from '../ui';
 import { Button } from '../../ui/button';
+import { FieldError } from '../../ui/field';
 
 export const KEY_HINTS: Record<string, string> = {
   ANTHROPIC_API_KEY: 'sk-ant-...',
@@ -437,12 +438,85 @@ export type SaveSettings = (patch: Patch) => Promise<boolean>;
 
 export type FormUpdater = (updater: (f: FormState) => FormState) => void;
 
+/**
+ * Server-side validation errors from the last `/settings` save, keyed by the
+ * controller's dotted path ('beds.crossSec', 'personas.0.name').
+ *
+ * `POST /settings` has answered with a `fieldErrors` payload since the patch
+ * registry landed, and until now the panel threw it away and showed a toast
+ * instead — which lib/notify's own header calls out as the wrong surface for
+ * field-level validation. This is the channel that fixes that.
+ *
+ * There is deliberately NO client-side pre-flight for these. The registry that
+ * maps a settings key to its schema is not itself a schema module, so it is not
+ * in the mirror, and hand-rebuilding that map in the browser would be exactly
+ * the drift the mirror exists to prevent. The server is the one source, and its
+ * answer lands on the input.
+ */
+export type SettingsFieldErrors = Record<string, string>;
+
+export type FormUpdaterOrErrors = SettingsFieldErrors;
+
 export interface SectionProps {
   data: SettingsData;
   form: FormState;
   setForm: FormUpdater;
   busy: boolean;
   saveSettings: SaveSettings;
+  fieldErrors: SettingsFieldErrors;
+}
+
+/**
+ * ARIA + rendering for one settings input's server error.
+ *
+ * Mirrors lib/form.ts's `fieldAria` — deliberately, since these sections are
+ * NOT react-hook-form shaped (each control owns its own save button posting a
+ * one-key patch, so there is no single submit to bind) and cannot use it
+ * directly. The ids and the `-error` suffix follow the same convention, so an
+ * operator gets the same behaviour whichever admin form they are on.
+ */
+/**
+ * One settings input's server error, or nothing.
+ *
+ * Wraps the same vendored `FieldError` primitive the react-hook-form-bound
+ * panels use, so the message looks and announces identically (`role="alert"`)
+ * whichever admin form the operator is on — these sections just get their error
+ * shape from the controller instead of from a resolver.
+ *
+ * `path` is the controller's dotted key, so the JSX names the exact string the
+ * server sends and a rename on either side is visible at the call site.
+ */
+export function SettingsFieldError({
+  path,
+  errors,
+  id,
+}: {
+  path: string;
+  errors: SettingsFieldErrors;
+  id?: string;
+}) {
+  const message = errors[path];
+  if (!message) return null;
+  return <FieldError id={id} errors={[{ message }]} />;
+}
+
+export function settingsFieldAria(baseId: string, message?: string) {
+  const invalid = !!message;
+  return {
+    invalid,
+    message,
+    labelProps: { htmlFor: baseId },
+    controlProps: {
+      id: baseId,
+      // Absent rather than aria-invalid="false" — the attribute only carries
+      // meaning when set.
+      'aria-invalid': invalid || undefined,
+      // Reference the id only when it is really in the DOM: a dangling
+      // aria-describedby is handled inconsistently across screen readers.
+      'aria-describedby': invalid ? `${baseId}-error` : undefined,
+    },
+    errorProps: { id: `${baseId}-error` },
+  } as const;
 }
 
 interface MetricSpec {

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -589,13 +589,52 @@ interface SaveBarProps {
   onSave: () => void;
   saveLabel: ReactNode;
   extra?: ReactNode;
+  /** Server errors from the last save, keyed by dotted path. */
+  errors?: SettingsFieldErrors;
+  /** The top-level settings keys this bar's save owns, e.g. ['search']. */
+  ownedKeys?: readonly string[];
 }
 
-// No inline status: success/failure goes through the global toaster (lib/notify).
-export function SaveBar({ note, busy, onSave, saveLabel, extra }: SaveBarProps) {
+/**
+ * Filter a fieldErrors map down to the paths a given save owns.
+ *
+ * Exported so a section can reuse the same scoping rule if it renders an error
+ * somewhere other than its save bar.
+ */
+export function ownedFieldErrors(
+  errors: SettingsFieldErrors | undefined,
+  ownedKeys: readonly string[] | undefined,
+): Array<[string, string]> {
+  if (!errors || !ownedKeys?.length) return [];
+  return Object.entries(errors).filter(([path]) =>
+    ownedKeys.some((key) => path === key || path.startsWith(`${key}.`)),
+  );
+}
+
+/**
+ * Success/failure still goes through the global toaster, but a VALIDATION
+ * failure now also lands here, beside the button that caused it.
+ *
+ * These sections save a whole block at once, so a per-input error would be the
+ * wrong shape: the operator pressed one button and several fields could have
+ * failed. Listing them at the save point names every one, and each message
+ * already carries its own dotted field (that is the settings registry's
+ * verbatim-message rule), so the path is not lost by grouping them here.
+ */
+export function SaveBar({ note, busy, onSave, saveLabel, extra, errors, ownedKeys }: SaveBarProps) {
+  const owned = ownedFieldErrors(errors, ownedKeys);
   return (
     <div className="flex flex-wrap items-center gap-3 border border-ink bg-[var(--ink-softer)] p-3">
       <span className="size-1.5 shrink-0 rounded-full bg-vermilion" />
+      {owned.length > 0 && (
+        // Full width so it sits on its own row above the note/button cluster,
+        // which is where a wrapped flex child lands anyway.
+        <div className="order-first w-full">
+          {owned.map(([path, message]) => (
+            <FieldError key={path} errors={[{ message }]} />
+          ))}
+        </div>
+      )}
       {/* min-w-0 + break-words: notes carry unbroken values (an
           `openai-compatible:Qwen3…gguf` model id) that would otherwise set the
           flex item's min-content and push the bar past a phone viewport. */}

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -2711,6 +2711,17 @@ export function weatherMoodsSchema(ctx: SettingsMoodContext) {
   return settingsMoodMap(SETTINGS_WEATHER_CONDITIONS, 'weatherMoods', true, ctx);
 }
 
+// Festival field bounds. Named rather than left as literals inside the schema
+// because the admin editor needs the same numbers for its maxLength / min / max
+// attributes, and it was hard-coding them — the drift that had already bitten
+// the persona editor.
+export const SETTINGS_FESTIVAL_NAME_MAX = 80;
+export const SETTINGS_FESTIVAL_DESCRIPTION_MAX = 200;
+// Days either side of the date on which the festival's mood applies. The
+// ceiling is deliberately low: past a fortnight a "festival window" is just a
+// season, which is what moodSchedule is for.
+export const SETTINGS_FESTIVAL_WINDOW_DAYS_MAX = 14;
+
 export function festivalsSchema(ctx: SettingsMoodContext) {
   const names = ctx.moodNames ? new Set(ctx.moodNames) : null;
   const list = ctx.moodNames ? ctx.moodNames.join(', ') : '';
@@ -2741,8 +2752,8 @@ export function festivalsSchema(ctx: SettingsMoodContext) {
         }
         const f = item as Record<string, unknown>;
         const name = String(f.name ?? '').trim();
-        if (name.length < 1 || name.length > 80) {
-          add(`festivals[${i}].name must be 1-80 chars`, 'name');
+        if (name.length < 1 || name.length > SETTINGS_FESTIVAL_NAME_MAX) {
+          add(`festivals[${i}].name must be 1-${SETTINGS_FESTIVAL_NAME_MAX} chars`, 'name');
           return;
         }
         const month = Number(f.month);
@@ -2773,8 +2784,15 @@ export function festivalsSchema(ctx: SettingsMoodContext) {
           return;
         }
         const windowDays = Number(f.windowDays ?? 0);
-        if (!Number.isInteger(windowDays) || windowDays < 0 || windowDays > 14) {
-          add(`festivals[${i}].windowDays must be an integer 0-14`, 'windowDays');
+        if (
+          !Number.isInteger(windowDays)
+          || windowDays < 0
+          || windowDays > SETTINGS_FESTIVAL_WINDOW_DAYS_MAX
+        ) {
+          add(
+            `festivals[${i}].windowDays must be an integer 0-${SETTINGS_FESTIVAL_WINDOW_DAYS_MAX}`,
+            'windowDays',
+          );
         }
       });
     })
@@ -2785,7 +2803,9 @@ export function festivalsSchema(ctx: SettingsMoodContext) {
         name: String(f.name ?? '').trim(),
         mood: String(f.mood ?? '').trim(),
         description:
-          typeof f.description === 'string' ? f.description.trim().slice(0, 200) : '',
+          typeof f.description === 'string'
+            ? f.description.trim().slice(0, SETTINGS_FESTIVAL_DESCRIPTION_MAX)
+            : '',
         windowDays: Number(f.windowDays ?? 0),
       })),
     );

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -8,6 +8,213 @@
 
 import { z } from 'zod';
 
+// ─── from controller/src/schemas/blocklist.ts ────────────────────────────
+
+// Shared never-play blocklist schema (#1300 FR 1) — the shape of a RULE entry
+// (attribute predicate + optional seasonal allow-window + optional show scope)
+// and of the id-entry create body, executed on BOTH sides. The controller runs
+// it in music/blocklist-rules.ts's validateRulePatch (the store's chokepoint,
+// reached by POST and PUT alike) and at the route boundary; the browser runs
+// the mirrored copy so BlockRulesCard can pre-flight a save.
+//
+// HARD RULE: this file may import ONLY from 'zod'. It is copied verbatim into
+// the web bundle, so a project import or a node builtin here breaks the mirror.
+// music/blocklist-rules.ts itself cannot be a schema module — it imports
+// show-filter's genre/tag normalisers for the MATCHING half — which is exactly
+// why the validation half moved here and is re-exported from there.
+//
+// WHAT DELIBERATELY DID NOT MOVE
+// ------------------------------
+// Rule ids and `addedAt` are minted by the store, not submitted, so they are
+// absent from the schema entirely (rather than optional): a client that sends
+// one is not describing a rule, and z.object strips it before the store sees it
+// — the same posture as a show's server-minted id, one step stricter because
+// nothing downstream points at a rule id the way a schedule slot points at a
+// show id.
+
+export const RULE_FIELDS = [
+  'genre',
+  'tag',
+  'mood',
+  'artist',
+  'album',
+  'title',
+  'playlist',
+] as const;
+
+export type RuleField = (typeof RULE_FIELDS)[number];
+
+export const RULES_MAX = 50;
+export const RULE_VALUES_MAX = 12;
+export const RULE_TEXT_MAX = 64;
+
+/** Id-entry granularity — a blocked track, its album, or its artist. */
+export const BLOCK_TYPES = ['track', 'album', 'artist'] as const;
+
+export interface SeasonWindow {
+  from: { month: number; day: number };
+  to: { month: number; day: number };
+}
+
+/**
+ * Trim, lowercase, collapse whitespace — the same normalisation the blocklist's
+ * name fallback uses, so a `tag`/`artist` rule value compares the way an id
+ * entry's name snapshot does. Used here only for DEDUPE; the stored value keeps
+ * its original casing.
+ */
+export const normText = (s: unknown) => String(s ?? '').trim().toLowerCase().replace(/\s+/g, ' ');
+
+// A month/day pair. Both halves are `Number(x)` + an integer/range test, not
+// z.number().int(), because the admin card posts them from <input type=number>
+// and a numeric STRING has always been accepted.
+function blocklistMonthDay(where: string) {
+  return z.unknown().optional().transform((raw, ctx) => {
+    const o = (raw ?? {}) as Record<string, unknown>;
+    const month = Number(o.month);
+    const day = Number(o.day);
+    if (!Number.isInteger(month) || month < 1 || month > 12) {
+      ctx.addIssue({ code: 'custom', message: `${where}.month must be 1-12` });
+      return z.NEVER;
+    }
+    if (!Number.isInteger(day) || day < 1 || day > 31) {
+      ctx.addIssue({ code: 'custom', message: `${where}.day must be 1-31` });
+      return z.NEVER;
+    }
+    return { month, day };
+  });
+}
+
+/**
+ * A seasonal ALLOW-window: inclusive month/day bounds, `from > to` wrapping the
+ * year end (Dec 1 → Jan 6). While in season the rule does NOT block.
+ *
+ * Deliberately NOT range-checked beyond each half: a wrapping window is the
+ * feature, so "from after to" is meaningful rather than backwards — unlike a
+ * show's era window, where the same shape IS an error.
+ */
+export const blockSeasonSchema = z.object({
+  from: blocklistMonthDay('rule.season.from'),
+  to: blocklistMonthDay('rule.season.to'),
+});
+
+/**
+ * The add/update payload for one rule, in the persisted shape minus the
+ * store-owned id/addedAt.
+ *
+ * Every message names `rule.<field>` because the route surfaces it verbatim,
+ * the same convention validateShowsStrict follows.
+ */
+export const blockRuleSchema = z.object({
+  label: z
+    .unknown()
+    .optional()
+    .transform((raw, ctx) => {
+      const v = String(raw ?? '').trim();
+      if (!v) {
+        ctx.addIssue({ code: 'custom', message: 'rule.label is required' });
+        return z.NEVER;
+      }
+      if (v.length > RULE_TEXT_MAX) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `rule.label must be at most ${RULE_TEXT_MAX} chars`,
+        });
+        return z.NEVER;
+      }
+      return v;
+    }),
+  field: z.enum(RULE_FIELDS, {
+    error: `rule.field must be one of: ${RULE_FIELDS.join(', ')}`,
+  }),
+  values: z
+    .array(z.unknown(), { error: 'rule.values must be an array' })
+    .transform((items, ctx) => {
+      // A blank entry is dropped and a duplicate is silently collapsed (same
+      // value twice is one value), but a NON-STRING entry and an over-long one
+      // are both refused — the operator typed something that isn't a value, and
+      // silently discarding it would block less than the card shows.
+      const out: string[] = [];
+      const seen = new Set<string>();
+      for (const v of items) {
+        if (typeof v !== 'string') {
+          ctx.addIssue({ code: 'custom', message: 'rule.values entries must be strings' });
+          return z.NEVER;
+        }
+        const t = v.trim();
+        if (!t) continue;
+        if (t.length > RULE_TEXT_MAX) {
+          ctx.addIssue({
+            code: 'custom',
+            message: `rule.values entries must be at most ${RULE_TEXT_MAX} chars`,
+          });
+          return z.NEVER;
+        }
+        const key = normText(t);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(t);
+      }
+      if (!out.length) {
+        ctx.addIssue({ code: 'custom', message: 'rule.values must have at least one entry' });
+        return z.NEVER;
+      }
+      if (out.length > RULE_VALUES_MAX) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `rule.values must have at most ${RULE_VALUES_MAX} entries`,
+        });
+        return z.NEVER;
+      }
+      return out;
+    }),
+  // Absent or null = no season, i.e. the rule always blocks.
+  season: z.preprocess((v) => (v == null ? undefined : v), blockSeasonSchema.nullable().default(null)),
+  // Empty = station-wide. Stale ids are inert by design (resolved against the
+  // live roster at evaluation time), so a non-string entry is DROPPED rather
+  // than refused — the same call persona.skills makes for the same reason.
+  showIds: z.preprocess(
+    (v) => (v == null ? undefined : v),
+    z
+      .array(z.unknown(), { error: 'rule.showIds must be an array of strings' })
+      .transform((items) => [
+        ...new Set(
+          items.filter((v): v is string => typeof v === 'string' && !!v.trim()),
+        ),
+      ])
+      .default([]),
+  ),
+});
+
+export type BlockRulePatch = z.output<typeof blockRuleSchema>;
+
+/**
+ * `POST /library/blocklist` — the id-entry create body.
+ *
+ * TWO accepted forms, which is why nothing but `type` is required: the UI flow
+ * posts `{type, trackId}` and the server resolves the album/artist ids and
+ * display snapshots from the track row, while a direct entry posts a
+ * pre-resolved `{type, id, …}`. Which of the two arrived is decided by the
+ * route (it needs Subsonic to resolve one of them), so the schema's job is only
+ * to pin the shape both share.
+ */
+export const blockEntrySchema = z.object({
+  type: z.enum(BLOCK_TYPES, { error: "type must be 'track', 'album' or 'artist'" }),
+  trackId: z.preprocess(
+    (v) => (v == null || v === '' ? undefined : v),
+    z.string({ error: 'trackId must be a string' }).optional(),
+  ),
+  id: z.preprocess(
+    (v) => (v == null || v === '' ? undefined : v),
+    z.string({ error: 'id must be a string' }).optional(),
+  ),
+  // Display snapshots — free text captured at block time so the Blocked tab can
+  // name a row whose source has since vanished. Null is meaningful ("unknown"),
+  // so it is preserved rather than folded to undefined.
+  name: z.string().nullable().optional(),
+  artist: z.string().nullable().optional(),
+  album: z.string().nullable().optional(),
+});
+
 // ─── from controller/src/schemas/imaging.ts ──────────────────────────────
 
 // Shared imaging schemas — the station's produced audio assets. Sound effects,
@@ -160,6 +367,90 @@ export const voiceImportSchema = z.object({
   name: imagingName,
 });
 
+// ─── from controller/src/schemas/library.ts ──────────────────────────────
+
+// Shared library-maintenance schemas — the operator-facing bodies under
+// /library that carry typed input rather than a bare id. Today that is
+// `POST /library/manual-tag`, the "tag this track (or its whole album) by hand,
+// no LLM involved" path behind the library row editor.
+//
+// HARD RULE: this file may import ONLY from 'zod'. It is copied verbatim into
+// the web bundle, so a project import or a node builtin here breaks the mirror.
+//
+// WHY A FACTORY
+// -------------
+// Moods are operator-editable (settings.moodVocab()), so a manual tag can only
+// be judged against the LIVE vocabulary — the same reason showSchema takes a
+// context. `moodNames: null` means "this caller cannot check that rule", which
+// is what lets the browser pre-flight the shape of a body whose vocabulary it
+// may not have fetched yet while the route still enforces membership.
+
+/** At most three moods per track — the tagger's own ceiling. */
+export const MANUAL_TAG_MOODS_MAX = 3;
+
+export const MANUAL_TAG_ENERGIES = ['low', 'medium', 'high'] as const;
+
+export interface ManualTagContext {
+  /** The live mood vocabulary, or null when the caller cannot know it. */
+  moodNames: string[] | null;
+}
+
+export const MANUAL_TAG_SHAPE_ONLY: ManualTagContext = { moodNames: null };
+
+export function manualTagSchema(ctx: ManualTagContext) {
+  return z.object({
+    // `!id || typeof id !== 'string'` — so a blank string is refused too, and
+    // with the same message, which is what the route has always answered.
+    id: z.unknown().optional().transform((raw, c) => {
+      if (typeof raw !== 'string' || !raw) {
+        c.addIssue({ code: 'custom', message: 'id is required' });
+        return z.NEVER;
+      }
+      return raw;
+    }),
+    // An EMPTY array is meaningful: it clears the track's tags entirely and
+    // returns it to the untagged pool. So this is required-but-may-be-empty,
+    // never defaulted — a missing key and an explicit [] must not be the same
+    // request.
+    moods: z
+      .array(z.unknown(), { error: 'moods must be an array of strings' })
+      .transform((items, c) => {
+        if (items.some((m) => typeof m !== 'string')) {
+          c.addIssue({ code: 'custom', message: 'moods must be an array of strings' });
+          return z.NEVER;
+        }
+        const values = items as string[];
+        if (values.length > MANUAL_TAG_MOODS_MAX) {
+          c.addIssue({
+            code: 'custom',
+            message: `at most ${MANUAL_TAG_MOODS_MAX} moods per track`,
+          });
+          return z.NEVER;
+        }
+        if (ctx.moodNames) {
+          const unknown = values.filter((m) => !ctx.moodNames!.includes(m));
+          if (unknown.length) {
+            c.addIssue({ code: 'custom', message: `unknown mood(s): ${unknown.join(', ')}` });
+            return z.NEVER;
+          }
+        }
+        return values;
+      }),
+    // null is the explicit "no energy", distinct from an omission only in that
+    // both land on null — matching `req.body?.energy ?? null`.
+    energy: z.preprocess(
+      (v) => (v === undefined ? null : v),
+      z
+        .enum(MANUAL_TAG_ENERGIES, {
+          error: "energy must be 'low', 'medium', 'high' or null",
+        })
+        .nullable(),
+    ),
+    // `=== true`, so anything else reads as off — unchanged.
+    applyToAlbum: z.unknown().optional().transform((v) => v === true),
+  });
+}
+
 // ─── from controller/src/schemas/onboarding.ts ───────────────────────────
 
 // Shared onboarding schemas — the two PROBE bodies and the handful of rules
@@ -252,6 +543,670 @@ export function fishAudioIssue(cloud: unknown): string | null {
   if (bad(c.model)) return 'Fish Audio model id must be 1-100 characters with no line breaks';
   if (bad(c.voice)) return 'Fish Audio voice reference id must be 1-100 characters with no line breaks';
   return null;
+}
+
+// ─── from controller/src/schemas/persona.ts ──────────────────────────────
+
+// Shared persona + prompt-library schema — the single source of truth for a
+// DJ persona's shape and for the `{engine, voice, cloudProvider}` voice slot,
+// executed on BOTH sides. The controller runs it in
+// settings.validate.validatePersonasStrict (the update() chokepoint) and in
+// settings.normalize.normalizePersona (the lenient load path); the browser runs
+// the mirrored copy (web/lib/schemas.generated.ts) so the Personas editor can
+// pre-flight a save against the exact rules the controller enforces.
+//
+// HARD RULE: this file may import ONLY from 'zod'. It is copied verbatim into
+// the web bundle, so a project import or a node builtin here breaks the mirror.
+// That includes OTHER schema modules — the mirror is one flat concatenation, so
+// gen-schemas.ts rejects every specifier but 'zod', enforces unique top-level
+// names across every module, and each module has to stand alone.
+//
+// WHICH IS WHY TWO REGEXES ARE DECLARED HERE RATHER THAN IMPORTED
+// ---------------------------------------------------------------
+// `PERSONA_ID_RE` is the same pattern as schemas/show.ts's SHOW_ID_RE, and
+// `PERSONA_SKILL_SLUG_RE` the same as schemas/skill.ts's SKILL_SLUG_RE. Neither
+// can be imported (see above) and neither can reuse the other's NAME (the flat
+// mirror would carry two declarations of it). Re-declaring is therefore
+// structural, not sloppiness — and the drift it invites is pinned by
+// scripts/persona-schema.test.ts, which asserts `.source` equality against both
+// originals. That is the same answer skill-schema.test.ts gives for
+// loader.SLUG_RE and vocab's SKILL_SLUG_RE.
+//
+// WHY THERE IS NO FACTORY
+// -----------------------
+// Unlike a show, a persona CAN be validated against itself: every rule is a
+// pure function of the submitted value. `skills` names skill slugs, but a slug
+// that no longer resolves is dropped rather than refused (see the field), so
+// the live catalogue is not an input. Rules that are NOT pure — id minting and
+// cross-row de-duplication — live in persona-server.ts, which is NOT mirrored.
+//
+// SETTINGS/VOCAB.TS RE-EXPORTS EVERY CONSTANT BELOW
+// -------------------------------------------------
+// The "first feature converted owns the constant" rule. No call site moved when
+// this landed; vocab.ts aliases these under the names the controller already
+// used (PERSONA_FREQUENCIES as FREQUENCIES, and so on). The web side must read
+// them from the mirror rather than hand-copying — a hand-copied cap is exactly
+// the SKILL_SLUG_RE drift this whole mechanism exists to prevent.
+
+// ── Persona vocabulary ───────────────────────────────────────────────────────
+
+/** Entity id. Same pattern as SHOW_ID_RE — see the header. */
+export const PERSONA_ID_RE = /^[a-z0-9_]{3,32}$/;
+
+/** Same pattern as schemas/skill.ts's SKILL_SLUG_RE — see the header. */
+export const PERSONA_SKILL_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,48}$/;
+
+// An avatar is stored as a BARE BASENAME, never a path: the id half reuses
+// PERSONA_ID_RE's character class so the field can never reference a file
+// outside the avatar dir.
+export const PERSONA_AVATAR_FILENAME_RE = /^[a-z0-9_]{3,32}\.(png|jpe?g|webp)$/;
+
+export const PERSONA_LIMIT = 48;
+export const PERSONA_NAME_MAX = 40;
+export const PERSONA_TAGLINE_MAX = 80;
+export const PERSONA_LANGUAGE_MAX = 60;
+// Every persona's soul rides in the system prompt on every call, so this is a
+// recurring per-call token cost rather than a structural limit.
+export const PERSONA_SOUL_MAX = 2000;
+export const PERSONA_SKILLS_LIMIT = 64;
+
+export const PERSONA_FREQUENCIES = [
+  'silent',
+  'quiet',
+  'moderate',
+  'chatty',
+  'aggressive',
+] as const;
+
+export const PERSONA_SCRIPT_LENGTHS = [
+  'one-liner',
+  'concise',
+  'extended',
+  'storyteller',
+] as const;
+
+// Per-persona tone dials — 0-10 with 5 the neutral default.
+export const PERSONA_DIAL_MIN = 0;
+export const PERSONA_DIAL_MAX = 10;
+export const PERSONA_DIAL_NEUTRAL = 5;
+
+/**
+ * Clamp any input to an integer dial, defaulting to neutral when unparseable.
+ *
+ * Never throws, on EITHER path — the strict validator has always run the same
+ * coercion the lenient one does, so a garbage dial has never been able to fail
+ * a persona save. Reproduced verbatim rather than tightened.
+ */
+export function clampPersonaDial(v: unknown): number {
+  const n = Math.round(Number(v));
+  return Number.isFinite(n)
+    ? Math.min(PERSONA_DIAL_MAX, Math.max(PERSONA_DIAL_MIN, n))
+    : PERSONA_DIAL_NEUTRAL;
+}
+
+// ── TTS voice slot ───────────────────────────────────────────────────────────
+//
+// The `{engine, voice, cloudProvider, gainDb, speed}` block. Shared by every
+// persona's `tts` AND by the station-wide rescue slot (`settings.tts.fallback`)
+// — the two carry the same shape by design, because a fallback slot is handed
+// to speakWith() as a synthetic persona. One implementation is what stops the
+// per-engine voice rules drifting between them.
+
+export const TTS_ENGINES = [
+  'piper',
+  'kokoro',
+  'chatterbox',
+  'pocket-tts',
+  'cloud',
+  'remote',
+] as const;
+
+export const TTS_CLOUD_PROVIDERS = [
+  'openai',
+  'elevenlabs',
+  'fish-audio',
+  'openai-compatible',
+] as const;
+
+// Kokoro voice ids are `<lang><gender>_<name>`, e.g. bf_isabella.
+export const TTS_KOKORO_VOICE_RE = /^[a-z]{2}_[a-z0-9]+$/;
+// Chatterbox (and pocket-tts zero-shot cloning) voices are reference-WAV
+// filenames in the shared voice folder — no path separators.
+export const TTS_CHATTERBOX_VOICE_RE = /^[A-Za-z0-9_.-]{1,80}\.wav$/;
+// PocketTTS built-in voice ids (alba, anna, charles, …).
+export const TTS_POCKET_VOICE_RE = /^[a-z][a-z0-9_-]{0,39}$/;
+// Piper voices are `.onnx` filenames in the shared voice folder.
+export const TTS_PIPER_VOICE_RE = /^[A-Za-z0-9_.-]{1,100}\.onnx$/;
+
+export const TTS_VOICE_MAX = 100;
+
+export const TTS_GAIN_CLAMP_DB = 12;
+export const TTS_SPEED_MIN = 0.5;
+export const TTS_SPEED_MAX = 2.0;
+export const TTS_SPEED_DEFAULT = 1.0;
+
+/**
+ * Coerce any value to a clean gain: finite, clamped to ±TTS_GAIN_CLAMP_DB,
+ * rounded to 0.1 dB. Garbage / non-finite → 0 (unity).
+ */
+export function clampTtsGain(v: unknown): number {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return 0;
+  const c = Math.max(-TTS_GAIN_CLAMP_DB, Math.min(TTS_GAIN_CLAMP_DB, n));
+  return Math.round(c * 10) / 10;
+}
+
+/**
+ * Coerce any value to a clean speech-rate multiplier.
+ *
+ * Unset (null/undefined/'') is unity, NOT 0 — unlike gain, 0 is not this dial's
+ * default and would clamp to the 0.5 floor instead of no-change.
+ */
+export function clampTtsSpeed(v: unknown): number {
+  if (v === null || v === undefined || v === '') return TTS_SPEED_DEFAULT;
+  const n = Number(v);
+  if (!Number.isFinite(n)) return TTS_SPEED_DEFAULT;
+  const c = Math.max(TTS_SPEED_MIN, Math.min(TTS_SPEED_MAX, n));
+  return Math.round(c * 20) / 20;
+}
+
+export interface TtsVoiceSlot {
+  engine: string;
+  cloudProvider: string;
+  voice: string;
+  gainDb: number;
+  speed: number;
+}
+
+/**
+ * The strict voice slot, as a factory over the settings path prefix.
+ *
+ * `where` is a FACTORY PARAMETER rather than a path zod derives, because these
+ * messages have always embedded the location in the text ("tts.fallback.voice
+ * must …") and both call sites read them as a flat toast string. The persona
+ * array passes `personas[].tts` and the station slot passes `tts.fallback`, so
+ * an operator reading a 400 still learns which of the two failed.
+ *
+ * Implemented as one transform rather than a z.object because the rules are
+ * SEQUENTIAL and cross-field: engine decides which voice rule applies, so
+ * reporting a voice issue before an engine issue would name a rule the operator
+ * never opted into. A transform reports exactly the first failure the
+ * hand-rolled validator reported, in the same order.
+ */
+export function ttsVoiceSlotSchema(where: string) {
+  // `.optional()` so an ABSENT block reaches the transform and is refused by the
+  // engine rule below ("tts.engine must be one of: …") rather than by zod's
+  // generic 'expected nonoptional' — the hand-rolled validator's `raw || {}`
+  // gave the operator the useful message, and that is the one worth keeping.
+  return z.unknown().optional().transform((raw, ctx): TtsVoiceSlot => {
+    // `raw || {}` — an absent or non-object block reads as "all defaults", which
+    // is how a persona written before this block existed still validates.
+    const t = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+
+    const engine = t.engine as string;
+    if (!(TTS_ENGINES as readonly string[]).includes(engine)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `${where}.engine must be one of: ${TTS_ENGINES.join(', ')}`,
+      });
+      return z.NEVER;
+    }
+    const cloudProvider = t.cloudProvider as string;
+    if (!(TTS_CLOUD_PROVIDERS as readonly string[]).includes(cloudProvider)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `${where}.cloudProvider must be one of: ${TTS_CLOUD_PROVIDERS.join(', ')}`,
+      });
+      return z.NEVER;
+    }
+
+    // String(x ?? '') and not z.string(): a numeric voice id posted by an older
+    // admin build has always coerced, and refusing it now would be a tightening.
+    let voice = String(t.voice ?? '').trim();
+    const fail = (message: string) => {
+      ctx.addIssue({ code: 'custom', message });
+      return z.NEVER;
+    };
+
+    if (engine === 'kokoro') {
+      if (!TTS_KOKORO_VOICE_RE.test(voice)) {
+        return fail(
+          `${where}.voice must match <lang><gender>_<name> for kokoro, e.g. bf_isabella`,
+        );
+      }
+    } else if (engine === 'chatterbox') {
+      // Empty = built-in default voice.
+      if (voice && !TTS_CHATTERBOX_VOICE_RE.test(voice)) {
+        return fail(
+          `${where}.voice for chatterbox must be a .wav filename (no path), or empty for the default voice`,
+        );
+      }
+    } else if (engine === 'pocket-tts') {
+      // A built-in voice id OR a .wav filename for zero-shot cloning (#213).
+      if (!voice) voice = 'alba';
+      if (!TTS_POCKET_VOICE_RE.test(voice) && !TTS_CHATTERBOX_VOICE_RE.test(voice)) {
+        return fail(
+          `${where}.voice for pocket-tts must be a built-in voice id (e.g. alba) or a .wav filename`,
+        );
+      }
+    } else if (engine === 'cloud') {
+      // openai-compatible voices are server-specific; empty lets the server use
+      // its own default. openai/elevenlabs both require a voice id.
+      if (cloudProvider === 'openai-compatible') {
+        if (voice.length > TTS_VOICE_MAX) {
+          return fail(`${where}.voice must be 0-${TTS_VOICE_MAX} chars`);
+        }
+      } else if (voice.length < 1 || voice.length > TTS_VOICE_MAX) {
+        return fail(`${where}.voice must be 1-${TTS_VOICE_MAX} chars`);
+      }
+    } else if (engine === 'remote') {
+      // Server-specific — the sidecar interprets them. Empty is valid.
+      if (voice.length > TTS_VOICE_MAX) {
+        return fail(`${where}.voice must be 0-${TTS_VOICE_MAX} chars`);
+      }
+    } else {
+      // piper: empty = the baked-in default. A Kokoro-shaped id is also
+      // accepted — the seed roster carries one per persona under piper so
+      // switching to Kokoro yields distinct voices with no extra editing, and
+      // resolvePiperVoice() falls back gracefully for it (#454).
+      if (
+        voice &&
+        !TTS_PIPER_VOICE_RE.test(voice) &&
+        !TTS_KOKORO_VOICE_RE.test(voice)
+      ) {
+        return fail(
+          `${where}.voice for piper must be an .onnx filename (no path), or empty for the default voice`,
+        );
+      }
+    }
+
+    return {
+      engine,
+      cloudProvider,
+      voice,
+      gainDb: clampTtsGain(t.gainDb),
+      speed: clampTtsSpeed(t.speed),
+    };
+  });
+}
+
+/**
+ * The lenient twin of ttsVoiceSlotSchema — the LOAD path.
+ *
+ * Where the schema refuses, this resets to a value the schema accepts. The
+ * output is therefore always schema-valid, which is what lets the load path run
+ * the real schema after repairing rather than maintaining a second set of rules.
+ */
+export function repairTtsVoiceSlot(raw: unknown): TtsVoiceSlot {
+  const r = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  const engine = (TTS_ENGINES as readonly string[]).includes(r.engine as string)
+    ? (r.engine as string)
+    : 'piper';
+  const cloudProvider = (TTS_CLOUD_PROVIDERS as readonly string[]).includes(
+    r.cloudProvider as string,
+  )
+    ? (r.cloudProvider as string)
+    : 'openai';
+  let voice =
+    typeof r.voice === 'string' && r.voice.trim()
+      ? r.voice.trim().slice(0, TTS_VOICE_MAX)
+      : '';
+
+  if (engine === 'kokoro' && !TTS_KOKORO_VOICE_RE.test(voice)) voice = 'bf_isabella';
+  // Invalid chatterbox filenames reset to empty rather than being rewritten to
+  // a Kokoro id.
+  if (engine === 'chatterbox' && voice && !TTS_CHATTERBOX_VOICE_RE.test(voice)) voice = '';
+  if (
+    engine === 'pocket-tts' &&
+    (!voice ||
+      (!TTS_POCKET_VOICE_RE.test(voice) && !TTS_CHATTERBOX_VOICE_RE.test(voice)))
+  ) {
+    voice = 'alba';
+  }
+  // A Kokoro-shaped id under piper is PRESERVED, not wiped — see the schema.
+  if (
+    engine === 'piper' &&
+    voice &&
+    !TTS_PIPER_VOICE_RE.test(voice) &&
+    !TTS_KOKORO_VOICE_RE.test(voice)
+  ) {
+    voice = '';
+  }
+  if (!voice && engine === 'cloud' && cloudProvider !== 'openai-compatible') voice = 'alloy';
+  if (
+    !voice &&
+    engine !== 'cloud' &&
+    engine !== 'chatterbox' &&
+    engine !== 'piper' &&
+    engine !== 'remote'
+  ) {
+    voice = 'bf_isabella';
+  }
+  return {
+    engine,
+    cloudProvider,
+    voice,
+    gainDb: clampTtsGain(r.gainDb),
+    speed: clampTtsSpeed(r.speed),
+  };
+}
+
+// ── Persona ──────────────────────────────────────────────────────────────────
+
+// Explicit null reads as "absent" on every OPTIONAL field. The pre-schema
+// validator accepted null everywhere it accepted an omission (`String(x ?? '')`,
+// `!== undefined && !== null` guards), and clients that write null for an empty
+// field relied on it. zod's `.default()` fires only on undefined.
+const personaNullToUndefined = (v: unknown) => (v == null ? undefined : v);
+
+/**
+ * `String(x ?? '').trim()` then a length check — the exact coercion the
+ * hand-rolled validator applied to name/soul/tagline.
+ *
+ * Deliberately NOT `z.string()`: a numeric or boolean value stringifies today
+ * (a persona named `123` saves), and refusing it would be a tightening. The
+ * message names its own field because it is also the flat `error` a 400 carries.
+ */
+// The `.optional()` is load-bearing on every z.unknown() field in this module,
+// and is NOT the same statement as "this field may be omitted". zod 4 treats a
+// bare z.unknown() inside z.object as a REQUIRED key and refuses an absent one
+// with 'expected nonoptional' before the transform ever runs — so without it a
+// persona that simply omits `tagline` (or a dial) fails, where the hand-rolled
+// validator read the omission as '' and 5 respectively. Optionality here restores
+// that: the transform still runs, and `String(undefined ?? '')` is what decides
+// the outcome — '' passes a min of 0 and fails a min of 1, exactly as before.
+function personaCoercedText(field: string, min: number, max: number) {
+  return z.unknown().optional().transform((raw, ctx) => {
+    const v = String(raw ?? '').trim();
+    if (v.length < min || v.length > max) {
+      ctx.addIssue({ code: 'custom', message: `${field} must be ${min}-${max} chars` });
+      return z.NEVER;
+    }
+    return v;
+  });
+}
+
+export interface PersonaParsed {
+  id?: string;
+  name: string;
+  tagline: string;
+  frequency: string;
+  scriptLength: string;
+  djMode: boolean;
+  humour: number;
+  localColour: number;
+  warmth: number;
+  soul: string;
+  language: string;
+  avatar: string;
+  tts: TtsVoiceSlot;
+  skills: string[] | null;
+}
+
+/**
+ * One persona.
+ *
+ * `id` is OPTIONAL and a malformed one is DROPPED rather than refused — the
+ * same call the shows conversion made, and for a stronger reason: a persona id
+ * is what every show's `personaId`, every guest list and `activePersonaId` point
+ * at, so refusing one bad id in a backup would refuse the whole roster.
+ * persona-server.ts's resolvePersonaIds mints the replacement.
+ *
+ * Field ORDER matters — zod reports issues in declaration order, and the
+ * hand-rolled validator checked name → soul → tagline → language → frequency →
+ * scriptLength → djMode → tts → skills → avatar. An operator with two bad
+ * fields must still be told about the same one first.
+ */
+export const personaSchema = z
+  .object({
+    name: personaCoercedText('name', 1, PERSONA_NAME_MAX),
+    soul: personaCoercedText('soul', 1, PERSONA_SOUL_MAX),
+    tagline: personaCoercedText('tagline', 0, PERSONA_TAGLINE_MAX),
+    // language — optional free text ("Turkish", "Türkçe", …). Absent/empty → ''
+    // (English, no directive injected). Unlike name/soul this one REFUSES a
+    // non-string instead of coercing, which is what the validator did.
+    language: z.preprocess(
+      personaNullToUndefined,
+      z
+        .string({ error: 'language must be a string' })
+        .trim()
+        .max(PERSONA_LANGUAGE_MAX, `language must be 0-${PERSONA_LANGUAGE_MAX} chars`)
+        .default(''),
+    ),
+    frequency: z.enum(PERSONA_FREQUENCIES, {
+      error: `frequency must be one of: ${PERSONA_FREQUENCIES.join(', ')}`,
+    }),
+    // Absent → 'concise' (the default and the historical behaviour).
+    scriptLength: z.preprocess(
+      personaNullToUndefined,
+      z
+        .enum(PERSONA_SCRIPT_LENGTHS, {
+          error: `scriptLength must be one of: ${PERSONA_SCRIPT_LENGTHS.join(', ')}`,
+        })
+        .default('concise'),
+    ),
+    // Absent → false (a plain narrator persona). Present must be a real boolean:
+    // unlike the `=== true` booleans on a show, BOTH paths never agreed here —
+    // the strict validator refused a non-boolean — so the refusal is preserved.
+    djMode: z.preprocess(
+      personaNullToUndefined,
+      z.boolean({ error: 'djMode must be a boolean' }).default(false),
+    ),
+    // An absent dial reads as neutral, which is what clampPersonaDial returns
+    // for undefined — see the note on personaCoercedText for the .optional().
+    humour: z.unknown().optional().transform(clampPersonaDial),
+    localColour: z.unknown().optional().transform(clampPersonaDial),
+    warmth: z.unknown().optional().transform(clampPersonaDial),
+    // A bare basename, never a path. The dedicated upload route is the only
+    // writer that creates the file; this just checks the persisted string.
+    avatar: z.preprocess(
+      (v) => (v == null || v === '' ? undefined : v),
+      z
+        .unknown()
+        .transform((raw, ctx) => {
+          const a = String(raw).trim();
+          if (!PERSONA_AVATAR_FILENAME_RE.test(a)) {
+            ctx.addIssue({
+              code: 'custom',
+              message: 'avatar must be a basename like <id>.png|jpg|jpeg|webp',
+            });
+            return z.NEVER;
+          }
+          return a;
+        })
+        .optional()
+        .transform((v) => v ?? ''),
+    ),
+    tts: ttsVoiceSlotSchema('tts'),
+    // skills — absent → null ("all skills", the legacy default). Present → an
+    // explicit slug array.
+    skills: z.preprocess(
+      personaNullToUndefined,
+      z
+        .array(z.unknown(), { error: 'skills must be an array of skill names' })
+        .max(PERSONA_SKILLS_LIMIT, `skills must be at most ${PERSONA_SKILLS_LIMIT} entries`)
+        .transform((items) => {
+          // A malformed entry is DROPPED, not refused. persona.skills is a
+          // subscription list resolved against the live skill catalogue at fire
+          // time, so an entry that can't name a skill can never fire — and the
+          // OLD shape check accepted forms the slug rule refuses (a leading
+          // hyphen), so a backup can legitimately carry one. Failing the whole
+          // roster over inert junk is the themeId lesson (#917) again.
+          const seen = new Set<string>();
+          const out: string[] = [];
+          for (const s of items) {
+            const v = String(s ?? '').trim();
+            if (!PERSONA_SKILL_SLUG_RE.test(v)) continue;
+            if (seen.has(v)) continue;
+            seen.add(v);
+            out.push(v);
+          }
+          return out;
+        })
+        .nullable()
+        .default(null),
+    ),
+    id: z.preprocess(
+      // A malformed id reads as absent so resolvePersonaIds mints one.
+      (v) => (typeof v === 'string' && PERSONA_ID_RE.test(v) ? v : undefined),
+      z.string().optional(),
+    ),
+  })
+  // The persisted key order, which several fixtures and the backup diff rely on.
+  .transform(
+    (p): PersonaParsed => ({
+      id: p.id,
+      name: p.name,
+      tagline: p.tagline,
+      frequency: p.frequency,
+      scriptLength: p.scriptLength,
+      djMode: p.djMode,
+      humour: p.humour,
+      localColour: p.localColour,
+      warmth: p.warmth,
+      soul: p.soul,
+      language: p.language,
+      avatar: p.avatar,
+      tts: p.tts,
+      skills: p.skills,
+    }),
+  );
+
+/**
+ * The whole roster.
+ *
+ * A station with NO persona has no one to speak, which is why the floor is 1
+ * rather than 0 — settings.load() falls back to the seeded roster instead.
+ */
+export const personasSchema = z
+  .array(personaSchema, { error: `personas must be an array of 1-${PERSONA_LIMIT} entries` })
+  .min(1, `personas must be an array of 1-${PERSONA_LIMIT} entries`)
+  .max(PERSONA_LIMIT, `personas must be an array of 1-${PERSONA_LIMIT} entries`);
+
+/**
+ * Every per-field repair the LOAD path applies before parsing.
+ *
+ * `undefined` lets the schema's own default apply. Each repair lands on a value
+ * the strict path accepts, so load and save still agree about what a valid
+ * persona is — the schema itself is still run on the result. A row that cannot
+ * be repaired into validity (no name, no soul) fails the parse and the caller
+ * drops it, exactly as normalizePersona returned null.
+ *
+ * `skillRenames` travels as plain DATA rather than being imported, because this
+ * module may import nothing but zod. The browser passes `{}`.
+ */
+export function repairPersonaForLoad(
+  raw: Record<string, unknown>,
+  skillRenames: Record<string, string> = {},
+): Record<string, unknown> {
+  return {
+    ...raw,
+    id: typeof raw.id === 'string' && PERSONA_ID_RE.test(raw.id) ? raw.id : undefined,
+    name: typeof raw.name === 'string' ? raw.name.trim().slice(0, PERSONA_NAME_MAX) : undefined,
+    soul: typeof raw.soul === 'string' ? raw.soul.trim().slice(0, PERSONA_SOUL_MAX) : undefined,
+    tagline:
+      typeof raw.tagline === 'string' ? raw.tagline.trim().slice(0, PERSONA_TAGLINE_MAX) : '',
+    language:
+      typeof raw.language === 'string'
+        ? raw.language.trim().slice(0, PERSONA_LANGUAGE_MAX)
+        : undefined,
+    frequency: (PERSONA_FREQUENCIES as readonly string[]).includes(raw.frequency as string)
+      ? raw.frequency
+      : 'moderate',
+    scriptLength: (PERSONA_SCRIPT_LENGTHS as readonly string[]).includes(
+      raw.scriptLength as string,
+    )
+      ? raw.scriptLength
+      : undefined,
+    djMode: raw.djMode === true ? true : undefined,
+    avatar:
+      typeof raw.avatar === 'string' && PERSONA_AVATAR_FILENAME_RE.test(raw.avatar.trim())
+        ? raw.avatar.trim()
+        : undefined,
+    tts: repairTtsVoiceSlot(raw.tts),
+    // Non-array → undefined → the schema's null default ("all skills"), which is
+    // what normalizeSkills returned. Renames are applied HERE and not in the
+    // schema: a rename is a migration of stored data, not a rule a submitted
+    // value has to satisfy, and the strict path has never applied them.
+    skills: Array.isArray(raw.skills)
+      ? raw.skills
+          .filter((s): s is string => typeof s === 'string')
+          .map((s) => skillRenames[s.trim()] || s.trim())
+          .filter((s) => PERSONA_SKILL_SLUG_RE.test(s))
+          .slice(0, PERSONA_SKILLS_LIMIT)
+      : undefined,
+  };
+}
+
+// ── DJ prompt library ────────────────────────────────────────────────────────
+
+export const DJ_PROMPT_LIMIT = 20;
+export const DJ_PROMPT_NAME_MAX = 60;
+export const DJ_PROMPT_TEXT_MIN = 50;
+export const DJ_PROMPT_TEXT_MAX = 4000;
+/** Every prompt template must address the persona by name. */
+export const DJ_PROMPT_PLACEHOLDER = '{name}';
+
+export interface DjPromptParsed {
+  id?: string;
+  name: string;
+  text: string;
+}
+
+export const djPromptSchema = z
+  .object({
+    name: personaCoercedText('name', 1, DJ_PROMPT_NAME_MAX),
+    text: z.unknown().optional().transform((raw, ctx) => {
+      const v = String(raw ?? '').trim();
+      if (v.length < DJ_PROMPT_TEXT_MIN || v.length > DJ_PROMPT_TEXT_MAX) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `text must be ${DJ_PROMPT_TEXT_MIN}-${DJ_PROMPT_TEXT_MAX} chars`,
+        });
+        return z.NEVER;
+      }
+      if (!v.includes(DJ_PROMPT_PLACEHOLDER)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `text must contain the ${DJ_PROMPT_PLACEHOLDER} placeholder`,
+        });
+        return z.NEVER;
+      }
+      return v;
+    }),
+    id: z.preprocess(
+      (v) => (typeof v === 'string' && PERSONA_ID_RE.test(v) ? v : undefined),
+      z.string().optional(),
+    ),
+  })
+  .transform((p): DjPromptParsed => ({ id: p.id, name: p.name, text: p.text }));
+
+export const djPromptsSchema = z
+  .array(djPromptSchema, {
+    error: `djPrompts must be an array of 0-${DJ_PROMPT_LIMIT} entries`,
+  })
+  .max(DJ_PROMPT_LIMIT, `djPrompts must be an array of 0-${DJ_PROMPT_LIMIT} entries`);
+
+/**
+ * The LOAD path's per-field repair for one prompt entry.
+ *
+ * Only `name` is repairable — the text IS the entry, so a text that can't render
+ * drops the row rather than being invented. `fallbackName` is supplied by the
+ * caller because the historical fallback ("Prompt 3") numbers by SURVIVING row,
+ * which this module cannot know.
+ */
+export function repairDjPromptForLoad(
+  raw: Record<string, unknown>,
+  fallbackName: string,
+): Record<string, unknown> {
+  const name =
+    (typeof raw.name === 'string' ? raw.name.trim().slice(0, DJ_PROMPT_NAME_MAX) : '') ||
+    fallbackName;
+  return {
+    ...raw,
+    id: typeof raw.id === 'string' && PERSONA_ID_RE.test(raw.id) ? raw.id : undefined,
+    name,
+  };
 }
 
 // ─── from controller/src/schemas/playlist.ts ─────────────────────────────
@@ -826,11 +1781,18 @@ export interface ScheduleOverrideContext {
 
 export function scheduleOverrideSchema(ctx: ScheduleOverrideContext) {
   return z
-    .object({
-      showId: z.string({ error: 'must be a show id' }).min(1, 'must be a show id'),
-      startedAt: z.number({ error: 'must be an epoch-ms number' }).finite('must be an epoch-ms number'),
-      expiresAt: z.number({ error: 'must be an epoch-ms number' }).finite('must be an epoch-ms number'),
-    })
+    .object(
+      {
+        showId: z.string({ error: 'must be a show id' }).min(1, 'must be a show id'),
+        startedAt: z.number({ error: 'must be an epoch-ms number' }).finite('must be an epoch-ms number'),
+        expiresAt: z.number({ error: 'must be an epoch-ms number' }).finite('must be an epoch-ms number'),
+      },
+      // Explicit, so a non-object never reaches an operator as zod's own
+      // 'Invalid input: expected object, received number'. Phrased WITHOUT the
+      // key, like the field messages above, because every caller roots this
+      // schema at 'scheduleOverride' — self-naming here would double it.
+      { error: 'must be an object' },
+    )
     .check((c) => {
       const { showId, startedAt, expiresAt } = c.value;
       if (ctx.showIds && !ctx.showIds.includes(showId)) {
@@ -1829,6 +2791,138 @@ export function festivalsSchema(ctx: SettingsMoodContext) {
     );
 }
 
+
+// ── theme ────────────────────────────────────────────────────────────────────
+
+/**
+ * `theme` — only `active` is a settings value; everything else in the block is
+ * derived at serve time.
+ *
+ * A NON-OBJECT block is a silent no-op (`patch.theme || {}`), so it is coerced
+ * rather than refused — the settingsBlockOf posture. And `active` is optional
+ * BECAUSE the branch acts only `if (t.active !== undefined)`: a patch of
+ * `{theme: {}}` has always been a legal no-op.
+ *
+ * What stays in update(): the "is this a theme id that actually exists" check.
+ * It is async (the registry reads the themes dir) and it FALLS BACK to the
+ * built-in default rather than refusing (#917 — throwing there aborted the whole
+ * restore for any install whose active theme id had since been retired), which
+ * is a repair only the server can make.
+ */
+export const themePatchSchema = z.preprocess(
+  (v) => (v && typeof v === 'object' && !Array.isArray(v) ? v : {}),
+  z.object({
+    active: z
+      .unknown()
+      .optional()
+      .transform((raw, ctx) => {
+        if (raw === undefined) return undefined;
+        const v = String(raw ?? '').trim();
+        if (!v) {
+          ctx.addIssue({ code: 'custom', message: 'theme.active must be a theme id' });
+          return z.NEVER;
+        }
+        return v;
+      }),
+  }),
+);
+
+// ── maxTrackSeconds ──────────────────────────────────────────────────────────
+
+/**
+ * The station-wide track-length cap. 0 = unlimited.
+ *
+ * BOUNDS ONLY. The crossfade-derived FLOOR ("a non-zero cap must leave solo
+ * airtime") stays in update(), for the reason ShowSchemaContext's
+ * `minTrackSeconds: null` documents: the floor is a function of the crossfade,
+ * which the SAME patch may be changing, so only update() — which applies the
+ * crossfade first — can judge it.
+ *
+ * The legacy `maxTrackMinutes` alias is deliberately NOT registered beside this.
+ * One branch serves both keys through `rawMaxTrackSec`, whose precedence rule is
+ * "seconds wins whenever it is present and non-empty" — so when both ride along,
+ * an unusable minutes value is IGNORED today, and a schema on that key would
+ * refuse a body that currently saves. An empty/absent seconds value passes here
+ * for the same reason: precedence hands off to minutes, and update() is still
+ * the authoritative chokepoint for whatever it resolves.
+ */
+export function maxTrackSecondsValueSchema(bounds: SettingsNumericBound) {
+  return settingsIntLike(
+    bounds,
+    `maxTrackSeconds must be int in [${bounds.min}, ${bounds.max}]`,
+  );
+}
+
+/**
+ * The REGISTRY entry — the same rule, one posture looser.
+ *
+ * `rawMaxTrackSec`'s precedence is "seconds wins whenever it is present and
+ * non-empty", so an absent or empty `maxTrackSeconds` beside a `maxTrackMinutes`
+ * is a legal body that hands off rather than a failure. update() validates the
+ * RESOLVED value with maxTrackSecondsValueSchema above, which is why the bound
+ * itself is written once.
+ *
+ * The legacy `maxTrackMinutes` alias is deliberately NOT registered: when both
+ * ride along, an unusable minutes value is IGNORED today, and a schema on that
+ * key would refuse a body that currently saves.
+ */
+export function maxTrackSecondsSchema(bounds: SettingsNumericBound) {
+  const value = maxTrackSecondsValueSchema(bounds);
+  return z.unknown().superRefine((raw, ctx) => {
+    if (raw == null || raw === '') return;
+    const r = value.safeParse(raw);
+    if (!r.success) {
+      for (const issue of r.error.issues) ctx.addIssue({ code: 'custom', message: issue.message });
+    }
+  });
+}
+
+// ── the DJ prompt selection ──────────────────────────────────────────────────
+
+/**
+ * `activeDjPromptId` — '' selects the built-in default, otherwise the id of a
+ * djPrompts entry.
+ *
+ * Coercion ONLY: `String(x ?? '').trim()` is the whole of what the branch does
+ * to this value. Whether the id resolves is a cross-key question answered after
+ * `djPrompts` has been applied, and it stays in update() — the same patch may be
+ * replacing the library the id has to name.
+ */
+export const activeDjPromptIdSchema = z
+  .unknown()
+  .optional()
+  .transform((raw) => String(raw ?? '').trim());
+
+/**
+ * `djPrompt` — the legacy single-field prompt (onboarding, older clients).
+ *
+ * Its two rules are pure and convert; what stays in update() is the MAPPING onto
+ * the library — '' selects the default, and custom text reuses the entry with
+ * identical text or appends a new "Custom prompt" — which reads and writes
+ * `next.djPrompts` and can hit the library cap.
+ */
+export function djPromptTextSchema(bounds: { min: number; max: number }) {
+  return z
+    .unknown()
+    .optional()
+    .transform((raw, ctx) => {
+      const v = String(raw ?? '').trim();
+      if (v === '') return v;
+      if (v.length < bounds.min || v.length > bounds.max) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `djPrompt must be empty (use the default) or ${bounds.min}-${bounds.max} chars`,
+        });
+        return z.NEVER;
+      }
+      if (!v.includes('{name}')) {
+        ctx.addIssue({ code: 'custom', message: 'djPrompt must contain the {name} placeholder' });
+        return z.NEVER;
+      }
+      return v;
+    });
+}
+
 // ─── from controller/src/schemas/show.ts ─────────────────────────────────
 
 // Shared show schema — the single source of truth for a show's shape, executed
@@ -2231,7 +3325,13 @@ export type ShowParsed = z.output<ReturnType<typeof showSchema>>;
 export type Show = ShowParsed & { id: string };
 
 export function showsSchema(ctx: ShowSchemaContext) {
-  return z.array(showSchema(ctx)).max(SHOWS_LIMIT, `must be at most ${SHOWS_LIMIT} entries`);
+  // The array-level error is explicit so a non-array never reaches an operator
+  // as zod's own 'Invalid input: expected array, received number'. Phrased
+  // WITHOUT the key, like every other message here, because both callers root
+  // this schema at 'shows'.
+  return z
+    .array(showSchema(ctx), { error: 'must be an array' })
+    .max(SHOWS_LIMIT, `must be at most ${SHOWS_LIMIT} entries`);
 }
 
 // POST /shows submits ONE show under a `show` key and merges it server-side.
@@ -2776,7 +3876,10 @@ export type WebhookParsed = z.output<typeof webhookSchema>;
 export type Webhook = WebhookParsed & { id: string };
 
 export const webhooksSchema = z
-  .array(webhookSchema)
+  // Explicit, so a non-array reads as something an operator can act on rather
+  // than zod's 'Invalid input: expected array, received number'. Both callers
+  // root this schema at 'webhooks'.
+  .array(webhookSchema, { error: 'must be an array' })
   .max(WEBHOOKS_LIMIT, `At most ${WEBHOOKS_LIMIT} webhooks`);
 
 // Both fields optional: the route lets the listener gate save on its own


### PR DESCRIPTION
Picks up the #1337 tracker, which was closed with its checklist ticked but had only ever covered the *shared-schema* half. This does the rest of that half and the browser half it deferred.

## Where coverage stood

Two axes, and only one was close to done:

- **shared schema** — 26/42 `/settings` keys; `personas`, the blocklist, and manual tagging had no schema at all, and three of those routes had **no validation middleware whatsoever**.
- **browser** — `POST /settings` had been answering with `fieldErrors` since #1348 and *nothing consumed it*. `lib/notify`'s own header says a toast is the wrong surface for field-level validation; a toast is what every one of those failures got.

## What this does

**Three new schema modules.** `schemas/persona.ts` (+ `persona-server.ts`) covers the roster and the DJ prompt library, and absorbs the `{engine, voice, cloudProvider}` **voice slot** that the station-wide rescue slot shares with every persona — so the per-engine voice rules live once. `schemas/blocklist.ts` and `schemas/library.ts` cover the never-play rules, the id-entry body, and the manual tagger. `settings/vocab.ts` now aliases 16 constants rather than declaring them.

**`/settings` registry: 26 → 36 keys.** Each new one keeps whatever half is genuinely stateful in `update()` — id minting, the async theme-exists fallback, the crossfade-derived floor, membership in a roster the same patch may be replacing. The six that stay unconverted are now pinned by a test naming each reason, so "why isn't `llm` done" has an answer in code.

**The `fieldErrors` channel actually lands on inputs.** `saveSettings` keeps the payload, scoped by top-level key so a fixed field clears while an unrelated section's error survives. Ten controls render inline; the five bulk-save sections get it through `SaveBar` in one edit.

## One real bug, found by the conversion

`personaValid()` was a hand-written reimplementation of the whole persona validator, and it had drifted:

```js
if (e === 'cloud') return v.length >= 1 && v.length <= 100;
```

The controller has always allowed an **empty** voice when the provider is `openai-compatible` — a self-hosted server picks its own default and there is no id to type. That predicate gates the Save button *and* paints the roster's validity dot, so an operator on such a server saw their persona marked invalid and **could not save the roster at all**, with nothing naming the field.

Verified by running the old predicate and the new one over the affected persona: refused before, accepted now, while plain `openai` with an empty voice is still refused.

A sweep for the same pattern — a bare literal beside a "keep in sync with the controller" comment — turned up three more (bitrate vocabularies, mood caps, festival bounds). None had drifted yet. That is the argument for doing them: the persona one had, and nothing was watching either.

## Notes for review

- **`validateBody` gains `messages: 'verbatim'`.** These schemas' messages already name their own field (`rule.label is required`), so the default prefixing would answer `label: rule.label is required` — and worse, the route would disagree with the store's own chokepoint about the same body. Same narrow exception the settings registry already documents; `fieldErrors` carries the dotted path either way.
- **`SETTINGS_PATCH_ROOTED_KEYS`.** An array key's messages are not self-locating, so the route must root them exactly as the strict validator does, or the two name different rows for the same body.
- **Zero behaviour change was the contract**, and most of the work was preserving accidental leniency: `String()` coercion on name/soul/tagline, an absent key reading as a default (zod 4 treats a bare `z.unknown()` as **required**), a malformed `skills` entry DROPPED where a malformed `language` is REFUSED, and a numeric skill slug surviving because `String(42)` is a legal slug.

## Deliberately not done

The big editors (`ShowEditor`, `SkillEditModal`, `PlaylistBuilderPanel`, imaging) keep their own state machines and already run the schema for their save gates — the call #1337 made for each of them. Binding them to react-hook-form is a rewrite that buys no new correctness guarantee, and belongs in its own PR.

## Testing

`controller`: lint clean (0 errors), **115/115 test files pass**. `web`: lint clean, `tsc` clean.

New: `persona-schema.test.ts` (41), `library-schema.test.ts` (21), `validate-wire-shape.test.ts` (8), plus additions to `settings-patch-schema.test.ts` (73 total).

`validate-wire-shape.test.ts` is worth a look — it asserts that the dotted paths hard-coded in `SettingsPanel`'s JSX are the paths the controller really sends. Without it, dropping or re-rooting `fieldErrors` would leave every inline error silently blank and read as "validation stopped working".

**Still to do before this leaves draft:** browser verification that the inline errors render where intended. The payload contract is covered by CI; the rendering is not.