### PR TITLE
fix(controller): stream.bufferSeconds was lost on every restart

### DIFF
--- a/controller/scripts/stations-pure.test.ts
+++ b/controller/scripts/stations-pure.test.ts
@@ -1,7 +1,5 @@
-// Unit pins for the pure multi-station helpers (spec:
-// docs/superpowers/specs/2026-07-24-multi-station-profiles-design.md §2/§5/§6).
-// Run: npx tsx scripts/stations-pure.test.ts — node:assert-via-tsx style of
-// scripts/llm-pure.test.ts; auto-discovered by npm test.
+// Unit pins for the pure multi-station helpers.
+// Run: npx tsx scripts/stations-pure.test.ts — auto-discovered by npm test.
 
 import assert from 'node:assert/strict';
 import {

--- a/controller/scripts/stream-buffer-seconds.test.ts
+++ b/controller/scripts/stream-buffer-seconds.test.ts
@@ -1,0 +1,110 @@
+// settings.stream.bufferSeconds — the Icecast burst depth, in seconds.
+//
+// load()'s stream block composes explicitly rather than spreading DEFAULTS, and
+// bufferSeconds was never listed (the "three edits" trap that also cost
+// llm.repeatPenalty, #1327). update() wrote it to settings.json and it worked in
+// memory for that process; the next cold load read `undefined`, and three things
+// went wrong at once:
+//
+//   - writeLiquidsoapSettings put the STRING "undefined" in the mixer handoff
+//     file, so the entrypoint's read_state_num fell back to 22 and the burst was
+//     sized for the default rather than the operator's value;
+//   - /now-playing advertised `?? 22`, so every player applied the wrong
+//     listener-time offset (#1114's whole point is that the two agree);
+//   - update()'s change gate compared against `undefined`, so a stream patch
+//     restarted the mixer unconditionally.
+//
+// Hence a COLD-LOAD round trip, not just a clamp check — an in-process assertion
+// passes on the broken code. Verified to fail on all four cases with the
+// load() line removed.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+// STATE_DIR is redirected at a throwaway dir BEFORE the first import of
+// anything config-derived (same pattern as scripts/llm-repeat-penalty.test.ts).
+const stateRoot = mkdtempSync(path.join(tmpdir(), 'subwave-buffer-seconds-'));
+process.env.STATE_DIR = stateRoot;
+
+const { setCache } = await import('../src/settings/store.js');
+const settings = await import('../src/settings.js');
+const { writeLiquidsoapSettings } = await import('../src/settings/liquidsoap.js');
+const { DEFAULTS } = await import('../src/settings/defaults.js');
+const { STREAM_BUFFER_SECONDS_BOUNDS } = await import('../src/schemas/settings.js');
+
+const SETTINGS_PATH = path.join(stateRoot, 'settings.json');
+const HANDOFF_PATH = path.join(stateRoot, 'liquidsoap_stream_buffer_seconds.txt');
+
+// Load a hand-written settings.json the way a controller restart would.
+async function coldLoad(stream: Record<string, unknown>) {
+  writeFileSync(SETTINGS_PATH, JSON.stringify({ stream }));
+  setCache(null);
+  await settings.load();
+  return settings.get().stream;
+}
+
+test('a configured buffer depth survives a controller restart', async () => {
+  const stream = await coldLoad({ bufferSeconds: 40 });
+  assert.equal(stream.bufferSeconds, 40);
+});
+
+test('the mixer handoff file carries the number, never "undefined"', async () => {
+  const s = await coldLoad({ bufferSeconds: 40 });
+  await writeLiquidsoapSettings(settings.get());
+  const written = readFileSync(HANDOFF_PATH, 'utf8');
+  assert.equal(written, '40');
+  // The entrypoint's read_state_num rejects anything non-numeric and falls back
+  // to 22, so a non-numeric write is silently the default — assert the shape it
+  // actually parses, not just "not undefined".
+  assert.match(written, /^[0-9]+$/);
+  assert.equal(s.bufferSeconds, 40);
+});
+
+test('0 is a real value (burst-on-connect off), not a falsy miss', async () => {
+  const stream = await coldLoad({ bufferSeconds: 0 });
+  assert.equal(stream.bufferSeconds, 0);
+  await writeLiquidsoapSettings(settings.get());
+  assert.equal(readFileSync(HANDOFF_PATH, 'utf8'), '0');
+});
+
+test('an absent value falls back to the shipped default', async () => {
+  const stream = await coldLoad({});
+  assert.equal(stream.bufferSeconds, DEFAULTS.stream.bufferSeconds);
+});
+
+test('load bounds a hand-edited value against the same figures update() checks', async () => {
+  // load() is the lenient path: it repairs rather than throwing, so a
+  // settings.json edited by hand can never wedge boot.
+  for (const bad of [
+    STREAM_BUFFER_SECONDS_BOUNDS.max + 1,
+    STREAM_BUFFER_SECONDS_BOUNDS.min - 1,
+    'forty',
+    null,
+    NaN,
+    {},
+  ]) {
+    const stream = await coldLoad({ bufferSeconds: bad });
+    assert.equal(
+      stream.bufferSeconds,
+      DEFAULTS.stream.bufferSeconds,
+      `bufferSeconds: ${JSON.stringify(bad)} should fall back to the default`,
+    );
+  }
+  // In-band values are kept, and a fraction rounds the way the save path rounds.
+  assert.equal((await coldLoad({ bufferSeconds: STREAM_BUFFER_SECONDS_BOUNDS.max })).bufferSeconds,
+    STREAM_BUFFER_SECONDS_BOUNDS.max);
+  assert.equal((await coldLoad({ bufferSeconds: 30.4 })).bufferSeconds, 30);
+});
+
+test('update() then a cold load agree — the save path stores what load accepts', async () => {
+  await coldLoad({});
+  await settings.update({ stream: { bufferSeconds: 45 } });
+  assert.equal(settings.get().stream.bufferSeconds, 45);
+  // Re-read from disk exactly as a restart would.
+  setCache(null);
+  await settings.load();
+  assert.equal(settings.get().stream.bufferSeconds, 45);
+});

--- a/controller/src/audio/audio-import.ts
+++ b/controller/src/audio/audio-import.ts
@@ -91,7 +91,7 @@ export function probeDurationSec(filePath: string): Promise<number | null> {
   });
 }
 
-export type TranscodeFormat = 'wav' | 'mp3';
+type TranscodeFormat = 'wav' | 'mp3';
 
 // ffmpeg's atempo filter only accepts 0.5–2.0 per instance; factors outside
 // that range are reached by chaining instances (e.g. 4.0 → atempo=2.0,atempo=2.0).

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -148,24 +148,21 @@ function resolveEngine(kind: string, personaTts: any): RescueSlot {
 }
 
 // Ordered runtime rescues after `primary` threw mid-render (cloud API 500,
-// worker crash, network timeout — a failure the pre-flight gate can't predict).
-// The operator's CONFIGURED fallback (settings.tts.fallback) comes first: it's
-// their explicit second choice, and unlike every rung behind it, it carries a
-// VOICE as well as an engine. Their default engine follows — jumping straight
-// past it to Piper meant a station whose default was, say, Kokoro still dropped
-// to the flattest voice in the box the moment a persona's provider hiccuped.
-// Then Piper as the universal local floor, then Kokoro for the case where Piper
-// itself was the primary.
+// worker crash, network timeout — failures the pre-flight gate can't predict).
 //
-// The hardcoded rungs are checked with the GLOBAL cloud provider (null), not the
-// persona's — falling back to `cloud` there means the station default's
-// credentials, not the ones that just failed — while the configured rung is
-// checked with its own provider. The rescue call agrees either way: speak()'s
-// chain loop hands speakWith() the slot's own `personaTts`, which is null for
-// every hardcoded rung (so a cloud-persona rescue can't re-apply the persona's
-// dead provider) and the operator's explicit choice for the configured one.
+// Order: the operator's CONFIGURED fallback (their explicit second choice, and
+// the only rung carrying a VOICE as well as an engine), then their default
+// engine — skipping straight to Piper dropped a Kokoro-default station to the
+// flattest voice in the box the moment a persona's provider hiccuped — then
+// Piper as the universal local floor, then Kokoro for when Piper was primary.
 //
-// At most four rescue attempts — the ordering itself is pure and pinned by
+// The hardcoded rungs are checked with the GLOBAL cloud provider (null), so a
+// `cloud` rescue uses the station default's credentials rather than the ones
+// that just failed; the configured rung uses its own. speak()'s chain loop hands
+// speakWith() the slot's own `personaTts`, which agrees: null for every
+// hardcoded rung, the operator's choice for the configured one.
+//
+// At most four attempts; the ordering is pure and pinned by
 // scripts/tts-fallback.test.ts.
 function fallbackChain(primary: string): RescueSlot[] {
   return orderedFallbacks(
@@ -193,21 +190,19 @@ export function voiceGainDb(kind: string, persona?: any): number {
   return settings.clampTtsGain(engineGain + personaGain);
 }
 
-// Effective speech-rate multiplier for a spoken segment of `kind` (1.0 =
-// engine default pace). Three factors multiply — engine base
-// (settings.tts.speed[engine]) × persona (persona.tts.speed) × daypart energy
-// (energyForDaypart().speed) — clamped to [0.5, 2.0]. The engine base applies
-// UNIVERSALLY, including jingles/default, mirroring the env-base
-// PIPER_SPEED/KOKORO_SPEED/CLOUD_TTS_SPEED behaviour; persona × daypart apply
-// only to live, persona-voiced kinds (a jingle cut at 2am must not carry 2am
-// pacing into a noon playout). `liveOverride` (speak()'s explicit `speedScale`)
-// replaces the persona/daypart term but still composes with the engine base.
-// Resolved-engine speed (post availability/key fallback) is used so the rate
-// matches the engine that will actually speak — same approach as voiceGainDb().
+// Effective speech-rate multiplier for a segment of `kind` (1.0 = engine default
+// pace). Three factors multiply, clamped to [0.5, 2.0]: engine base x persona x
+// daypart energy. The engine base applies UNIVERSALLY, jingles included,
+// mirroring the env-base PIPER_SPEED/KOKORO_SPEED/CLOUD_TTS_SPEED behaviour;
+// persona x daypart apply only to live persona-voiced kinds, since a jingle cut
+// at 2am must not carry 2am pacing into a noon playout. `liveOverride` replaces
+// the persona/daypart term but still composes with the engine base. Reads the
+// RESOLVED engine (post availability/key fallback) so the rate matches whichever
+// engine actually speaks, like voiceGainDb().
 //
-// Exported for the intro-budget word ceiling (issue #962): a persona speaking
-// at 0.8× fits fewer words in the same intro runway, so
-// broadcast/dj-agent.ts feeds this scale into dj.enforceIntroBudget().
+// Exported for the intro-budget word ceiling (#962): a persona at 0.8x fits
+// fewer words in the same runway, so dj-agent.ts feeds this into
+// dj.enforceIntroBudget().
 export function speechPaceScale(kind: string, persona?: any, liveOverride?: number | null): number {
   const personaTts = djPersonaTts(kind, persona);
   const { engine: primary } = resolveEngine(kind, personaTts);
@@ -497,18 +492,19 @@ export async function speak(
       const fallback = slot.engine;
       console.error(`[tts] ${lastEngine} failed for kind=${kind}: ${lastErr.message} — falling back to ${fallback}`);
       try {
-        // The on-air persona's OWN tts is deliberately never forwarded to a
-        // rescue: speakWith()'s per-engine branches only read an override when
-        // its engine === the engine being spoken, and the chain excludes the
-        // primary — so for every rescue it's inert EXCEPT the one corner where a
-        // cloud persona was pre-flight-rerouted (its provider unconfigured) and
-        // the rescue engine is `cloud`: forwarding it would re-apply the
-        // persona's dead provider/voice instead of the credentials the chain
-        // probe just validated. What DOES ride is the slot's own override —
-        // null for the hardcoded rungs (same as before), and the operator's
-        // configured engine+voice for their configured rung, which is the one
-        // case where an override is an explicit instruction rather than a
-        // leftover. Probe and call stay in agreement either way. The persona's
+        // The on-air persona's OWN tts is never forwarded to a rescue.
+        // speakWith()'s per-engine branches read an override only when its
+        // engine matches the one being spoken, and the chain excludes the
+        // primary, so it is inert for every rescue EXCEPT one corner: a cloud
+        // persona pre-flight-rerouted for an unconfigured provider, rescued onto
+        // `cloud`. Forwarding there would re-apply the persona's dead
+        // provider/voice instead of the credentials the chain probe just
+        // validated.
+        //
+        // What DOES ride is the slot's own override — null for the hardcoded
+        // rungs, the operator's engine+voice for their configured one, which is
+        // the one case where an override is an explicit instruction rather than
+        // a leftover. Probe and call agree either way; the persona's
         // `language`/`soul` hints still ride via opts.
         const result = await speakWith(fallback, rescueText, { outPath, speedScale: scale, language, soul }, slot.personaTts);
         if (typeof result === 'string') await applyEdgeFades(result);

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -115,24 +115,20 @@ async function repickFromSeen({ seen, badId, wantLink, showAt = null, playlistRe
   }
 }
 
-// Request-flavoured corrective re-pick (D1): mirrors repickFromSeen above —
-// the request agent returned an id outside its own discovery trail. Observed
-// live: the SAME hallucinated id recurring across independent requests hours
-// apart (e.g. `1q8OwSA2qIzk4n1ikV06wa`, `OAlSQiljTZx5b8OvwfEAIg`, both seen
-// twice) — which looks like the model copying an id out of a session event
-// turn (every pick event tags the current track `[id: …]`) rather than
-// fabricating one fresh; the idInSessionWindow diagnostic on the eventual
-// pick.rejected event (runRequestViaAgent below) is what turns that hunch
-// into a number instead of a guess. One djObject call constrained to the
-// run's own candidates (z.enum — a decode-time grammar on local models, a
-// Zod reject elsewhere, same story as repickFromSeen) salvages the run
-// instead of discarding it wholesale to the caller's stateless matcher
-// cascade — which still runs when this misses too (no candidates, or the
-// call itself fails). Reuses requestSystem() and requestSchema()'s own field
-// wording, gated on the same autoVoiceAllowed() check for `intro`, so a
-// re-picked request stays byte-consistent with a first-try one. Never
-// throws — a salvage failure falls through to the caller's rejection path
-// unchanged.
+// Request-flavoured corrective re-pick (D1): mirrors repickFromSeen above, for
+// when the request agent returns an id outside its own discovery trail. Seen
+// live as the SAME hallucinated id recurring across independent requests hours
+// apart, which looks like the model copying an id out of a session event turn
+// (every pick event tags the current track `[id: …]`) rather than fabricating
+// one — the idInSessionWindow diagnostic on the pick.rejected event is what
+// turns that hunch into a number.
+//
+// One djObject call constrained to the run's own candidates (z.enum — a
+// decode-time grammar on local models, a Zod reject elsewhere) salvages the run
+// instead of discarding it to the caller's stateless matcher cascade, which
+// still runs when this misses too. Reuses requestSystem()/requestSchema()'s own
+// wording and the same autoVoiceAllowed() gate for `intro`, so a re-picked
+// request is consistent with a first-try one. Never throws.
 async function repickRequestFromSeen({ seen, badId, requester, text }:
   { seen: Map<string, any>; badId: string | null; requester: string; text: string }) {
   const ids = [...seen.keys()];
@@ -347,35 +343,30 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
     throw Object.assign(new Error(failure.message), { pickFailure: failure });
   }
 
-  // Back-to-back artist guard (#1124). The discovery tools — especially
-  // tracksLikeThis / tracksThatSoundLikeThis — return a tight cluster around
-  // the current track, which is frequently a run of the SAME artist, and the
-  // agent path (unlike the pool picker) carries no recentArtists / maxPerArtist
-  // filter (see the buildPickerTools note: an artist strip inside the tools
-  // gutted the similarity pool to ~1 survivor on niche catalogues, #618). So
-  // enforce variety at the point of choice instead: if the pick repeats the
-  // on-air artist and the run surfaced ANY other-artist candidate, re-pick from
-  // just those (a constrained djObject over the run's own `seen`, so it still
-  // reasons about flow and writes a coherent link).
+  // Back-to-back artist guard (#1124). The discovery tools return a tight
+  // cluster around the current track — frequently a run of the SAME artist — and
+  // the agent path carries no recentArtists/maxPerArtist filter, because an
+  // artist strip inside the tools gutted the similarity pool to ~1 survivor on
+  // niche catalogues (#618). So variety is enforced at the point of choice: if
+  // the pick repeats the on-air artist and the run surfaced any other-artist
+  // candidate, re-pick from just those (a constrained djObject over the run's
+  // own `seen`, so it still reasons about flow and writes a coherent link).
   //
-  // When that isn't possible — the run's whole candidate set is the one artist,
-  // or the constrained re-pick call failed — do NOT relax yet (#1187). `seen` is
-  // the RUN's view, not the library's: tracksLikeThis answering with eight
-  // tracks by the on-air artist while no other tool contributed leaves `seen`
-  // single-artist on a 50k-track catalogue, and reading that as "no alternative
-  // exists" is exactly the false negative that put the repeats back on air. Ask
-  // the normal fallback pool for a pick that excludes this artist first (a hard
-  // block, so the pool can't never-starve back to the artist we're avoiding) and
-  // only allow the repeat if even that comes back empty. That last case is
-  // logged with the candidate count so an operator can still tell "no
-  // alternative existed" from a real bug (#1124 ask #2).
+  // When that isn't possible, do NOT relax yet (#1187). `seen` is the RUN's view,
+  // not the library's — tracksLikeThis answering with eight tracks by the on-air
+  // artist while no other tool contributed leaves it single-artist on a 50k
+  // catalogue, and reading that as "no alternative exists" is the false negative
+  // that put the repeats back on air. Ask the fallback pool for a pick that hard-
+  // blocks this artist (so it can't never-starve back to the one we're avoiding)
+  // and allow the repeat only if even that comes back empty — logged with the
+  // candidate count so "no alternative existed" stays distinguishable from a bug.
   //
-  // Both sides of the comparison — and the alternative set — are keyed on the
-  // LEAD artist (#1251), so "Marvin Gaye & Tammi Terrell" no longer walks past a
-  // guard on "Marvin Gaye". The alternatives also step around the artists of the
-  // last few plays (alternativeCandidates), because a re-pick that knows only
-  // the on-air artist keeps returning to whoever ranks next-highest — the
-  // every-other-slot repeat this guard was supposed to prevent.
+  // Both sides of the comparison, and the alternative set, are keyed on the LEAD
+  // artist (#1251), so "Marvin Gaye & Tammi Terrell" can't walk past a guard on
+  // "Marvin Gaye". The alternatives also step around the artists of the last few
+  // plays, because a re-pick that knows only the on-air artist keeps returning to
+  // whoever ranks next-highest — the every-other-slot repeat this guard exists
+  // to prevent.
   const curArtist = artistRootKey(current || {});
   if (curArtist && artistRootKey(song) === curArtist) {
     const { alt, dropped, starved } = alternativeCandidates<any>(
@@ -478,21 +469,20 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
   return true;
 }
 
-// The link's context, with the clock stepped forward to `airAt` — the moment
-// the link actually AIRS (showAt minus the show-attribution padding, resolved
-// by linkClockAt). ctx resolved at showAt is right for show identity but its
+// The link's context with the clock stepped forward to `airAt`, the moment the
+// link actually AIRS. ctx resolved at showAt is right for show IDENTITY but its
 // clock runs PICK_SHOW_LOOKAHEAD_SEC fast, and every pick-attached link spoke
-// that padded time on air — "Local time eight fifty" logged at 08:48 (#1282).
-// The same identity/clock split runPickCycle's handoff already makes with its
-// live-clock override: show/mood/festival stay on showAt, only the
-// clock-derived fields (at/date/clock/time) move to air time. `isDark` rides
-// over from ctx — it comes from the weather fetch, not the clock, and a
-// two-minute shift can't flip it.
-// `airAt` null means the air moment isn't forecastable well enough to speak
-// (no look-ahead, or too little runway left — #1314): ctx comes back untouched
-// and the caller passes clockIsAirTime false, which withholds the "Local time"
-// line from the prompt entirely rather than showing a time the model must be
-// trusted not to use.
+// that padded time — "Local time eight fifty" logged at 08:48 (#1282). So the
+// same identity/clock split runPickCycle's handoff makes: show/mood/festival
+// stay on showAt, only the clock-derived fields move to air time. `isDark` rides
+// over from ctx — it comes from the weather fetch, and a two-minute shift can't
+// flip it.
+//
+// `airAt` null means the air moment isn't forecastable well enough to speak (no
+// look-ahead, or too little runway — #1314): ctx comes back untouched and the
+// caller passes clockIsAirTime false, withholding the "Local time" line from the
+// prompt entirely rather than showing a time the model must be trusted not to
+// use.
 function linkAirContext(ctx: any, airAt: Date | null) {
   if (!airAt || !ctx) return ctx;
   const clock: any = getClockContext(airAt);
@@ -641,20 +631,18 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     const { rankTarget, audioWaypoint } = advanceRun(djMode, current);
     const inRun = runActive();
 
-    // The link clause differs in DJ mode: a working DJ doesn't just announce the
-    // next track, they TEASE it — name the artist or capture its feel so
-    // listeners know what's coming. The agent already knows its own pick when
-    // it writes `say`, so this costs nothing extra. The link is FORWARD-LOOKING
-    // only — it introduces the pick, never back-announces "${current?.title}".
-    // The link airs when the pick starts, but a listener request can slip ahead
-    // of the pick in the meantime, so naming what "just played" goes stale (it
-    // names a track one older than reality); introducing the pick is always
-    // correct whatever aired before it.
-    // The "nod to it in the link" half only makes sense when a link is actually
-    // being written — gate it on wantLink so a silent mid-run pick ("Stay silent
-    // — no link this time.") doesn't also get told it may phrase something in a
-    // link that won't exist. The energy-direction guidance is pick selection, so
-    // it stays unconditional.
+    // In DJ mode the link TEASES the next track — artist or feel — rather than
+    // just announcing it. The agent already knows its own pick when it writes
+    // `say`, so this costs nothing extra.
+    //
+    // FORWARD-LOOKING only, never a back-announce: the link airs when the pick
+    // starts, but a listener request can slip ahead in the meantime, so naming
+    // what "just played" goes stale. Introducing the pick is correct whatever
+    // aired before it.
+    //
+    // The "nod to it in the link" half is gated on wantLink, so a silent mid-run
+    // pick isn't told it may phrase something in a link that won't exist. The
+    // energy-direction guidance is pick selection, so it stays unconditional.
     const runClause = inRun
       ? ` You're mid-run — keep the energy moving in the same direction (a touch ${energyForDaypart().speed >= 1 ? 'brisker' : 'mellower'}).`
         + (wantLink ? ' You may nod to it in the link, but never say tempo numbers.' : '')
@@ -673,19 +661,19 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     // steer clear of. Only when a link is actually being written.
     const linkAngle = wantLink ? dj.pickAngle('link') : null;
     const recentOpeners = wantLink ? queue.getRecentOpeners() : [];
-    // Clock discipline for the link (issue #864). The agent path carries no
-    // clock at all — the model extrapolates one from stale stamped lines in
-    // its session window, then the link airs a further full track after it's
-    // written, so spoken times ran 10-20 minutes behind. When the queue
-    // watcher resolved the look-ahead (showAt), the link's air moment is
-    // knowable — but showAt's own clock carries the show-attribution padding
-    // and ran two minutes FAST on air (#1282), so step it back to air time
-    // (linkAirDate) before handing it over as the only time the link may
-    // speak; without the look-ahead (unknown duration), ban the clock
-    // outright. linkClockAt bans it in one more case (#1314): when so little
-    // of the on-air track is left that this round may not land before the
-    // seam, the forecast is a coin flip and a link that names a time would
-    // name the wrong one for a whole filler track.
+    // Clock discipline for the link (#864). The agent path carries no clock of
+    // its own, so the model extrapolates one from stale stamped lines in its
+    // session window — and the link then airs a full track later, putting spoken
+    // times 10-20 minutes behind.
+    //
+    // With the look-ahead resolved (showAt) the air moment is knowable, but
+    // showAt's clock carries the show-attribution padding and ran two minutes
+    // FAST (#1282), so step it back to air time via linkAirDate before handing
+    // it over as the only time the link may speak. Without the look-ahead, ban
+    // the clock outright. linkClockAt bans it once more (#1314): with too little
+    // of the on-air track left for this round to land before the seam, the
+    // forecast is a coin flip and would name the wrong time for a whole filler
+    // track.
     const airAt = linkClockAt(showAt, Date.now());
     const airClock = airAt && ctx?.clock?.hhmm ? getClockContext(airAt) : null;
     const clockClause = wantLink
@@ -730,19 +718,17 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     const effectClause = settings.effectsActive()
       ? ` Set "transition" by what THIS moment needs, per the TRANSITION EFFECTS guidance — "washout"/"loop" end your pick, "sweep"/"dissolve"/"chop" resolve a clash, "blend" only for an exceptionally locked pair, "normal" otherwise. Vary your craft: never the same transition three picks running, and if your last pick used an effect, lean "normal" now unless the moment clearly calls again.${historyNote}`
       : '';
-    // The turn is split in two: `text` is the factual event (what the booth
-    // log on /admin/dash shows the operator), `meta.promptSuffix` carries the
-    // model-facing coaching clauses (transition nudge, clock rule, run/journey
-    // steering). windowMessages() re-joins them for the agent, so the model
-    // sees the same message as before — the operator just stops reading
-    // prompt engineering in the booth log.
-    // Listener favourites (#991) ride the event turn, not the system prompt:
+    // The turn is split in two: `text` is the factual event the booth log shows
+    // the operator, `meta.promptSuffix` carries the model-facing coaching
+    // clauses. windowMessages() re-joins them, so the model sees one message and
+    // the operator stops reading prompt engineering in the booth log.
+    //
+    // Listener favourites (#991) ride the EVENT turn, not the system prompt:
     // they change as likes land, and a system prompt that re-renders per call
-    // breaks the byte-stable prefix that automatic prompt caching
-    // (DeepSeek/OpenAI/OpenRouter) keys on. windowMessages keeps only the
-    // latest pick event, so the list never multiplies across the window.
-    // Mirrored by the pool picker's listener-liked candidate source, so both
-    // paths lean the same way. A lean, never a lock: VARIETY still applies.
+    // breaks the byte-stable prefix automatic prompt caching keys on.
+    // windowMessages keeps only the latest pick event, so the list never
+    // multiplies across the window. Mirrored by the pool picker's listener-liked
+    // source so both paths lean the same way — a lean, never a lock.
     const favClause = likes.favouritesClause(settings.get()?.likes);
     // Exploration nudge (ε-greedy seed break, music/airing.ts): every pick
     // seeding discovery from the on-air track is a random walk that never
@@ -874,20 +860,19 @@ async function runRequestViaAgent(queue: any, { requester, text }: { requester: 
     // pickViaAgent uses for the identical reason.
     let object = run.object;
 
-    // Chat escape (C1): an explicit kind:"chat" WITH a null id means "this
-    // wasn't a music request" — answer in persona, queue nothing, skip the
-    // cascade entirely. The `kind` half is load-bearing: a null id on its own
-    // is also what an OMITTED id looks like by the time coerceModelPayload is
-    // done with it (schemas.ts requestSchema), and a weak model forgetting the
-    // field would otherwise silently turn a real music request into "nothing
-    // plays". Without kind:"chat" this falls through to the repick salvage and
-    // then the caller's stateless cascade, so the listener still gets music.
-    // Echo guard (A2): this ack is the model's own free-text answer, generated
-    // straight from a message that may carry an injected script — guard it the
-    // same way the cascade's chat branch does (request.ts). Not just a display
-    // concern: this text becomes a `dj`-role session turn that later
-    // `windowMessages()` calls condition on, so an unguarded echo here can
-    // poison future generations even though it never reaches tts.speak.
+    // Chat escape (C1): an explicit kind:"chat" WITH a null id means this
+    // wasn't a music request — answer in persona, queue nothing, skip the
+    // cascade. The `kind` half is load-bearing: a null id ALONE is also what an
+    // omitted id looks like once coerceModelPayload is done with it, so a weak
+    // model forgetting the field would otherwise turn a real music request into
+    // "nothing plays". Without kind:"chat" this falls through to the repick
+    // salvage and the stateless cascade, so the listener still gets music.
+    //
+    // Echo guard (A2): the ack is the model's own free text, generated from a
+    // message that may carry an injected script, so it is guarded like the
+    // cascade's chat branch. Not just display — this text becomes a `dj`-role
+    // session turn later `windowMessages()` calls condition on, so an unguarded
+    // echo poisons future generations even though it never reaches tts.speak.
     if (object?.kind === 'chat' && !object?.id && typeof object?.ack === 'string' && object.ack.trim()) {
       const screened = screenAck(object.ack, text, 'Heard you loud and clear.');
       if (screened.guard) queue.log('request-guard', `agent chat ack echoed request text — replaced`);

--- a/controller/src/broadcast/dj-agent/schemas.ts
+++ b/controller/src/broadcast/dj-agent/schemas.ts
@@ -131,21 +131,18 @@ export function requestSchema() {
 // only one with no framing at all behind it.
 export const LISTENER_TEXT_CLAUSE = instruction('shared', 'listener-text');
 
-// Ultra-minimal — persona + editorial criteria, nothing else. The AI SDK
-// already conveys everything else through its own channels: tool descriptions
-// (llm/tools.js), the done-tool description (llm/sdk.js), schema field
-// descriptions (PICK_SCHEMA above), and the per-pick event message in the
-// session window ("Stay silent — no link this time." vs "Also write a short
-// link to speak over this track now."). Duplicating those in prompt text
-// competes with the framework's structural signals and derails smaller
-// models. PICKER_CRITERIA stays because it's editorial preference (flow,
-// context, variety, interest) — that's not in any tool or schema.
-// The transition-effects guidance (PICK_SCHEMA.transition) now lives in
-// llm/internal/prompts/picker.ts (dj.effectsGuidance) so the pool picker
-// shares it verbatim — it's appended to the picker system prompt ONLY when
-// effects are active (the on-air persona's djMode — see
-// settings.effectsActive; there is no separate toggle). Invisible otherwise,
-// so the model leaves "transition" null.
+// Ultra-minimal — persona + editorial criteria, nothing else. The AI SDK already
+// conveys the rest through its own channels: tool descriptions, the done-tool
+// description, schema field descriptions, and the per-pick event message in the
+// session window. Duplicating those in prompt text competes with the framework's
+// structural signals and derails smaller models. PICKER_CRITERIA stays because
+// editorial preference (flow, context, variety, interest) is in no tool or
+// schema.
+//
+// The transition-effects guidance lives in prompts/picker.ts (dj.effectsGuidance)
+// so the pool picker shares it verbatim, and is appended ONLY when effects are
+// active (settings.effectsActive — there is no separate toggle). Invisible
+// otherwise, so the model leaves "transition" null.
 
 // `showAt` — resolve the show brief/leans for that future moment instead of
 // now: the pick airs when the current track ends, so near a show boundary the

--- a/controller/src/broadcast/drain-policy.ts
+++ b/controller/src/broadcast/drain-policy.ts
@@ -52,7 +52,7 @@ export function remainingSec(
   return (startedAtMs + effective * 1000 - nowMs) / 1000;
 }
 
-export type DrainAction = 'send-pair' | 'send-intrinsic' | 'hold';
+type DrainAction = 'send-pair' | 'send-intrinsic' | 'hold';
 
 // Decide what the drain loop does with the FIRST unsent item:
 //  - 'send-pair'      — its successor is already queued behind it; stamp the

--- a/controller/src/broadcast/likes.ts
+++ b/controller/src/broadcast/likes.ts
@@ -39,7 +39,7 @@ export const OPERATOR_KEY = 'operator';
 const operatorAiringKey = (songId: string) => `${songId}|operator`;
 const isOperator = (r: LikeRecord) => r.via === 'operator';
 
-export interface LikedTrack {
+interface LikedTrack {
   id: string;
   title: string;
   artist?: string;
@@ -49,7 +49,7 @@ export interface LikedTrack {
   duration?: number;
 }
 
-export interface LikeRecord {
+interface LikeRecord {
   songId: string;
   track: LikedTrack;
   // `${songId}|${startedAt}` — one airing of one song. The same song aired

--- a/controller/src/broadcast/liquidsoap-control.ts
+++ b/controller/src/broadcast/liquidsoap-control.ts
@@ -171,13 +171,13 @@ export async function stopStream() {
   }
 }
 
-// How long an on-air reading is reused. Every telnet take costs a connection,
-// and radio.liq logs a `New client` / `Client disconnected` pair for each one at
-// its default log level — with the admin UI polling GET /settings every 3s, an
-// uncached read filled the mixer log forever for anyone with an admin tab open
-// (issue #1300, bug 16b). 10s keeps the badge honest (the operator's own on/off
-// toggle invalidates below, so a deliberate change is never stale) while making
-// the connect rate independent of how many admin tabs are watching.
+// How long an on-air reading is reused. Every telnet take costs a connection and
+// radio.liq logs a `New client`/`Client disconnected` pair for each at its
+// default log level, so with the admin UI polling GET /settings every 3s an
+// uncached read filled the mixer log forever for anyone with a tab open (#1300
+// bug 16b). 10s keeps the badge honest — the operator's own toggle invalidates
+// below, so a deliberate change is never stale — while making the connect rate
+// independent of how many admin tabs are watching.
 //
 // What the TTL does NOT cover: a mixer that goes off air OUTSIDE the controller
 // (`docker compose restart broadcast`, an OOM kill, the restart policy cycling

--- a/controller/src/broadcast/listeners.ts
+++ b/controller/src/broadcast/listeners.ts
@@ -4,19 +4,19 @@
 // broadcast mounts (/stream.mp3 + /stream.opus), so the DJ gates can ask "is
 // anyone listening?" without each one hitting Icecast.
 //
-// The count *folds Safari's double connection* into one (see groupConnections /
+// The count folds Safari's double connection into one (groupConnections /
 // dedupeListeners): iOS/macOS Safari opens two identical sockets per client, so
-// a raw sum double-counts every Apple listener. We can't key on IP, for two
-// reasons that both survive the trusted-proxy work: behind a reverse proxy
-// (Caddy → Icecast) a connection only carries the listener's real address when
-// the operator has named that proxy in icecast's <x-forwarded-for> (rendered by
-// docker/broadcast-entrypoint.sh — unset, and every row is the proxy's own IP);
-// and even with it set, a household behind one NAT is several listeners on one
-// address. Instead we count every non-Safari socket as a listener
-// and pair Safari's two near-simultaneous sockets by user-agent + connect-time.
-// That dedup needs the per-connection admin feed (/admin/listclients); the
-// public status-json.xsl still supplies online/bitrate and the fallback sum
-// when the admin endpoint is unavailable.
+// a raw sum double-counts every Apple listener.
+//
+// Keying on IP is not an option, and neither reason is fixed by the
+// trusted-proxy work: behind a reverse proxy a row carries the listener's real
+// address only when the operator named that proxy in icecast's
+// <x-forwarded-for>, and even then a household behind one NAT is several
+// listeners on one address. So every non-Safari socket counts as a listener and
+// Safari's two near-simultaneous sockets are paired by user-agent + connect
+// time. That needs the per-connection admin feed (/admin/listclients); the
+// public status-json.xsl supplies online/bitrate and the fallback sum when the
+// admin endpoint is unavailable.
 //
 // Fail-open: if Icecast is unreachable the count is null and djCallsAllowed()
 // treats the station as occupied — a stats outage must never silence the DJ.
@@ -256,15 +256,14 @@ export function getListenerCount() {
 // failures reach STALE_STATUS_LIMIT (see gatedCount above).
 //
 // This is what djCallsAllowed() and the idle monitor (stream-idle.ts) must read
-// — never the raw lastCount. Issue #1256: both gates fail OPEN on null, so with
-// the raw count a SINGLE 1.5s fetch timeout was enough to release the idle pause
-// and reopen the LLM gate. The idle monitor forces a poll every 5s while paused
-// (~120 per 10-minute pause), so a sub-1% failure rate fired inside nearly every
-// pause window: the programme paused, resumed ~28s later, and the power save was
-// inactive ~95% of the time it should have been active.
+// — never the raw lastCount. Both fail OPEN on null, so on the raw count a
+// SINGLE fetch timeout released the idle pause and reopened the LLM gate; since
+// the idle monitor forces a poll every 5s while paused (~120 per 10-minute
+// pause), a sub-1% failure rate fired inside nearly every pause window and the
+// power save was inactive ~95% of the time it should have been active (#1256).
 //
 // The fail-open doctrine is unchanged — a genuinely unreachable Icecast still
-// reads null and still resumes/keeps the DJ on air. Only the definition of
+// reads null and still keeps the DJ on air. Only the definition of
 // "unreachable" tightened, from one blip to sustained failure, matching the
 // hysteresis the cached status has had since #461.
 export function gatedListenerCount(): number | null {
@@ -309,15 +308,13 @@ export async function refresh() {
 // skip-history flag.
 //
 // Returns the GATED count, not pollCount's raw result. The quiet gate
-// (music/analyze-quiet-pure.ts) is the THIRD fail-open-on-unknown reader in the
-// codebase, and it needs the same hysteresis as the other two for the same
-// reason (#1256) — its fail-open direction is the opposite one, so a single
-// blip here starts a heavy DSP pass while somebody is listening rather than
-// releasing a pause. The child's own module state carries the hysteresis: it
-// polls once per track (or every 30s while waiting out the window), so
-// consecutive failures accumulate across calls exactly as they do in the
-// monitor loop, and the first call still reads unknown because lastGoodCount
-// is null — boot behaviour is unchanged.
+// (music/analyze-quiet-pure.ts) is the third fail-open-on-unknown reader and
+// needs the same hysteresis for the same reason (#1256) — its fail-open runs the
+// OPPOSITE way, so a single blip here starts a heavy DSP pass while somebody is
+// listening rather than releasing a pause. The child's own module state carries
+// the hysteresis: it polls once per track (or every 30s while waiting out the
+// window), so consecutive failures accumulate across calls exactly as in the
+// monitor loop.
 export async function probeListenerCount(): Promise<number | null> {
   await pollCount(false);
   return gatedListenerCount();
@@ -339,9 +336,9 @@ export function setStreamIdle(v: boolean) {
 //
 // Reads gatedListenerCount(), so "unknown" means sustained failure rather than
 // one timed-out poll (#1256). This also gates POST /request, which forces a
-// fresh poll first: under a real outage that poll's failures reach the limit
-// and requests are accepted exactly as before, so only a single blip — where
-// the held reading is seconds old and accurate — now decides differently.
+// fresh poll first: under a real outage those failures reach the limit and
+// requests are accepted as before, so only a single blip — where the held
+// reading is seconds old and accurate — decides differently.
 //
 // An idle-paused stream blocks DJ calls regardless of the LLM toggle: the
 // voice queues aren't being pulled while the idle gate is up, so any WAV

--- a/controller/src/broadcast/programme.ts
+++ b/controller/src/broadcast/programme.ts
@@ -138,13 +138,12 @@ function featureKindMenu(host: { skills?: string[] } | null | undefined): { kind
 // a real generation failure marks it `fallback` for the episode (beats then
 // run brief-only — one failed producer call shouldn't burn a retry per tick).
 //
-// `now` defaults to the moment the CONTEXT describes (contextDate), not the
-// wall clock: queue.onTrackStarted rolls the session on a look-ahead context,
-// and judging the episode with a live `now` inside that window makes
-// activeEpisode compare the incoming session key against the OUTGOING show —
-// a silent null, so the plan never builds and the handoff greeting airs with
-// no episode angle. A live context carries a live `at`, so live callers are
-// unchanged.
+// `now` defaults to the moment the CONTEXT describes (contextDate), not the wall
+// clock. queue.onTrackStarted rolls the session on a look-ahead context, and
+// judging the episode with a live `now` inside that window makes activeEpisode
+// compare the incoming session key against the OUTGOING show — a silent null, so
+// the plan never builds and the handoff greeting airs with no angle. A live
+// context carries a live `at`, so live callers are unaffected.
 export async function ensurePlan(ctx: SessionContext, now = session.contextDate(ctx)): Promise<void> {
   const ep = activeEpisode(now);
   if (!ep) return;

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -378,28 +378,26 @@ class Queue {
     return 0;
   }
 
-  // Push a listener request. Adds to upcoming and kicks off the Liquidsoap sender.
-  // `introScript` is the spoken intro/link tied to THIS track — it is NOT aired
-  // at queue time. drainToLiquidsoap renders it to a WAV ahead of time and
-  // airIntro() writes that WAV to Liquidsoap only when the track actually starts
-  // playing (see onTrackStarted), so the voice always lands over the right song.
-  // `introKind` picks both the TTS engine routing and the duck channel:
-  //   'dj-speak' → say.txt   (HEAVY duck — request intros)
-  //   'link'     → intro.txt (LIGHT duck — between-track auto-DJ links)
-  // `linkPrev` is the track this item's intro/link BACK-ANNOUNCES (the one that
-  // was on-air when the pick was made). A between-track link is written as "that
-  // was X, here's this" against the track playing then; deferring it to air time
-  // (#189) is only valid while this pick is still the immediately-next track. If
-  // a listener request slips into `upcoming` ahead of it before it airs, that
-  // request plays first, so the baked-in "that was X" would name a track one (or
-  // more) older than what actually just played. airIntro() uses linkPrev to
-  // detect that and drop the now-stale back-announce rather than air a wrong
-  // name. Left null for request intros (they never back-announce).
-  // `linkClockAt` is the air moment `introScript` was written against, present
-  // only when the generator gave the model a clock to speak (#1314). airIntro
-  // drops the line if the real seam lands too far from it — a forecast made
-  // from the on-air track's remaining play goes badly wrong when the pick
-  // misses that seam and auto.m3u fills the slot instead.
+  // Add a track to `upcoming` and kick off the Liquidsoap sender.
+  //
+  // `introScript` is tied to THIS track but is NOT aired at queue time:
+  // drainToLiquidsoap renders it to a WAV ahead of time and airIntro() writes
+  // that WAV only when the track actually starts, so the voice lands over the
+  // right song. `introKind` picks the engine routing and the duck channel —
+  // 'dj-speak' → say.txt (HEAVY duck, request intros), 'link' → intro.txt
+  // (LIGHT duck, between-track links).
+  //
+  // `linkPrev` is the track the intro BACK-ANNOUNCES. Deferring the line to air
+  // time (#189) is only valid while this pick is still immediately-next; a
+  // listener request slipping in ahead of it would make the baked-in "that was
+  // X" name the wrong song, so airIntro uses linkPrev to detect that and drop
+  // the back-announce. Null for request intros, which never back-announce.
+  //
+  // `linkClockAt` is the air moment the script was written against, set only
+  // when the generator gave the model a clock to speak (#1314). airIntro drops
+  // the line if the real seam lands too far from it — the forecast is made from
+  // the on-air track's remaining play and goes badly wrong when the pick misses
+  // that seam and auto.m3u fills the slot.
   async push({ track, requestedBy = null, intent = null, introScript = null, introKind = 'dj-speak', introPersona = null, aiPicked = false, allowDuplicate = false, linkPrev = null, linkClockAt = null }: {
     track: Track;
     requestedBy?: string | null;
@@ -412,21 +410,11 @@ class Queue {
     linkPrev?: { id?: string | null; title?: string | null; artist?: string | null } | null;
     linkClockAt?: Date | number | null;
   }) {
-    // Dedup guard. Applies to AI picks AND listener requests: two listener
-    // requests resolving to the same song over the 25-45s identify/match window
-    // each read queuedIds() before either reaches push(), so the early read
-    // can't see the other (issue #619). This check is the only synchronous
-    // point where both are visible — there is no await between it and the
-    // upcoming.push() below, so within the single-threaded event loop it's
-    // atomic and closes the race. Returns -1 so the caller can acknowledge
-    // honestly ("already on the way") instead of queuing a second back-to-back
-    // play. `allowDuplicate` opts an explicit operator action (the studio
-    // queue-track route) out — a deliberate manual queue always fires.
-    // Global never-play gate — the blocklist is absolute (operator's call:
-    // even explicit manual queueing is refused until the entry is unblocked),
-    // so it sits above allowDuplicate. Every playback path funnels through
-    // push() (dj-agent, requests, MCP, studio queue), making this the last
-    // line even for sources that bypass the subsonic/library filters.
+    // The blocklist is absolute — even explicit manual queueing is refused
+    // until the entry is unblocked — so it sits above `allowDuplicate`. Every
+    // playback path funnels through push() (dj-agent, requests, MCP, studio
+    // queue), making this the last line even for sources that bypass the
+    // subsonic/library filters.
     const blockHit = blocklist.hitOf(track);
     if (blockHit) {
       // Name what refused it — an id entry reads as before; a rule names
@@ -438,6 +426,13 @@ class Queue {
       this.log('blocked', `${track?.title} — ${track?.artist} (${why})`);
       return -2;
     }
+    // Applies to AI picks AND listener requests: two requests resolving to the
+    // same song over the 25-45s identify/match window each read queuedIds()
+    // before either reaches push(), so neither early read sees the other (#619).
+    // This is the only synchronous point where both are visible — no await
+    // between it and the upcoming.push() below — so it closes the race. -1 lets
+    // the caller acknowledge honestly instead of queuing a back-to-back play;
+    // `allowDuplicate` opts out an explicit operator action.
     if (!allowDuplicate && track?.id) {
       const dominated = this.upcoming.some(i => i.track?.id === track.id)
         || (this.current?.track?.id === track.id);
@@ -516,26 +511,15 @@ class Queue {
     };
   }
 
-  // Resolve a track's integrated loudness + peak and stash a clamped gain
-  // offset toward the operator's loudness target on the track as `gainDb`.
-  // Source ladder is settings.loudness.source: an embedded ReplayGain tag
-  // (whole-file stereo R128 via Navidrome, issue #998) outranks the analyzer's
-  // measured LUFS (leading-window only) unless the operator pins one source.
-  // A track object without the `replayGain` key came through a projection
-  // that dropped it (the agent's slim candidates, a JSON round trip), so a
-  // one-row getSong recovers it — `replayGain: {}`/null means Navidrome was
-  // asked and the file is untagged, no lookup. Measured values resolve track
-  // object first, else a library lookup. The peak lets gainForLoudness cap
-  // the boost by real headroom instead of a blind clamp; a ReplayGain
-  // loudness keeps its own trackPeak (mixing it with the analyzer's window
-  // peak would cap against a different scan). Null loudness from every
-  // allowed source → leaves gainDb undefined, so getAnnotatedUri emits no
-  // liq_amplify and the track plays at unity gain.
+  // Stash a clamped gain offset toward the operator's loudness target on the
+  // track as `gainDb`. Null loudness from every allowed source leaves it
+  // undefined, so getAnnotatedUri emits no liq_amplify and the track plays at
+  // unity.
   //
-  // The resolution itself lives in music/loudness.ts because the stem-blend
-  // render needs the SAME answer (#1240) — a clip carries no liq_amplify, so
-  // the render bakes this figure in, and a second implementation there is how
-  // rendered seams ended up at a different level than the tracks around them.
+  // The resolution lives in music/loudness.ts because the stem-blend render
+  // needs the SAME answer (#1240) — a clip carries no liq_amplify, so the render
+  // bakes this figure in, and a second implementation there is how rendered
+  // seams ended up at a different level than the tracks around them.
   async applyLoudnessGain(track: Track | null) {
     if (!track) return;
     const gain = await loudness.resolveGainDb(track, msg => this.log('warn', msg));
@@ -573,25 +557,18 @@ class Queue {
     this.log('mix', `${kind} dropped (${reason})`);
   }
 
-  // DJ-mode mixing applied to the transition INTO `item`'s track (features 1 &
-  // 2, plus the sweep/washout transition effects). No-op unless the active
-  // persona is in DJ mode. Stashes a per-transition crossfade length on the
-  // track (read by subsonic.getAnnotatedUri → liq_cross_duration) and, on a
-  // notable upward tempo jump, fires a rate-limited riser across the blend.
-  // Beds — push an instrumental bed into dj_queue ahead of `item` when its link
-  // would outlast the song's own intro, so the DJ talks over the bed instead of
-  // over the song. Sets item.bedded, which is how the bed's start event (see
-  // onBedStarted) finds the item whose link it should air.
+  // Push an instrumental bed into dj_queue ahead of `item` when its link would
+  // outlast the song's own intro, so the DJ talks over the bed rather than over
+  // the song. Sets item.bedded, which is how the bed's start event
+  // (onBedStarted) finds the item whose link it should air.
   //
-  // Everything this needs already exists at this point in the drain: the link's
-  // WAV was rendered a few lines up, so its real length is readable NOW, before
-  // the track URI is written. That ordering is what makes the whole feature a
-  // controller-side change rather than a mixer one.
+  // Ordering is what makes this a controller-side feature rather than a mixer
+  // one: the link's WAV was rendered a few lines up, so its real length is
+  // readable here, before the track URI is written.
   //
   // Silent no-op on every path that isn't a bedded link — beds off, a request
-  // intro (heavy duck by design, see the design doc), no script, a script that
-  // fits the intro, or no bed long enough. All of them leave today's behaviour
-  // untouched.
+  // intro (heavy duck by design), no script, a script that fits the intro, or no
+  // bed long enough.
   async maybePushBed(item: QueueItem) {
     const cfg = settings.get()?.beds;
     if (!cfg?.enabled) return;
@@ -704,34 +681,29 @@ class Queue {
     const cur = this.mixAnalysisFor(prevTrack);
     const next = this.mixAnalysisFor(item.track);
 
-    // Feature 1 — the pair-sized adaptive blend — is NOT computed here. It
-    // was #749's wall for years: liq_cross_duration governs the crossfade at
-    // the STAMPED track's OWN end, but at this point in the FIFO drain the
-    // predecessor is already annotated and gone, so the value could never be
-    // attached to the right track. The pair-drain hold (drain-policy.ts)
-    // dissolved the wall: applyPairStamps() sizes the blend for the seam OUT
-    // of an item once its successor is known at drain time — the direction
-    // the old comment prescribed. This function keeps only the
-    // track-intrinsic work: ending-aware exit canvas + effect gating below.
-    // The operator crossfade ceiling still caps every canvas stamped here.
+    // The pair-sized adaptive blend is NOT computed here — liq_cross_duration
+    // governs the crossfade at the STAMPED track's OWN end, and at this point in
+    // the FIFO drain the predecessor is already annotated and gone. The
+    // pair-drain hold (drain-policy.ts) is what makes it possible at all:
+    // applyPairStamps() sizes the blend once the successor is known (#749). This
+    // function keeps only the track-intrinsic work — ending-aware exit canvas
+    // plus effect gating — still capped by the operator crossfade ceiling.
     const maxSec = settings.get()?.crossfadeDuration ?? null;
 
     // DJ transition effects (sweep/washout) — the agent proposes, the data
-    // disposes. A rejected flag is stripped so getAnnotatedUri never stamps it. On success the
-    // washout also gets its canvas + tempo stamps: cross-duration physics puts
-    // both on the flagged track itself (its liq_cross_duration governs its OWN
-    // end, exactly where the wash fires — overriding the feature-1 value). The
-    // sweep needs no stamps: the transition INTO it is already sized, and its
-    // envelope scales to whatever d it gets.
-    // Length-cap exit (max-track-length × effects): when this pick will be CUT
-    // by the cap (duration > effectiveMaxTrackSec → drain stamps liq_cue_out),
-    // its ending is a forced mid-song exit — and the classic DJ move for
-    // leaving a record before it ends is the echo-out. Auto-arm a washout so
-    // the cut sounds intentional instead of broken. Deterministic, not an LLM
-    // choice: the controller KNOWS which tracks will be capped. The flag rides
-    // the ending track, exactly like a DJ-chosen washout, and coexists with a
-    // sweep on the same pick (sweep shapes its ENTRY, washout its EXIT).
-    // Requests are exempt from the cap (requestedBy) so they never arm this.
+    // disposes; a rejected flag is stripped so getAnnotatedUri never stamps it.
+    // A washout also gets canvas + tempo stamps on the flagged track ITSELF,
+    // since its liq_cross_duration governs its own end, exactly where the wash
+    // fires. The sweep needs no stamps: the transition into it is already sized
+    // and its envelope scales to whatever d it gets.
+    //
+    // Auto-arm a washout when the cap will CUT this pick (duration >
+    // effectiveMaxTrackSec → drain stamps liq_cue_out): the ending is a forced
+    // mid-song exit, and the echo-out is what makes it sound intentional rather
+    // than broken. Deterministic rather than an LLM choice — the controller
+    // knows which tracks will be capped. Coexists with a sweep on the same pick
+    // (sweep shapes ENTRY, washout EXIT). Requests are exempt from the cap, so
+    // they never arm it.
     const capSec = item.requestedBy ? null : settings.effectiveMaxTrackSec();
     const durSec = knownDurationSec(item.track);
     const cappedExit = !!(capSec && durSec > capSec);
@@ -788,20 +760,19 @@ class Queue {
       }
     }
 
-    // The two flags are independent boundaries — sweep shapes this pick's
-    // ENTRY, washout its EXIT — so both can ride one pick; validate and stamp
-    // them separately. No cooldown by design: pacing is the DJ's call (the
-    // prompt tells it to let ordinary blends breathe between effects); the
-    // analyzer veto is the only deterministic guard, and it only judges
-    // sweeps (musically wrong between locked tracks), never frequency.
-    // Anti-streak: the model imitates its own session history, so once it
-    // finds a defensible favourite it repeats it mechanically (observed twice:
-    // all-normal, then all-blend). The third consecutive IDENTICAL CHOICE is
-    // stripped — variety is a station rule, not a model virtue. The ledger
-    // tracks what the model ASKED FOR, not what aired: a stripped blend still
-    // evidences monoculture, so a stuck model gets everything past the second
-    // stripped until it genuinely varies. Auto (length-cap) washouts are
-    // deterministic, not choices — invisible to the ledger in both directions.
+    // The two flags are independent boundaries — sweep shapes ENTRY, washout
+    // EXIT — so both can ride one pick and are validated separately. No cooldown
+    // by design: pacing is the DJ's call, and the analyzer veto only judges
+    // whether a sweep is musically wrong between locked tracks, never frequency.
+    //
+    // Anti-streak: the model imitates its own session history, so once it finds
+    // a defensible favourite it repeats it mechanically (observed as all-normal,
+    // then all-blend). The third consecutive IDENTICAL choice is stripped —
+    // variety is a station rule, not a model virtue. The ledger tracks what the
+    // model ASKED FOR, not what aired, so a stripped blend still evidences
+    // monoculture and a stuck model stays stripped until it genuinely varies.
+    // Auto (length-cap) washouts are deterministic, not choices, and are
+    // invisible to the ledger in both directions.
     const choice: string | null =
       item.track.sweep ? 'sweep' : item.track.blend ? 'blend'
         : item.track.dissolve ? 'dissolve'
@@ -987,14 +958,14 @@ class Queue {
     return names;
   }
 
-  // Pair-sized exit blend (feature 1 — the #749 fix, applied at last): with
-  // the successor known at drain time, size THIS track's own exit crossfade
-  // for the actual pair — compatibility curve, daypart nudge, bar-snap,
-  // capped to the successor's instrumental intro. Precedence: washout/loop
-  // own their canvases outright (their physics stamped them); the
-  // ending-aware canvas from applyMixTransition is narrowed, never widened —
-  // the pair value wins only when SHORTER, so a cold ending's tight cut
-  // survives a clash's long wash and a measured fade never doubles under a
+  // Pair-sized exit blend (#749): with the successor known at drain time, size
+  // THIS track's own exit crossfade for the actual pair — compatibility curve,
+  // daypart nudge, bar-snap, capped to the successor's instrumental intro.
+  //
+  // Precedence: washout/loop own their canvases outright (their physics stamped
+  // them), and applyMixTransition's ending-aware canvas is narrowed, never
+  // widened — the pair value wins only when SHORTER, so a cold ending's tight
+  // cut survives a clash's long wash and a measured fade never doubles under a
   // locked pair's 4s blend.
   applyPairStamps(item: QueueItem, successor: QueueItem) {
     if (!settings.getEffectivePersona()?.djMode) return;
@@ -1103,17 +1074,13 @@ class Queue {
         // liq_amplify. No loudness from any source → no liq_amplify → unity.
         await this.applyLoudnessGain(item.track);
 
-        // Hard length cap (#447 max-track-length): stamp a cue_out so Liquidsoap
-        // cuts an over-length autonomous pick mid-air. Explicit listener requests
-        // (requestedBy set) stay exempt — a requested long mix plays in full,
-        // mirroring the request path's selection-cap exemption in the picker tools.
-        // Beds: if this item's link would outlast the song's own intro, push an
-        // instrumental bed into dj_queue AHEAD of the track. The DJ then talks
-        // over the bed and the track ramps in under the closing words, instead
-        // of the link being talked over the song it's introducing.
+        // Hard length cap (#447): stamp a cue_out so Liquidsoap cuts an
+        // over-length autonomous pick mid-air. Listener requests stay exempt —
+        // a requested long mix plays in full, mirroring the picker tools'
+        // selection-cap exemption.
         //
-        // Order matters and dj_queue is FIFO, so the bed must be handed over
-        // before the track URI below.
+        // Then the bed, if this item's link would outlast the song's own intro.
+        // dj_queue is FIFO, so it must be handed over BEFORE the track URI below.
         await this.maybePushBed(item);
 
         const maxDurationSec = item.requestedBy ? null : settings.effectiveMaxTrackSec();
@@ -1216,16 +1183,15 @@ class Queue {
     }
   }
 
-  // Commit the queued pick to Liquidsoap before an operator skip (#1300 bug
-  // 6). Under pair-aware drain the held pick isn't in dj_queue for most of
-  // each track's runtime — a bare telnet skip falls through to the randomized
-  // auto playlist while the admin queue shows a different "next". Force-drain
-  // whatever is held, then wait until the dj_queue_status probe reports a
-  // RESOLVED request waiting (a sent-but-still-downloading request loses the
-  // fallback race just the same), bounded by SKIP_COMMIT_WAIT_MS — past it
-  // the skip proceeds anyway (ending THIS track is the operator's intent) and
-  // the caller reports the miss honestly. Never throws: a skip must not fail
-  // on its safety net.
+  // Commit the queued pick to Liquidsoap before an operator skip (#1300 bug 6).
+  // Under pair-aware drain the held pick isn't in dj_queue for most of a track's
+  // runtime, so a bare telnet skip falls through to the randomized auto playlist
+  // while the admin queue shows a different "next". Force-drain whatever is
+  // held, then wait for the dj_queue_status probe to report a RESOLVED request
+  // (a sent-but-still-downloading one loses the fallback race just the same),
+  // bounded by SKIP_COMMIT_WAIT_MS. Past it the skip proceeds anyway — ending
+  // THIS track is the operator's intent — and the caller reports the miss
+  // honestly. Never throws: a skip must not fail on its safety net.
   async commitBeforeSkip(): Promise<{ pending: boolean; committed: boolean; waitedMs: number }> {
     if (skipPrepAction(this.upcoming.length) === 'skip-now') {
       return { pending: false, committed: false, waitedMs: 0 };
@@ -1256,20 +1222,16 @@ class Queue {
     return { pending: true, committed: false, waitedMs: Date.now() - t0 };
   }
 
-  // Speak something without queueing a track — for hourly time checks,
-  // weather updates, station IDs, and auto DJ links.
+  // Speak something without queueing a track — hourly time checks, weather,
+  // station IDs, auto-DJ links. Two Liquidsoap voice channels, picked by kind:
+  //   - 'link' → intro.txt → intro_queue → LIGHT duck (talk-over feel: the song
+  //              that just started stays audible under the voice)
+  //   - else   → say.txt   → voice_queue → HEAVY duck (solo voice dominates)
   //
-  // Dispatches to one of two Liquidsoap voice channels based on kind:
-  //   - 'link' → intro.txt → intro_queue → LIGHT duck (talk-over feel: the
-  //              song that just started stays audible underneath the voice)
-  //   - everything else → say.txt → voice_queue → HEAVY duck (solo voice
-  //              dominates; used for station ID / hourly / weather)
-  //
-  // `opts.persona` overrides the on-air persona for THIS clip's voice — the
-  // persona-handoff mic-pass voices the outgoing DJ after the hour has flipped
-  // (see broadcast/dj-agent.runPersonaHandoff). `opts.meta` is merged into the
-  // session turn (e.g. tagging the sign-off with the outgoing persona id). Both
-  // default to absent, so every existing call site is byte-identical.
+  // `opts.persona` overrides the on-air persona for THIS clip — the mic-pass
+  // voices the OUTGOING DJ after the hour has flipped (dj-agent.runPersonaHandoff).
+  // `opts.meta` is merged into the session turn, e.g. tagging the sign-off with
+  // the outgoing persona id.
   async announce(text, kind = 'announcement', { persona = null, meta = {} }: { persona?: Persona | null; meta?: TurnMeta } = {}) {
     if (!text || !text.trim()) return;
     try {
@@ -1330,19 +1292,18 @@ class Queue {
     return true;
   }
 
-  // Defer a spoken segment to the NEXT track boundary instead of airing it
-  // immediately. Used for station idents: they have no real-time constraint
-  // (unlike the hourly time check), so ducking the current song mid-vocal at
-  // an arbitrary wall-clock minute is pure loss — at a transition the same
-  // ident lands like real radio. The WAV is rendered NOW (TTS latency off the
-  // air path); onTrackStarted airs it via the light-duck intro channel so the
-  // incoming song stays audible underneath, same feel as an auto-DJ link.
+  // Defer a spoken segment to the NEXT track boundary. Used for station idents:
+  // unlike the hourly time check they have no real-time constraint, so ducking
+  // the current song mid-vocal at an arbitrary minute is pure loss, where at a
+  // transition the same ident lands like real radio. The WAV renders NOW (TTS
+  // latency off the air path) and onTrackStarted airs it via the light-duck
+  // intro channel.
   //
-  // One slot only: a newer pending segment replaces an unaired older one (on
-  // an aggressive station a fresh ident supersedes a stale one rather than
-  // stacking). All bookkeeping (djLog → recap/opener anti-repeat, session
-  // turn, webhook) happens at AIR time, so the DJ's memory reflects what
-  // actually reached the stream, not what was merely scheduled.
+  // One slot only: a newer pending segment replaces an unaired older one, so a
+  // fresh ident supersedes a stale one rather than stacking. All bookkeeping
+  // (djLog → recap/opener anti-repeat, session turn, webhook) happens at AIR
+  // time, so the DJ's memory reflects what reached the stream, not what was
+  // merely scheduled.
   async announceAtNextTrack(text, kind = 'announcement', { persona = null, meta = {} }: { persona?: Persona | null; meta?: TurnMeta } = {}) {
     if (!text || !text.trim()) return;
     try {
@@ -1482,15 +1443,13 @@ class Queue {
       this.persist();
       return;
     }
-    // The WAV was rendered at drain time, and the voice reaper deletes clips
-    // older than ~1h — a predecessor longer than that (long-form mixes are
-    // supported) outlives the file. A silent return here used to be a lost
-    // link; for a bedded item the bed is already committed and airing, so it
-    // would air naked. The WAV may also never have been rendered at all: the
-    // drain skips the render while the station voice is off, and this item
-    // lived to air because the switch came back on. Either way the script is
-    // still on the item: render it now. introAired is already set above, so
-    // the render can't double-air.
+    // Two ways the WAV can be missing: the voice reaper deletes clips older
+    // than ~1h, so a long-form predecessor outlives the file; or it was never
+    // rendered, because the drain skips the render while the station voice is
+    // off and this item lived to air after the switch came back on. A silent
+    // return would lose the link, and a bedded item would air its bed naked. The
+    // script is still on the item either way, so render it now — introAired is
+    // set above, so this can't double-air.
     if (!item.introWav || !existsSync(item.introWav)) {
       if (!item.introScript) return;
       try {
@@ -1571,13 +1530,12 @@ class Queue {
 
     // Stem-blend safety guard: metadata matching a NOT-YET-SENT upcoming item
     // means a rendered clip annotated as that track is airing while the track
-    // itself was never handed to Liquidsoap (controller restart between the
-    // pair drain and the clip airing, or a missed deadline). Consuming it as
-    // "played" here would orphan it — the clip would finish and Liquidsoap
-    // would fall to auto.m3u; the track the clip just introduced would never
-    // air. Force-drain it NOW (bypassing the pair hold) and leave this fire
-    // unprocessed — lastSeenKey stays unset, so the track's REAL fire (same
-    // key) re-enters and the normal consume path takes over.
+    // itself never reached Liquidsoap (a restart between the pair drain and the
+    // clip, or a missed deadline). Consuming it as "played" would orphan it —
+    // the clip ends, Liquidsoap falls to auto.m3u, and the track the clip just
+    // introduced never airs. Force-drain NOW (bypassing the pair hold) and leave
+    // this fire unprocessed: lastSeenKey stays unset, so the track's REAL fire
+    // re-enters and the normal consume path takes over.
     if (np.subsonic_id && this.upcoming.some(u => !u.sent && u.track.id === np.subsonic_id)) {
       this.log('scheduler', `"${np.title}" fired while its queue item was still unsent — force-draining it (clip-as-track guard)`);
       void this.drainToLiquidsoap(true);
@@ -1806,35 +1764,26 @@ class Queue {
     this.pickerBusy = true;
     (async () => {
       try {
-        // The pick made now airs when the track it FOLLOWS ends — so near a
-        // show boundary the rules to pick by are the NEXT show's, not this
-        // one's (a pick queued minutes before the boundary used to follow the
-        // outgoing show's brief, handing the incoming DJ an off-format
-        // opener). Probe a little past the pick's expected start so a pick
-        // that begins just shy of the boundary — and plays mostly inside the
-        // new show — also counts as the new show's. Without a held
-        // predecessor the pick follows the on-air track, so the lead is what
-        // REMAINS of it (never its full duration — this cycle also runs from
-        // the deadline backstop and from boot recovery, part-way through a
-        // track, and the elapsed part would push `showAt` over the next
-        // boundary early, #1205); with one (deadline path) it follows the
-        // HELD track, so the lead is on-air remaining + the held track's
-        // length (knownDurationSec — the same library fallback every other
-        // duration read uses). Unknown clock → no look-ahead — rarer than it
-        // was pre-#1205: untracked auto plays carry a start stamp and
-        // usually a library duration, so remainingSecOnAir now gives them a
-        // real lead where the old duration-only read never could.
+        // The pick made now airs when the track it FOLLOWS ends, so near a show
+        // boundary the rules to pick by are the NEXT show's. PICK_SHOW_LOOKAHEAD
+        // probes a little past the expected start so a pick beginning just shy
+        // of the boundary — and playing mostly inside the new show — counts as
+        // the new show's.
+        //
+        // The lead is what REMAINS of the on-air track, never its full duration:
+        // this cycle also runs from the deadline backstop and from boot
+        // recovery, part-way through a track, where the elapsed part would push
+        // `showAt` over the next boundary early (#1205). With a held predecessor
+        // (deadline path) the pick follows the HELD track instead, so the lead
+        // adds that track's length. Unknown clock → no look-ahead.
         //
         // This ONE date then drives the whole boundary sequence below — roll,
-        // episode plan, mic-pass, episode hook — not just the pick. It used
-        // to drive only the pick, with the roll and handoff left on the live
-        // clock; that split is what let the two disagree. At 09:58 the live
-        // grid still says "morning show", so the roll here never fired and
-        // the :00 cron won it mid-song — the changeover track (already picked
-        // under the incoming brief) aired BEFORE anyone handed over. Keying
-        // both off `showAt` makes the mic-pass land in front of that track,
-        // and makes it structurally impossible for the pick's brief and the
-        // on-air persona to disagree: there is no second date to disagree with.
+        // episode plan, mic-pass, episode hook — not just the pick. Leaving the
+        // roll and handoff on the live clock is what let the two disagree: at
+        // 09:58 the live grid still says "morning show", so the roll never fired
+        // here and the :00 cron won it mid-song, airing the changeover track
+        // (already picked under the incoming brief) BEFORE anyone handed over.
+        // With one date there is no second date to disagree with.
         const leadSec = pickLeadSec(
           this.remainingSecOnAir(),
           predecessorItem ? knownDurationSec(predecessorItem.track) : null,
@@ -1901,17 +1850,17 @@ class Queue {
     })();
   }
 
-  // Pair-drain deadline routine (feature: pair-aware transitions), run every
-  // watcher tick. When the on-air track nears its end and the NEXT track to
-  // air is still held without a successor, fire the pick cycle for that
-  // successor — the push() it ends in re-runs the drain loop, which then
-  // sends the held item pair-aware. Fires only for the item that airs
-  // immediately after the on-air track (head of `upcoming` unsent, and the
-  // only unsent item): once its successor lands, the fresh pick becomes the
-  // new held tail whose own deadline is a full track away — without the
-  // head-only condition every tick would pick another track and run the
-  // pipeline ahead unbounded. Past the hard deadline the pick window closes
-  // and drainToLiquidsoap's intrinsic path owns the endgame.
+  // Pair-drain deadline routine, run every watcher tick. When the on-air track
+  // nears its end and the NEXT track is still held without a successor, fire the
+  // pick cycle for that successor — the push() it ends in re-runs the drain
+  // loop, which then sends the held item pair-aware.
+  //
+  // Fires ONLY for the item airing immediately after the on-air track (head of
+  // `upcoming` unsent, and the only unsent item). Without that condition every
+  // tick would pick another track and run the pipeline ahead unbounded; with it,
+  // the fresh pick becomes the new held tail whose own deadline is a full track
+  // away. Past the hard deadline the window closes and drainToLiquidsoap's
+  // intrinsic path owns the endgame.
   maybeDeadlinePick() {
     if (!this.autoPick || this.pickerBusy || !djCallsAllowed()) return;
     if (!this.pairDrainActive()) return;
@@ -1956,19 +1905,16 @@ class Queue {
     try {
       const liveIds = await liquidsoapControl.getDjQueueIds();
 
-      // Empty dj_queue while we still hold sent items. On a single read this is
-      // ambiguous — a pick may be mid-poll (written to next.txt, not yet pulled
-      // in), Liquidsoap may have restarted and lost the queue, or the last item
-      // is on-air (popped from the queue) but its metadata didn't match in
-      // onTrackStarted so it never left `upcoming`. Don't drop on one read, but
-      // count consecutive empties: once the queue has been authoritatively empty
-      // for EMPTY_DJ_QUEUE_CLEAR_THRESHOLD checks the sent items are genuinely
-      // gone (restart) or stuck, so clear them and let the auto-DJ — gated on
-      // `upcoming.length === 0` — start picking again. This restores the restart
-      // self-heal the old `_autoMisses` clear provided, without its false wipes:
-      // it advances only on an authoritatively empty queue, so an interleaved
-      // jingle or an artist-string mismatch (with tracks still queued) resets it
-      // instead of tripping it.
+      // Empty dj_queue while we still hold sent items. A single read is
+      // ambiguous: a pick may be mid-poll, Liquidsoap may have restarted and
+      // lost the queue, or the last item is on air (popped) but its metadata
+      // didn't match in onTrackStarted so it never left `upcoming`. So count
+      // consecutive empties instead of dropping on one — after
+      // EMPTY_DJ_QUEUE_CLEAR_THRESHOLD the sent items are genuinely gone or
+      // stuck, and clearing them lets the auto-DJ (gated on
+      // `upcoming.length === 0`) pick again. The counter advances only on an
+      // authoritatively empty queue, so an interleaved jingle or an artist-string
+      // mismatch resets it rather than tripping it.
       if (liveIds.size === 0) {
         this._emptyDjQueueStreak++;
         if (this._emptyDjQueueStreak >= EMPTY_DJ_QUEUE_CLEAR_THRESHOLD) {
@@ -2126,19 +2072,16 @@ class Queue {
   }
 
   // The last `n` DISTINCT tracks played — the count-based HARD no-repeat guard
-  // (filterPickerCandidates hardRecent*; never relaxed). Clock-independent: it
-  // walks the rolling sidecar newest-first and stops once it has seen `n`
-  // distinct tracks, so a busy or a quiet hour blocks the same number of songs.
+  // (filterPickerCandidates hardRecent*, never relaxed). Clock-independent: it
+  // walks the sidecar newest-first until it has seen `n` distinct tracks, so a
+  // busy hour and a quiet one block the same number of songs.
   //
-  // Counts DISTINCT tracks, not raw rows: the sidecar can hold two entries for
-  // one play (recordPlay logs it with an id at track-end; the boot events
-  // backfill logs an id-less copy at track-start), and those collapse here —
-  // `n` means n songs, not n rows — so the guard's strength matches the
-  // configured number regardless of the double-write. Collapses an id-less
-  // (backfilled) row against an id'd row of the same track via the shared
-  // title|artist key. Returns BOTH ids and keys so a candidate is blocked by
-  // whichever identifier it carries; the current track is added on top so a
-  // mid-song pick can't re-pick it. Empty sets when n <= 0.
+  // DISTINCT tracks, not raw rows: the sidecar can hold two entries for one play
+  // (recordPlay logs it with an id at track-end, the boot backfill logs an
+  // id-less copy at track-start), collapsed here via the shared title|artist
+  // key, so `n` means n songs regardless of the double-write. Returns BOTH ids
+  // and keys so a candidate is blocked by whichever identifier it carries, plus
+  // the current track so a mid-song pick can't re-pick it.
   recentlyPlayedByCount(n = 0): { ids: Set<string>; keys: Set<string> } {
     const ids = new Set<string>();
     const keys = new Set<string>();
@@ -2264,16 +2207,15 @@ class Queue {
 
   // A bed started feeding the music chain — air the link it was pushed for.
   //
-  // Unlike waitForJingleClear (which computes a deadline on demand and sleeps
-  // it out), this genuinely has to be an event: the bed is pushed minutes
-  // before it airs, and the link must land ON it. radio.liq writes
-  // bed-playing.json the moment the bed's metadata fires; a new startedAt is
-  // the edge. Dedupe on that value, exactly as onTrackStarted dedupes on the
-  // track key — the file is never deleted, so a stale marker must not re-fire.
+  // Unlike waitForJingleClear (which computes a deadline and sleeps it out),
+  // this has to be an event: the bed is pushed minutes before it airs and the
+  // link must land ON it. radio.liq writes bed-playing.json the moment the bed's
+  // metadata fires, so a new startedAt is the edge — deduped on that value, like
+  // onTrackStarted's track key, since the file is never deleted and a stale
+  // marker must not re-fire.
   //
-  // Song B's own onTrackStarted will also call airIntro for the same item a bed
-  // later; airIntro sets introAired before any await, so the double-call is
-  // already idempotent and no guard is needed here.
+  // Song B's own onTrackStarted also calls airIntro for this item a bed later;
+  // airIntro sets introAired before any await, so that is already idempotent.
   onBedStarted() {
     // The bed is pushed immediately ahead of its item, so the item a marker
     // belongs to is the first bedded one still waiting to speak. No such item

--- a/controller/src/broadcast/queue/pure.ts
+++ b/controller/src/broadcast/queue/pure.ts
@@ -73,18 +73,17 @@ export function linkAirDate(showAt: Date): Date {
 // +120s overshoot that had been masking this undershoot on average.
 //
 // Sized off the pick round itself, measured over 788 rounds: 27.7% ran longer
-// than 45s and 18.3% longer than 60s, but only 0.3% longer than 120s. The
-// exposed population is maybeDeadlinePick's empty-queue backstop, which fires
-// with DRAIN_DEADLINE_SEC..HARD_DEADLINE_SEC of runway on ANY station whatever
-// its track lengths — so the floor is that same deadline: speak the clock only
-// when the pick is being made AHEAD of the endgame window, never inside it. A
-// track-start pick on a normal 3-5 minute track clears it comfortably and keeps
-// its clock; below it the link simply doesn't state a time, which is the
-// pre-#864 behaviour for an unknowable air moment. The flip side is accepted,
-// not accidental: a library whose tracks run under ~2 minutes (punk, hardcore)
-// never has this much runway even at track start, so its links simply never
-// speak the clock — that library's every seam sits inside the risk window the
-// floor exists to silence, and hourly checks still tell the time.
+// than 45s, 18.3% longer than 60s, only 0.3% longer than 120s. The exposed
+// population is maybeDeadlinePick's empty-queue backstop, which fires with
+// DRAIN_DEADLINE_SEC..HARD_DEADLINE_SEC of runway on ANY station whatever its
+// track lengths — so the floor is that same deadline: speak the clock only when
+// the pick is made AHEAD of the endgame window, never inside it. Below the floor
+// the link states no time, the pre-#864 behaviour for an unknowable air moment.
+//
+// The flip side is accepted, not accidental: a library whose tracks run under
+// ~2 minutes never has this much runway even at track start, so its links never
+// speak the clock — every one of its seams sits inside the risk window the floor
+// exists to silence, and hourly checks still tell the time.
 export const LINK_CLOCK_MIN_RUNWAY_SEC = DRAIN_DEADLINE_SEC;
 
 // The instant a pick-attached link may claim to air at, or null when the
@@ -119,15 +118,14 @@ export const LINK_CLOCK_DRIFT_TOLERANCE_SEC = 90;
 // predecessor cueing out early moves the seam the other way.
 //
 // Deliberately NOT narrowed to lines that demonstrably state a time, the way
-// shouldDropStaleLink narrows to lines that name their predecessor. That guard
-// can afford `mentionsTrack` because it matches exact title/artist strings; a
-// clock has no such handle — the model may write "18:38", "twenty to seven" or,
-// under a spell-out house rule, "eighteen thirty-eight", and a detector that
-// misses one airs the wrong time, which is the whole failure. So the stamp is
-// the offer, not the usage: a link that was given a clock and chose not to use
-// it can be dropped for nothing. With LINK_CLOCK_MIN_RUNWAY_SEC in front, that
-// costs a link in the 0.3% tail — cheaper than a regex that has to be right
-// about every phrasing an LLM might reach for.
+// shouldDropStaleLink narrows to lines naming their predecessor. That guard can
+// afford `mentionsTrack` because it matches exact title/artist strings; a clock
+// has no such handle — "18:38", "twenty to seven", or under a spell-out house
+// rule "eighteen thirty-eight" — and a detector that misses one airs the wrong
+// time, which is the whole failure. So the stamp records the clock being
+// OFFERED, not used: a link that was given one and didn't use it can be dropped
+// for nothing. Behind LINK_CLOCK_MIN_RUNWAY_SEC that costs a link in the 0.3%
+// tail, cheaper than a regex that has to be right about every phrasing.
 export function linkClockDrifted(clockAtMs: number | null | undefined, nowMs: number): boolean {
   if (typeof clockAtMs !== 'number' || !Number.isFinite(clockAtMs)) return false;
   return Math.abs(nowMs - clockAtMs) > LINK_CLOCK_DRIFT_TOLERANCE_SEC * 1000;
@@ -136,15 +134,14 @@ export function linkClockDrifted(clockAtMs: number | null | undefined, nowMs: nu
 // Seconds from NOW until the pick being made will start airing — the lead the
 // show look-ahead adds to the wall clock (see runPickCycle).
 //
-// It must be measured from the on-air track's REMAINING time, never its full
-// duration. The pick cycle doesn't only run at a track start: the pair-drain
-// deadline backstop fires it with an empty queue ~2 min from the end, and boot
-// recovery fires it for a track already part-played. Using the full duration
-// there overstates the lead by everything already elapsed — up to a whole
-// track — which walks `showAt` across the next schedule boundary while the
-// real next track still starts inside the current show. That is what aired a
-// handoff five-plus minutes early, over the middle of a song, with the session
-// flipped to a show `/now-playing` still reported as the old one (#1205).
+// Measured from the on-air track's REMAINING time, never its full duration. The
+// pick cycle doesn't only run at a track start — the pair-drain deadline
+// backstop fires it ~2 min from the end, and boot recovery fires it part-way
+// through a track. Full duration there overstates the lead by everything already
+// elapsed, walking `showAt` across the next schedule boundary while the real
+// next track still starts inside the current show: that aired a handoff
+// five-plus minutes early, over the middle of a song, with the session flipped
+// to a show `/now-playing` still reported as the old one (#1205).
 //
 //  - `heldSec` null → the pick follows the ON-AIR track: lead = its remaining.
 //  - `heldSec` set  → the deadline path, where the pick follows a HELD track
@@ -274,9 +271,9 @@ export function shouldDropStaleLink(
 // only thing that would speak and it should. Pure + exported so the rule is
 // unit-pinned (scripts/ident-link-collision.test.ts).
 //
-// The rule mirrors airIntro's own airing decision, and `opts` carries the two
-// runtime drop paths the item's fields alone can't predict — both of which
-// leave the boundary silent, so the ident may take it after all:
+// The rule mirrors airIntro's own airing decision, and `opts` carries the
+// runtime drop paths the item's fields alone can't predict — all of which leave
+// the boundary silent, so the ident may take it after all:
 //   - `voiceAllowed` — airIntro's station-voice backstop (settings.tts.enabled
 //     off) drops the line outright. The pending segment itself may still air:
 //     manual /dj/segment triggers are exempt from the voice switch.

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -518,14 +518,13 @@ export async function runHourlyCheck() {
 // Every step traps its own errors — node-cron doesn't catch async throws, and
 // the route callers are fire-and-forget.
 //
-// `airHandoff` decides whether this call site may air the mic-pass itself.
-// The hourly cron passes false: it must still roll the session and plan the
-// episode (that state has to be right whether or not a track boundary is
-// near), but airing at wall-clock :00 ducks the middle of a song. Leaving the
-// handoff pending hands it to the next track boundary, which is where it
-// belongs. The takeover routes keep the default true — an operator action is
-// explicit and should air promptly, the same reasoning that exempts the manual
-// /dj/segment runners from the budget gate.
+// `airHandoff` decides whether this call site may air the mic-pass itself. The
+// hourly cron passes false: it must still roll the session and plan the episode
+// (that state has to be right regardless), but airing at wall-clock :00 ducks
+// the middle of a song, so leaving the handoff pending hands it to the next
+// track boundary. The takeover routes keep the default true — an operator action
+// is explicit and should air promptly, the same reasoning that exempts the
+// manual /dj/segment runners from the budget gate.
 export async function rollSessionNow({ airHandoff = true }: { airHandoff?: boolean } = {}) {
   let ctx: Awaited<ReturnType<typeof getFullContext>> | null = null;
   try {
@@ -699,14 +698,13 @@ async function skillsTick() {
 
 // ---------------------------------------------------------------------------
 // PROGRAMME BEATS
-// The feature beat mid-hour (station-minute :35–:39) and the outro in the
-// closing minutes of the final hour (station-minute :55+). Placement is a
-// STATION-clock fact, but station zones sit at :30/:45 offsets (IST, Nepal),
-// so fixed process-minute crons can land mid-show — the tick runs every 5
-// minutes and dispatches on programme.dueBeat() instead; the beat flags make
-// the repeat ticks inside a window no-ops. The intro has no cron of its own:
-// it rides the session-settled hook (hourlyCheck above + queue's track-start
-// path). Gating (listeners, budget, beat-already-aired) lives in programme.ts.
+// The feature beat mid-hour (station-minute :35–:39) and the outro in the final
+// hour's closing minutes (station-minute :55+). Placement is a STATION-clock
+// fact, but station zones sit at :30/:45 offsets (IST, Nepal), so a fixed
+// process-minute cron would land mid-show — instead the tick runs every 5
+// minutes and dispatches on programme.dueBeat(), with the beat flags making
+// repeat ticks inside a window no-ops. The intro has no cron of its own; it
+// rides the session-settled hook. Gating lives in programme.ts.
 // ---------------------------------------------------------------------------
 
 async function programmeTick() {
@@ -907,7 +905,7 @@ export function startScheduler() {
   // Initial run
   refreshAutoPlaylist().catch(err => queue.log('error', `Initial playlist failed: ${err.message}`));
 
-  // Auto-playlist refresh every 10 minutes
+  // Auto-playlist refresh, every AUTO_QUEUE_REFRESH_MINUTES (default 60)
   cron.schedule(`*/${config.show.autoQueueRefreshMinutes} * * * *`, refreshAutoPlaylist);
 
   // Top of every hour

--- a/controller/src/broadcast/session.ts
+++ b/controller/src/broadcast/session.ts
@@ -455,40 +455,32 @@ function softShift(ctx: SessionContext, nextKey: string): Session {
 // Consecutive same-role turns are coalesced because some providers (Anthropic)
 // require strictly alternating user/assistant messages.
 //
-// Four turn kinds get filtered out of the window because they derail the
-// picker agent in long sessions:
+// Four turn kinds are filtered out because they derail the picker in long
+// sessions:
 //
-// - `scenario` events (controller restart notes, session boundaries) — infra
-//   noise, not part of the DJ's conversation. Every restart leaves "Controller
-//   restarted — session resumed" in the window, eventually appearing 3-4
-//   times in a single coalesced user message.
+// - `scenario` events (restart notes, session boundaries) — infra noise. Every
+//   restart leaves "Controller restarted", eventually appearing 3-4 times in one
+//   coalesced user message.
 //
-// - `kind: 'play'` track turns ("▶ Title — Artist") — redundant. Every pick
-//   event already contains the current AND previous track ("Now playing X.
-//   Pick the next track (after Y)..."), and recently-played TRACKS are filtered
-//   at the tool layer (recentIds/recentKeys in buildPickerTools) so they can't
-//   be re-picked regardless.
+// - `kind: 'play'` turns ("▶ Title — Artist") — redundant. Every pick event
+//   already names the current AND previous track, and recently-played tracks are
+//   filtered at the tool layer (recentIds/recentKeys) regardless.
 //
-// - `kind: 'sfx'` cue turns (queue.playSfx records the effect NAME as a turn) —
-//   an audio-production cue, not conversation. Left in, a bare effect name like
-//   "whoosh" coalesces into the assistant block and reads as a word the DJ
-//   spoke; the effect already aired, so the picker gains nothing from seeing it.
+// - `kind: 'sfx'` cue turns — an audio-production cue, not conversation. Left
+//   in, a bare effect name like "whoosh" coalesces into the assistant block and
+//   reads as a word the DJ spoke.
 //
-// - OLD `kind: 'pick'` events (role='event') — the "Now playing X. Pick the
-//   next track" user-side instruction is kept only for the LATEST pick.
-//   Previous ones were already answered and just add ambiguity ("which of
-//   these 11 'pick next' requests am I responding to?"). Without this filter,
-//   gemini's reliability drops from 5/5 short → 2-3/5 long in the
-//   picker-test.mjs LONG benchmark, with "No output generated" failures.
+// - OLD `kind: 'pick'` events: only the LATEST is kept. Previous ones were
+//   already answered and just add ambiguity ("which of these 11 'pick next'
+//   requests am I responding to?"). Without this filter gemini drops from 5/5
+//   short to 2-3/5 long, with "No output generated" failures.
 //
-// The DJ's own reasons (role='dj' kind='pick') stay — but only the most recent
-// RATIONALE_WINDOW of them. Each one is the agent's 12-word scratchpad ("Punjabi
-// thread continues, …"); left unbounded, ~15-20 accumulate in the window and the
-// agent reads its own running commentary as a mandate to keep the thread going
-// (one artist re-airing every ~1.2h). Keeping the last few preserves short-term
-// "what did I just play" memory without the momentum. Track-recency is enforced
-// at the tool layer regardless (recentIds/recentKeys in buildPickerTools), so
-// trimming these costs the picker no track-level anti-repeat coverage.
+// The DJ's own reasons (role='dj' kind='pick') stay, but only the most recent
+// RATIONALE_WINDOW of them. Each is the agent's 12-word scratchpad; left
+// unbounded, ~15-20 accumulate and the agent reads its own running commentary as
+// a mandate to keep the thread going (one artist re-airing every ~1.2h). Keeping
+// a few preserves short-term memory without the momentum, and track-recency is
+// enforced at the tool layer either way.
 export function windowMessages() {
   if (!_session) return [];
   const raw: { role: 'user' | 'assistant'; content: string }[] = [];

--- a/controller/src/broadcast/stem-blend.ts
+++ b/controller/src/broadcast/stem-blend.ts
@@ -37,7 +37,7 @@ export type BlendTrack = loudness.LoudnessTrack & {
   gainDb?: number;
 };
 
-export interface BlendPlan {
+interface BlendPlan {
   clipPath: string;
   blendStartSec: number; // X's liq_cue_out
   inCueSec: number;      // Y's liq_cue_in

--- a/controller/src/broadcast/stream-idle-pure.ts
+++ b/controller/src/broadcast/stream-idle-pure.ts
@@ -3,7 +3,7 @@
 // in the monitor's heavy imports (queue.ts → llm/tts/subsonic), same split
 // as programme-pure.ts.
 
-export type IdleAction = 'pause' | 'resume' | 'reassert' | null;
+type IdleAction = 'pause' | 'resume' | 'reassert' | null;
 
 export interface IdleState {
   idle: boolean;

--- a/controller/src/broadcast/tagger.ts
+++ b/controller/src/broadcast/tagger.ts
@@ -141,13 +141,14 @@ export function startTagger(
   // documented per-flag, full-library meaning.)
   //
   // Exception — the reseed-only "then tag" chain: dropping --rescan runs raw
-  // --reseed, whose forward pass drops all vectors, RE-EMBEDS THE WHOLE LIBRARY
-  // (phaseEmbed's allTaggedIds sweep re-vectorises the tagged set the drop wiped),
-  // then seed→propagate→active-learn tags the untagged remainder — exactly the run
-  // the stale-embedding banner was blocking. Only when reseed is the sole re-*
-  // pass: mixing forward discovery into a targeted reEnrich/reAnalyze/upgrade
-  // re-scan isn't well-defined, so any other re-* flag keeps today's --rescan
-  // scoping and ignores thenTag.
+  // --reseed, whose forward pass drops all vectors, re-embeds the whole library
+  // (phaseEmbed's allTaggedIds sweep re-vectorises what the drop wiped), then
+  // seed→propagate→active-learn tags the untagged remainder. That is exactly the
+  // run the stale-embedding banner was blocking.
+  //
+  // ONLY when reseed is the sole re-* pass: mixing forward discovery into a
+  // targeted reEnrich/reAnalyze/upgrade re-scan isn't well-defined, so any other
+  // re-* flag keeps --rescan scoping and ignores thenTag.
   const reseedOnly = !!reseed && !reEnrich && !reAnalyze && !upgrade;
   const chainTag = reseedOnly && thenTag === true;
   const rescan = !!(reseed || reEnrich || reAnalyze || upgrade) && !chainTag;

--- a/controller/src/community/registry.ts
+++ b/controller/src/community/registry.ts
@@ -100,7 +100,7 @@ export interface CommunityShow {
 
 // Stations are the public directory (a map of listeners' stations) — pass-through
 // JSON, shape-owned by web/lib/stations.ts. We keep them loose here.
-export type CommunityStation = Record<string, unknown> & { slug?: string };
+type CommunityStation = Record<string, unknown> & { slug?: string };
 
 interface Catalog {
   skills: CommunitySkill[];

--- a/controller/src/config.ts
+++ b/controller/src/config.ts
@@ -242,19 +242,18 @@ export const config = {
     // both honestly suppliable from the sidecar, with margin. ~300KB of JSON,
     // rewritten once per play — negligible either way.
     recentPlaysMax: 2500,
-    // Count-based hard no-repeat guard: the picker (both pool and agent paths)
-    // never re-airs any of the last N DISTINCT plays. Unlike the time-window
-    // guard (recencyWindowsForLibrary) this is non-relaxable — it survives the
-    // filterPickerCandidates starvation cascade, closing the hole where a
-    // thin/over-visited mood cluster let the cascade drop the recent-track guard
-    // and re-serve a just-played song. Clamped to library size at use
-    // (effectiveNoRepeatWindow) so a small catalogue never fully blocks; 0
-    // disables. Seeds settings.llm.noRepeatWindow — the live, admin-tunable
-    // value; env wins. Listener requests stay exempt (request path is untouched).
-    // Default 250 (was 100): 100 distinct blocked ~6-8h of air — a bubble of
-    // ~300 tracks satisfied it forever. 250 is still auto-scaled DOWN on small
-    // libraries by effectiveNoRepeatWindow's 37.5% ceiling, so only catalogues
-    // that can absorb the memory actually carry it.
+    // Count-based hard no-repeat guard: neither pick path re-airs any of the
+    // last N DISTINCT plays. Unlike the time-window guard this is non-relaxable
+    // — it survives the filterPickerCandidates starvation cascade, closing the
+    // hole where a thin mood cluster let the cascade drop the recent-track guard
+    // and re-serve a just-played song. Clamped to library size at use so a small
+    // catalogue never fully blocks; 0 disables. Seeds the live, admin-tunable
+    // settings.llm.noRepeatWindow (env wins); listener requests stay exempt.
+    //
+    // 250 rather than 100 because 100 distinct blocked only ~6-8h of air, which
+    // a bubble of ~300 tracks satisfied forever. effectiveNoRepeatWindow's 37.5%
+    // ceiling still scales it DOWN on small libraries, so only catalogues that
+    // can absorb the memory carry it.
     noRepeatWindow: parseInt(process.env.NO_REPEAT_WINDOW || '250', 10),
   },
   curiosity: {

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -55,7 +55,7 @@ export interface ToolCallLike {
   input?: unknown;
   args?: unknown;
 }
-export interface ToolResultLike {
+interface ToolResultLike {
   output?: unknown;
   result?: unknown;
 }
@@ -299,22 +299,17 @@ export function budgetMode(
 //   isUpstreamOverloaded→ withFailover switches to the BACKUP leg (a reachable
 //                         gateway relayed a saturated upstream — see below).
 // isUnreachable is a strict subset of isTransient: it EXCLUDES 408/425/429/5xx,
-// because a host that answers with a status is reachable — those stay with
-// transient retry on the configured model rather than being masked by a silent
-// failover to a different model (discussion #320). The ONE exception is a
-// quota/auth rejection (isQuotaOrAuthError): the leg answered, but it can't
-// recover this call, so it is pulled OUT of the transient set and fails over
-// instead of pointlessly retrying a dead leg (issue #438 — Ollama Cloud's
-// "weekly usage limit" 429s looped on the exhausted leg and never failed over).
+// because a host that answers with a status is reachable, and those should stay
+// on transient retry rather than be masked by a silent failover to a different
+// model (discussion #320). The ONE exception is isQuotaOrAuthError — the leg
+// answered but cannot recover this call, so it is pulled OUT of the transient
+// set and fails over instead of retrying a dead leg (#438).
 //
-// isUpstreamOverloaded is the inverse-shaped sibling: it is ADDED to the
-// failover set but deliberately LEFT IN the transient set. An OpenRouter
-// "Upstream error from <provider>: ResourceExhausted" (issue #671) or an
-// Anthropic 529 "Overloaded" means the chosen model/route is saturated right
-// now — which, unlike a quota cap, CAN clear in a second. So withTransientRetry
-// gets first crack on the chosen model (honouring #320); only when the overload
-// persists past that budget does withFailover try the configured fallback model,
-// instead of the call dying on the saturated route having never tried the backup.
+// isUpstreamOverloaded is the inverse-shaped sibling: ADDED to the failover set
+// but deliberately LEFT IN the transient set. An OpenRouter "ResourceExhausted"
+// (#671) or an Anthropic 529 means the route is saturated right now which,
+// unlike a quota cap, can clear in a second — so transient retry gets first
+// crack on the chosen model, and only a persistent overload reaches failover.
 
 // The AI SDK's built-in retry (generateText's default maxRetries: 2) throws
 // AI_RetryError once its attempts are spent — a wrapper with NO statusCode,
@@ -384,17 +379,16 @@ export function isUnreachable(err: ErrorLike | null | undefined): boolean {
   return false;
 }
 
-// Provider refused this leg in a way that retrying the SAME model won't fix
-// this call: a quota / usage-limit / billing rejection, or an authentication
-// failure (bad / missing API key). The host is UP (it answered), so this is NOT
-// isUnreachable — but unlike a transient "slow down" 429, the same leg can't
-// recover, so withFailover treats it like host-down and switches to the backup
-// leg (issue #438). Detected by message because providers surface quota/auth
-// differently and the AI SDK often flattens the status into the message text;
-// a bare 429 with no quota signature stays a plain transient rate-limit.
-// "requires more credits" / "can only afford" are OpenRouter's per-request
-// affordability 402 — no "insufficient"/"quota" token, so it only classified
-// while the 402 status survived; match it by text too (Discord out-of-credit run).
+// The leg was refused in a way retrying the SAME model won't fix: a quota /
+// usage-limit / billing rejection, or an auth failure. The host is UP, so this
+// is NOT isUnreachable — but unlike a "slow down" 429 the leg can't recover, so
+// withFailover treats it like host-down and switches to the backup (#438).
+//
+// Detected by MESSAGE because providers surface quota/auth differently and the
+// AI SDK often flattens the status into the text; a bare 429 with no quota
+// signature stays a plain transient rate-limit. "requires more credits" /
+// "can only afford" are OpenRouter's per-request affordability 402, which
+// carries no "insufficient"/"quota" token, so it is matched by text too.
 const QUOTA_RE = /usage limit|quota|exceeded your current|insufficient[ _]?(quota|funds|credit|balance)|requires more credits|can only afford|upgrade for higher|out of credit|payment required/i;
 const AUTH_RE = /invalid[ _]?api[ _]?key|incorrect[ _]?api[ _]?key|unauthorized|authentication (failed|error)|forbidden|api key (not|is|was) /i;
 
@@ -414,21 +408,20 @@ export function isQuotaOrAuthError(err: ErrorLike | null | undefined): boolean {
   return false;
 }
 
-// A reachable gateway relayed a saturated upstream: the host answered, but the
-// model/route it fronts is at capacity right now. OpenRouter surfaces this as
-// "Upstream error from <provider>: ResourceExhausted: Worker local total
-// request limit reached (32/32)" (issue #671); Anthropic as a 529 "Overloaded";
-// Vertex/gRPC as RESOURCE_EXHAUSTED. Unlike a quota cap this is NOT the user's
-// account being out of credit (so it is NOT isQuotaOrAuthError) and the host is
-// UP (so it is NOT isUnreachable) — it is a transient capacity blip that CAN
-// clear on a retry. So it deliberately STAYS in the transient set
-// (withTransientRetry gets first crack on the chosen model); withFailover then
-// adds it as a failover trigger, so a persistent overload finally tries the
-// configured fallback model rather than dying on the saturated route. Matched
-// by message because the signal is in the relayed text, plus Anthropic's 529.
-// Kept tight to avoid stealing plain rate-limit 429s (which should stay same-leg
-// transient retries): only an explicit upstream/overload/exhausted phrase or a
-// 529 qualifies — a bare 503 or "rate limit exceeded, slow down" does not.
+// A reachable gateway relayed a SATURATED upstream: the host answered, but the
+// route it fronts is at capacity. OpenRouter reports "Upstream error from
+// <provider>: ResourceExhausted" (#671), Anthropic a 529 "Overloaded",
+// Vertex/gRPC RESOURCE_EXHAUSTED.
+//
+// Neither a quota cap (the account has credit, so not isQuotaOrAuthError) nor a
+// dead host (not isUnreachable) — a capacity blip that CAN clear on retry. So it
+// STAYS in the transient set, letting withTransientRetry try the chosen model
+// first, and withFailover adds it as a trigger so a persistent overload finally
+// reaches the fallback rather than dying on the saturated route.
+//
+// Matched by message plus Anthropic's 529, and kept tight so it can't steal
+// plain rate-limit 429s: only an explicit upstream/overload/exhausted phrase or
+// a 529 qualifies, never a bare 503 or "rate limit exceeded, slow down".
 const UPSTREAM_OVERLOAD_RE = /upstream error|resource[ _]?exhausted|overloaded|no instances?\b.*\bavailable|worker local total request limit/i;
 
 export function isUpstreamOverloaded(err: ErrorLike | null | undefined): boolean {
@@ -440,22 +433,18 @@ export function isUpstreamOverloaded(err: ErrorLike | null | undefined): boolean
   return UPSTREAM_OVERLOAD_RE.test(msg);
 }
 
-// A plain rate-limit 429 with no quota/usage-limit wording (issue #738): the
-// free-tier daily/per-minute request cap on a provider like Gemini/Groq/
-// OpenRouter. This is the case isQuotaOrAuthError deliberately does NOT catch
-// (see its comment above), so it stays isTransient and gets same-leg retries
-// first via withTransientRetry. If those retries exhaust and the 429 is still
-// live, withFailover treats it the same as a quota/auth rejection and switches
-// to the backup leg — a request-per-minute/day cap on the primary provider is
-// exactly the "keep the station on air on a free tier" case the issue asks
-// for, and retrying the same exhausted leg forever will never recover it.
+// A plain rate-limit 429 with no quota wording (#738) — a free-tier daily or
+// per-minute request cap. This is the case isQuotaOrAuthError deliberately does
+// NOT catch, so it stays isTransient and gets same-leg retries first; if those
+// exhaust with the 429 still live, withFailover switches to the backup, since a
+// request cap on the primary is exactly the "keep the station on air on a free
+// tier" case and retrying the exhausted leg never recovers it.
 //
-// Deliberately NOT any bare 429: a status alone must also carry rate-limit
-// wording or a Retry-After header to qualify. A self-hosted llama.cpp/vLLM box
-// answering 429 on a momentary concurrency spike sends neither — that stays a
-// plain same-leg transient retry and never silently switches the station onto
-// a (possibly paid) cloud fallback (PR #751 review). Every provider #738
-// names does send the wording and/or the header.
+// Deliberately NOT any bare 429: the status must also carry rate-limit wording
+// or a Retry-After header. A self-hosted llama.cpp/vLLM box answering 429 on a
+// momentary concurrency spike sends neither, and must stay a same-leg retry
+// rather than silently switching the station onto a possibly-paid cloud
+// fallback. Every provider #738 names does send the wording and/or header.
 const RATE_LIMIT_RE = /rate.?limit|too many requests|requests? per (?:minute|day|hour)|\b[rt]p[mdh]\b/i;
 
 export function isRateLimited(err: ErrorLike | null | undefined): boolean {
@@ -516,28 +505,21 @@ export function flattenToolCalls(result: { steps?: StepLike[] } | null | undefin
 // tool loop that stalled can be finished by the single-turn forced-tool path
 // (objectViaToolCall's `emit`) instead of yet another multi-turn continuation.
 //
-// Why the shape and not the forcing: llama.cpp / LM Studio running Hermes-class
-// models answer the terminal `done` step in prose no matter what `tool_choice`
-// says — the operator's server trace on #1157 shows `tools:[done]` +
-// `tool_choice:'required'` going out and `tool_calls: []`, `finish_reason:
-// 'stop'` coming back, on BOTH LM Studio and a bare `llama-server --jinja`. The
-// same backend and model call a forced tool reliably when the request is a
-// single user prompt carrying one tool — which is exactly why the stateless
-// pool picker keeps working for those operators while the agent path does not.
-// The variable that moves is the conversation SHAPE (a continuation after
-// tool-result turns vs. a fresh one-shot), so the last resort changes the shape.
-// This also subsumes what the clean-context retry was reaching for: GLM's
-// "keeps declining once it has declined in this conversation" is a fresh
-// single-turn call by another name.
+// The fix is the SHAPE, not more forcing. llama.cpp / LM Studio running
+// Hermes-class models answer the terminal `done` step in prose no matter what
+// `tool_choice` says (#1157: `tools:[done]` + `tool_choice:'required'` out,
+// `tool_calls: []` + `finish_reason:'stop'` back, on both LM Studio and a bare
+// `llama-server --jinja`) — yet the same backend and model call a forced tool
+// reliably from a single user prompt, which is why the stateless pool picker
+// keeps working for those operators while the agent path does not. GLM's "keeps
+// declining once it has declined in this conversation" is the same thing.
 //
-// The findings block is what keeps the answer honest. The discovery tools ran
-// during the earlier attempts and their results are the only place real
-// candidate ids exist; drop them and a cornered model can only fabricate one
-// (the 100%-unknown-id failure the trail-carrying recovery was added to fix).
-// Truncation is per-result and then whole-block, both announced in the text —
-// a clipped candidate list costs at worst a pick from a shorter menu, and the
-// caller's nearestId/repickFromSeen salvage still covers an id that came back
-// mangled, exactly as it does for every other branch of the cascade.
+// The findings block keeps the answer honest: the discovery tools' results are
+// the only place real candidate ids exist, and dropping them leaves a cornered
+// model able only to fabricate one. Truncation is per-result then whole-block,
+// both announced in the text — a clipped candidate list costs at worst a pick
+// from a shorter menu, and the caller's nearestId/repickFromSeen salvage still
+// covers a mangled id as it does for every other branch of the cascade.
 
 export interface TerminalMessageLike {
   role?: string;
@@ -917,16 +899,13 @@ export function modelTolerant<T extends z.ZodObject<z.ZodRawShape>>(
 }
 
 // Strip every `description` key from a JSON-Schema-shaped value, recursively.
-// z.toJSONSchema() carries every Zod .describe() call through verbatim —
-// several of this codebase's schemas (e.g. the picker's `transition` field)
-// have a multi-hundred-word description, since that prose is the primary
-// channel for coaching the model on the native/tool-forced paths. Embedded
-// verbatim into schemaHint's recovery prompt, that same prose would bloat the
-// retry's token count for every caller, not just the one schema that needs
-// it (Copilot review, PR #923) — and the recovery prompt only needs the
-// STRUCTURE (field names, types, required-ness, enum values) to stop the
-// model guessing at keys; the coaching prose already lives in the original
-// system/prompt text passed alongside it.
+// z.toJSONSchema() carries every .describe() through verbatim, and several
+// schemas here (the picker's `transition`) run to hundreds of words, since that
+// prose is the primary channel for coaching the model on the native/tool-forced
+// paths. In schemaHint's recovery prompt it would bloat the retry's token count
+// for every caller — and that prompt needs only the STRUCTURE (field names,
+// types, required-ness, enums) to stop the model guessing at keys, since the
+// coaching prose already rides in the system/prompt text alongside it.
 function stripDescriptions(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(stripDescriptions);
   if (value && typeof value === 'object') {
@@ -986,22 +965,21 @@ export function clipText(s: unknown, max: number): unknown {
   return (onWord.length >= max * 0.6 ? onWord : cut).trim();
 }
 
-// A persona `soul` is capped at settings.SOUL_MAX (2000) because it is injected
-// into every free-text generation call for THAT persona — the seat it was
-// written for, which earns the full length. Two consumers inline a soul where
-// that reasoning doesn't hold, and they clamp to this instead:
+// A persona `soul` gets SOUL_MAX (2000) because it is injected into every
+// free-text call for THAT persona — the seat it was written for. Two consumers
+// inline a soul where that reasoning doesn't hold and clamp to this instead:
 //
 //   - the multi-voice cast blocks (prompts/banter.ts, prompts/programme.ts) —
-//     one entry per cast member (host + up to 3 guests), and the block exists
-//     to say who is in the room, not to hand each of them a character document;
-//   - the cloud-TTS delivery hint (speech/cloud-speech.ts) — rebuilt and sent
-//     on EVERY spoken line, and it only steers tone and pacing, so backstory
-//     and recurring bits enlarge each request without changing the read.
+//     one entry per cast member, and the block exists to say who is in the room,
+//     not to hand each of them a character document;
+//   - the cloud-TTS delivery hint (speech/cloud-speech.ts) — rebuilt on EVERY
+//     spoken line, and it only steers tone and pacing, so backstory enlarges
+//     each request without changing the read.
 //
 // Both want the opening sketch, which is where operators put the voice.
-// Whitespace is collapsed because a soul is multi-line free text and the cast
-// blocks are one-bullet-per-speaker — a raw newline would break the list. The
-// ellipsis marks the sketch as abridged rather than reading as a full stop.
+// Whitespace is collapsed because a soul is multi-line and the cast blocks are
+// one bullet per speaker; the ellipsis marks the sketch as abridged rather than
+// reading as a full stop.
 export const SOUL_BRIEF_MAX = 320;
 export function soulBrief(soul: unknown, max: number = SOUL_BRIEF_MAX): string {
   const s = String(soul ?? '').trim().replace(/\s+/g, ' ');

--- a/controller/src/llm/internal/prompts/picker.ts
+++ b/controller/src/llm/internal/prompts/picker.ts
@@ -26,7 +26,7 @@ export function effectsGuidance(): string {
   return `\n\n${instruction('pick-criteria', 'effects')}`;
 }
 
-export type ShowEra = { fromYear?: number | null; toYear?: number | null };
+type ShowEra = { fromYear?: number | null; toYear?: number | null };
 export type ShowMusic = { name: string; topic: string; moods?: string[]; genres?: string[]; eras?: ShowEra[]; energies?: string[]; vocals?: string | null; filtersStrict?: boolean };
 
 // One era window as prose ("1990–1999", "1970 onward", "up to 1989").

--- a/controller/src/llm/internal/provider/capabilities.ts
+++ b/controller/src/llm/internal/provider/capabilities.ts
@@ -7,15 +7,13 @@
 // Pure: every function here is a function of the passed `cfg` only — no settings
 // or SDK imports — so the mappings are unit-pinned (controller/scripts/llm-pure.test.ts).
 //
-// Thinking control rides AI SDK 7's top-level `reasoning` call option
-// ('none'|'minimal'|'medium'|…), which each first-party provider — and
-// ai-sdk-ollama v4 — translates to its native knob per call. That replaced the
-// old per-provider providerOptions fragments (thinkingBlock): the SDK NEVER
-// merges the two, and reasoning-related providerOptions silently win over the
-// top-level param, so the fragments had to go entirely when this migrated.
-// Providers with no per-call channel (OpenRouter, and the body-injection
-// openai-compatible/locca path) return undefined here and keep their
-// construction-time wiring in registry.ts.
+// Thinking control rides AI SDK 7's top-level `reasoning` call option, which
+// each first-party provider — and ai-sdk-ollama v4 — translates to its native
+// knob per call. Never mix it with providerOptions: the SDK does NOT merge the
+// two, and reasoning-related providerOptions silently win. Providers with no
+// per-call channel (OpenRouter, and the body-injection openai-compatible/locca
+// path) return undefined here and keep their construction-time wiring in
+// registry.ts.
 
 interface ThinkingArgs {
   modelId: string;
@@ -60,22 +58,21 @@ export interface ProviderCapabilities {
   // forceNoThink opt). Everyone else suppresses per-call and leaves this false.
   reasoningConstructionOnly?: boolean;
   // How many FREE discovery steps the tool-loop agent gets before `done` is
-  // forced (gatedDiscoveryPrepareStep in strategy/agent.ts). Absent → DISCOVERY_STEPS_MIN.
+  // forced (gatedDiscoveryPrepareStep in strategy/agent.ts). Absent →
+  // DISCOVERY_STEPS_MIN.
   //
-  // This is the loop-shape knob, and it is per-provider for the same reason
-  // objectStrategy is: the ceiling that keeps a local GGUF model compliant is
-  // not the ceiling a frontier model needs. The forced-tool providers emit
-  // schema-valid objects WITHOUT exploring and ignore `toolChoice` when several
-  // tools are visible, so they keep the single cornered discovery call that was
-  // the global value. Native-strategy providers honour tool_choice and reason
-  // across results, so they get room to seed, refine, and cross-check.
+  // Per-provider for the same reason objectStrategy is: the ceiling that keeps a
+  // local GGUF model compliant is not the one a frontier model needs. Forced-tool
+  // providers emit schema-valid objects WITHOUT exploring and ignore
+  // `toolChoice` with several tools visible, so they keep a single cornered
+  // discovery call; native-strategy providers get room to seed, refine and
+  // cross-check.
   //
-  // Widening this does NOT widen the number of `done` attempts: the effective
-  // step cap is derived as `discoverySteps + 1`, so the main run always makes
-  // exactly ONE forced-done attempt before handing off to agent.ts's recovery
-  // cascade — which is the invariant the GLM finding in dj-agent/agents.ts
-  // depends on (extra done steps grow an "I already declined" trail and make
-  // compliance worse, so the rescue is recovery, never more steps).
+  // Widening this does NOT widen the number of `done` attempts — the step cap is
+  // derived as `discoverySteps + 1`, so the main run always makes exactly ONE
+  // forced-done attempt before handing off to agent.ts's recovery cascade. Extra
+  // done steps grow an "I already declined" trail and make compliance worse, so
+  // the rescue is recovery, never more steps (see dj-agent/agents.ts).
   discoverySteps?: number;
 }
 

--- a/controller/src/llm/internal/provider/registry.ts
+++ b/controller/src/llm/internal/provider/registry.ts
@@ -94,65 +94,52 @@ export function noThinkFetch(url: any, init: any, baseFetch: any = fetch) {
 // that schema is dropped. We inject them straight into the JSON request body
 // instead (servers ignore keys they don't recognise, same bet the existing
 // chat_template_kwargs injection already makes):
-//   • repeat_penalty — llama.cpp's own default is 1.0 (OFF), so the operator's
-//     configured repetition floor is otherwise never applied and the tool-loop
-//     agent can run away repeating a token block (gist quirk #2). This is the
-//     ONLY path that carries it to the agent/object calls, which never pass
-//     repeat_penalty through providerOptions. `repeat_penalty` is llama.cpp's
-//     param name (vLLM's is `repetition_penalty`); to opt out, set
-//     llm.repeatPenalty to 1.0. We never clobber a value already on the body —
-//     an inert guard in practice, and NOT the reason a configured penalty can
-//     go missing: @ai-sdk/openai has no repeat_penalty field at all, and its
-//     providerOptions schema drops one you try to pass, so the key is only ever
-//     on the body if we put it there. #1327 was reported as this guard firing
-//     against an SDK-supplied 1.0 and was actually settings.load() dropping the
-//     field; check `settings.get().llm.repeatPenalty` before touching the guard.
+//   • repeat_penalty — llama.cpp defaults to 1.0 (OFF), so without this the
+//     operator's configured floor is never applied and the tool-loop agent can
+//     run away repeating a token block. This is the ONLY path that carries it to
+//     the agent/object calls. llama.cpp's param name; vLLM's is
+//     `repetition_penalty`. Set llm.repeatPenalty to 1.0 to opt out. The
+//     never-clobber guard is inert in practice and is NOT how a configured
+//     penalty goes missing — @ai-sdk/openai has no such field and drops it from
+//     providerOptions, so the key is only ever on the body if we put it there.
+//     #1327 looked like this guard and was settings.load() dropping the field;
+//     check `settings.get().llm.repeatPenalty` before touching it.
 //   • reasoning off → enable_thinking:false PLUS reasoning_format PLUS an
-//     OpenRouter-style `reasoning:{enabled:false}` block (see
-//     reasoningMandatoryModel below for the effort:'minimal' exception).
-//     The chat_template_kwargs family is a llama.cpp dialect — an operator
-//     pointing this provider at a CLOUD aggregator (openrouter.ai/api/v1,
-//     or any hosted /v1 that speaks OpenRouter's reasoning extension) gets
-//     no thinking suppression from it at all: measured 57/96 with 16 leaked
-//     cells for qwen3.5-9b via openrouter.ai, vs 86/96 through the native
-//     openrouter provider whose extraBody sends exactly this block. Servers
-//     that don't know the key ignore it — the same bet as every other knob
-//     here. Gemma-4's
-//     chat template pre-seeds an empty <|channel|>thought block even with
-//     enable_thinking:false, and with reasoning_format unset (defaults to none)
-//     llama.cpp routes that thought to `content`, so it leaks into the visible
-//     script and reaches TTS. reasoning_format:"deepseek" routes it to
-//     reasoning_content, which the SDK surfaces as a reasoning part, not text
-//     (gist quirk #4). GLM-family models (Zhipu/Z.ai — including the GLM
-//     Coding Plan's api.z.ai/api/coding/paas/v4 endpoint) ignore
-//     enable_thinking entirely and read a DIFFERENT, top-level `thinking.type`
-//     field instead, so their thinking never actually turned off via the
-//     knobs above alone — the hidden chain-of-thought burned through
-//     maxOutputTokens/step budgets before a forced tool call could land,
-//     surfacing as multi-minute calls or "agent did not call the done tool
-//     before stopping". Send it alongside the others — an unrecognised field
-//     is silently ignored by servers that don't define it, same bet as the
-//     other body-injection knobs here.
+//     OpenRouter-style `reasoning:{enabled:false}` block (reasoningMandatoryModel
+//     below carries the effort:'minimal' exception). All three are needed
+//     because each covers a different server:
+//       - chat_template_kwargs is a llama.cpp dialect and does nothing on a
+//         CLOUD aggregator behind this provider — measured 57/96 with 16 leaked
+//         cells for qwen3.5-9b via openrouter.ai, vs 86/96 through the native
+//         openrouter provider, which sends the `reasoning` block.
+//       - Gemma-4's chat template pre-seeds an empty <|channel|>thought block
+//         even with enable_thinking:false, and with reasoning_format unset
+//         llama.cpp routes that thought to `content`, where it leaks into the
+//         script and reaches TTS. reasoning_format:"deepseek" routes it to
+//         reasoning_content, which the SDK surfaces as a reasoning part.
+//       - GLM-family models (Zhipu/Z.ai) ignore enable_thinking entirely and
+//         read a top-level `thinking.type` instead, so their hidden
+//         chain-of-thought burned through the output/step budget before a forced
+//         tool call could land — multi-minute calls, or "agent did not call the
+//         done tool before stopping".
 //   • parallel_tool_calls:false on tool-bearing requests — absent, llama.cpp
-//     resolves it from the chat template's capability default, which is true
-//     for Gemma-4-family templates; the model then emits several tool calls in
-//     one turn and the peg-gemma4 parser 500s on call #2, failing the whole
-//     pick/segment attempt (issue #940). The agent design is one call per step
-//     (gated discovery, COMMIT_AFTER_STEPS=1), so forcing max one call matches
-//     intent everywhere. Only sent when tools are present — strict servers
-//     reject the field on tool-less requests.
+//     takes the chat template's capability default, true for Gemma-4 templates;
+//     the model then emits several tool calls in one turn and the peg-gemma4
+//     parser 500s on call #2, failing the whole attempt (#940). The agent design
+//     is one call per step anyway. Only sent when tools are present — strict
+//     servers reject the field on tool-less requests.
 //
-// `forceNoThink` suppresses thinking on THIS instance even when the operator
-// left reasoning on: the forced-tool structured-output legs (picker done-tool,
-// objectViaToolCall) run no-think so a reasoning model doesn't burn its whole
-// output budget thinking and then truncate mid-<think> (→ NoObjectGeneratedError
-// on every pick) or fail to emit the forced tool. Unlike Anthropic/DeepSeek
-// (per-call providerOptions) and OpenRouter (construction-time reasoning), the
-// only no-think lever these self-hosted servers have is this body injection, so
-// forceNoThink has to be honoured HERE — a distinct no-think model instance is
-// built for the picker legs (see languageModel's bodyNoThink). Without it a
-// reasoning-on locca/openai-compatible model failed schema validation on picks
-// and looped </think> at handoffs (the free-text signoff path, issue #914).
+// `forceNoThink` suppresses thinking on THIS instance even with reasoning left
+// on: the forced-tool structured-output legs run no-think so a reasoning model
+// doesn't burn its output budget thinking and then truncate mid-<think>
+// (NoObjectGeneratedError on every pick) or fail to emit the forced tool.
+//
+// Body injection is the ONLY no-think lever these self-hosted servers have —
+// unlike Anthropic/DeepSeek (per-call providerOptions) and OpenRouter
+// (construction-time) — so forceNoThink must be honoured here, via a distinct
+// no-think model instance for the picker legs (languageModel's bodyNoThink).
+// Without it a reasoning-on locca/openai-compatible model failed schema
+// validation on picks and looped </think> at handoffs (#914).
 export function openAICompatibleFetch(cfg: any, baseFetch: any = fetch, forceNoThink = false) {
   const penalty = appliedRepeatPenalty(cfg);
   const noThink = forceNoThink || cfg?.reasoning !== true;

--- a/controller/src/llm/internal/speech/cloud-speech.ts
+++ b/controller/src/llm/internal/speech/cloud-speech.ts
@@ -32,22 +32,22 @@ const CLOUD_DEFAULT_MODELS: Record<string, string> = {
 };
 
 // Pure resolution rule for the cloud TTS model a persona will be voiced by,
-// mirroring speak() below plus resolveEngine() in audio/tts.ts: the persona
-// owns the engine when set, otherwise the station defaultEngine speaks; a
-// persona that overrode the provider away from the global one falls back to
-// the new provider's default (openai-compatible has no default so it keeps
-// the global model); a persona voiced by the DEFAULT cloud engine carries no
-// provider override (speakWith only builds cloudOverride for an explicit
-// persona engine === 'cloud'). An unrecognised persona engine string fails
-// closed to '' — resolveEngine would route it to the defaultEngine, but a
-// missing hint is harmless while a wrong one is spoken aloud. Empty string =
-// not voiced by cloud / unresolved — callers treat that as "don't apply
-// model-specific hints". Kept pure and unit-pinned in scripts/llm-pure.test.ts
-// so the "mirror of speak()" claim is testable rather than comment-enforced.
-// Managed legacy inline keys and authenticated compatibility-server bearers
-// occupy separate slots. That provider scoping lets a compat persona keep its
-// credential when the station-wide Cloud provider differs without forwarding
-// an OpenAI/ElevenLabs secret to an arbitrary URL. Fish stays env/secrets-only.
+// mirroring speak() below plus resolveEngine() in audio/tts.ts: the persona owns
+// the engine when set, else the station defaultEngine speaks; a persona that
+// overrode the provider falls back to the new provider's default
+// (openai-compatible has none, so it keeps the global model); a persona voiced
+// by the DEFAULT cloud engine carries no provider override.
+//
+// An unrecognised persona engine fails CLOSED to '' — a missing hint is harmless
+// while a wrong one is spoken aloud. '' also means "not cloud / unresolved", so
+// callers apply no model-specific hints. Pure and unit-pinned in
+// scripts/llm-pure.test.ts, so the "mirror of speak()" claim is testable rather
+// than comment-enforced.
+//
+// Managed legacy inline keys and compatibility-server bearers occupy separate
+// slots, so a compat persona keeps its credential when the station-wide Cloud
+// provider differs, without forwarding an OpenAI/ElevenLabs secret to an
+// arbitrary URL. Fish stays env/secrets-only.
 export function sharedCloudApiKeyForRequest(
   provider: string,
   globalProvider: string,
@@ -238,14 +238,12 @@ function cloudCfg() {
 }
 
 // Merge the operator's extra body fields into the outgoing /audio/speech POST
-// (issue #1317). This has to happen at the fetch layer because the AI SDK's
-// OpenAI speech model builds a CLOSED body — `{model, input, voice,
-// response_format, speed, instructions}` and nothing else. Its
-// `providerOptions.openai` escape hatch is no use either: the schema accepts
-// only `instructions` + `speed`, and in @ai-sdk/openai 4.0.11 the merge loop
-// that would copy them into the body iterates an empty object, so nothing gets
-// through at all. Rewriting the serialized body is the one hook that works
-// without forking the provider.
+// (#1317). It has to happen at the FETCH layer: the AI SDK's OpenAI speech model
+// builds a CLOSED body, and its `providerOptions.openai` hatch is no use either
+// — the schema accepts only `instructions` + `speed`, and in @ai-sdk/openai
+// 4.0.11 the merge loop that would copy them iterates an empty object. Rewriting
+// the serialized body is the one hook that works short of forking the
+// provider.
 //
 // Everything here degrades to a pass-through rather than throwing: a param that
 // doesn't make it costs an un-tuned render, while an exception costs the whole
@@ -366,13 +364,12 @@ export async function speak(
   // sent when it differs from default so default stations are unaffected and
   // providers that ignore the field never see it.
   //
-  // openai-compatible servers NEVER receive `speed` — their implementations
-  // are wildly uneven (issue #942: a Chatterbox shim behind LiteLLM produced
-  // comb-filtered "echo chamber" audio with broken mp3 frame timestamps
-  // whenever `speed` was present, and daypart energy makes it non-unity most
-  // of the day). Instead the server renders at its natural 1x and the rate is
-  // applied locally below via ffmpeg atempo — the slider/persona/daypart knobs
-  // still work (the point of #897), but the fragile server-side path is gone.
+  // openai-compatible servers NEVER receive `speed` — implementations are
+  // wildly uneven (#942: a Chatterbox shim behind LiteLLM produced comb-filtered
+  // "echo chamber" audio with broken mp3 frame timestamps whenever `speed` was
+  // present, and daypart energy makes it non-unity most of the day). The server
+  // renders at 1x and the rate is applied locally via ffmpeg atempo below, so
+  // every knob still works without the fragile server-side path.
   const isCompat = c.provider === 'openai-compatible';
   const speed = clampSpeed(config.tts.cloudSpeed * (speedScale != null ? speedScale : 1), c.provider);
   const stretchLocally = isCompat && speed !== 1.0;

--- a/controller/src/llm/internal/strategy/agent.ts
+++ b/controller/src/llm/internal/strategy/agent.ts
@@ -7,19 +7,16 @@
 //
 // STRATEGY (resolved per leg by agentPlan() below):
 //   1. Native-first (non-Ollama tool-using agents): native Output.object with
-//      AUTO tool_choice. Needs no forced tool_choice, so it sidesteps the whole
-//      "thinking mode does not support this tool_choice" class (Anthropic +
-//      DeepSeek reject forced tools while thinking). Verified 5/5 across openai
-//      (gpt-4.1-mini), anthropic (claude-haiku-4.5), google (gemini-3.5-flash),
-//      openrouter (kimi-k2.6); deepseek needs thinking off (5/5 off vs 1/5 on —
-//      forceNoThink handles it). On any miss it falls through to (2), so worst
-//      case is the prior behaviour, never a regression. Older models still fail
-//      native (gemini-2.5-flash, llama-3.3-70b → 0/n) — the fall-through covers them.
+//      AUTO tool_choice. Forcing nothing sidesteps the whole "thinking mode does
+//      not support this tool_choice" class (Anthropic + DeepSeek reject forced
+//      tools while thinking; deepseek needs thinking off, which forceNoThink
+//      handles). Older models fail native outright (gemini-2.5-flash,
+//      llama-3.3-70b), and any miss falls through to (2), so the worst case is
+//      the prior behaviour rather than a regression.
 //   2. Done-tool (Ollama always; everyone else on a native miss): the forced
 //      tool-calling pattern below. Ollama is excluded from native because its
-//      tool-loop Output.object returns schema-valid-but-EMPTY JSON WITHOUT ever
-//      calling discovery (verified 0/3 on glm-5.1/qwen3.5/nemotron:cloud), so the
-//      done-tool path is the only one that works there.
+//      tool-loop Output.object returns schema-valid but EMPTY JSON without ever
+//      calling discovery, so the done-tool path is the only one that works.
 //
 // The done-tool pattern (the AI SDK's documented "Forced Tool Calling"): a
 // synthetic `done` tool whose inputSchema IS the schema is added alongside the

--- a/controller/src/llm/internal/tools/picker/scope.ts
+++ b/controller/src/llm/internal/tools/picker/scope.ts
@@ -5,17 +5,15 @@
 // from pickViaAgent (broadcast/dj-agent.ts) to the tools as a single
 // `PickerScope` object that is never destructured into fields along the way.
 //
-// That is the fix for a real defect class, not a style preference. The old shape
-// passed ~13 separate keys through an untyped args bag: pickViaAgent listed them,
-// agents.ts re-listed them in a destructure, then re-listed them AGAIN in the
-// buildPickerTools call. A lock named in one list and forgotten in another was
-// not a type error and not a crash — it fell through to a `null` default and that
-// whole dimension silently stopped being enforced on the agent path, while the
-// pool picker still honoured it. The two pick paths then disagreed about the same
-// show, which is precisely what music/show-filter.ts exists to prevent. It
-// happened for real on #1300 FR 13 (vocalLock resolved, passed, dropped by both
-// lists) and needed a source-scraping test to catch, because there was no runtime
-// seam between "passed" and "destructured".
+// That fixes a real defect class, not a style preference. The old shape passed
+// ~13 keys through an untyped args bag, listed three times over (pickViaAgent,
+// agents.ts's destructure, the buildPickerTools call). A lock named in one list
+// and forgotten in another was neither a type error nor a crash — it fell
+// through to a `null` default and that whole dimension silently stopped being
+// enforced on the agent path while the pool picker still honoured it, so the two
+// pick paths disagreed about the same show. That happened for real (#1300 FR 13,
+// vocalLock) and needed a source-scraping test to catch, because there was no
+// runtime seam between "passed" and "destructured".
 //
 // With one object there are no lists to disagree. Adding a lock means adding a
 // field here; nothing downstream re-names it. Do NOT reintroduce a per-field
@@ -263,23 +261,20 @@ export function buildPickerContext(scope: PickerScope): PickerContext {
 
   // Seed-similarity with a cross-index rescue (#1247).
   //
-  // A seed tool that comes back empty is far more expensive than a slow one: on
-  // a forced-tool provider the harness allows exactly ONE discovery call
-  // (discoveryStepsFor, llm/internal/provider/capabilities.ts) and then pins
-  // activeTools to `done`, so an empty result leaves the model cornered with
-  // nothing to commit — and the only real, well-formed track id anywhere in its
-  // context is the on-air seed it was handed to pass in here. Both salvage
-  // stages in pickViaAgent then no-op on an empty `seen` (nearestId has no keys
-  // to match, repickFromSeen returns null on its first line), so the whole run
-  // is discarded to the pool picker.
+  // An empty seed tool is far more expensive than a slow one: on a forced-tool
+  // provider the harness allows exactly ONE discovery call and then pins
+  // activeTools to `done`, so an empty result corners the model with nothing to
+  // commit — and the only real, well-formed track id in its context is the
+  // on-air seed it was handed. Both salvage stages in pickViaAgent then no-op on
+  // an empty `seen`, so the whole run is discarded to the pool picker.
   //
-  // Both indexes answer the same question ("tracks like this seed"), and each is
-  // registered on whether it holds ANY vectors — never on whether it covers THIS
-  // seed. Coverage is routinely partial and uneven (CLAP analysis backfills over
-  // days; the text index needs the tagger to have reached the track), so the
-  // seed falling in the other index's gap is ordinary, not exceptional. When the
-  // index the model reached for doesn't cover the seed, answer from the other one
-  // and SAY so, rather than handing back a result that can only end the run.
+  // Both indexes answer the same question, and each is registered on whether it
+  // holds ANY vectors — never on whether it covers THIS seed. Coverage is
+  // routinely partial and uneven (CLAP backfills over days; the text index needs
+  // the tagger to have reached the track), so the seed falling in the other
+  // index's gap is ordinary. When the index the model reached for doesn't cover
+  // the seed, answer from the other one and SAY so, rather than handing back a
+  // result that can only end the run.
   //
   // Deliberately gated on the primary index returning NOTHING AT ALL (matched
   // === 0 — the seed has no vector there). A primary that DID match but whose

--- a/controller/src/middleware/validate.ts
+++ b/controller/src/middleware/validate.ts
@@ -61,24 +61,20 @@ export function validateBody(schema: ZodType, opts?: ValidateBodyOptions) {
 }
 
 /**
- * Same validation, LISTENER-facing error shape. For public forms only — today
- * that is POST /request and nothing else.
+ * Same validation, LISTENER-facing error shape. Public forms only — today that
+ * is POST /request and nothing else. Two differences from validateBody, both
+ * because the reader is a listener looking at a request box rather than an
+ * operator looking at an admin form:
  *
- * Two differences from validateBody, both because the reader is a listener
- * looking at a request box in a player skin rather than an operator looking at
- * an admin form:
- *
- *  - **No dotted-path prefix.** `firstMessage` prefixes unconditionally, which
- *    is right when the operator has to find `webhooks.1.url` among nine rows,
- *    and wrong when the string is rendered on its own: "text: Keep it under 280
- *    characters." reads as a bug to a listener. The schema's messages are
- *    already written to stand alone.
- *  - **`success: false` and `message` ride along.** The web player runs the
- *    mirrored schema as a pre-flight and never meets this 400 at all, but the
- *    native app posts /request directly and reads `data.message` on a failure.
- *    It ships through the app stores, so it cannot be updated in lockstep with
- *    the controller — an already-installed build meeting a new refusal has to
- *    have something to render, or the drawer shows an empty failure card.
+ *  - **No dotted-path prefix.** `firstMessage` prefixes unconditionally, right
+ *    when the operator has to find `webhooks.1.url` among nine rows and wrong
+ *    when the string stands alone: "text: Keep it under 280 characters." reads
+ *    as a bug to a listener.
+ *  - **`success: false` and `message` ride along.** The web player pre-flights
+ *    the mirrored schema and never meets this 400, but the native app posts
+ *    /request directly and reads `data.message`. It ships through the app
+ *    stores, so an already-installed build meeting a new refusal must have
+ *    something to render or the drawer shows an empty failure card.
  */
 export function validatePublicBody(schema: ZodType) {
   return (req: Request, res: Response, next: NextFunction) => {

--- a/controller/src/music/analyze-capability.ts
+++ b/controller/src/music/analyze-capability.ts
@@ -20,14 +20,14 @@
 // The messages ARE the contract here: this is the only place an operator with a
 // broken analyzer finds out what broke.
 
-export type AnalysisDimension = 'audio' | 'vocal' | 'stem';
+type AnalysisDimension = 'audio' | 'vocal' | 'stem';
 
 // Which backend is answering, so the retry advice names something that exists.
 // 'sidecar' has an analyzer container to restart; 'local' (a librosa venv, and
 // every AIO image) runs the worker as a child of the controller, so restarting
 // "the analyzer" is either impossible or a no-op there — the latch lives in the
 // controller process and goes when that does.
-export type AnalysisBackend = 'sidecar' | 'local' | string | null;
+type AnalysisBackend = 'sidecar' | 'local' | string | null;
 
 export interface CapabilityInputs {
   dimension: AnalysisDimension;

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -274,25 +274,20 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     : db.needsAnalysisIds(cap);
   let ids = bpmIds;
 
-  // Audio backfill: also target already-analysed tracks that lack a CLAP audio
-  // vector, so enabling embeddings on a previously-analysed library fills it in
-  // without a full --re-analyze. Re-running analysis on these recomputes bpm/key
-  // (same values, harmless) and stores the new audio vector from the same call.
-  // `audioBackfill` stays the "CLAP wanted + producible" signal (drives the
-  // per-track embed flag below); the widening is gated separately on
-  // !reAnalyzeScope. A re-scan re-analyse already has a FIXED scope (the
-  // previously-analysed set) and re-embeds CLAP for those via embed:true — so it
-  // must NOT widen, or it'd pull the whole library back in (every track looks
-  // vector-less right after the clear).
-  // ...and ONLY when the backend can actually emit CLAP vectors. A backend that
-  // can't never fills the vector column, so widening would re-analyse every
-  // already-analysed track on every run for a guaranteed no-vector — the same
-  // churn the vocal gate below prevents. The `false` there used to mean exactly
-  // one thing (a lean image) and got exactly one message; a heavy image whose
-  // weights fail to DOWNLOAD lands on the same false and needs the opposite
-  // advice, so both the gate and its wording now come from the pure
-  // backfillDecision (analyze-capability.ts). `null` (local backend / not yet
-  // probed) still widens — unknown is not a no.
+  // Audio backfill: also target already-analysed tracks lacking a CLAP vector,
+  // so enabling embeddings on an analysed library fills in without a full
+  // --re-analyze. Re-running recomputes bpm/key (same values, harmless) and
+  // stores the vector from the same call.
+  //
+  // Two gates, both narrow. NOT under a fixed re-scan scope: that already covers
+  // the previously-analysed set and re-embeds via embed:true, so widening would
+  // drag the whole library back in (every track looks vector-less right after
+  // the clear). And ONLY when the backend can actually emit CLAP vectors — one
+  // that can't never fills the column, so widening re-analyses everything on
+  // every run for a guaranteed no-vector. `false` covers two opposite causes (a
+  // lean image vs a heavy image whose weights failed to download), so the gate
+  // AND its wording come from the pure backfillDecision (analyze-capability.ts).
+  // `null` (local backend / not yet probed) still widens — unknown is not a no.
   const audioWanted = opts.audioBackfill ?? audioBackfillDefault();
   const audioDecision = backfillDecision({
     dimension: 'audio',
@@ -315,25 +310,23 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     logEvent(analyzer.audioEmbeddingError() ? 'warning' : 'info', audioDecision.notice);
   }
 
-  // Vocal backfill: same idea for tracks missing vocal-activity ranges. The
-  // Demucs separation is the expensive part, so this only widens the scope when
-  // the operator opted in (env/admin toggle); the `vocal:true` flag below then
-  // forces the backend to run it for this pass.
-  // ...but ONLY when the backend can actually produce vocal ranges. A sidecar
-  // built without Demucs (WITH_DEMUCS=0) reports vocalActivityAvailable()===false;
-  // its vocal column then stays NULL forever, so backfilling would re-scan the
-  // WHOLE library on every run for a guaranteed no-op (the churn behind the
-  // "275/7093" report). `false` = definitively not built → skip; `null` (local
-  // backend / not yet probed) keeps today's behaviour. isAvailable() above has
-  // already probed the sidecar, so the capability is current here.
-  // (vocalWanted / vocalBackfill resolved up front — see the clear above.)
-  // Widening is suppressed under a fixed re-scan scope for the same reason as
-  // audio above; the per-track vocal:true flag below still re-runs Demucs for the
-  // in-scope tracks, so vocal ranges are rebuilt without dragging in the remainder.
-  // Tail widening (feature: vocal-aware transitions): also re-target tracks
-  // whose outro predates tail vocal detection — ONLY when the backend
-  // advertises the capability (=== true). Old sidecars never report the flag,
-  // so a stale image keeps the original head-only scope and can't churn.
+  // Vocal backfill: same idea for tracks missing vocal-activity ranges. Demucs
+  // separation is the expensive part, so the scope widens only when the operator
+  // opted in; the `vocal:true` flag below then forces the backend to run it.
+  //
+  // Same two gates as audio above. ONLY when the backend can produce vocal
+  // ranges: a sidecar built without Demucs reports
+  // vocalActivityAvailable()===false and its vocal column stays NULL forever, so
+  // backfilling would re-scan the WHOLE library every run for a guaranteed no-op
+  // (the churn behind the "275/7093" report). `false` = definitively not built,
+  // `null` = unknown and keeps today's behaviour; isAvailable() above has already
+  // probed, so the capability is current here. And suppressed under a fixed
+  // re-scan scope, where the per-track vocal:true flag still rebuilds ranges for
+  // the in-scope tracks without dragging in the remainder.
+  //
+  // Tail widening also re-targets tracks whose outro predates tail vocal
+  // detection — ONLY on an explicit `=== true` capability, since old sidecars
+  // never report the flag and a stale image must keep the head-only scope.
   const includeTailMissing = analyzer.tailVocalAvailable() === true;
   if (vocalBackfill && !reAnalyzeScope) {
     const seen = new Set(ids);
@@ -350,34 +343,27 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     logEvent(analyzer.vocalActivityError() ? 'warning' : 'info', vocalDecision.notice);
   }
 
-  // Stem backfill: the fourth widening (after CLAP vectors, vocal ranges and
-  // the tail-vocal re-target), for tracks that have never had a stem
-  // pass. Without it, turning the stem cache on did NOTHING to an
-  // already-analysed library — the scope above only re-targets missing CLAP
-  // vectors and missing vocal ranges, so a fully-scanned library reported
-  // "all tracks current" and the operator's only route was a --re-analyze
-  // that wipes every vector and can't resume across runs.
+  // Stem backfill: the fourth widening, for tracks that never had a stem pass.
+  // Without it, turning the stem cache on did nothing to an already-analysed
+  // library — it reported "all tracks current" and the only route was a
+  // --re-analyze that wipes every vector and can't resume.
   //
-  // `stemCache` already carries the capability gate (Demucs present), the same
-  // guard the vocal widening needs to avoid re-scanning the library forever for
-  // a guaranteed no-op. Suppressed under a fixed re-scan scope for the same
-  // reason as the other two: those tracks re-separate anyway via stems_dir.
+  // `stemCache` already carries the Demucs capability gate. Suppressed under a
+  // fixed re-scan scope like the other widenings: those tracks re-separate
+  // anyway via stems_dir.
   //
-  // Capped at what the budget can still hold. The stem set for a track is a
-  // full Demucs separation; queuing thousands the LRU sweep will evict on the
-  // way out is hours of GPU time thrown away, and it's why a big library
-  // looked like it "only ever caches the last 600 songs". The cap is announced
-  // — a silent truncation would read as "the backfill finished".
+  // Capped at what the budget can still hold, and the cap is ANNOUNCED — a stem
+  // set is a full Demucs separation, so queuing thousands the LRU sweep will
+  // evict is hours of GPU time thrown away, and a silent truncation would read
+  // as "the backfill finished".
   //
-  // The same headroom figure then gates EVERY stem write in the loop below
-  // (#1257): stems ride along with any analysis when the cache is on, and the
-  // ride-alongs used to bypass this cap entirely — a vocal backfill over a big
-  // library grew a 500 GB budget to 674 GB with the backfill happily reporting
-  // "skipped — cache is at budget" the whole time. One figure per pass:
-  // stemSlotsLeft is decremented per NET-NEW dir requested (a rewrite of an
-  // existing dir costs nothing — see stemCacheStore.stemWriteDecision), so the
-  // pass can overshoot by at most the estimate's error before the sweep
-  // settles the bill.
+  // The same headroom figure gates EVERY stem write in the loop below (#1257):
+  // stems ride along with any analysis when the cache is on, and those
+  // ride-alongs used to bypass the cap entirely — a vocal backfill grew a 500 GB
+  // budget to 674 GB while reporting "skipped — cache is at budget" throughout.
+  // One figure per pass, decremented per NET-NEW dir (a rewrite of an existing
+  // dir is free — see stemCacheStore.stemWriteDecision), so the pass overshoots
+  // by at most the estimate's error before the sweep settles the bill.
   let stemSlotsLeft = 0;
   let existingStemDirs: Set<string> = new Set();
   if (stemCache) {
@@ -687,26 +673,23 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     } catch (err: any) {
       failed += 1;
       consecutiveFailures += 1;
-      // The analysis columns stay NULL so the next run retries — but record
-      // WHY, and count it. Without the stamp a permanently unanalysable track
-      // (a corrupt file, a library row whose file is gone) is indistinguishable
-      // from one that has never been attempted, so it re-enters the scope on
-      // every pass forever and nothing anywhere can name it. After
-      // MAX_ANALYSIS_FAILURES consecutive failures the exclusion in the scope
-      // queries drops it, and the admin list is where it goes to be seen.
+      // The analysis columns stay NULL so the next run retries — but record WHY
+      // and count it. Without the stamp a permanently unanalysable track (a
+      // corrupt file, a row whose file is gone) is indistinguishable from one
+      // never attempted, so it re-enters the scope forever and nothing can name
+      // it. After MAX_ANALYSIS_FAILURES the scope queries exclude it and the
+      // admin list is where it goes to be seen.
       //
-      // ...but ONLY while the throw is evidence about the file. Past a run of
-      // SYSTEMIC_FAILURE_RUN with no success in between, the shared cause is
-      // the pass, not the track — Navidrome gone (isAvailable() gates the pass
-      // on the ANALYZER being up, never on the music backend), the sidecar
-      // dying mid-run, a mount that went away — and counting those would
-      // sentence up to a whole batch to the exclusion list over three such
-      // passes, recoverable only by hand. Which is why stamps are BUFFERED
-      // (pendingFailureStamps) rather than written here: a persistent outage
-      // used to still stamp the five tracks in front of the guard on every
-      // pass, sentencing the scope in id order five tracks per three passes —
-      // and an excluded track can't self-heal, because the success that would
-      // clear its count is exactly what exclusion prevents.
+      // Only counted while the throw is evidence about the FILE. Past
+      // SYSTEMIC_FAILURE_RUN with no success in between the cause is the pass,
+      // not the track — Navidrome gone (isAvailable() gates on the ANALYZER
+      // being up, never the music backend), the sidecar dying, a mount that went
+      // away — and counting those would sentence a whole batch to the exclusion
+      // list over three passes, recoverable only by hand. Hence stamps are
+      // BUFFERED (pendingFailureStamps): writing them here still condemned the
+      // five tracks in front of the guard on every pass, and an excluded track
+      // can't self-heal, because the success that would clear its count is
+      // exactly what exclusion prevents.
       const reason = String(err?.message || err);
       console.error(`[analyze] ${id} failed: ${reason}`);
       if (failureCountsAgainstTrack(consecutiveFailures)) {

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -761,16 +761,13 @@ function isTimeoutError(err: unknown): boolean {
 // their non-text behaviour, never throw. `timeoutMs` lets interactive callers
 // (a picker tool mid-pick) use a shorter deadline than a bulk pass.
 //
-// One retry on TIMEOUT only: since the idle model release also runs on CPU
-// (#1204), an interactive call can land on a cold worker whose CLAP reload
-// (seconds on a typical box, longer on the small hosts the release exists
-// for) eats the whole deadline. The backend keeps loading after we stop
-// waiting — the request is already queued behind its single-flight lock — so
-// a second wait usually lands on a warm model instead of failing the search.
-// Non-timeout failures (refused, 404, 500) stay single-shot: they're fast,
-// definitive "not available" signals. Bulk callers whose deadline is already
-// generous pass `coldRetry: false` — a 10-minute timeout means real trouble,
-// not a cold model.
+// One retry on TIMEOUT only: with the idle model release (#1204) an interactive
+// call can land on a cold worker whose CLAP reload eats the whole deadline. The
+// backend keeps loading after we stop waiting — the request is already queued
+// behind its single-flight lock — so a second wait usually lands on a warm
+// model. Non-timeout failures (refused, 404, 500) stay single-shot: fast,
+// definitive "not available" signals. Bulk callers pass `coldRetry: false` —
+// a 10-minute timeout means real trouble, not a cold model.
 export async function embedTexts(
   texts: string[],
   opts: { timeoutMs?: number; coldRetry?: boolean } = {},

--- a/controller/src/music/blocklist.ts
+++ b/controller/src/music/blocklist.ts
@@ -2,29 +2,26 @@
 // track/album/artist granularity, persisted to <stateDir>/blocklist.json
 // (sibling to schedule.json; deliberately NOT in library.db so Library →
 // Reset/Reconcile can't wipe it). Enforced through isBlocked() at the subsonic
-// reject chokepoint, the library-db song sources, and the final queue.push()
-// gate — see docs/superpowers/specs/2026-07-12-never-play-blocklist-design.md.
+// reject chokepoint, the library-db song sources, and the final queue.push() gate.
 //
 // matchOf() is the one matcher; isBlocked() is a predicate over it. The admin
 // listing surfaces use annotate() instead of rejectBlocked(), so the operator
-// can SEE a blocked track (and which entry blocks it) rather than wondering
-// why one of two identical songs never airs — see
-// docs/superpowers/specs/2026-08-01-never-play-visibility-design.md.
+// can SEE a blocked track and which entry blocks it, rather than wondering why
+// one of two identical songs never airs.
 //
 // Matching is id-first (song.id / albumId / artistId), with a normalised-name
 // fallback for album/artist entries because library-db rows carry only name
 // strings — without it an artist block would leak through the mood/vector
 // sources. Track entries never name-match (covers/re-recordings share titles).
 //
-// RULE entries (#1300 FR 1, closes #752) live beside the id entries in the
-// same file: attribute/tag predicates ("anything tagged christmas"), optional
-// seasonal allow-window, optional show scope — see
-// docs/superpowers/specs/2026-08-05-exclusion-rules-design.md. Pure matching
-// lives in blocklist-rules.ts; this module owns state, persistence, and the
-// evaluation context (station-zone clock, active show, playlist member sets).
-// Because every song source already flows through rejectBlocked/isBlocked,
-// rules are enforced at every chokepoint the id entries cover, with zero new
-// enforcement sites. hitOf() is the one entries-then-rules answer.
+// RULE entries (#1300 FR 1, closes #752) live beside the id entries in the same
+// file: attribute/tag predicates ("anything tagged christmas"), an optional
+// seasonal allow-window, an optional show scope. Pure matching lives in
+// blocklist-rules.ts; this module owns state, persistence, and the evaluation
+// context (station-zone clock, active show, playlist member sets). Since every
+// song source already flows through rejectBlocked/isBlocked, rules are enforced
+// at every chokepoint the id entries cover with zero new enforcement sites.
+// hitOf() is the one entries-then-rules answer.
 import { config } from '../config.js';
 import { readFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
@@ -146,12 +143,6 @@ function activeCompiledRules(): CompiledRule[] {
   ruleCtxCache = { at: now, active };
   maybeRefreshPlaylistMembers();
   return active;
-}
-
-// Test seam + rule-mutation hook: drop the memo so the next evaluation
-// re-reads the clock and show.
-export function invalidateRuleContext() {
-  ruleCtxCache = null;
 }
 
 // ── Playlist member sets (field: 'playlist' rules) ──────────────────────────

--- a/controller/src/music/embeddings.ts
+++ b/controller/src/music/embeddings.ts
@@ -298,24 +298,19 @@ export function resolveIndexTextMode(
   return preferredTextMode();
 }
 
-// What text format the index as a whole should be RECORDED as, given what's
-// already in it (#1246). Mirrors resolveIndexTextMode above, and answers a
-// question with the same shape: the meta row describes the vectors that exist,
-// not the recipe the current build happens to use.
+// What text format the index should be RECORDED as, given what's already in it
+// (#1246). The meta row describes the vectors that EXIST, not the recipe this
+// build happens to use — same shape as resolveIndexTextMode above.
 //
-// A normal forward run embeds only tracks that have no vector yet, so an
-// existing index becomes a MIX — old rows at the stored format, new rows at the
-// current one. Recording the current version there would erase the only signal
-// that a re-embed is worth running, so the stored (older) format wins and the
-// advisory stays up until a reseed genuinely rebuilds everything. An empty
-// index has nothing to be inconsistent with, so it adopts the current format —
-// which is why a fresh install never sees the advisory at all.
+// A forward run embeds only vectorless tracks, so the index becomes a MIX. The
+// stored (older) format therefore wins: recording the current one would erase
+// the only signal that a re-embed is worth running. An empty index has nothing
+// to be inconsistent with and adopts the current format, which is why a fresh
+// install never sees the advisory.
 //
-// A stored format NEWER than this build (a downgraded controller) clamps to
-// this build's version for the same mixed-index reason: this run embeds any
-// new vectors at ITS shape, so the oldest shape now present is its own — and
-// recording it means the newer controller, once restored, sees the mix and
-// raises the advisory again.
+// A stored format NEWER than this build (a downgraded controller) clamps down
+// for the same reason — this run embeds at ITS shape, so the oldest shape now
+// present is its own, and the newer controller sees the mix once restored.
 //
 // `reseed` is the one case that rewrites every vector, so it always adopts.
 export function resolveIndexTextFormat(
@@ -373,7 +368,7 @@ export async function embedQueryText(
 // instead of a Node stack trace. Issue #174.
 // ---------------------------------------------------------------------------
 
-export type ProbeCode =
+type ProbeCode =
   | 'ok'
   | 'disabled'
   | 'not_found'           // Ollama 404 — model isn't pulled

--- a/controller/src/music/library-db/queries.ts
+++ b/controller/src/music/library-db/queries.ts
@@ -175,11 +175,10 @@ export function trackIdsByGenreDecade(): Map<string, string[]> {
 
 // ---------------------------------------------------------------------------
 // Per-genre embedding centroids — the mean text-embedding vector across every
-// tagged+embedded track in each genre. Powers the genre-cloud 2D projection
-// (music/genre-cloud.ts): semantically similar genres land near each other.
-// One streaming SQL join so a multi-thousand-track library stays light on
-// memory — vectors are accumulated into per-genre running sums, never all held
-// at once.
+// tagged+embedded track in each genre, so semantically similar genres land near
+// each other. Consumed by music/genre-suggest.ts. One streaming SQL join keeps a
+// multi-thousand-track library light on memory — vectors accumulate into
+// per-genre running sums rather than all being held at once.
 // ---------------------------------------------------------------------------
 export function genreCentroids(): Array<{ genre: string; count: number; centroid: Float32Array }> {
   // json_each over the multi-genre array: a Hip-Hop + Rap track contributes

--- a/controller/src/music/library-db/schema.ts
+++ b/controller/src/music/library-db/schema.ts
@@ -362,12 +362,10 @@ export async function migrate(embeddingDim: number, reseed = false, adoptStoredD
     //
     // A track whose analysis throws — a corrupt file, a stale library row, a
     // container the decoder can't open — leaves every analysis column NULL,
-    // which is byte-identical to "never attempted". needsAnalysisIds therefore
-    // re-targets it on every pass, forever, and nothing anywhere records that
-    // it has already failed forty times or why. That is the second half of the
-    // "same count every run" report: the first half is a capability the backend
-    // lied about, and this is a file that will never analyse no matter who is
-    // asking.
+    // indistinguishable from "never attempted". needsAnalysisIds then re-targets
+    // it on every pass forever, and nothing records that it has already failed
+    // forty times or why. That is half the "same count every run" report; the
+    // other half is a capability the backend lied about.
     //
     // Three columns because the three questions are different: how many
     // consecutive failures (the scope gate), when the last one was (is this

--- a/controller/src/music/lyric-vocal.ts
+++ b/controller/src/music/lyric-vocal.ts
@@ -15,7 +15,7 @@
 //
 // Pure + side-effect-free: unit-pinned by scripts/lyric-vocal.test.ts.
 
-export interface LyricLine {
+interface LyricLine {
   startMs: number; // milliseconds from track start; NaN when unsynced
   text: string;
 }

--- a/controller/src/music/mix.ts
+++ b/controller/src/music/mix.ts
@@ -301,27 +301,26 @@ export function crossSecondsFor(
 
 // --- Ending-aware exit canvas (feature: outro analysis) ---------------------
 // Canvas for a track's OWN exit, sized by its measured ENDING. Unlike the
-// pair-sized crossSecondsFor above — which can't be applied (#749: a track's
-// liq_cross_duration governs its own end, and its successor is unknown when it
-// is annotated) — the ending is a property of the track alone, so this CAN be
-// stamped correctly at annotation time. A measured fade earns a long canvas
-// that rides the wind-down out under whatever follows; a cold end cuts tight
-// (the short cross IS the intent — stretching a hard ending smears it).
-// Returns null when the ending is unknown, so the caller leaves crossSec unset
-// and Liquidsoap keeps the operator's default — today's behaviour.
+// pair-sized crossSecondsFor above — which cannot be applied at annotation time
+// (#749: liq_cross_duration governs the stamped track's own end, and its
+// successor is unknown then) — the ending is a property of the track alone, so
+// this CAN be stamped correctly. A measured fade earns a long canvas that rides
+// the wind-down out under whatever follows; a cold end cuts tight, because the
+// short cross IS the intent and stretching a hard ending smears it. Null when
+// the ending is unknown, so the caller leaves crossSec unset and Liquidsoap
+// keeps the operator's default.
 //
-// `windDownSec` is the measured wind-down length (duration − outro.startMs);
-// a fade's canvas spans it (clamped 8..12 so the wash stays broadcast-shaped).
-// Bar-snapped to the track's own tempo like the other canvases — prefer the
-// TAIL tempo (outro.bpm) in `a` when the caller has it; outros drift.
+// `windDownSec` is the measured wind-down (duration − outro.startMs); a fade's
+// canvas spans it, clamped 8..12 so the wash stays broadcast-shaped, and
+// bar-snapped to the TAIL tempo (outro.bpm) where the caller has it — outros
+// drift.
 //
-// Tail-loudness shaping (feature: outro analysis): how far the tail actually
-// drops below the track's body decides how much of the wind-down deserves the
-// overlap. Below this drop the "fade" barely recedes — a full-length overlap
-// doubles two near-full-level tracks — so the canvas trims toward its 8s
-// floor; at or past FADE_DROP_DEEP_DB it's a true fade and keeps the full
-// wind-down ride. Linear in between. Needs BOTH the tail and body LUFS
-// (opts.tailLufs / opts.bodyLufs) — either missing → no shaping.
+// Tail-loudness shaping: how far the tail drops below the body decides how much
+// of the wind-down deserves overlap. Below the drop the "fade" barely recedes
+// and a full-length overlap would double two near-full-level tracks, so the
+// canvas trims toward its 8s floor; at or past FADE_DROP_DEEP_DB it is a true
+// fade and keeps the full ride. Linear in between. Needs BOTH tailLufs and
+// bodyLufs — either missing → no shaping.
 export const FADE_DROP_SHALLOW_DB = 3;
 export const FADE_DROP_DEEP_DB = 12;
 
@@ -463,19 +462,21 @@ export function loopCrossSecondsFor(a: Analysis, maxSec: number | null = null): 
   return Math.round(secs * 10) / 10;
 }
 
-// The LLM proposes, the data disposes. A sweep is the move that hides a seam —
-// between tempo/key-locked tracks a tight beat-blend is better and a filter
-// ride reads as gratuitous — so it only survives a real clash. Un-analysed
-// tracks pass (the data can't contradict the DJ). Washout is an editorial
-// "close the chapter" gesture, not a compatibility repair: always allowed —
-// the caller's cooldown rations it.
+// The LLM proposes, the data disposes. A sweep hides a seam, so it survives only
+// a real clash — between tempo/key-locked tracks a tight beat-blend is better
+// and a filter ride reads as gratuitous. Un-analysed tracks pass, since the data
+// can't contradict the DJ. Washout is an editorial "close the chapter" gesture
+// rather than a compatibility repair, so it is always allowed and the caller's
+// cooldown rations it.
 //
-// The effects map onto a small grid: blend = the rhythmic move for COMPATIBLE
-// pairs, washout = the rhythmic exit (always allowed), sweep = the dramatic
-// textural move across a clash, dissolve = the smooth textural move across a
-// clash (the reverb wash — hides the seam the sweep would announce), chop =
-// the percussive move across a clash (the crossfader cut — announces the seam
-// on the beat instead of choking it like the sweep).
+// The effects map onto a small grid:
+//   blend    rhythmic, for COMPATIBLE pairs
+//   washout  rhythmic exit (always allowed)
+//   sweep    dramatic textural move across a clash
+//   dissolve smooth textural move across a clash — the reverb wash, hiding the
+//            seam the sweep would announce
+//   chop     percussive move across a clash — the crossfader cut, announcing the
+//            seam on the beat instead of choking it like the sweep
 export function effectAllowedFor(kind: 'sweep' | 'washout' | 'blend' | 'dissolve' | 'chop' | 'loop', cur: Analysis, next: Analysis): boolean {
   if (kind === 'washout') return true;
   // loop (exit loop) is editorial like the washout — an intentful way to

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -249,22 +249,20 @@ function sampleFresh(items: Candidate[], recentIds: Set<string>, cap: number): C
 // The DEDICATED SHOW sources (show-genre, show-playlist) keep the never-starve
 // that sampleFresh drops, because zero from them does not mean the same thing.
 //
-// A discovery source contributing nothing simply removes itself from the pool
-// and the other sources carry the pick. These two are the pool's only in-filter
-// contributors, and the STRICT end-filters below never-starve on an empty
-// result — `if (inPl.length) selectionPool = inPl` keeps the FULL pool when no
-// playlist track survived, and applyStrictLocks(starve:false) skips a dimension
-// with zero matches. So a show pinned to a 40-track playlist whose tracks are
-// all inside the (now library-scaled, up to 36 h) recency window contributes
-// nothing here and the strict show is then handed nothing BUT off-playlist
-// discovery candidates — the exact opposite of what the lock is for. Same path
-// for a strict-genre show and the genre dimension.
+// A discovery source contributing nothing just removes itself and the others
+// carry the pick. These two are the pool's only in-filter contributors, and the
+// STRICT end-filters never-starve on an empty result — `if (inPl.length)` keeps
+// the FULL pool when no playlist track survived, and applyStrictLocks(starve:
+// false) skips a dimension with zero matches. So a show pinned to a 40-track
+// playlist whose tracks all sit inside the recency window would contribute
+// nothing here and then be handed nothing BUT off-playlist candidates: the exact
+// opposite of what the lock is for. Same path for a strict-genre show.
 //
-// Recency still wins whenever anything fresh exists; the fallback only fires
-// when the alternative is abandoning the show's own universe. The hard
-// no-repeat guard (hardRecentIds/hardRecentKeys) is applied later by
-// filterPickerCandidates and is NOT relaxed here, so a track that just aired
-// still cannot come back — this only re-admits the softer time-window set.
+// Recency still wins whenever anything fresh exists; this fires only when the
+// alternative is abandoning the show's own universe. The HARD no-repeat guard is
+// applied later by filterPickerCandidates and is not relaxed here, so a track
+// that just aired still cannot come back — only the softer time-window set is
+// re-admitted.
 function sampleShowSource(items: Candidate[], recentIds: Set<string>, cap: number): Candidate[] {
   const fresh = items.filter(notRecent(recentIds));
   return (fresh.length > 0 ? fresh : items).slice(0, cap);
@@ -628,21 +626,20 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   }
 
   // 7. Exploration slot — ALWAYS contributes, unlike the thin-pool fallback
-  // below (which never fires while a track is on air: source 1 alone clears
-  // its <8 gate, so the old pool contained zero Navidrome randomness in the
-  // common case). A small server-random sample, freshness-ordered
-  // (music/airing.ts) so never-aired tracks lead, is the pool's only
-  // library-wide draw that isn't anchored on the current track or a frozen
-  // album window — without it every source is a similarity neighbourhood or a
-  // fixed crate and the pool can never leave the bubble it is in.
+  // below, which never fires while a track is on air (source 1 alone clears its
+  // <8 gate, so the pool held zero Navidrome randomness in the common case). A
+  // small server-random sample, freshness-ordered so never-aired tracks lead, is
+  // the pool's only library-wide draw not anchored on the current track or a
+  // frozen album window — without it every source is a similarity neighbourhood
+  // or a fixed crate and the pool can never leave its bubble.
   //
   // Skipped for a strict-playlist show, mirroring the coast's identical source
-  // (scheduler.ts §2b — keep the two in step): a library-wide random draw
-  // can't be playlist-filtered, so every track it contributes is either
-  // discarded by the strict end-filter below — a wasted Navidrome round trip on
-  // every pick — or, on the never-starve branch, becomes a live OFF-playlist
-  // candidate for the LLM. Strict GENRE shows keep it: lean() filters it
-  // server-agnostically on the way in, so it still lands in-genre.
+  // (scheduler.ts §2b — keep the two in step): a library-wide random draw can't
+  // be playlist-filtered, so every track it contributes is either discarded by
+  // the strict end-filter (a wasted round trip per pick) or, on the never-starve
+  // branch, becomes a live OFF-playlist candidate for the LLM. Strict GENRE
+  // shows keep it — lean() filters it on the way in, so it still lands
+  // in-genre.
   if (!strictPlaylist) {
     try {
       const wide = await subsonic.getRandomSongs({ size: 12 });

--- a/controller/src/music/playlist-jobs.ts
+++ b/controller/src/music/playlist-jobs.ts
@@ -15,7 +15,7 @@
 import { randomUUID } from 'node:crypto';
 import type { GenerateResult } from './playlist-gen.js';
 
-export type JobStatus = 'running' | 'done' | 'error';
+type JobStatus = 'running' | 'done' | 'error';
 
 export interface GenerateJob {
   id: string;

--- a/controller/src/music/recency.ts
+++ b/controller/src/music/recency.ts
@@ -28,7 +28,7 @@ export interface CandidateLike {
   durationSec?: number | null;
 }
 
-export interface CandidateFilterState {
+interface CandidateFilterState {
   recentIds?: Set<string>;
   recentKeys?: Set<string>;
   recentArtists?: Set<string>;
@@ -96,23 +96,21 @@ const JOIN_SPLIT = /\s+(?:&|\+|and)\s+/i;
 //   "Kanye West (feat. Jay-Z)"     → "kanye west"
 //   "Sly & the Family Stone"       → "sly & the family stone"   (unchanged)
 //
-// The `the …` exception on the join is what keeps band names whole: "X & the
-// Y" / "X and the Y" is one act, not two credits, and stripping it would key
-// half the Motown and soul bench onto a first name. Everything else after a
-// join is treated as a second credited act — imperfect on "Hall & Oates"-shaped
-// duos (keyed "hall"), but a wrong key here can only over-match, and every
-// caller reads an over-match as "pick someone else", never as a hard drop.
+// The `the …` exception on the join keeps band names whole: "X & the Y" is one
+// act, not two credits, and stripping it would key half the Motown and soul
+// bench onto a first name. Everything else after a join is a second credited act
+// — imperfect on "Hall & Oates"-shaped duos (keyed "hall"), but a wrong key here
+// can only over-match, and every caller reads an over-match as "pick someone
+// else", never as a hard drop.
 //
-// Only the LEAD is normalised: "Tammi Terrell" and "Marvin Gaye & Tammi
+// Only the LEAD is normalised, so "Tammi Terrell" and "Marvin Gaye & Tammi
 // Terrell" still key apart. Matching every credited act would need the same
-// name-vs-credit judgement on the tail that the `the …` exception exists to
-// dodge, and the guard's whole job is the artist a listener just heard fronting
-// a track.
+// name-vs-credit judgement on the tail that the exception exists to dodge, and
+// the guard's job is the artist a listener just heard fronting a track.
 //
-// NOT a replacement for `artistKey`: that one is an identity key (it feeds
-// `trackKey`, which must stay byte-identical to the `title|artist` keys
-// queue.recentlyPlayed builds from raw tag text). This one is a MATCHING key,
-// for "is this the same act as the one that just played".
+// NOT a replacement for `artistKey`, which is an IDENTITY key feeding
+// `trackKey` and must stay byte-identical to the `title|artist` keys
+// queue.recentlyPlayed builds from raw tag text. This is a MATCHING key.
 export function artistRootKey(song: CandidateLike | string): string {
   const raw = typeof song === 'string' ? song : (song?.artist || '');
   const base = raw.toLowerCase().trim();

--- a/controller/src/music/show-filter.ts
+++ b/controller/src/music/show-filter.ts
@@ -105,11 +105,10 @@ function tagCoversGenre(tag: string, target: string): boolean {
 //   show "Pop Punk"  ← track "Pop"                ✗ broader than asked
 //   show "Rap"       ← track "Trap"               ✗ not a word boundary
 //
-// Matching the reverse way too (a track tag that merely CONTAINS the show's
-// genre as a substring) is what let strict emo / pop-punk shows fill up with
-// anything tagged plain "Pop" or "Rock", and unbounded substrings pulled Trap
-// into a Rap show. Both directions were deliberate once; neither survives
-// contact with a strict show.
+// Do NOT reintroduce the reverse direction: matching a track tag that merely
+// CONTAINS the show's genre let strict emo / pop-punk shows fill with anything
+// tagged plain "Pop" or "Rock", and unbounded substrings pulled Trap into a Rap
+// show.
 export function genreMatches(t: FilterTrack | null | undefined, targetNorms: string[]): boolean {
   if (!targetNorms.length) return false;
   const tags = trackGenres(t).filter(Boolean);
@@ -465,21 +464,20 @@ export type StrictLocks = {
 // source of truth for "make this pool strict", shared by both pick paths and
 // the auto-playlist coast so they can't drift on what strict means.
 //
-//   starve: true  — every dimension drops hard, even to empty. The agent-tool
-//     contract (llm/internal/tools/picker-tools.ts): a tool that ends up empty
-//     contributes nothing, and dead-air is guarded at a WIDER scope — a run
-//     with zero candidates fails into the pool picker, which never-starves.
+//   starve: true  — every dimension drops hard, even to empty. That is the
+//     agent-tool contract: an empty tool contributes nothing, and dead air is
+//     guarded at a WIDER scope, since a run with zero candidates fails into the
+//     pool picker, which never-starves.
 //   starve: false — never-starve PER DIMENSION: a dimension whose filter would
-//     empty the running pool is skipped, so the OTHER dimensions' purity
-//     survives. This replaces the old all-or-nothing joint revert, where one
-//     zero-coverage tag class (e.g. a mood on an un-tagged library) threw away
-//     an otherwise genre- and era-pure pool and leaked off-filter tracks back.
+//     empty the running pool is skipped, so the others' purity survives. Not an
+//     all-or-nothing joint revert, which let one zero-coverage tag class (a mood
+//     on an un-tagged library) throw away an otherwise genre- and era-pure pool.
 //
 // Order is genre → era → mood → energy → vocals; with starve:false each step
 // commits only if it left something, so a starved late dimension can't undo an
-// earlier one's tightening. Vocals goes last deliberately: it's the dimension
-// most likely to have no coverage at all (Demucs is the opt-in heavy tier), and
-// last is where a skipped step costs the least.
+// earlier one's tightening. Vocals goes last because it is the dimension most
+// likely to have no coverage at all (Demucs is the opt-in heavy tier), and last
+// is where a skipped step costs least.
 export function applyStrictLocks<T extends FilterTrack>(
   tracks: T[],
   locks: StrictLocks,

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -178,15 +178,14 @@ export async function ping(): Promise<{ ok: boolean; reason?: string }> {
 // Music-source test/save flow. Unlike ping() it never touches config.navidrome
 // and never mutates anything; callers pass exactly what to try. Never throws.
 //
-// One retry on ANY first failure — broader than ping()'s fast-fail-only rule,
-// deliberately. ping()'s 30s timeout makes a slow retry expensive; this probe
-// is 5s-bounded, so the retry costs at most ~5.5s against a truly-dead server.
-// It covers both failure shapes of a warm-but-stale connection pool: the
-// instant reset on reusing a stale socket, AND the full-timeout stall seen
-// when the Navidrome process restarts under pooled connections (the aborted
-// attempt's teardown is what un-wedges the pool, so the second try connects
-// fresh). A Test button reporting either blip as "unreachable" sends the
-// operator chasing a config that actually works.
+// One retry on ANY first failure, broader than ping()'s fast-fail-only rule:
+// ping()'s 30s timeout makes a slow retry expensive, but this probe is
+// 5s-bounded, so the retry costs at most ~5.5s against a truly-dead server. It
+// covers both failure shapes of a warm-but-stale connection pool — the instant
+// reset on reusing a stale socket, and the full-timeout stall when Navidrome
+// restarts under pooled connections (the aborted attempt's teardown is what
+// un-wedges the pool). A Test button reporting either blip as "unreachable"
+// sends the operator chasing a config that actually works.
 export async function pingWith(target: {
   url: string;
   user: string;
@@ -383,16 +382,14 @@ export async function resolveGenreName(name) {
 // ---------------------------------------------------------------------------
 // Fuzzy artist resolution
 // ---------------------------------------------------------------------------
-// Navidrome's search3 does exact token/substring matching only, so a one-letter
-// transliteration variance ("Sikandar" vs the library's "Sikander") or a
-// dropped accent ("Beyonce" vs "Beyoncé") returns zero artists, and a bare
-// "play <artist>" request silently falls through to mood filler. resolveArtist
-// is to artists what resolveGenreName is to genres: normalise the free text,
-// try an exact index hit, then relax to per-token index searches and
-// fuzzy-rank the candidates against the whole request. Returns the best
-// matching artist object ({ id, name, ... }) or null. Library-relative — it
-// ranks against whatever artists THIS operator actually has, so it needs no
-// per-library data and works on every install.
+// Navidrome's search3 matches exact tokens/substrings only, so a one-letter
+// transliteration variance ("Sikandar" vs "Sikander") or a dropped accent
+// ("Beyonce" vs "Beyoncé") returns zero artists and a bare "play <artist>"
+// request falls through to mood filler. resolveArtist is to artists what
+// resolveGenreName is to genres: normalise, try an exact index hit, then relax
+// to per-token searches and fuzzy-rank candidates against the whole request.
+// Ranks against whatever artists THIS operator has, so it needs no per-library
+// data. Returns the best artist object or null.
 
 function normArtist(s: string): string {
   return String(s || '')
@@ -936,19 +933,18 @@ export function getAnnotatedUri(song, opts: { maxDurationSec?: number | null; cu
   // it here because the predecessor's own annotation is already sent).
   if (song.chop) fields.push('liq_chop="true"');
   if (song.chopPeriod != null) fields.push(`liq_chop_period="${escAnnotate(song.chopPeriod)}"`);
-  // Hard track-length cap (issue #447 / max-track-length). When the caller passes
-  // a positive cap, stamp `liq_cue_out` so radio.liq's `cue_cut` stops the track
-  // at that second offset — a real ceiling that fires no matter how the track
-  // reached the stream, not just a selection bias. Only the capped paths set it
-  // (autonomous picks in queue.drainToLiquidsoap + the auto.m3u fallback);
-  // explicit listener requests pass null and play in full. A cue_out past a
-  // shorter track's end is a Liquidsoap no-op, so sub-cap tracks play untouched.
-  // Stem-blend cue points (feature: stem-blend transitions): an explicit
-  // cueOutSec (the blend start in the OUTGOING track) folds with the length
-  // cap — whichever cuts earlier wins, so a blend can never resurrect audio
-  // past the operator's cap. cueInSec skips the INCOMING track past the head
-  // its rendered clip already played. Liquidsoap 2.4 honours both labels
-  // natively at request resolution; no radio.liq change.
+  // Hard track-length cap (#447): a positive cap stamps `liq_cue_out` so
+  // radio.liq's `cue_cut` stops the track at that offset — a real ceiling
+  // whatever path the track took to the stream, not a selection bias. Only the
+  // capped paths set it (autonomous picks + the auto.m3u fallback); listener
+  // requests pass null and play in full. A cue_out past a shorter track's end is
+  // a Liquidsoap no-op.
+  //
+  // Stem-blend cue points fold in here too: an explicit cueOutSec (the blend
+  // start in the OUTGOING track) competes with the cap and whichever cuts
+  // earlier wins, so a blend can never resurrect audio past the operator's cap.
+  // cueInSec skips the INCOMING track past the head its rendered clip already
+  // played. Liquidsoap 2.4 honours both labels at request resolution.
   const cueOut = [opts.maxDurationSec, opts.cueOutSec]
     .filter((v): v is number => typeof v === 'number' && Number.isFinite(v) && v > 0);
   if (cueOut.length) {

--- a/controller/src/music/tag-library.ts
+++ b/controller/src/music/tag-library.ts
@@ -178,18 +178,19 @@ async function main() {
       ? embedCfg.seedCount
       : null;
 
-  // Shared vote plumbing for phase 3, the phase-4 re-propagation rounds and
-  // the post-run self-check: KNN → neighbour-tag lookup → similarity-weighted
-  // vote. Same-album+artist neighbours vote at half weight — a track's text
-  // embedding is dominated by artist/album, so its KNN list is mostly its own
-  // album mates; at full weight one mistagged seed swept its whole album, and
-  // cross-album corroboration never got a say (the same-album echo chamber).
+  // Shared vote plumbing for phase 3, the phase-4 re-propagation rounds and the
+  // post-run self-check: KNN → neighbour-tag lookup → similarity-weighted vote.
   //
-  // When the track has a CLAP "sounds-like" vector, audio-KNN neighbours are
-  // fused into the list at audioFusionWeight before the vote — sound is the
-  // stronger mood signal for instrumentals / thin-metadata tracks, and CLAP
-  // doesn't cluster by album. knnAudioById returns [] for un-analysed tracks,
-  // so fusion degrades to text-only per track, not per run.
+  // Same-album+artist neighbours vote at HALF weight: a text embedding is
+  // dominated by artist/album, so a track's KNN list is mostly its own album
+  // mates, and at full weight one mistagged seed swept the whole album while
+  // cross-album corroboration never got a say.
+  //
+  // With a CLAP "sounds-like" vector, audio-KNN neighbours fuse in at
+  // audioFusionWeight before the vote — sound is the stronger mood signal for
+  // instrumentals and thin-metadata tracks, and CLAP doesn't cluster by album.
+  // knnAudioById returns [] for un-analysed tracks, so fusion degrades to
+  // text-only per track, not per run.
   const SAME_ALBUM_WEIGHT = 0.5;
   // Same artist, DIFFERENT album — damped too. On a label-only text index (no
   // Last.fm key, no lyrics, no CLAP) "nearest neighbours" is mostly the

--- a/controller/src/routes/backup.ts
+++ b/controller/src/routes/backup.ts
@@ -13,13 +13,12 @@
 // extracted back under STATE_DIR. See discussion #404.
 //
 // Two restore entry points share one `applyBackupZip()` core:
-//   POST /backup/import       — the zip is the raw request body (browser upload).
-//   POST /backup/import-file  — restore a zip already sitting in STATE_DIR.
-// The disk path exists because a big-library backup (29k tracks ⇒ a tag DB well
-// over 100 MB) can exceed an edge proxy's upload cap (Cloudflare rejects with a
-// 413 before the request ever reaches the controller). Dropping the file into
-// the station's state/ folder and restoring from there bypasses the proxy body
-// limit entirely. GET /backup/restorable lists the candidate zips. See #612.
+//   POST /backup/import       — the zip is the raw request body (browser upload)
+//   POST /backup/import-file  — restore a zip already sitting in STATE_DIR
+// The disk path exists because a big-library backup (29k tracks → a tag DB well
+// over 100 MB) can exceed an edge proxy's upload cap — Cloudflare 413s before
+// the request reaches the controller — and dropping the file into state/
+// bypasses that entirely. GET /backup/restorable lists candidates (#612).
 import express from 'express';
 import AdmZip from 'adm-zip';
 import { existsSync, readFileSync } from 'node:fs';

--- a/controller/src/routes/library.ts
+++ b/controller/src/routes/library.ts
@@ -125,13 +125,11 @@ router.get('/library/history', requireAdmin, async (req, res) => {
 // Query: limit=50 offset=0 sort=recent|count|artist q=foo
 //
 // Sourced from the likes store rather than library.db, then enriched from the
-// index where a row exists. That order matters: a liked track may never have
-// been walked or tagged (listeners heart whatever is on air), and the Browse
-// tab's tagged-only gate would hide exactly those. The stored snapshot is
-// always present, so every liked track renders either way.
-//
-// It lives here rather than in routes/likes.ts because it does the library-db
-// enrichment and returns the row shape the library table already renders.
+// index where a row exists. The order matters: a liked track may never have been
+// walked or tagged (listeners heart whatever is on air) and the Browse tab's
+// tagged-only gate would hide exactly those, whereas the stored snapshot is
+// always present. Lives here rather than routes/likes.ts because it does the
+// library-db enrichment and returns the row shape the library table renders.
 // ---------------------------------------------------------------------------
 router.get('/library/liked', requireAdmin, async (req, res) => {
   try {
@@ -306,15 +304,11 @@ router.get('/library/genres/related', requireAdmin, async (_req, res) => {
 // is returned with `sampled`/`truncated` flags. Station-archive rows are dropped
 // (issue #273).
 // ---------------------------------------------------------------------------
-// Default node cap (env-overridable) and the hard ceiling the client may raise
-// it to from the UI (?max=). 25000 covers most personal libraries in full while
-// keeping the payload sane; above it the observatory's MAP SIZE control dials up
-// to OBSERVATORY_HARD_MAX. Above the cap we return a stratified sample. The web
-// client sends no ?max= until the operator picks one, so this default (and the
-// OBSERVATORY_MAX override) governs the UI too; the response reports the
-// applied `max` + `defaultMax` so the MAP SIZE control can display it.
-// (Libraries above ~3k render on the canvas renderer; only small ones keep the
-// animated SVG path.)
+// Default node cap (env-overridable) and the hard ceiling the UI may raise it to
+// via ?max=. 25000 covers most personal libraries in full while keeping the
+// payload sane. The web client sends no ?max= until the operator picks one, so
+// this default also governs the UI; the response reports the applied `max` +
+// `defaultMax` so the MAP SIZE control can display it.
 const OBSERVATORY_DEFAULT_MAX = Math.max(500, Number(process.env.OBSERVATORY_MAX) || 25000);
 // The 500k ceiling is stress-verified (scripts/observatory-scale.test.ts + the
 // browser harness, both run at 200k/400k/500k): lean sampled reads stay ~1–4 s,
@@ -714,14 +708,12 @@ router.post('/library/reset', requireAdmin, async (_req, res) => {
 // Goes through the same machinery as `npm run tag`:
 //   1. Resolve metadata (body wins; falls back to Subsonic search).
 //   2. Refresh enrichment (Last.fm tags + lyrics excerpt) per settings.
-//   3. Re-embed with the current model so future propagation runs use a
-//      fresh vector grounded in current metadata.
+//   3. Re-embed with the current model.
 //   4. LLM-tag via tagBatch([song]) using the same batch prompt as bulk.
 //
-// We always go to the LLM here (not propagation) — "retag" semantically
-// means "override what's there", and the operator is sitting in front of
-// the UI waiting for a fresh decision. Embedding/enrichment updates are
-// best-effort: a failure there logs and continues to the LLM step.
+// Always the LLM here, never propagation: "retag" means "override what's there",
+// and the operator is waiting on a fresh decision. Embedding/enrichment updates
+// are best-effort — a failure logs and continues to the LLM step.
 // ---------------------------------------------------------------------------
 router.post('/library/retag', requireAdmin, async (req, res) => {
   const id = req.body?.id;
@@ -875,13 +867,11 @@ router.post('/library/retag', requireAdmin, async (req, res) => {
 // Body: { id, moods: string[], energy?: 'low'|'medium'|'high'|null,
 //         applyToAlbum?: boolean }
 //
-// `moods: []` clears the tags entirely (track returns to the untagged pool).
-// `applyToAlbum` resolves the whole album server-side from the track id
-// (subsonic.getSong → albumId → getAlbum) and applies the same tags to every
-// track — this is the "tag an album/folder for targeted queuing" path
-// (discussion #336). Moods are restricted to the live vocabulary
-// (settings.moodVocab()) so manual rows feed songsByMood()/MOOD_NEIGHBOURS
-// exactly like LLM-tagged ones.
+// `moods: []` clears the tags entirely (the track returns to the untagged pool).
+// `applyToAlbum` resolves the album server-side from the track id and applies
+// the same tags to every track — the "tag an album/folder for targeted queuing"
+// path (discussion #336). Moods are restricted to the live vocabulary so manual
+// rows feed songsByMood()/MOOD_NEIGHBOURS exactly like LLM-tagged ones.
 // ---------------------------------------------------------------------------
 router.post(
   '/library/manual-tag',

--- a/controller/src/routes/likes.ts
+++ b/controller/src/routes/likes.ts
@@ -10,16 +10,14 @@
 //   DELETE /likes     admin    clear the store
 //
 // A like optionally mirrors to Navidrome as a Subsonic star
-// (settings.likes.starInNavidrome) — fire-and-forget, so a slow or down
-// Navidrome never blocks the tap. Deleting likes here does NOT unstar in
-// Navidrome: stars there are the operator's catalogue data; prune them in a
-// Subsonic client if wanted.
+// (settings.likes.starInNavidrome), fire-and-forget so a slow Navidrome never
+// blocks the tap. Deleting likes here does NOT unstar: those are the operator's
+// catalogue data, to prune from a Subsonic client.
 //
-// The ONE exception is the operator un-heart, and only when the song has no
-// likes left at all. That is the operator toggling their own heart rather than
-// pruning listener data, and a toggle that stars on but never off is a bug.
-// The "no likes remain" guard is what keeps it safe: a star earned by twenty
-// listener likes is never discarded because the operator un-hearted.
+// The ONE exception is the operator un-heart, and only when no likes remain —
+// that is the operator toggling their own heart rather than pruning listener
+// data, and a toggle that stars on but never off is a bug. The "none remain"
+// guard is what stops a star earned by twenty listener likes being discarded.
 
 import express from 'express';
 import { queue } from '../broadcast/queue.js';

--- a/controller/src/routes/mcp.ts
+++ b/controller/src/routes/mcp.ts
@@ -11,11 +11,11 @@
 // /api/* proxy handles like any other. GET/DELETE are 405 (nothing to resume).
 //
 // Auth mirrors the REST API: the endpoint is open, but each tool call goes
-// through a loopback SubwaveClient pointed at the controller's own port that
+// through a loopback SubwaveClient — pointed at the controller's own port — that
 // FORWARDS the caller's Authorization header. Public tools work for anyone;
-// admin tools (say/segment/skill/skip/queue/search/sfx/refresh) 401 without
-// valid creds — the exact surface of the endpoints the tools wrap. So the tools
-// reuse the live routes with no handler refactor, and requireAdmin is untouched.
+// admin tools 401 without valid creds, matching the exact surface of the
+// endpoints they wrap. The tools reuse the live routes with no handler refactor,
+// and requireAdmin is untouched.
 import express from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -290,19 +290,21 @@ router.get('/now-playing', async (req, res) => {
         sampleRate: stream.sampleRate,
         channels: stream.channels,
         // How far behind the live edge a listener is: Icecast bursts this many
-        // seconds of already-broadcast audio on connect, and the client plays
-        // it out at 1x, so the offset holds for the whole connection.
+        // seconds of already-broadcast audio on connect and the client plays it
+        // out at 1x, so the offset holds for the whole connection.
         //
-        // Every timestamp on this payload (startedAt included) is stamped at
-        // the LIVE EDGE by radio.liq's pre-cross on_metadata hook. Players are
-        // expected to subtract this to render listener-time — without it the
-        // title and elapsed clock run this far ahead of the audio, which is
-        // the "Now Spinning is ahead of real time" report (issue #1114).
-        // This is the ADVERTISED depth; a player that can measure its real
-        // per-connection lag (web: buffered.end − currentTime) should prefer
-        // the measurement and use this only as the fallback — the true lag
-        // varies with the mount's byte rate and the burst actually received.
-        // Operator surfaces (admin dash, MCP) intentionally keep live edge.
+        // Every timestamp on this payload (startedAt included) is stamped at the
+        // LIVE EDGE by radio.liq's pre-cross on_metadata hook, so players
+        // subtract this to render listener-time; without it the title and
+        // elapsed clock run this far ahead of the audio (#1114).
+        //
+        // This ADVERTISED depth is the whole offset — do NOT prefer a
+        // client-side measurement. `buffered.end - currentTime` reports only the
+        // window the browser has DEMUXED, not the distance from the live edge
+        // (Chrome holds the connect burst in a cache `buffered` never exposes):
+        // measured 22.5s true vs 2.25s buffered against a 22s advertised depth,
+        // so preferring it flipped every title ~20s early. Operator surfaces
+        // (admin dash, MCP) intentionally keep live edge.
         bufferSeconds: stationSettings.stream?.bufferSeconds ?? 22,
         opusEnabled: stationSettings.stream?.opusEnabled === true,
         flacEnabled: stationSettings.stream?.flacEnabled === true,
@@ -329,12 +331,11 @@ router.get('/now-playing', async (req, res) => {
 // and software players (Sonos, VLC, moOde, car receivers). A listener adds the
 // station by pasting one URL instead of hunting for the raw /stream.mp3 mount.
 //
-// All wrap the always-served MP3 floor first (the universal entry every player
-// can decode); the optional Opus / FLAC / AAC mounts are appended only when the
-// operator has enabled each. Origin comes from publicOrigin() (SITE_URL when
-// set, else the request host) so the link works from however the listener
-// reached the site. Unauthenticated by design — these expose nothing beyond the
-// already-public stream URL and station name.
+// The always-served MP3 floor comes first (the universal entry every player can
+// decode); optional Opus / FLAC / AAC mounts are appended only when enabled.
+// Origin comes from publicOrigin() (SITE_URL when set, else the request host) so
+// the link works however the listener reached the site. Unauthenticated by
+// design — nothing here isn't already public.
 // ---------------------------------------------------------------------------
 function listenMounts(req: express.Request) {
   const origin = publicOrigin(req);
@@ -558,15 +559,14 @@ router.get('/state', (req, res) => {
 // always Icecast, so per-IP limiting would throttle every listener through
 // one bucket. The password never gets logged.
 //
-// That "the caller is always Icecast" premise only holds because the edge
-// refuses this path — the bundled Caddyfiles 404 /api/listener-auth, and
-// Icecast reaches the controller directly over the internal network. It was
-// NOT true before that: handle_path /api/* forwarded everything, so the
-// internet could POST here and brute-force the shared privacy.password at full
-// speed, bypassing the 20-per-15-min cap /station-auth puts on the SAME
-// password. byo-proxy operators own their own route table, so failures are
-// also damped in-handler below (successes are never delayed — see
-// listenerAuthFailureDelayMs).
+// That "the caller is always Icecast" premise holds only because the edge
+// refuses this path: the bundled Caddyfiles 404 /api/listener-auth, and Icecast
+// reaches the controller over the internal network. Before that, handle_path
+// /api/* forwarded everything, so the internet could POST here and brute-force
+// the shared privacy.password at full speed, bypassing the 20-per-15-min cap
+// /station-auth puts on the SAME password. byo-proxy operators own their own
+// route table, so failures are also damped in-handler below (successes are never
+// delayed — see listenerAuthFailureDelayMs).
 //
 // This endpoint fails OPEN when listenerAuth is off — see listenerAuthDecision.
 // The web UI must NOT use it for that reason; it has /station-auth below.

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -165,12 +165,11 @@ async function resolveGenre(name) {
 // `ctx` from getFullContext() is fetched once here and threaded through every
 // path, instead of the four separate fetches the inline handler used to do.
 // ---------------------------------------------------------------------------
-// Append the durable debug record once, at a request's terminal state. Reads
-// the trace fields the resolution paths stash on `entry` as they go (path,
-// pickSource, the matcher breakdown, the full picked track + intro script).
-// Best-effort — never let a logging hiccup affect the listener's outcome. Used
-// by both resolveRequest's terminal closures and the crash catch below, so a
-// request that throws mid-resolution still lands in the log.
+// Append the durable debug record once, at a request's terminal state, from the
+// trace fields the resolution paths stash on `entry` as they go. Best-effort —
+// a logging hiccup must never affect the listener's outcome. Called from both
+// resolveRequest's terminal closures and the crash catch below, so a request
+// that throws mid-resolution still lands in the log.
 function recordOutcome(entry) {
   try {
     requestLog.record({
@@ -740,13 +739,13 @@ async function resolveRequest(entry) {
 // synchronously, then returns a request id immediately and resolves in the
 // background. The listener never waits on the LLM.
 //
-// The shared schema (schemas/request.ts — also run pre-flight by the player's
-// request boxes) owns the SHAPE: text present and under the cap, name under
-// its cap. Over-cap text used to be silently sliced to 280 here, which could
-// cut a request mid-thought and have the DJ answer half of it; now it refuses,
-// and the box tells the listener before the network is touched. The guard
-// pipeline below (sanitize → strip → screen) stays route-owned: it repairs
-// rather than refuses, and needs server state the schema can't see.
+// The shared schema (schemas/request.ts, also run pre-flight by the player's
+// request boxes) owns the SHAPE: text present and under the cap, name under its
+// cap. Over-cap text REFUSES rather than being sliced — a silent slice could cut
+// a request mid-thought and have the DJ answer half of it — and the box tells
+// the listener before the network is touched. The guard pipeline below
+// (sanitize → strip → screen) stays route-owned: it repairs rather than refuses,
+// and needs server state the schema can't see.
 // ---------------------------------------------------------------------------
 // validatePublicBody, not validateBody: this is the one LISTENER-facing form,
 // so the 400 carries an unprefixed message plus the success/message keys the

--- a/controller/src/schemas/persona.ts
+++ b/controller/src/schemas/persona.ts
@@ -16,28 +16,24 @@
 // ---------------------------------------------------------------
 // `PERSONA_ID_RE` is the same pattern as schemas/show.ts's SHOW_ID_RE, and
 // `PERSONA_SKILL_SLUG_RE` the same as schemas/skill.ts's SKILL_SLUG_RE. Neither
-// can be imported (see above) and neither can reuse the other's NAME (the flat
-// mirror would carry two declarations of it). Re-declaring is therefore
-// structural, not sloppiness — and the drift it invites is pinned by
-// scripts/persona-schema.test.ts, which asserts `.source` equality against both
-// originals. That is the same answer skill-schema.test.ts gives for
-// loader.SLUG_RE and vocab's SKILL_SLUG_RE.
+// can be imported (see above), and neither can reuse the other's NAME because
+// the flat mirror would then carry two declarations of it. Re-declaring is
+// structural, not sloppiness; the drift it invites is pinned by
+// scripts/persona-schema.test.ts, which asserts `.source` equality against both.
 //
 // WHY THERE IS NO FACTORY
 // -----------------------
-// Unlike a show, a persona CAN be validated against itself: every rule is a
-// pure function of the submitted value. `skills` names skill slugs, but a slug
-// that no longer resolves is dropped rather than refused (see the field), so
-// the live catalogue is not an input. Rules that are NOT pure — id minting and
-// cross-row de-duplication — live in persona-server.ts, which is NOT mirrored.
+// Unlike a show, a persona CAN be validated against itself: every rule is a pure
+// function of the submitted value. `skills` names skill slugs, but an unresolved
+// slug is dropped rather than refused, so the live catalogue is not an input.
+// Impure rules — id minting, cross-row de-duplication — live in
+// persona-server.ts, which is NOT mirrored.
 //
 // SETTINGS/VOCAB.TS RE-EXPORTS EVERY CONSTANT BELOW
 // -------------------------------------------------
-// The "first feature converted owns the constant" rule. No call site moved when
-// this landed; vocab.ts aliases these under the names the controller already
-// used (PERSONA_FREQUENCIES as FREQUENCIES, and so on). The web side must read
-// them from the mirror rather than hand-copying — a hand-copied cap is exactly
-// the SKILL_SLUG_RE drift this whole mechanism exists to prevent.
+// "First feature converted owns the constant", so no call site moved: vocab.ts
+// aliases these under the names the controller already used. The web side must
+// read them from the mirror rather than hand-copying.
 import { z } from 'zod';
 
 // ── Persona vocabulary ───────────────────────────────────────────────────────

--- a/controller/src/schemas/settings.ts
+++ b/controller/src/schemas/settings.ts
@@ -7,40 +7,37 @@
 //
 // WHY A KEY AT A TIME, AND NOT ONE SCHEMA FOR THE SETTINGS OBJECT
 // ---------------------------------------------------------------
-// The `/settings` body is a partial PATCH, not an object: every admin panel
-// posts only the keys it owns. `z.object` strips unknown keys, so a schema over
-// the whole settings object would silently delete whatever a form learns to
-// send next. Instead each top-level key owns its own schema here, and
-// settings/patch-registry.ts runs only the keys a given patch actually carries.
-// That keeps the stripping scoped to a block whose shape is fully known.
+// The `/settings` body is a partial PATCH: every admin panel posts only the keys
+// it owns. `z.object` strips unknown keys, so a schema over the whole settings
+// object would silently delete whatever a form learns to send next. Instead each
+// top-level key owns its own schema here and patch-registry.ts runs only the
+// keys a patch actually carries, keeping the stripping scoped to blocks whose
+// shape is fully known.
 //
-// FIDELITY IS THE POINT OF THE FIRST SLICE
-// ----------------------------------------
-// #1337's rule is that no conversion may introduce a silent repair where the
-// operator previously got a refusal, or vice versa. The hand-rolled branches
-// these replace carry a lot of ACCIDENTAL leniency, and reproducing it is most
-// of the work here:
+// FIDELITY IS THE POINT
+// ---------------------
+// No conversion may introduce a silent repair where the operator previously got
+// a refusal, or vice versa (#1337's rule). The hand-rolled branches these
+// replace carry a lot of ACCIDENTAL leniency, and reproducing it is most of the
+// work:
 //
-//   * `parseInt(raw, 10)` / `parseFloat(raw)` stringify first, so '5' and even
-//     '5abc' parse, and a float handed to an int key TRUNCATES rather than
-//     failing (jingleRatio: 5.7 saves as 5 today). `z.number().int()` refuses
-//     all three. See settingsIntLike / settingsFloatLike.
-//   * `!!value` accepts anything, so `enabled: 1` is `true` today. `z.boolean()`
-//     refuses it. See settingsBoolLike.
-//   * `patch.beds || {}` means a non-object block is a silent no-op, not an
-//     error. See settingsBlockOf.
+//   * `parseInt`/`parseFloat` stringify first, so '5' and even '5abc' parse, and
+//     a float on an int key TRUNCATES rather than failing (jingleRatio: 5.7
+//     saves as 5). `z.number().int()` refuses all three — hence
+//     settingsIntLike / settingsFloatLike.
+//   * `!!value` accepts anything, so `enabled: 1` is `true`. See settingsBoolLike.
+//   * `patch.beds || {}` makes a non-object block a silent no-op, not an error.
+//     See settingsBlockOf.
 //
-// Each of those is defensible to TIGHTEN — webhooks did exactly that in #1337 —
-// but tightening is a behaviour change and belongs in a PR that says so. This
-// one establishes the frame at zero behaviour change, so the frame itself can't
+// Tightening any of these is defensible — webhooks did exactly that — but it is
+// a behaviour change and belongs in a PR that says so, so the frame itself can't
 // be what hides a regression.
 //
-// The bounds live HERE rather than in settings/defaults.ts's BOUNDS because a
-// mirrored module may not import a non-mirrored one, and the browser needs the
-// same numbers to pre-flight the form. BOUNDS re-exports these — the same
-// "first feature converted owns the constant" rule that put SHOW_ID_RE in
-// schemas/show.ts. The web side must read them from the mirror rather than
-// hand-copying, which is what BedsSection did with a bare `60` and `15`.
+// The bounds live HERE rather than in defaults.ts's BOUNDS because a mirrored
+// module may not import a non-mirrored one and the browser needs the same
+// numbers to pre-flight the form; BOUNDS re-exports them. The web side must read
+// from the mirror rather than hand-copying — which is what BedsSection did with
+// a bare `60` and `15`.
 import { z } from 'zod';
 
 // Every top-level name in schemas/*.ts shares ONE scope in the flat mirror
@@ -332,6 +329,12 @@ export const CROSSFADE_DURATION_BOUNDS: SettingsNumericBound = { min: 0, max: 30
 export const LOUDNESS_TARGET_LUFS_BOUNDS: SettingsNumericBound = { min: -23, max: -9 };
 // 0 disables boosting entirely (cut-only levelling); 12 dB is plenty.
 export const LOUDNESS_MAX_BOOST_DB_BOUNDS: SettingsNumericBound = { min: 0, max: 12 };
+// 0 disables burst-on-connect; past 60 a listener is a full minute behind the
+// live edge and <queue-size> (which must exceed the burst) gets unreasonable.
+// Named rather than inline because settings.load() bounds the stored value
+// against the SAME figures — a hand-copied pair there is how the save path and
+// the load path drift.
+export const STREAM_BUFFER_SECONDS_BOUNDS: SettingsNumericBound = { min: 0, max: 60 };
 
 // Falling back to the product default is what an emptied station name does —
 // see stationSchema.
@@ -451,8 +454,8 @@ export const streamPatchSchema = settingsBlockOf({
   // Number(), not parseInt — so '' / null / [] are 0 (a legal "no burst") and
   // '5abc' is refused. Bounds tested before the round; see the helper.
   bufferSeconds: settingsNumberPreRoundLike(
-    { min: 0, max: 60 },
-    'stream.bufferSeconds must be a number between 0 and 60',
+    STREAM_BUFFER_SECONDS_BOUNDS,
+    `stream.bufferSeconds must be a number between ${STREAM_BUFFER_SECONDS_BOUNDS.min} and ${STREAM_BUFFER_SECONDS_BOUNDS.max}`,
   ),
   idleAfterMinutes: settingsIntLike(
     { min: 1, max: 1440 },

--- a/controller/src/schemas/show.ts
+++ b/controller/src/schemas/show.ts
@@ -12,14 +12,12 @@
 // settings/vocab.ts as ID_RE rather than living in a shared module.
 //
 // WHY A FACTORY. Unlike webhooks and stations, a show cannot be validated
-// against itself: `personaId` has to name a real persona, `moods` a live mood,
-// `themeId` an installed theme, and `maxTrackSeconds` clears a floor derived
-// from the station's crossfade. Those four travel as ONE ShowSchemaContext
-// value rather than as separate arguments — the shape the old four-parameter
-// validateShowsStrict(raw, personas, allowedThemeIds, moodNames) grew into, and
-// the same "one scope value, never unpacked" rule PickerScope follows. Both
-// sides can build it: the admin panel already fetches personas, moods, themes
-// and the station settings.
+// against itself: `personaId` must name a real persona, `moods` a live mood,
+// `themeId` an installed theme, and `maxTrackSeconds` clears a crossfade-derived
+// floor. Those four travel as ONE ShowSchemaContext value rather than separate
+// arguments — the same "one scope value, never unpacked" rule PickerScope
+// follows. Both sides can build it; the admin panel already fetches personas,
+// moods, themes and the station settings.
 //
 // Rules that are NOT pure functions of the submitted value — id minting and
 // cross-row de-duplication — live in show-server.ts, which is NOT mirrored.

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -86,7 +86,7 @@ import {
 } from './settings/defaults.js';
 import { validateCompatParams } from './settings/compat-params.js';
 import { parseSettingsPatchKey } from './settings/patch-registry.js';
-import { maxTrackSecondsValueSchema } from './schemas/settings.js';
+import { STREAM_BUFFER_SECONDS_BOUNDS, maxTrackSecondsValueSchema } from './schemas/settings.js';
 import { minTrackSeconds, peek, setCache } from './settings/store.js';
 import {
   SKILL_RENAMES,
@@ -419,6 +419,19 @@ export async function load() {
         typeof stored.stream?.oggIcyMetadata === 'boolean'
           ? stored.stream.oggIcyMetadata
           : DEFAULTS.stream.oggIcyMetadata,
+      // Bounded against the SAME constant the save path checks
+      // (schemas/settings.ts streamSchema), so a value update() accepted always
+      // survives a restart. Omitting this line is what made the setting revert
+      // to 22 on every cold load — the mixer handoff file got the string
+      // "undefined" and the entrypoint fell back, while /now-playing advertised
+      // the default to every player.
+      bufferSeconds:
+        typeof stored.stream?.bufferSeconds === 'number' &&
+        Number.isFinite(stored.stream.bufferSeconds) &&
+        stored.stream.bufferSeconds >= STREAM_BUFFER_SECONDS_BOUNDS.min &&
+        stored.stream.bufferSeconds <= STREAM_BUFFER_SECONDS_BOUNDS.max
+          ? Math.round(stored.stream.bufferSeconds)
+          : DEFAULTS.stream.bufferSeconds,
       idleWhenEmpty:
         typeof stored.stream?.idleWhenEmpty === 'boolean'
           ? stored.stream.idleWhenEmpty
@@ -1107,24 +1120,23 @@ export async function update(patch) {
         restart = true;
       }
     }
-    // Listener-side buffer depth (Icecast <burst-size>, in seconds). Deep =
-    // survives a dead zone but sits further behind the live edge; shallow =
-    // tighter sync, likelier to stall. 0 disables burst-on-connect entirely.
-    // Capped at 60s: past that a listener is a full minute behind and
-    // <queue-size> (which must comfortably exceed the burst) gets unreasonable.
+    // Listener-side buffer depth (Icecast <burst-size>, seconds). Deep survives
+    // a dead zone but sits further behind the live edge; shallow syncs tighter
+    // and stalls more. 0 disables burst-on-connect. Capped at 60s: past that a
+    // listener is a full minute behind and <queue-size> (which must comfortably
+    // exceed the burst) gets unreasonable.
     //
-    // restart=true is load-bearing here and NOT just a mixer concern: burst
-    // lives in icecast.xml, which is rendered once by the broadcast entrypoint
-    // at container boot. It applies anyway because liquidsoap and icecast
-    // share a container and the entrypoint `wait -n`s on both — the telnet
-    // restart shuts liquidsoap down, the container bounces, and the entrypoint
-    // re-renders the template on the way back up.
-    // NOTE cur.stream.bufferSeconds is `undefined` on any cold-loaded process —
-    // load()'s stream block never composes it (the documented "three edits"
-    // trap). That makes this comparison always true, so a bufferSeconds patch
-    // always restarts. Preserved deliberately: fixing load() would turn an
-    // unconditional restart into a conditional one, which is a behaviour change
-    // and belongs in its own PR.
+    // restart=true is not just a mixer concern — burst lives in icecast.xml,
+    // rendered once by the broadcast entrypoint at container boot. It applies
+    // anyway because liquidsoap and icecast share a container the entrypoint
+    // `wait -n`s on: the telnet restart shuts liquidsoap down, the container
+    // bounces, and the template re-renders on the way back up.
+    //
+    // Change-gated against `cur` like the encoder fields above, which needs
+    // load() to actually compose bufferSeconds — while it didn't, `cur` read
+    // `undefined` on every cold-loaded process, so this fired unconditionally
+    // AND the operator's value was lost on restart. Kept out of the loop above
+    // because it is not an encoder field and restarts for a different reason.
     if (st.bufferSeconds !== undefined && st.bufferSeconds !== cur.stream.bufferSeconds) {
       next.stream.bufferSeconds = st.bufferSeconds as number;
       restart = true;

--- a/controller/src/settings/defaults.ts
+++ b/controller/src/settings/defaults.ts
@@ -1,7 +1,5 @@
-// The shipped default settings object and the numeric bounds update() checks
-// patches against, plus the few pure helpers that read them.
-//
-// Part of the settings/ split — see ../settings.ts for the public barrel.
+// Shipped defaults, the numeric bounds update() checks patches against, and the
+// pure helpers that read them. Part of the settings/ split — see ../settings.ts.
 
 import { config } from '../config.js';
 import {
@@ -31,179 +29,119 @@ import {
 export const DEFAULTS = {
   jingleRatio: 30, // 1 jingle per N music tracks
   crossfadeDuration: 10.0, // seconds
-  // Station-wide cap (seconds) on how long a single autonomously-picked track
-  // may be — keeps hour-long album mixes and DJ sets out of normal rotation
-  // (issue #447). 0 = no cap (default, unchanged behaviour). A scheduled show
-  // can override this with its own `maxTrackSeconds` (0 there = "unlimited",
-  // i.e. opt back out of the station cap for a long-form show). Listener
-  // requests bypass the cap entirely — an explicit ask always plays.
+  // Station-wide cap on autonomously-picked track length; 0 = no cap (#447). A
+  // show's own maxTrackSeconds overrides it (0 there = unlimited). Listener
+  // requests always bypass it.
   maxTrackSeconds: 0,
   // Hourly archive output. Off by default — the second MP3 encoder is the
-  // largest constant CPU cost in the broadcast container, and most operators
-  // don't use the archives, so they opt in via admin → Settings rather than
-  // paying for the tape by default (issue #137). Dropping the bitrate (e.g.
-  // 128 → 64 mono in a future change) also helps for operators who want it.
-  // retentionDays: hourly recordings older than this many days are deleted by
-  // the scheduler's hourly cleanup. Bounded by default — the old keep-forever
-  // default (0) grew ~1.4 GB/day at 128 kbps until the disk filled, and
-  // operators only noticed at 99 GB. The default must NOT reach installs that
-  // already archive under keep-forever: normalizeArchiveRetentionDays keeps
-  // them at 0 (see settings/normalize.ts), so upgrades never delete tapes.
+  // largest constant CPU cost in the broadcast container (#137). retentionDays
+  // bounds disk growth (~1.4 GB/day at 128 kbps); normalizeArchiveRetentionDays
+  // keeps pre-existing keep-forever installs at 0 so upgrades never delete tapes.
   archive: { enabled: false, bitrate: 128, retentionDays: 30 },
-  // Secondary Ogg-Opus broadcast mount (/stream.opus). Off by default — only
-  // Blink (Chrome/Edge) clients ever select it (web/hooks/usePlayer.ts keeps
-  // Safari/iOS/Firefox on MP3), and it adds a continuous Opus encoder + a
-  // 44.1→48k resample, so operators opt in rather than pay that CPU unasked.
-  // The mandatory /stream.mp3 mount always serves everyone.
   stream: {
+    // Secondary Ogg-Opus mount (/stream.opus). Off by default — only Blink
+    // selects it (web/hooks/usePlayer.ts), and it costs a continuous encoder
+    // plus a 44.1→48k resample. /stream.mp3 always serves everyone.
     opusEnabled: false,
     opusBitrate: 96,
     flacEnabled: false,
     aacEnabled: false,
     aacBitrate: 192,
     bitrate: 192,
-    // Seconds of already-broadcast audio Icecast bursts to a client on
-    // connect (<burst-size>), so a cellular dead zone drains the buffer
-    // instead of stalling (issue #993). Specified in SECONDS, not bytes:
-    // burst-size is a byte count, so a fixed one silently stretches at low
-    // bitrates — the old flat 512 KB was ~22s at 192k but ~66s at 64k. The
-    // broadcast entrypoint converts this to bytes using stream.bitrate, so
-    // the depth an operator picks is the depth every bitrate gets.
+    // Icecast <burst-size> expressed in SECONDS, not bytes: a fixed byte count
+    // stretches at low bitrates (512 KB is ~22s at 192k but ~66s at 64k), so the
+    // entrypoint converts per mount (#993).
     //
-    // This is also exactly how far behind the live edge every listener sits
-    // for their whole connection, which is why /now-playing publishes it as
-    // stream.bufferSeconds — players subtract it to line the now-playing
-    // title and elapsed clock up with the audio actually in someone's ears
-    // rather than the live edge (issue #1114).
+    // This is also how far behind the live edge every listener sits for their
+    // whole connection, so /now-playing publishes it as stream.bufferSeconds and
+    // players subtract it to line titles up with the audio in someone's ears (#1114).
     bufferSeconds: 22,
-    // ICY (out-of-band) per-track titles on the Ogg mounts (/stream.opus +
-    // /stream.flac). ON by default: most internet-radio clients (Ferrosonic,
-    // Cast receivers, Symfonium) read the in-band Ogg comment only once at
-    // connect and freeze on that title without ICY (issue #1052). foobar2000
-    // is the known exception — it parses the in-band chained-Ogg tags
-    // correctly, and the ICY channel on top breaks its Ogg-FLAC metadata — so
-    // operators with fb2k listeners turn this off. Which camp a station's
-    // listeners fall in is unknowable from here, hence a toggle rather than a
-    // hardcoded value. MP3/AAC always use ICY and are unaffected.
+    // ICY (out-of-band) titles on the Ogg mounts. ON by default: most clients
+    // read the in-band Ogg comment once at connect and then freeze on that title
+    // (#1052). foobar2000 is the exception — it parses chained-Ogg tags correctly
+    // and the ICY channel breaks its Ogg-FLAC metadata — hence a toggle.
+    // MP3/AAC always use ICY and are unaffected.
     oggIcyMetadata: true,
-    // Idle pause (broadcast/stream-idle.ts). When on, the controller flips
-    // radio.liq's idle gate after idleAfterMinutes with zero Icecast
-    // listeners: the mounts keep serving (silence), but the music chain
-    // stops being pulled — no track decode, no Navidrome downloads — and
-    // resumes mid-track within seconds of anyone connecting. Off by default:
-    // a radio that plays to an empty room is the product's default fiction,
-    // so going dark while unobserved is an explicit operator choice.
+    // Idle pause (broadcast/stream-idle.ts): after idleAfterMinutes with zero
+    // listeners the mounts keep serving silence but the music chain stops being
+    // pulled — no decode, no Navidrome downloads — resuming mid-track on connect.
     idleWhenEmpty: false,
     idleAfterMinutes: 10,
   },
-  // Per-track loudness normalisation (music/mix.ts gainForLoudness). targetLufs
-  // is what every measured track is pulled toward; maxBoostDb caps the upward
-  // direction only — cuts have a fixed wide clamp, and the boost is further
-  // limited by the track's own measured peak headroom, so widening this on a
-  // dynamic library won't slam the broadcast limiter. Read live per track at
-  // annotate time; no mixer restart. `source` picks where the loudness figure
-  // comes from (issue #998): embedded ReplayGain tags (whole-file stereo R128,
-  // via Navidrome's OpenSubsonic replayGain field) vs the analyzer's measured
-  // LUFS (leading window only). The default prefers the tag and falls back to
-  // the measurement, so untagged libraries behave exactly as before.
+  // Per-track loudness normalisation (music/mix.ts gainForLoudness), read live at
+  // annotate time. maxBoostDb caps the upward direction only, and the boost is
+  // further limited by the track's own measured peak headroom. `source` picks the
+  // figure: embedded ReplayGain tags (whole-file R128) vs the analyzer's measured
+  // LUFS (leading window only) (#998).
   loudness: {
     targetLufs: -14,
     maxBoostDb: 6,
     source: 'replaygain-then-measured' as LoudnessSource,
   },
   weather: {
-    // Precise point. The ONLY thing Open-Meteo sees, and the only location
-    // data that never reaches a prompt, a listener, or a public response.
+    // The ONLY location data Open-Meteo sees, and the only kind that never
+    // reaches a prompt, a listener, or a public response.
     lat: 30.7333,
     lng: 76.7794,
-    // Operator-facing label for those coordinates — admin UI, /debug, CLI
-    // status. Never spoken on air, never published. onAirLocation is what
-    // listeners and the LLM get.
+    // Operator-facing label for those coordinates. Never spoken, never published.
     locationName: 'Punjab',
-    // The place the station CLAIMS to broadcast from: the DJ prompt's
-    // {location}, and the `location` in GET /dj + GET /now-playing. Blank
-    // falls back to locationName, so installs that never set it are
-    // unchanged. Lets an operator name a broad area ("the Peak District")
-    // while the weather still reads their exact coordinates — a station's
-    // public URL shouldn't be able to dox its operator.
+    // Where the station CLAIMS to broadcast from: the prompt's {location}, and
+    // `location` in GET /dj + /now-playing. Blank falls back to locationName.
+    // Lets an operator name a broad area while the weather reads exact
+    // coordinates — a public station URL shouldn't be able to dox its operator.
     onAirLocation: '',
     units: 'metric' as 'metric' | 'imperial',
   },
-  // Operator-facing station name. Substituted into the DJ prompt's {station}
-  // placeholder and returned by GET /dj for the landing page. The product is
-  // still called SUB/WAVE — this is what the operator's station running on it
-  // is called (e.g. "Frequency 88", "Late Shift Radio").
+  // The operator's station name (the product is still SUB/WAVE). Substituted into
+  // the prompt's {station} and returned by GET /dj.
   station: 'SUB/WAVE',
-  // Station-level blurb for link previews (og:description, twitter:description,
-  // meta description). Deliberately NOT the on-air persona's tagline: that
-  // changes with whoever is on air, so a shared station link would describe
-  // itself differently depending on the hour (issue #1086). Empty = unset, and
-  // the web app falls back to the persona tagline, preserving the behaviour of
-  // installs that predate this field. Never enters the DJ prompt.
+  // Blurb for link previews (og:description et al). Deliberately NOT the on-air
+  // persona's tagline — that changes with the hour, so a shared link would
+  // describe itself differently depending on when it was opened (#1086). Empty =
+  // unset, and the web app falls back to the tagline. Never enters the DJ prompt.
   stationDescription: '',
-  // Station clock — IANA zone driving everything with local-time semantics
-  // (time-of-day moods, schedule slots, hourly time checks, festival dates).
-  // Empty = Auto: the container's own TZ, so existing installs are untouched.
-  // Applied live via time.ts setStationTimezone(); no restart.
+  // IANA zone driving everything with local-time semantics (time-of-day moods,
+  // schedule slots, hourly checks, festival dates). Empty = the container's TZ.
+  // Applied live via time.ts setStationTimezone().
   timezone: '',
-  // Operator-facing locale for display copy/time formatting. Defaults to the
-  // existing UK English + 24-hour clock behaviour; en-US switches visible
-  // clocks to AM/PM without changing schedule/time-of-day semantics.
+  // Display copy / time formatting only; en-US switches visible clocks to AM/PM
+  // without changing schedule or time-of-day semantics.
   locale: 'en-GB' as 'en-GB' | 'en-US',
-  // Station-wide visual theme — every listener and the admin UI render with
-  // this palette. The id resolves through controller/src/themes.ts, which
-  // ships the built-ins and reads optional user JSONs from
-  // ${STATE_DIR}/themes/. Stored as id only; the actual token map lives with
-  // the theme registry so it stays in sync with the file on disk.
+  // Station-wide palette. Stored as an id only — the token map lives with the
+  // theme registry (controller/src/themes.ts + ${STATE_DIR}/themes/) so it stays
+  // in sync with the file on disk.
   theme: { active: DEFAULT_THEME_ID },
-  // Festival calendar — mood-forming dates the DJ leans into. Persisted here
-  // so operators can add/edit/remove entries from the admin UI. Fall back to
-  // FESTIVAL_DEFAULTS when empty/absent.
+  // Mood-forming dates the DJ leans into. Falls back to FESTIVAL_DEFAULTS when
+  // empty/absent.
   festivals: FESTIVAL_DEFAULTS,
-  // Operator-editable mood system (/admin/moods). `moods` is the vocabulary +
-  // per-mood CLAP prompt; `moodSchedule` maps each fixed day-period to a mood;
-  // `weatherMoods` maps each fixed weather condition to a mood ('' = no steer).
-  // All read live via the moodVocab()/moodScheduleFor()/weatherMoodFor()
-  // accessors. Seeded here; the operator's edits replace them.
+  // Operator-editable mood system (/admin/moods): the vocabulary + per-mood CLAP
+  // prompt, the day-period → mood map, and the weather-condition → mood map
+  // ('' = no steer). Read live via moodVocab()/moodScheduleFor()/weatherMoodFor().
   moods: MOOD_DEFAULTS,
   moodSchedule: PERIOD_MOOD_DEFAULTS,
   weatherMoods: WEATHER_MOOD_DEFAULTS,
-  // Listener-player UI toggles — purely presentational, station-wide. The web
-  // player reads these via GET /state (alongside the theme) and applies them
-  // live; no restart. `boothBuddy` gates the DJ-line mascot — OFF by default,
-  // so the line shows the classic ♪/◇ marker until an operator opts in.
-  // `skin` is the station-wide player-skin id — the web app owns the skin
-  // registry and falls back to its default on an unknown id, so the
-  // controller only stores a slug, never validates against a list.
-  // `tuneInOverlay` gates the full-bleed "Tap to tune in" gate — ON by default;
-  // OFF drops the takeover and listeners start via the skin's own play button
-  // (browsers still can't autoplay, so a tap is always required somewhere).
+  // Presentational player toggles, read via GET /state and applied live.
+  // `boothBuddy` gates the DJ-line mascot. `skin` is a slug only — the web app
+  // owns the registry and falls back on an unknown id, so nothing validates it
+  // here. `tuneInOverlay` gates the full-bleed tune-in gate; off drops the
+  // takeover and listeners start via the skin's own play button.
   ui: { boothBuddy: false, skin: 'classic', tuneInOverlay: true },
-  // Private-station controls (issue #478). Two independent locks over ONE
-  // shared `password`. `privatePlayer` gates the public web pages behind a
-  // password prompt — UI-level only, applies live. `listenerAuth` puts
-  // Icecast listener auth on every stream mount via URL auth calling back
-  // into POST /listener-auth; no per-user accounts (Icecast can only do basic
-  // auth). Toggling listenerAuth re-renders icecast.xml, so it needs a mixer
-  // restart; password changes apply live (the controller validates every
-  // connect). Either lock being on requires a password — see update().
-  // `publishPersonaSouls` is NOT a lock and takes no part in the password rule
-  // above — it governs DISCLOSURE on the roster-wide public reads (/schedule's
-  // persona index, GET /personas). A soul is the persona's system prompt, not a
-  // bio: operators write it assuming it stays backstage, so publishing every
-  // one of them is opt-in and OFF by default (an upgrade changes nothing).
-  // GET /dj is deliberately unaffected — it has always published the ON-AIR
-  // persona's soul, one at a time, and removing that would break existing
-  // public clients. This toggle is about handing over the whole roster at once.
+  // Two independent locks over ONE shared password (#478). `privatePlayer` gates
+  // the public web pages — UI-level, applies live. `listenerAuth` puts Icecast
+  // listener auth on every mount via URL auth calling back into
+  // POST /listener-auth, so toggling it re-renders icecast.xml and needs a mixer
+  // restart; password changes apply live. Either lock on requires a password —
+  // see update().
+  //
+  // `publishPersonaSouls` is NOT a lock and takes no part in that password rule.
+  // It governs disclosure on the roster-wide public reads (/schedule's persona
+  // index, GET /personas). A soul is the persona's system prompt, not a bio, so
+  // handing over every one at once is opt-in. GET /dj is deliberately unaffected:
+  // it has always published the ON-AIR soul, one at a time.
   privacy: { privatePlayer: false, listenerAuth: false, password: '', publishPersonaSouls: false },
-  // Listener-request pipeline gates (request-system hardening, 2026-07-28).
-  // `enabled` is the master on/off for POST /request. The rest bound the
-  // request rate from a few angles at once: `maxPending` caps the queue depth
-  // regardless of source, `globalHourlyCap` bounds total requests/hour across
-  // all listeners, `repeatCooldownMin` blocks the same track being
-  // re-requested too soon (0 = off), `cooldownSec` is the minimum gap between
-  // any two requests, and `perIpHourlyCap`/`onePendingPerIp` bound a single
-  // IP's share. Every field applies live — no restart.
+  // Listener-request gates, all applied live. They bound the rate from several
+  // angles at once: queue depth, requests/hour station-wide, per-track repeat
+  // cooldown (0 = off), minimum gap between any two, and a single IP's share.
   requests: {
     enabled: true,
     maxPending: 6,
@@ -213,298 +151,214 @@ export const DEFAULTS = {
     perIpHourlyCap: 8,
     onePendingPerIp: true,
   },
-  // Global DJ prompt template. '' means "use DEFAULT_DJ_PROMPT_TEMPLATE".
-  // Always the RESOLVED text of the active djPrompts entry — kept so
-  // renderDjPrompt() (and an older controller sharing the same settings.json)
-  // never has to chase the library.
+  // Global DJ prompt template; '' = DEFAULT_DJ_PROMPT_TEMPLATE. Always the
+  // RESOLVED text of the active djPrompts entry, so renderDjPrompt (and an older
+  // controller sharing the same settings.json) never has to chase the library.
   djPrompt: '',
-  // Saved prompt-template library + which entry is active ('' = built-in
-  // default). Switching templates just moves activeDjPromptId.
   djPrompts: [],
   activeDjPromptId: '',
-  // Station house rules — per-station rules (TTS control tags, "spell out
-  // numbers", locale orthography) appended to EVERY spoken-output prompt:
-  // both the scripted-talk path (renderDjPrompt) and the agent paths
-  // (agentPersonaPreamble), which the djPrompt template never reaches
-  // (issue #1182). '' = off; default installs stay byte-identical.
+  // Per-station rules (TTS control tags, "spell out numbers", orthography)
+  // appended to EVERY spoken-output prompt — both renderDjPrompt and
+  // agentPersonaPreamble, which the djPrompt template never reaches (#1182).
   djHouseRules: '',
-  // The persona roster. One persona is "active" at a time (activePersonaId);
-  // a scheduled show can override which persona is on-air for its hour.
+  // One persona is active at a time; a scheduled show can override who is on air.
   personas: SEED_PERSONAS,
   activePersonaId: SEED_PERSONAS[0].id,
-  // Reusable show definitions, placed into the weekly schedule grid.
   shows: [],
   // 7-day x 24-hour grid of showId|null. An empty hour = run autonomously.
   schedule: emptyWeek(),
-  // Timed takeover (#930): { showId, startedAt, expiresAt } epoch-ms window
-  // that outranks the weekly grid in resolveActiveShow while it's live.
-  // null = no takeover. Persisted in schedule.json alongside shows/schedule.
+  // Timed takeover (#930): an epoch-ms window that outranks the weekly grid in
+  // resolveActiveShow while live. Persisted in schedule.json.
   scheduleOverride: null,
   tts: {
-    // Station-wide voice switch. false = music only: the DJ never speaks — no
-    // links, idents, hourly checks, segments, banter, mic-passes, programme
-    // beats or listener-request intros — and, crucially, the scripts for those
-    // are never GENERATED, so an off station spends no LLM tokens on talk.
-    // Picks keep running (the stream needs a next track) and jingles keep
-    // playing (pre-rendered WAVs on Liquidsoap's own rotate — silence those
-    // with jingleRatio: 0). Manual /dj/segment triggers stay exempt: an
-    // explicit operator action always fires. Policy lives in exactly one
-    // place — broadcast/voice-policy.ts. Applies live; no restart.
+    // Station-wide voice switch. false = music only: no links, idents, hourly
+    // checks, segments, banter, mic-passes, programme beats or request intros —
+    // and the scripts are never GENERATED, so an off station spends no tokens on
+    // talk. Picks keep running and jingles keep playing (silence those with
+    // jingleRatio: 0). Manual /dj/segment triggers stay exempt. Policy lives in
+    // exactly one place: broadcast/voice-policy.ts.
     enabled: true,
     defaultEngine: 'piper',
     // Operator-chosen rescue voice — the TTS analogue of settings.llm.fallback.
-    // When a persona's engine is known-unavailable up front, or throws
-    // mid-render, this slot speaks instead: engine AND voice, where the
-    // hardcoded chain behind it (defaultEngine → piper → kokoro) only ever
-    // chose an engine and spoke with whatever global default it carried.
-    // `enabled: false` (and an absent block, which normalises to this) keeps
-    // the pre-fallback behaviour byte-for-byte. Same {engine, voice,
-    // cloudProvider} shape as a persona's own tts block — deliberately, since
-    // audio/tts.ts hands it to speakWith() as a synthetic persona.
+    // Speaks when a persona's engine is known-unavailable up front or throws
+    // mid-render. Unlike the hardcoded chain behind it (defaultEngine → piper →
+    // kokoro) it carries a VOICE, not just an engine. Same {engine, voice,
+    // cloudProvider} shape as a persona's tts block — audio/tts.ts hands it to
+    // speakWith() as a synthetic persona.
     fallback: { enabled: false, engine: 'piper', voice: '', cloudProvider: 'openai' },
-    // Advisory flag — does the operator intend to run the optional tts-heavy
-    // sidecar (Chatterbox + PocketTTS)? Both setup wizards (CLI + /onboarding)
-    // write to this so each surface knows the other's choice. Nothing in the
-    // controller branches on it — engine availability is still read from
-    // chatterbox.isAvailable() / pocketTts.isAvailable() at call time, which
-    // is the source of truth. This is purely for the UI to show consistent
-    // state and for the CLI to know whether to write COMPOSE_PROFILES.
+    // Advisory only: does the operator intend to run the tts-heavy sidecar?
+    // Nothing branches on it — availability is read from isAvailable() at call
+    // time. Both wizards write it so each surface knows the other's choice, and
+    // the CLI uses it to decide whether to write COMPOSE_PROFILES.
     heavyEnabled: false,
     kokoro: { voice: 'bf_isabella', lang: '' },
-    // Global Chatterbox fallback — used as the reference voice when the
-    // engine resolves to chatterbox but no persona-level voice is set.
-    // Empty filename means "use the model's built-in default voice".
+    // Reference voice used when the engine resolves to chatterbox with no
+    // persona-level voice. Empty = the model's built-in default.
     chatterbox: { referenceVoice: '' },
-    // Global PocketTTS default voice — used when the engine resolves to
-    // pocket-tts but no persona-level voice is set. Built-in voice id.
+    // Built-in voice id used when the engine resolves to pocket-tts with no
+    // persona-level voice.
     pocketTts: { voice: 'alba' },
-    // Cloud engine config — used when an engine resolves to 'cloud'. A persona
-    // chooses provider+voice; `model` stays shared here. Managed credentials
-    // use provider env vars; authenticated compatibility servers use the
-    // dedicated `compatApiKey` slot below.
-    // `enabled` is the operator's "Off" switch — when false the cloud engine
-    // reports unavailable regardless of key, so the engine pickers grey it out.
+    // Used when an engine resolves to 'cloud'. A persona chooses provider+voice;
+    // `model` stays shared. `enabled: false` makes the engine report unavailable
+    // regardless of key, so the pickers grey it out.
     cloud: {
       enabled: false,
       provider: 'openai',
       model: 'gpt-4o-mini-tts',
       voice: 'alloy',
-      // Legacy managed-provider inline key. New managed credentials live in
-      // secrets.env; retained for backward compatibility with older settings.
+      // Legacy managed-provider inline key; new credentials live in secrets.env.
       apiKey: '',
-      // Dedicated bearer for authenticated openai-compatible TTS servers. It
-      // remains provider-scoped even when personas use compat alongside a
-      // different station-wide Cloud provider.
+      // Bearer for authenticated openai-compatible servers. Stays
+      // provider-scoped even when personas use compat alongside a different
+      // station-wide cloud provider.
       compatApiKey: '',
-      // Base URL for the openai-compatible provider, including the /v1 suffix
-      // (e.g. http://192.168.1.101:5000/v1). Required — and only used — when
-      // provider === 'openai-compatible'.
+      // Includes the /v1 suffix. Required — and only used — when provider is
+      // 'openai-compatible'.
       baseUrl: '',
-      // ElevenLabs voice_settings. Applied ONLY when provider is 'elevenlabs';
-      // ignored (and never sent) for openai / openai-compatible. All four match
-      // ElevenLabs' native ranges: stability, style, similarity_boost ∈ [0,1],
-      // use_speaker_boost is a bool. Defaults mirror ElevenLabs' UI defaults so
-      // an unconfigured install renders exactly like the SDK's own baseline
-      // (issue #696).
+      // ElevenLabs voice_settings, sent only for that provider. Ranges match
+      // ElevenLabs' native ones; defaults mirror its UI so an unconfigured
+      // install renders like the SDK's baseline (#696).
       voiceStability: 0.5,
       voiceStyle: 0,
       voiceSimilarityBoost: 0.75,
       voiceUseSpeakerBoost: true,
-      // Fish Audio S2.1 synthesis controls. Persisted alongside the shared
-      // cloud config so switching providers preserves the operator's tuning,
-      // but sent only when provider === 'fish-audio'.
+      // Fish Audio S2.1 controls. Persisted alongside the shared cloud config so
+      // switching providers preserves the tuning, but sent only for fish-audio.
       temperature: 0.7,
       topP: 0.7,
       latency: 'normal' as 'low' | 'normal' | 'balanced',
-      // Free-form extra body fields for openai-compatible servers (issue
-      // #1317) — Chatterbox's temperature/seed/exaggeration, and whatever the
-      // next self-hosted engine invents. Stored as text pairs and coerced to
-      // JSON types at send time; sent ONLY when provider ===
-      // 'openai-compatible'. Empty = today's request shape, byte for byte.
-      // Rules live in settings/compat-params.ts.
+      // Free-form extra body fields for openai-compatible servers (#1317) —
+      // Chatterbox's temperature/seed/exaggeration and whatever the next engine
+      // invents. Stored as text and coerced to JSON types at send time. Rules
+      // live in settings/compat-params.ts.
       compatParams: [] as { key: string; value: string }[],
     },
-    // Remote engine — a user-configured self-hosted TTS endpoint that renders
-    // audio over HTTP (POST /speak → audio body, gated on a /health probe).
-    // The TTS equivalent of the LLM's custom base URL. Empty → engine reports
-    // unavailable; the dispatcher falls back.
+    // Self-hosted TTS endpoint over HTTP (POST /speak → audio body, gated on a
+    // /health probe) — the TTS equivalent of the LLM's custom base URL.
     remote: { url: '' },
-    // Per-engine voice level trim (dB), applied via Liquidsoap's liq_amplify on
-    // every spoken segment that resolves to that engine. Levels the loudness gap
-    // between engines (e.g. boost PocketTTS to match raw Piper). Stacks with each
-    // persona's own tts.gainDb. All 0 = unity = today's behaviour. See
-    // TTS_GAIN_CLAMP_DB and audio/tts.ts:voiceGainDb().
+    // Per-engine trim (dB) applied via liq_amplify on every spoken segment, to
+    // level the loudness gap between engines. Stacks with each persona's own
+    // tts.gainDb. See TTS_GAIN_CLAMP_DB and audio/tts.ts:voiceGainDb().
     gainDb: { piper: 0, kokoro: 0, chatterbox: 0, 'pocket-tts': 0, cloud: 0, remote: 0 },
-    // Per-engine speech-rate multiplier (0.5–2.0×, 1.0 = no change), composed
-    // on top of the daypart energy and each persona's own tts.speed in
-    // audio/tts.ts:speak(). Only Piper/Kokoro/cloud honour it; chatterbox/
-    // pocket-tts/remote ignore speed so their entries are inert. See clampTtsSpeed().
+    // Per-engine speech-rate multiplier (0.5–2.0x), composed on top of the
+    // daypart energy and each persona's tts.speed. Only piper/kokoro/cloud honour
+    // it — the other entries are inert. See clampTtsSpeed().
     speed: { piper: 1, kokoro: 1, chatterbox: 1, 'pocket-tts': 1, cloud: 1, remote: 1 },
-    // Operator speech corrections — find→replace pairs applied to every
-    // booth-bound line before any TTS engine sees it (audio/speech-text.ts).
-    // Each entry: { from: 'GHz', to: 'gigahertz' }. Empty by default.
+    // Find→replace pairs applied to every booth-bound line before any engine sees
+    // it (audio/speech-text.ts), e.g. { from: 'GHz', to: 'gigahertz' }.
     corrections: [],
   },
   llm: {
     provider: 'ollama',
     model: '',
-    // Legacy single inline-key slot. Superseded by `keys` (per-provider) — kept
-    // only so an old settings.json migrates cleanly. Always '' after load();
-    // resolution reads `keys`, never this. See llmKeyFor() / normalizeLlmKeys().
+    // Legacy single inline-key slot, superseded by `keys`. Always '' after
+    // load(); resolution reads `keys`, never this.
     apiKey: '',
-    // Per-provider inline API keys, keyed by provider id (issue #657). Only the
-    // inline-key providers (openai-compatible, locca) ever populate this from the
-    // UI — env-var providers (openrouter, anthropic, …) keep their key in
-    // state/secrets.env. Namespacing by provider means switching providers can
-    // never leave one provider's key in the slot another provider then reads.
+    // Per-provider inline API keys (#657). Only the inline-key providers
+    // (openai-compatible, locca) populate this from the UI; env-var providers
+    // keep their key in state/secrets.env. Namespacing by provider means
+    // switching providers can never leave one provider's key where another reads.
     keys: {},
-    // Ollama server URL. Empty → fall back to config.ollama.url. Only used
-    // when provider === 'ollama'.
+    // Empty → config.ollama.url. Only used when provider === 'ollama'.
     ollamaUrl: '',
-    // Per-provider server base URLs. Keyed by provider id so switching providers
-    // never overwrites another provider's saved URL (issue #1082). Replaces the
-    // legacy single `baseUrl` field; at runtime `baseUrl` is derived from this map
-    // in load()/applyLlmLegPatch(). The legacy field is kept as a migration source
-    // on load only — it is never written after the first save with the new schema.
+    // Per-provider base URLs, so switching providers never overwrites another
+    // provider's saved URL (#1082). `baseUrl` below is derived from this in
+    // load()/applyLlmLegPatch() and kept only as a migration source.
     providerBaseUrls: {} as Record<string, string>,
-    // Deprecated single slot — kept so an old settings.json migrates cleanly.
-    // Always derived from `providerBaseUrls` after load(). See
-    // normalizeLlmProviderBaseUrls().
     baseUrl: '',
-    // Whether to let reasoning ("thinking") models emit a chain-of-thought
-    // before the answer. Off by default: the DJ writes short scripts and
-    // structured picks that don't benefit from reasoning, and an uncapped
-    // <think> block on a small model balloons every call (see llm/sdk.js
-    // token caps + llm/provider.js no-think fetch).
+    // Let reasoning models emit a chain-of-thought. Off by default: the DJ writes
+    // short scripts and structured picks that don't benefit from it, and an
+    // uncapped <think> block on a small model balloons every call.
     reasoning: false,
-    // How SUB/WAVE forces a tool call in the structured-output paths (the emit /
-    // done-tool harness). 'required' (default) makes the model call the tool —
-    // the reliable path for local models that ignore JSON mode. Switch to 'auto'
-    // ONLY if your server crashes on tool_choice:"required": recent vLLM
-    // implements it via a guided-decoding backend that some images (newer
-    // Intel/XPU builds) mishandle, while "auto" never engages it (issue #570).
-    // On 'auto' the done-tool path keeps its activeTools pinning + instructions,
-    // so a capable model still calls the tool; misses fall back to the pool
-    // picker. Leave on 'required' unless you hit that crash.
+    // How the structured-output paths force a tool call. 'required' is the
+    // reliable path for local models that ignore JSON mode. Switch to 'auto' ONLY
+    // if your server crashes on tool_choice:"required" — recent vLLM implements it
+    // via a guided-decoding backend some images mishandle (#570). On 'auto' the
+    // done-tool path keeps its activeTools pinning, so a capable model still calls
+    // the tool and misses fall back to the pool picker.
     toolChoice: 'required',
-    // How many DISCOVERY rounds the DJ agent gets before it must commit its pick
-    // (`done`). 0 (the default) follows the provider capability table — 1 for
-    // the forced-tool providers (ollama, openai-compatible, locca), 3 for the
-    // rest; see discoveryStepsFor() in llm/internal/provider/capabilities.ts.
-    // Set 1–5 to override.
+    // DISCOVERY rounds the DJ agent gets before it must commit (`done`).
+    // 0 = follow the provider capability table (discoveryStepsFor()); 1–5 overrides.
     //
     // The override exists because the descriptor keys off the PROVIDER and can't
-    // know which model that provider is serving, and the two failure directions
-    // are opposite. RAISE it (2–3) when a capable model sits behind a
-    // forced-tool provider — a good local model on llama.cpp/vLLM gets one
-    // cornered round it doesn't need, and a seed tool that comes back empty then
-    // leaves it with nothing to commit. LOWER it to 1 when a cloud model wanders
-    // across its three rounds, or simply to cut tokens: every extra round is a
-    // separate billable call counting against dailyTokenCap, and all rounds share
-    // the one agentTimeoutMs deadline with the recovery legs behind them.
+    // know which model it serves, and the two failure directions are opposite.
+    // RAISE it when a capable model sits behind a forced-tool provider — one
+    // cornered round plus an empty seed tool leaves it nothing to commit. LOWER it
+    // when a cloud model wanders, or to cut tokens: every round is a separate
+    // billable call against dailyTokenCap, and all rounds share one agentTimeoutMs.
     //
-    // Raising it never buys extra attempts at `done` — the step cap is derived
-    // as budget + 1, so the run still commits once and then hands off to the
-    // recovery cascade. The picker prompt follows this number too, so the model
-    // is told how many rounds it actually has.
+    // Raising it never buys extra attempts at `done` — the step cap is budget + 1,
+    // so the run still commits once before handing off to recovery. The picker
+    // prompt follows this number, so the model is told how many rounds it has.
     discoverySteps: 0,
-    // Ollama context window (num_ctx), local Ollama only. Ollama's own default
-    // is 4096, but the session DJ agent feeds ~8k+ (the 40-turn session window
-    // + tool schemas + discovery results), so the default silently truncates
-    // the front of the prompt — dropping the system instructions and tool
-    // defs — and the model never calls `done` ("agent did not call the done
-    // tool", issue #291). 16384 holds a full picker turn comfortably on a 7–9B
-    // model / 12GB GPU. Reasoning models burn more of it on <think>, so bump it
-    // if you run those. Ignored for `:cloud` models and every other provider
-    // (they manage their own context). 0 → don't send num_ctx (Ollama default).
+    // Ollama num_ctx, local Ollama only. Ollama's own 4096 default silently
+    // truncates the front of a ~8k+ picker prompt — dropping the system
+    // instructions and tool defs — so the model never calls `done` (#291). 16384
+    // holds a full turn on a 7–9B model / 12GB GPU; reasoning models need more.
+    // 0 → don't send num_ctx. Ignored for `:cloud` models and other providers.
     numCtx: 16384,
-    // Repetition penalty for local openai-compatible / locca servers (llama.cpp,
-    // vLLM, LM Studio). llama.cpp's own default is 1.0 = OFF, which lets the
-    // tool-loop picker run away repeating a token block until it hits the output
-    // cap and never calls `done`. 1.15 is a sane floor; raise toward 1.25 if a
-    // model still loops, or set 1.0 to disable (e.g. a vLLM server that rejects
-    // the `repeat_penalty` body field). Injected into the request body — the AI
-    // SDK's openai provider has no field for it. Ignored by every other provider
-    // (incl. Ollama: ai-sdk-ollama v4 has no per-call repeat_penalty channel).
+    // Repetition penalty for local openai-compatible / locca servers. llama.cpp
+    // defaults to 1.0 = OFF, which lets the tool-loop picker repeat a token block
+    // until it hits the output cap and never calls `done`. Raise toward 1.25 if a
+    // model still loops; 1.0 disables (e.g. a vLLM server that rejects the body
+    // field). Injected into the request body — the AI SDK has no field for it —
+    // and ignored by every other provider, Ollama included.
     repeatPenalty: 1.15,
-    // When on, the session DJ agent drives track-picking, links and listener
-    // requests as a tool-loop over the session chat history (broadcast/
-    // dj-agent.js). When off, the stateless pool picker runs instead — still
-    // inside a session, still logged, just without the conversational loop.
+    // On: the session DJ agent drives picks, links and requests as a tool-loop
+    // over the session chat history. Off: the stateless pool picker runs instead,
+    // still inside a session and still logged.
     pickerAgent: true,
-    // Count-based hard no-repeat window: the picker never re-airs any of the
-    // last N DISTINCT plays. Non-relaxable (survives the filterPickerCandidates
-    // starvation cascade), so it closes the hole where a thin mood cluster let
-    // the cascade re-serve a just-played song. Clamped to library size at use
-    // (effectiveNoRepeatWindow) so a small catalogue never fully blocks; 0
-    // disables. Seeded from config.queue.noRepeatWindow (env NO_REPEAT_WINDOW);
-    // listener requests stay exempt. See music/recency.ts + broadcast/queue.ts.
+    // The picker never re-airs any of the last N DISTINCT plays. Non-relaxable
+    // (survives the filterPickerCandidates starvation cascade), which closes the
+    // hole where a thin mood cluster let the cascade re-serve a just-played song.
+    // Clamped to library size at use so a small catalogue never fully blocks; 0
+    // disables. Listener requests are exempt. See music/recency.ts.
     noRepeatWindow: config.queue.noRepeatWindow,
-    // When on, the listener-request agent (djAgentRequest only — never the
-    // per-track picker) gets an extra `identifyRequestedTrack` tool that resolves
-    // a DESCRIBED track ("the song from the new Dune movie") via web search, then
-    // matches it against the local library. Off by default: it needs a web-search
-    // provider (settings.search) and costs a web round-trip + a small extraction
-    // call per use. No-op unless searchReady() — see llm/internal/tools/picker/tools/identify-requested-track.ts.
+    // Gives the listener-request agent (never the per-track picker) an
+    // `identifyRequestedTrack` tool that resolves a DESCRIBED track via web search
+    // and matches it locally. Off by default: needs a search provider and costs a
+    // web round-trip plus a small extraction call per use. No-op unless
+    // searchReady().
     requestWebResolve: false,
-    // Hard wall-clock ceiling (ms) on a single DJ-agent generation (track
-    // picks and listener requests). Enforced by withDeadline in llm/sdk.ts;
-    // the main and recovery runs each get the full budget, so worst case per
-    // pick is ~2× this before the stateless fallback takes over. Raise it for
-    // slow models (reasoning-heavy cloud models routinely need 20-40s per
-    // pick); lower it if you want snappier fallbacks.
+    // Hard wall-clock ceiling on a single DJ-agent generation, enforced by
+    // withDeadline. The main and recovery runs each get the full budget, so worst
+    // case per pick is ~2x this before the stateless fallback. Reasoning-heavy
+    // cloud models routinely need 20-40s.
     agentTimeoutMs: 45000,
-    // When on, autonomous DJ LLM work (track picks, links, station IDs,
-    // hourly checks, segments) and listener requests pause whenever Icecast
-    // reports zero listeners — the stream coasts on the auto playlist — and
-    // resume as soon as someone tunes in. Off by default.
+    // Pause autonomous DJ LLM work and listener requests whenever Icecast reports
+    // zero listeners — the stream coasts on the auto playlist.
     pauseWhenEmpty: false,
-    // Daily LLM token budget — a safety net against bill-shock on a metered
-    // provider (the DJ calls the model on essentially every track transition,
-    // 24/7). 0 = unlimited (the default — most installs run free local Ollama
-    // and must be unaffected). When set, the day's token usage (UTC, summed
-    // from the same usage stats as the lifetime ticker) drives a two-tier
-    // degradation: at `budgetSoftPct` of the cap the DJ drops to the cheap pool
-    // picker and mutes optional segments (links, station IDs, hourly, weather/
-    // news/etc.); at the cap it stops calling the model entirely and the stream
-    // coasts on the LLM-free auto playlist — music never stops. Enforced in
-    // broadcast/dj-budget.ts; see llm/internal/core/pure.ts `budgetMode`.
+    // Daily token budget against bill-shock on a metered provider (the DJ calls
+    // the model on essentially every transition, 24/7). 0 = unlimited. When set,
+    // the day's UTC usage drives two tiers: at budgetSoftPct the DJ drops to the
+    // cheap pool picker and mutes optional segments; at the cap it stops calling
+    // the model entirely and coasts on the LLM-free auto playlist — music never
+    // stops. Enforced in broadcast/dj-budget.ts.
     dailyTokenCap: 0,
-    // When the day's usage crosses this percent of dailyTokenCap, enter the
-    // "soft" tier (cheap picker, no optional segments). 0 or 100 disables the
-    // soft tier and goes straight from normal to hard at the cap.
+    // Percent of dailyTokenCap that enters the soft tier. 0 or 100 disables it and
+    // goes straight from normal to hard at the cap.
     budgetSoftPct: 80,
-    // When on (the default), listener requests are still answered by the agent
-    // even over the hard cap — a human asked, so honour it. When off, requests
-    // over the cap fall through to the stateless matcher cascade like every
-    // other LLM path. No effect until dailyTokenCap is set.
+    // On: listener requests are still answered by the agent over the hard cap — a
+    // human asked. Off: they fall through to the stateless matcher cascade. No
+    // effect until dailyTokenCap is set.
     exemptRequests: true,
-    // Per-call max OUTPUT tokens — distinct from dailyTokenCap (a cumulative
-    // daily budget). This caps the size of each individual model response. The
-    // strategy primitives default to generous built-ins (4000 text / 8000
-    // object / 8000 agent); 0 = use those defaults. Set a value (clamped
-    // 500–8000) to override all three — the lever for a local model on a small
-    // context window, where an 8000-token response allowance can crowd out the
-    // system prompt / tool listing and risk truncation, and is pure waste with
-    // reasoning off. Resolved via resolveMaxOutputTokens(); see issue #712.
+    // Per-call max OUTPUT tokens, distinct from the cumulative dailyTokenCap.
+    // 0 = the strategy primitives' built-ins (4000 text / 8000 object / 8000
+    // agent); a value (clamped 500–8000) overrides all three. The lever for a
+    // local model on a small context window, where an 8000-token allowance can
+    // crowd out the system prompt and risk truncation (#712).
     maxOutputTokens: 0,
-    // When on (or when LLM_DEBUG_RAW is set in the env), every outbound model
-    // request's exact body is captured to ${STATE_DIR}/logs/llm-debug.log (the
-    // last 10, newest first) and dumped to stderr — a copy-pasteable view of
-    // exactly what SUB/WAVE sends the provider, for debugging odd model
-    // behaviour. The admin toggle (admin → Debug) means no-CLI operators can
-    // flip it without editing env; the env flag can only force it on. Off by
-    // default: zero file writes / overhead when disabled.
+    // Capture every outbound request body to ${STATE_DIR}/logs/llm-debug.log (last
+    // 10, newest first) and stderr. LLM_DEBUG_RAW forces it on. The admin toggle
+    // exists so no-CLI operators can flip it without editing env.
     debugRawRequests: false,
-    // Optional backup LLM. When `enabled`, any LLM call whose primary host is
-    // unreachable (connection refused / DNS / timeout — NOT a 429/5xx from a
-    // host that's up) is retried once against this leg, then routed straight
-    // back to the primary on the next call (stateless fail-back). Built for the
-    // "primary is a GPU box that's sometimes powered off, backup is the
-    // always-on server running a smaller model" case (discussion #320). Same
-    // connection fields as the primary; the station-level toggles (pickerAgent,
-    // pauseWhenEmpty) are not per-leg. Heavy work (library tagging via
-    // embeddings) does NOT fail over — it stays on the primary.
+    // Optional backup LLM. When enabled, a call whose primary host is UNREACHABLE
+    // (connection refused / DNS / timeout — not a 429/5xx from a host that's up)
+    // retries once here, then routes straight back to the primary next call
+    // (stateless fail-back). Built for "primary is a GPU box that's sometimes
+    // powered off" (discussion #320). Station-level toggles (pickerAgent,
+    // pauseWhenEmpty) are not per-leg, and heavy work (library tagging via
+    // embeddings) does NOT fail over.
     fallback: {
       enabled: false,
       provider: 'ollama',
@@ -517,84 +371,69 @@ export const DEFAULTS = {
       toolChoice: 'required',
       numCtx: 16384,
       repeatPenalty: 1.15,
-      // Per-leg like toolChoice/numCtx above: the backup may be a different
-      // provider running a different model, so it resolves its own budget.
+      // Per-leg like toolChoice/numCtx: the backup may be a different provider
+      // running a different model, so it resolves its own budget.
       discoverySteps: 0,
     },
   },
-  // Embedding-propagated library tagger (music/tag-library.ts).
-  //
-  // The tagger embeds every track's metadata text once (free if Ollama-local,
-  // ~$1 for 50k via OpenAI), LLM-tags a small representative seed set, then
-  // KNN-propagates moods/energy to the rest. Cuts LLM call count ~10x vs.
+  // Embedding-propagated library tagger (music/tag-library.ts): embed every
+  // track's metadata text once, LLM-tag a small representative seed set, then
+  // KNN-propagate moods/energy to the rest — ~10x fewer LLM calls than
   // brute-force batched tagging.
   //
-  // `provider` and `model` default to following settings.llm; set them here
-  // to use a different provider for embeddings than for chat. Anthropic has
-  // no first-party embedding API — Anthropic users either set a different
-  // embedding provider or set OPENAI_API_KEY for the embedding leg.
+  // `provider`/`model` default to following settings.llm. Anthropic has no
+  // first-party embedding API, so Anthropic users need a different embedding
+  // provider or an OPENAI_API_KEY for this leg.
   embedding: {
     enabled: true,
     provider: '',         // empty → follow settings.llm.provider
     model: '',            // empty → sensible default per provider
-    // Embeddings often need a DIFFERENT endpoint than chat: one llama.cpp /
-    // locca server can't serve both chat and embeddings, so a dedicated
-    // embedding server runs on its own port. Empty → inherit settings.llm's
-    // baseUrl / ollamaUrl (fine only when the chat server also does embeddings,
-    // e.g. Ollama). See issue #405.
-    providerBaseUrls: {} as Record<string, string>, // per-provider embedding server URLs (issue #1082)
-    baseUrl: '',          // deprecated single slot — migration source only, never written after first save
+    // Embeddings often need a DIFFERENT endpoint than chat — one llama.cpp/locca
+    // server can't serve both, so a dedicated embedding server runs on its own
+    // port. Empty → inherit settings.llm's URL, which is only correct when the
+    // chat server also does embeddings (e.g. Ollama). See #405, #1082.
+    providerBaseUrls: {} as Record<string, string>,
+    baseUrl: '',          // deprecated single slot — migration source only
     ollamaUrl: '',        // Ollama embedding server URL (ollama provider)
-    apiKey: '',           // empty -> inherit settings.llm.apiKey
-    seedCount: 0,         // 0 → auto (see autoSeedCount in tag-library.ts: ~4% of
-                          //   the library, floored 200 / capped 2500)
-    // Propagation defaults. These were 5 / 0.6 / 0.6 and propagated almost
-    // nothing: confidence is topSim×coverage (a product of two sub-1 terms — see
-    // tag-propagator.ts), so a 0.6 gate rejected even strong matches and dumped
-    // the library into expensive active-learning. Loosened so KNN propagation
-    // actually carries the bulk of tagging. NOTE: only affects NEW installs / a
-    // reset — an existing settings.json keeps its saved values (loadWithDefaults
-    // below prefers a stored value), so operators are never silently overridden.
-    knnNeighbours: 10,        // was 5 — a broader, more stable neighbour vote
-    moodVoteThreshold: 0.4,   // was 0.6 — a mood carried by ~a third propagates
-    confidenceThreshold: 0.35, // was 0.6 — see the topSim×coverage note above
+    apiKey: '',           // empty → inherit settings.llm.apiKey
+    seedCount: 0,         // 0 → auto (autoSeedCount: ~4% of the library, 200–2500)
+    // Confidence is topSim x coverage — a product of two sub-1 terms (see
+    // tag-propagator.ts) — so the original 0.6 gates rejected even strong matches
+    // and dumped the library into expensive active-learning. These only affect new
+    // installs: loadWithDefaults prefers a stored value, so operators are never
+    // silently overridden.
+    knnNeighbours: 10,
+    moodVoteThreshold: 0.4,
+    confidenceThreshold: 0.35,
     maxActiveLearningRounds: 3,
-    // CLAP audio fusion in mood propagation: tracks with a "sounds-like"
-    // audio vector also pull neighbours from the audio-KNN space, scaled by
-    // this weight, before the mood vote (tag-propagator.ts fuseNeighbours).
-    // Sound is the stronger mood signal for instrumentals / thin-metadata
-    // tracks, and CLAP neighbours don't cluster by album. 0 = text-only
-    // (today's behaviour); 1 = trust audio similarity as much as text. Only
-    // bites where the acoustic analysis has produced audio vectors.
+    // CLAP audio fusion in mood propagation: tracks with a "sounds-like" vector
+    // also pull neighbours from the audio-KNN space, scaled by this weight, before
+    // the mood vote (tag-propagator.ts fuseNeighbours). Sound is the stronger mood
+    // signal for instrumentals and thin-metadata tracks, and CLAP neighbours don't
+    // cluster by album. 0 = text-only; 1 = trust audio as much as text.
     audioFusionWeight: 0.5,
     batchSize: 25,
     enrichment: {
-      // Last.fm crowd tags. Tri-state: true = always fetch, false = never,
-      // null = auto (fetch only when a Last.fm api_key is configured — see
-      // music/lastfm.ts + the gate in tag-library.ts phaseEnrich).
+      // Last.fm crowd tags. Tri-state: true = always fetch, false = never, null =
+      // auto (only when a Last.fm api_key is configured).
       //
-      // Tags now come straight from the Last.fm REST API (artist.getTopTags)
-      // reusing the scrobbling api_key, which actually returns tag[]. The old
-      // path went through Navidrome's getArtistInfo2, where vanilla Navidrome's
-      // agent only surfaces bio + images — never tag[] — so tags always came
-      // back empty. That Navidrome path stays as the fallback when lastfmTags
-      // is forced on (true) but no api_key is set (custom Navidromes that DO
-      // expose tag[]). Default `null` avoids the wasted round trip for keyless
-      // vanilla-Navidrome installs.
+      // Tags come from the Last.fm REST API (artist.getTopTags), reusing the
+      // scrobbling api_key. The older path went through Navidrome's
+      // getArtistInfo2, where vanilla Navidrome's agent only surfaces bio +
+      // images and tags always came back empty; it stays as the fallback when
+      // forced on with no api_key, for custom Navidromes that DO expose tag[].
       lastfmTags: null as boolean | null,
       lyrics: true,       // fetch + include lyric excerpt in embed text
-      // Resolve original release years for compilation-album tracks via
-      // MusicBrainz (issue #842) — a compilation's `year` tag is the
-      // compilation's own release date, so era-bounded shows both mis-include
-      // and miss its tracks until each song's true year is known. Keyless API
-      // (1 req/s, throttled in music/musicbrainz.ts), so default-on.
+      // Resolve original release years for compilation tracks via MusicBrainz
+      // (#842) — a compilation's `year` tag is the compilation's release date, so
+      // era-bounded shows both mis-include and miss its tracks until each song's
+      // true year is known. Keyless API (throttled to 1 req/s), so default-on.
       originalYear: true,
     },
   },
   // Web-search backend for the segment director's web-search capability.
-  // Default `duckduckgo` works out of the box with no key; `tavily` and
-  // `brave` read their key from SEARCH_API_KEY (or the optional override
-  // below). `apiKey` is only meaningful for the keyed providers.
+  // `duckduckgo` needs no key; `tavily` and `brave` read SEARCH_API_KEY (or the
+  // override here).
   search: {
     provider: 'duckduckgo',
     apiKey: '',
@@ -603,93 +442,73 @@ export const DEFAULTS = {
   skills: {
     enabled: {},
   },
-  // Audio (CLAP) "sounds-like" embeddings — drive the audio-similar picker
-  // source, the tracksThatSoundLikeThis tool and sonic journeys. When on, the
-  // analysis pass asks the backend for an embedding per track; the backend
-  // needs the CLAP stack (tts-heavy built with WITH_CLAP=1, or a local venv
-  // with torch+transformers) — without it the request is a clean no-op and
-  // the pass still fills bpm/key. ANALYZE_AUDIO_EMBEDDING=1 in the env also
-  // enables it regardless of this toggle (env wins on, never off).
   audio: {
+    // CLAP "sounds-like" embeddings — drive the audio-similar picker source, the
+    // tracksThatSoundLikeThis tool and sonic journeys. Needs the CLAP stack in the
+    // analysis backend; without it the request is a clean no-op and the pass still
+    // fills bpm/key. ANALYZE_AUDIO_EMBEDDING=1 also enables it (env wins on,
+    // never off) — as do the env flags on the two toggles below.
     embeddings: false,
-    // Demucs vocal-activity ranges — drives content-aware talk timing and a
-    // vocal-absence intro detector. When on, the analysis pass asks the backend
-    // for vocal ranges per track; the backend needs the demucs stack (tts-heavy
-    // built WITH_DEMUCS=1, or a local venv with torch+demucs) — without it the
-    // request is a clean no-op. ANALYZE_VOCAL_ACTIVITY=1 also enables it
-    // regardless of this toggle (env wins on, never off). Expensive — opt-in.
+    // Demucs vocal-activity ranges — drive content-aware talk timing and the
+    // vocal-absence intro detector. Needs the demucs stack; expensive, so opt-in.
+    // ANALYZE_VOCAL_ACTIVITY=1 also enables it.
     vocalActivity: false,
-    // Stem cache (feature: stem-blend transitions). When on, the analysis
-    // pass keeps the Demucs stems it already computes (head + tail windows)
-    // as FLAC under state/stems/<id>/ so transition renders are a fast mix
-    // instead of a fresh separation. Needs the demucs stack like
-    // vocalActivity; ~13-25 MB per track (field average ~13, #1257),
-    // LRU-swept to stemCacheGb.
+    // Keep the Demucs stems the analysis pass already computes (head + tail
+    // windows) as FLAC under state/stems/<id>/, so a transition render is a fast
+    // mix instead of a fresh separation. Needs the demucs stack like
+    // vocalActivity; ~13-25 MB per track (#1257), LRU-swept to stemCacheGb.
     stemCache: false,
     stemCacheGb: 15,
-    // Quiet-times gate (#1099): pause the analysis pass while anyone is
-    // listening, resuming once the stream has been listener-free for
-    // analyzeQuietMinutes. Checked between tracks inside runAnalysisPass, so
-    // it covers both the server-spawned tagger child and `npm run analyze`,
-    // and applies to manual "Analyse now" runs too (a pass outlives the
-    // click; the bypass is turning this off). ANALYZE_QUIET_ONLY=1 also
-    // enables it (env wins on, never off), mirroring the toggles above.
+    // Pause the analysis pass while anyone is listening, resuming once the stream
+    // has been listener-free for analyzeQuietMinutes (#1099). Checked between
+    // tracks inside runAnalysisPass, so it covers the tagger child, `npm run
+    // analyze` and manual "Analyse now" runs alike — a pass outlives the click, so
+    // the bypass is turning this off. ANALYZE_QUIET_ONLY=1 also enables it.
     analyzeQuietOnly: false,
     analyzeQuietMinutes: 10,
   },
   // Transition scheduling + stem-blend rendering (docs/stem-transitions-research.md).
   transitions: {
-    // Pair-aware drains (the #749 fix): hold each queued pick unsent until
-    // its successor is known (or the on-air track nears its end), so its
-    // exit stamps — adaptive crossfade length, and stem-blend clips when
-    // enabled — can be sized for the actual pair. Kill-switch: off reverts
-    // to the historical eager drain, byte-for-byte.
+    // Hold each queued pick unsent until its successor is known (or the on-air
+    // track nears its end), so its exit stamps — adaptive crossfade length, and
+    // stem-blend clips — can be sized for the actual pair (#749). Kill-switch: off
+    // reverts to the eager drain.
     pairDrain: true,
-    // Pre-rendered stem-blend transitions (needs pairDrain + the heavy
-    // analyzer with the stem cache warmed). Off by default — opt-in like
-    // every heavy audio feature.
+    // Needs pairDrain plus the heavy analyzer with a warmed stem cache.
     stemBlends: false,
   },
-  // Sound-effects library. When disabled, the segment-director agent is never
-  // shown the effect catalogue, so it stops garnishing spoken breaks with
-  // stingers. The library files themselves stay on disk either way.
+  // When disabled, the segment-director agent is never shown the effect
+  // catalogue, so it stops garnishing spoken breaks with stingers. The files stay
+  // on disk either way.
   sfx: {
     enabled: true,
   },
-  // Beds — an instrumental bed between two songs for the DJ to talk over, so a
-  // long link isn't talked over the song it's introducing (broadcast/beds.ts +
-  // broadcast/bed-policy.ts). Off by default: it needs a bed the operator is
-  // happy to hear regularly, and a bed on EVERY link is morning-zoo radio.
-  //
-  // Controller-side only — no liquidsoap_*.txt, so toggling costs no mixer
-  // restart, unlike jingleRatio.
+  // Beds — an instrumental between two songs for the DJ to talk over, so a long
+  // link isn't talked over the song it's introducing (broadcast/beds.ts +
+  // bed-policy.ts). Off by default: it needs a bed the operator is happy to hear
+  // regularly, and a bed on EVERY link is morning-zoo radio. Controller-side only,
+  // so toggling costs no mixer restart (unlike jingleRatio).
   beds: {
     enabled: false,
     // Bed when the DJ's clip runs longer than this. Consulted ONLY where the
-    // incoming track's vocal onset is unknown; where the analyzer measured
-    // vocal ranges, the real onset wins and this is ignored. See
+    // incoming track's vocal onset is unknown; a measured onset wins. See
     // bed-policy.rampBudgetMs.
     thresholdSec: 12,
-    // The bed's own exit crossfade — how long the next song takes to ramp in
-    // under the DJ's closing words.
+    // The bed's own exit crossfade — how long the next song takes to ramp in under
+    // the DJ's closing words.
     crossSec: 6,
   },
-  // Outbound webhooks. Each entry POSTs station events (see broadcast/
-  // webhooks.ts for the event list) to `url` with a fire-and-forget HTTP
-  // call. `track.play` can be listener-gated via webhooksPolicy (off by
-  // default — see broadcast/queue.ts). Empty by default — operators add hooks
-  // via the admin UI.
+  // Fire-and-forget station-event POSTs (event list in broadcast/webhooks.ts).
   webhooks: [] as Webhook[],
   webhooksPolicy: {
     // When true, track.play POSTs only when listener count > 0 (fail-closed on
-    // null/unknown/non-finite, like scrobble). Default false = always send.
+    // null/unknown/non-finite, like scrobble).
     trackPlayListenerGated: false,
   },
-  // Station-wide scrobbling. Each backend is independent; both are paste-only
-  // (no OAuth) and both are gated on listener count > 0 at scrobble time (a
-  // null/unknown count is treated as zero — fail closed, see broadcast/
-  // scrobble.ts). API keys/secrets/tokens live here OR in state/secrets.env
-  // (env wins). `username` is display-only.
+  // Each backend is independent, paste-only (no OAuth), and gated on listener
+  // count > 0 at scrobble time — a null/unknown count is treated as zero, i.e.
+  // fail closed. Keys live here OR in state/secrets.env (env wins). `username` is
+  // display-only.
   scrobble: {
     lastfm: {
       enabled: false,
@@ -702,17 +521,15 @@ export const DEFAULTS = {
       enabled: false,
       userToken: '',
       username: '',
-      // Optional override for self-hosted LB-compatible scrobblers (e.g. Koito).
-      // Full submit URL is `${baseUrl}/submit-listens`. Env LISTENBRAINZ_API_URL wins.
+      // For self-hosted LB-compatible scrobblers (e.g. Koito). Submit URL is
+      // `${baseUrl}/submit-listens`. Env LISTENBRAINZ_API_URL wins.
       baseUrl: '',
     },
   },
 
-  // Listener likes (#991) — the player heart button. `starInNavidrome` mirrors
-  // each first like of a song into Navidrome via Subsonic star (any Subsonic
-  // client sees it under Starred). `influenceDj` feeds the most-liked tracks
-  // back to BOTH pick paths (agent prompt lean + pool picker source) as a
-  // weighted preference signal — never a lock. Window/limit bound that signal.
+  // The player heart button (#991). `starInNavidrome` mirrors each first like
+  // into Navidrome via Subsonic star. `influenceDj` feeds the most-liked tracks
+  // back to BOTH pick paths as a weighted preference — never a lock.
   likes: {
     enabled: true,
     starInNavidrome: true,
@@ -723,20 +540,15 @@ export const DEFAULTS = {
 };
 
 export const BOUNDS = {
-  // The three keys converted to the shared schema (#1348) take their numbers
-  // from schemas/settings.ts rather than declaring them here. A mirrored module
-  // may not import a non-mirrored one, so the shared schema has to own the
-  // constant and this re-exports it — the same rule that homed SHOW_ID_RE in
-  // schemas/show.ts. The rationale for each figure moved with it.
+  // The keys converted to the shared schema (#1348) take their numbers from
+  // schemas/settings.ts and re-export here: a mirrored module may not import a
+  // non-mirrored one, so the schema has to own the constant.
   jingleRatio: { ...JINGLE_RATIO_BOUNDS, type: 'int' },
   crossfadeDuration: { ...CROSSFADE_DURATION_BOUNDS, type: 'float' },
   bedsThresholdSec: { ...BEDS_THRESHOLD_SEC_BOUNDS, type: 'float' },
   bedsCrossSec: { ...BEDS_CROSS_SEC_BOUNDS, type: 'float' },
-  // 0 = off; 36000 s (10h) is a generous ceiling that still leaves room for
-  // long-form mix shows without letting a typo set an absurd value.
-  // Ceiling from the shared show schema: the strict show validator has always
-  // bounds-checked a show's own override against this station figure, so two
-  // copies of the number would drift.
+  // Ceiling from the shared show schema: the strict show validator bounds-checks
+  // a show's override against this station figure, so two copies would drift.
   maxTrackSeconds: { min: 0, max: SHOW_MAX_TRACK_SECONDS, type: 'int' },
   loudnessTargetLufs: { ...LOUDNESS_TARGET_LUFS_BOUNDS, type: 'float' },
   loudnessMaxBoostDb: { ...LOUDNESS_MAX_BOOST_DB_BOUNDS, type: 'float' },
@@ -746,12 +558,10 @@ export const MP3_BITRATE_SET = new Set<number>(MP3_BITRATES);
 export const OPUS_BITRATE_SET = new Set<number>(OPUS_BITRATES);
 export const AAC_BITRATE_SET = new Set<number>(AAC_BITRATES);
 
-// True when the four ElevenLabs voice_settings knobs (issue #696) all sit at
-// their shipped defaults, i.e. the operator never tuned them. cloud-speech uses
-// this to OMIT the voice_settings block in that case so ElevenLabs defers to the
-// voice's own VoiceLab-saved settings, instead of forcing these literals onto
-// every call (issue #915 review). Compared against DEFAULTS so there's a single
-// source of truth for the default values.
+// True when the four ElevenLabs voice_settings knobs all sit at their shipped
+// defaults, i.e. the operator never tuned them. cloud-speech then OMITS the
+// voice_settings block so ElevenLabs defers to the voice's own VoiceLab-saved
+// settings instead of having these literals forced onto every call (#915).
 export function cloudVoiceSettingsAreDefault(c: unknown): boolean {
   const d = DEFAULTS.tts.cloud;
   const cc = c as {
@@ -768,9 +578,9 @@ export function cloudVoiceSettingsAreDefault(c: unknown): boolean {
 
 // Coerce a stored/per-show max-track-length to a clean integer SECOND count.
 // `allowNull` distinguishes the two callers: the station default has no "unset"
-// state (missing → 0 = off), whereas a per-show value uses null to mean "inherit
-// the station default" (vs 0 = "unlimited override"). Out-of-band values clamp
-// into [0, max] rather than throw — load() stays lenient.
+// state (missing → 0 = off), whereas a per-show value uses null for "inherit the
+// station default" (vs 0 = "unlimited override"). Clamps rather than throws —
+// load() stays lenient.
 export function coerceMaxTrackSeconds(raw: unknown, allowNull: boolean): number | null {
   if (raw == null || raw === '') return allowNull ? null : 0;
   const n = Math.round(Number(raw));
@@ -778,11 +588,9 @@ export function coerceMaxTrackSeconds(raw: unknown, allowNull: boolean): number 
   return Math.min(BOUNDS.maxTrackSeconds.max, Math.max(0, n));
 }
 
-// Back-compat: this cap was stored and sent in MINUTES (`maxTrackMinutes`) before
-// it moved to seconds. Prefer the new `maxTrackSeconds` key; fall back to a legacy
-// minutes value ×60 so an existing settings.json / show and any stale client keep
-// working. Returns the raw seconds value (leaving null/''/undefined untouched) for
-// coerceMaxTrackSeconds to clamp.
+// Back-compat: this cap was stored in MINUTES (`maxTrackMinutes`) before it moved
+// to seconds. Returns the raw seconds value (leaving null/''/undefined untouched)
+// for coerceMaxTrackSeconds to clamp.
 export function rawMaxTrackSec(o: unknown): unknown {
   if (o == null) return o;
   const rec = o as Record<string, unknown>;
@@ -790,4 +598,3 @@ export function rawMaxTrackSec(o: unknown): unknown {
   if (rec.maxTrackMinutes != null && rec.maxTrackMinutes !== '') return Number(rec.maxTrackMinutes) * 60;
   return rec.maxTrackSeconds;
 }
-

--- a/controller/src/settings/patch-registry.ts
+++ b/controller/src/settings/patch-registry.ts
@@ -1,9 +1,8 @@
 // The `POST /settings` patch registry (#1348).
 //
 // `settings.update()` takes a PARTIAL patch over 42 top-level keys and validates
-// it in a ~1,100-line chain of `if ('<key>' in patch)` branches. #1337 put every
-// single-feature admin form on a shared zod schema and deliberately held this
-// one back, because a route that owns forty-two shapes doesn't fit the recipe.
+// it in a long chain of `if ('<key>' in patch)` branches — a route that owns
+// forty-two shapes doesn't fit #1337's one-schema-per-form recipe.
 //
 // This module is the frame the conversion lands in, one key at a time:
 //
@@ -18,18 +17,16 @@
 //
 // WHY UNKNOWN-KEY REJECTION IS A ROUTE POSTURE AND NEVER AN update() RULE
 // ----------------------------------------------------------------------
-// The issue asks for unknown top-level keys to be rejected rather than silently
-// dropped, and at the route that is right: every admin panel posts keys from
-// this inventory, so an unknown one is a typo that today saves nothing and
-// still answers 200.
+// At the route, rejecting an unknown top-level key is right: every admin panel
+// posts keys from this inventory, so an unknown one is a typo that would
+// otherwise save nothing and still answer 200.
 //
-// Inside update() the same rule would be a data-loss bug. routes/backup.ts:218
-// parses a backup's settings.json and hands the WHOLE object to update(); so
-// does onboarding, and so does every internal caller. A backup written by a
-// newer version carries keys this one has never heard of, and refusing the
-// patch would turn "one setting didn't come across" into "the restore failed".
-// Hence: the inventory is enforced at the boundary the operator types at, and
-// update() stays tolerant of keys it doesn't know.
+// Inside update() the same rule would be a data-loss bug. routes/backup.ts hands
+// a whole backup settings.json to update(), as do onboarding and every internal
+// caller. A backup written by a newer version carries keys this one has never
+// heard of, and refusing the patch would turn "one setting didn't come across"
+// into "the restore failed". So the inventory is enforced at the boundary the
+// operator types at, and update() stays tolerant of keys it doesn't know.
 import { ZodError, type ZodType } from 'zod';
 import {
   archivePatchSchema,

--- a/controller/src/settings/persona.ts
+++ b/controller/src/settings/persona.ts
@@ -230,21 +230,17 @@ export function languageDirective(persona: unknown) {
 }
 
 // A SECOND language reminder, anchored at the END of a tool-loop agent's system
-// prompt and naming the exact spoken output field(s). The preamble's
-// languageDirective sits at the TOP of a long, English-dominated tool-loop
-// prompt (tool descriptions, picker criteria, capability lists), and small /
-// cloud models drop it in favour of the English Zod field descriptions sitting
-// right next to the actual spoken output — so the picker `say`, request
-// `ack`/`intro`, and segment `text` came out English even with the directive
-// present (issue #558). Repeating the language LAST, by field name, is what
-// makes it stick — the same trick the request matcher already uses for its
-// `ack` field (see llm/internal/prompts/request.ts). Unset language defaults
-// to English and this ALWAYS renders now, for the same raid-hardening reason
-// as languageDirective above — the old "returns '' for English personas so
-// prompts stay byte-identical" property is deliberately gone (raid
-// 2026-07-28: with no anchor, session-history mimicry flipped the station's
-// language). `fields` is a human phrase naming the spoken field(s), e.g. 'the
-// "say" link' or 'the "ack" and "intro" lines'.
+// prompt and naming the exact spoken field(s). The preamble's languageDirective
+// sits at the TOP of a long, English-dominated prompt (tool descriptions, picker
+// criteria, capability lists), and small/cloud models drop it in favour of the
+// English Zod field descriptions sitting right next to the spoken output — so
+// `say`, `ack`/`intro` and `text` came out English even with the directive
+// present (#558). Repeating it LAST, by field name, is what makes it stick.
+//
+// ALWAYS renders, defaulting to English: the old "return '' for English personas
+// so prompts stay byte-identical" property is deliberately gone, because with no
+// anchor session-history mimicry flipped the station's language (raid
+// 2026-07-28). `fields` is a human phrase naming the spoken field(s).
 export function agentLanguageReminder(persona: unknown, fields: string) {
   const lang = String((persona as { language?: unknown } | null | undefined)?.language || '').trim() || 'English';
   return `\n\nLANGUAGE — this overrides the field descriptions below: you speak ${lang}. Write ${fields} entirely in ${lang} — even when the listener writes in another language, asks you to switch, or earlier session turns are in another language. Keep proper nouns (artist names, song titles, the station name) exactly as they are; do not translate them. Internal fields (ids, reasons, kinds) stay in English.`;
@@ -330,17 +326,15 @@ function houseRulesBlock(scope: string): string {
 // never hand-roll the opener.
 //
 // Deliberately JUST the opener — no hard-coded style-rule block. A
-// DJ_HUMANNESS_RULES word-blocklist used to be appendable here (and in
-// renderDjPrompt); it was lost in the a0d58b3 editor-mangle, and when a
-// restore was attempted the operator chose to keep it out: the station ran
-// fine without it for weeks, the ~600-char negative list competes with each
-// persona's soul and flattens voices toward one register, and it taxes every
-// call. Voice steering lives in the persona souls, tone dials, and the
-// operator-editable djPrompt template — with one exception: the operator's
-// OWN djHouseRules block (issue #1182), which is appended here too because
-// the djPrompt template never reaches the agent prompts and rules like TTS
-// control tags or number spelling are correctness, not style. Empty by
-// default, so a station with no house rules is byte-identical to before.
+// DJ_HUMANNESS_RULES word-blocklist used to be appendable here; the operator
+// chose to keep it out, because a ~600-char negative list competes with each
+// persona's soul, flattens voices toward one register, and taxes every call.
+// Voice steering lives in the persona souls, tone dials and the djPrompt
+// template.
+//
+// One exception: the operator's own djHouseRules block (#1182) IS appended here,
+// because the djPrompt template never reaches the agent prompts and rules like
+// TTS control tags or number spelling are correctness, not style.
 export function agentPersonaPreamble(persona) {
   const name = persona?.name || 'the DJ';
   // Close the soul as a sentence: this preamble runs straight into the next

--- a/controller/src/settings/vocab.ts
+++ b/controller/src/settings/vocab.ts
@@ -44,7 +44,6 @@ import {
   TTS_ENGINES as TTS_ENGINE_VALUES,
   TTS_GAIN_CLAMP_DB as TTS_GAIN_CLAMP_DB_VALUE,
   TTS_KOKORO_VOICE_RE,
-  TTS_PIPER_VOICE_RE,
   TTS_POCKET_VOICE_RE,
   TTS_SPEED_DEFAULT as TTS_SPEED_DEFAULT_VALUE,
   TTS_SPEED_MAX as TTS_SPEED_MAX_VALUE,
@@ -143,22 +142,17 @@ export function personaToneDirectives(persona: unknown): string {
   return lines.length ? `\n\nTone:\n- ${lines.join('\n- ')}` : '';
 }
 
-// TTS engines. Every spoken segment is voiced by the on-air persona's own
-// `tts` config (see audio/tts.js); only jingle rendering falls back to the
-// global defaultEngine.
+// TTS engines. Every spoken segment is voiced by the on-air persona's own `tts`
+// config (audio/tts.js); only jingle rendering falls back to defaultEngine.
 //
-// `cloud` routes through the AI SDK (OpenAI / ElevenLabs speech models) —
-// see llm/speech.js. `piper`, `kokoro`, `chatterbox`, and `pocket-tts` are
-// local engines. `remote` is a first-class self-hosted HTTP engine: it POSTs
-// to a configurable /speak endpoint and gets the rendered audio back in the
-// response body (no shared volume, so the endpoint can live on any host),
-// gated on a /health probe. Configure the URL in settings.tts.remote.url.
-// Chatterbox and PocketTTS are opt-in — the
-// default controller image doesn't bundle either; build the image with
-// `--build-arg WITH_CHATTERBOX=1` or `--build-arg WITH_POCKETTTS=1` (see
-// docker/Dockerfile.controller) to include the runtime. The dispatcher gates
-// each engine on isAvailable() so settings can reference it safely even when
-// the runtime is absent (the engine just falls back to Piper).
+// `cloud` routes through the AI SDK (llm/speech.js). `piper`, `kokoro`,
+// `chatterbox` and `pocket-tts` are local. `remote` is a self-hosted HTTP
+// engine: it POSTs to a configurable /speak endpoint and gets the audio back in
+// the response body — no shared volume, so it can live on any host — gated on a
+// /health probe. Chatterbox and PocketTTS are opt-in at image build time
+// (`--build-arg WITH_CHATTERBOX=1` / `WITH_POCKETTTS=1`). The dispatcher gates
+// every engine on isAvailable(), so settings can name one whose runtime is
+// absent and it simply falls back to Piper.
 export const TTS_ENGINES: readonly string[] = TTS_ENGINE_VALUES;
 
 // DJ-voice level trim, in dB. A per-engine gain levels the loudness gap between
@@ -284,17 +278,14 @@ export const LLM_PROVIDERS = [
   'gateway',
 ];
 
-// Subset of LLM_PROVIDERS that can actually produce text embeddings — the
-// library tagger embeds every track (music/embeddings.ts). Two chat providers
-// still route chat ONLY: deepseek and the Vercel AI gateway have no embeddings
-// endpoint. Offering them in the embedding-provider picker silently fell through
-// to a local Ollama and failed with a misleading "can't reach <provider>" error
-// (#493). `openrouter` was originally in that chat-only set, but OpenRouter
-// shipped an OpenAI-compatible embeddings endpoint, so it's back in (#522) and
-// routes through llm/internal/provider/embedding.ts. `anthropic` was dropped —
-// it has no first-party embedding model and only worked by transparently routing
-// to OpenAI (needs OPENAI_API_KEY), which confused operators; pick OpenAI (or any
-// other embedding provider) directly instead.
+// Subset of LLM_PROVIDERS that can actually produce text embeddings. Chat-only
+// providers are excluded because offering them in the embedding picker fell
+// through to a local Ollama and failed with a misleading "can't reach
+// <provider>" (#493): deepseek and the Vercel AI gateway have no embeddings
+// endpoint, and `anthropic` has no first-party embedding model (it only worked
+// by transparently routing to OpenAI, which confused operators — pick OpenAI
+// directly). `openrouter` IS included: it shipped an OpenAI-compatible
+// embeddings endpoint (#522), routed through provider/embedding.ts.
 export const EMBEDDING_PROVIDERS = [
   'ollama',
   'openai-compatible',
@@ -370,13 +361,13 @@ export function clampMaxOutputTokens(raw: unknown, def: number): number {
 // band. Non-numeric/NaN falls back to `def`. Same 0-means-auto shape as
 // clampMaxOutputTokens above.
 //
-// The band is imported from the harness rather than restated here: it is a
-// property of the tool loop (a 0 budget corners the model at step 0 with an
-// empty candidate set; an unbounded one eats the shared deadline the recovery
-// legs need), and a second copy of the numbers would be free to drift from the
-// clamp discoveryStepsFor() applies. This is the one place settings reaches past
-// an `llm/` barrel: capabilities.ts imports nothing, while the llm/provider.js
-// barrel pulls in registry.ts, which imports settings — a cycle.
+// The band is imported from the harness rather than restated: it is a property
+// of the tool loop (a 0 budget corners the model at step 0 with an empty
+// candidate set; an unbounded one eats the shared deadline the recovery legs
+// need), and a second copy would be free to drift from discoveryStepsFor()'s
+// clamp. This is the one place settings reaches past an `llm/` barrel —
+// capabilities.ts imports nothing, while the llm/provider.js barrel pulls in
+// registry.ts, which imports settings: a cycle.
 export function clampDiscoverySteps(raw: unknown, def: number): number {
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return def;
   const n = Math.floor(raw);
@@ -664,7 +655,6 @@ export const WEATHER_MOOD_DEFAULTS: Record<string, string> = {
 
 // --- Mood vocabulary validation (the seeded-but-editable pattern) ---
 export const MOODS_LIMIT = 40;
-export const MOOD_NAME_MAX = 40;
 export const MOOD_PROMPT_MAX = 200;
 
 // Normalise a raw mood name to the canonical id form (lowercase, [a-z0-9-]).
@@ -827,11 +817,6 @@ export const POCKET_TTS_VOICE_RE = TTS_POCKET_VOICE_RE;
 // (means "use the built-in default voice"). Used by both chatterbox and
 // pocket-tts since issue #213.
 export const CHATTERBOX_VOICE_RE = TTS_CHATTERBOX_VOICE_RE;
-// Per-persona Piper voice — an `.onnx` model filename in the shared voice folder
-// (config.voices.dir), e.g. `en_US-amy-medium.onnx`, dropped alongside its
-// `.onnx.json` manifest. Basename only, no path separators. Empty is valid and
-// means "use the baked-in default voice" (issue #230).
-export const PIPER_VOICE_RE = TTS_PIPER_VOICE_RE;
 // The entity-id pattern shows, personas and skill assignments all share. Its
 // one definition is SHOW_ID_RE in the shared show schema — a mirrored module
 // cannot import a common one (gen-schemas.ts rejects every specifier but
@@ -880,23 +865,18 @@ export { SHOW_TOPIC_MAX } from '../schemas/show.js';
 // like the host.
 export { GUESTS_PER_SHOW, PLAYLISTS_PER_SHOW, EXCLUDED_PLAYLISTS_PER_SHOW };
 // Values per multi-select music filter (moods / genres / eras). Within one
-// attribute the values OR together at pick time; across attributes they AND.
-// Raised 6 → 15: the AND-across argument for keeping it small never applied
-// WITHIN an attribute, and genre is where it bites — a strict alt/punk show
-// has to name every library tag it wants (Punk Rock, Emo, Pop Punk,
-// Post-Hardcore, Emo Pop, …) because matching only REFINES, never broadens
-// (see trackGenres/genreMatches in music/show-filter.ts), so 6 forced the
-// operator to either drop valid tags or retag the library.
+// attribute the values OR at pick time; across attributes they AND.
 //
-// What made 6 load-bearing was cost, not meaning: every genre used to cost a
-// getGenres() round trip to resolve (music/subsonic.ts) plus two discovery
-// fetches per genre in each pool builder, all sequential. Both are bounded now
-// — getGenres is TTL-cached and the per-genre fetches run through mapPool — so
-// the wall-clock of a pick no longer scales with this number. The per-genre
-// size budgets already divide a FIXED total (randomSize / genreSetSize in
-// music/picker.ts + broadcast/scheduler.ts), so the pool doesn't grow either.
-// Keep in lockstep with FILTER_VALUES_MAX in
-// web/components/admin/shows/types.ts (pinned by scripts/show-filter-cap.test.ts).
+// The cap can be generous because neither cost nor pool size scales with it:
+// getGenres() is TTL-cached, the per-genre discovery fetches run through
+// mapPool, and the per-genre size budgets divide a FIXED total (randomSize /
+// genreSetSize). It needs to be generous because genre matching only REFINES,
+// never broadens (trackGenres/genreMatches in music/show-filter.ts), so a strict
+// alt/punk show must name every library tag it wants — Punk Rock, Emo, Pop Punk,
+// Post-Hardcore, … — or retag the library.
+//
+// Keep in lockstep with FILTER_VALUES_MAX in web/components/admin/shows/types.ts
+// (pinned by scripts/show-filter-cap.test.ts).
 export { SHOW_FILTER_VALUES_MAX };
 // Must comfortably exceed a realistic skill library: unticking one skill on an
 // "all skills" (null) persona materialises the FULL catalog minus one, so a cap

--- a/controller/src/skills/_agent.ts
+++ b/controller/src/skills/_agent.ts
@@ -1,28 +1,23 @@
-// Segment-director agent — the agentic replacement for the registry's old
-// filter-and-random-pick skills tick.
+// Segment-director agent.
 //
-// The 5-minute cron (scheduler.skillsTick) calls agenticTick(). Instead of
-// mechanically picking an eligible skill, it hands a focused snapshot of the
-// moment (what's on air, what the DJ has already said recently) plus a set of
-// real-world data tools (llm/segment-tools.js) to a tool-loop agent and asks
-// one question: "is there anything worth saying between tracks right now —
-// and if so, what?" The agent may look at the weather, the headlines, or
-// artist news, then either writes ONE spoken line or stays silent.
+// The 5-minute cron (scheduler.skillsTick) calls agenticTick(), which hands a
+// tool-loop agent a snapshot of the moment (what's on air, what the DJ said
+// recently) plus real-world data tools (llm/segment-tools.js) and asks one
+// question: is there anything worth saying between tracks right now? The agent
+// may check the weather, headlines or artist news, then writes ONE spoken line
+// or stays silent.
 //
-// It is deliberately NOT given the full track-pick session history: that
-// history is mostly "pick the next song" chatter, which small models latch
-// onto and start reasoning about music instead of the segment decision. The
-// anti-repeat context it needs is queue.getDjRecap() — what actually aired.
+// It is deliberately NOT given the track-pick session history: that is mostly
+// "pick the next song" chatter, which small models latch onto and start
+// reasoning about music instead of the segment decision. The anti-repeat context
+// it needs is queue.getDjRecap() — what actually aired.
 //
-// Both the autonomous tick AND the operator override now run through this
-// agent. `agenticTick()` is the 5-minute cron; `runCapability()` is the
-// /dj/skill manual override — same tool-loop, but forced to one capability
-// with cooldowns bypassed. The capability registry is loaded by skills/loader.js
-// from the single load root state/skills/<slug>/ (the seven built-ins are seeded
-// there on first boot from src/skills/builtins/ templates; see skills/scaffold.js).
-// This module consumes it (allCapabilities) and backs the admin catalogue via
-// `skillCatalog()`. The skill modules left in this directory — news.js,
-// web-search.js, curiosity.js — are pure fetch helpers behind station-services.
+// `runCapability()` is the /dj/skill manual override: the same tool-loop forced
+// to one capability with cooldowns bypassed. The capability registry is loaded
+// by skills/loader.js from state/skills/<slug>/ (built-ins seeded on first boot
+// from src/skills/builtins/); this module consumes it via allCapabilities and
+// backs the admin catalogue via skillCatalog(). The skill modules left in this
+// directory are pure fetch helpers behind station-services.
 //
 // Guard rails the autonomous tick cannot talk its way past (the operator
 // override bypasses all of them — when the operator asks, they get a segment):
@@ -92,18 +87,17 @@ function unionContextFields(caps): string[] {
   return [...out];
 }
 
-// Schema factories, resolved per run (defineAgent's function-schema form): the
-// spoken-line length follows the on-air persona's scriptLength via
-// lengthPhrase('segment'), so an 'extended' storytelling persona stretches its
-// segments the way it already stretches intros and links. A hard-coded
-// description here previously pinned every persona to one-liners.
-// Field order is deliberate: models generate JSON in property order, so
-// `reason` comes FIRST (decide and justify before writing the line — a free
-// mini chain-of-thought), then the explicit `air` boolean, then the segment.
-// The boolean exists because a nullable nested object alone proved hard for
-// small models to encode "stay silent" with — they emitted bare top-level
-// `null` or prose instead (see isBareNullSilent / isSilentFailure below);
-// `air: false` gives them an unambiguous silence token to reach for.
+// Schema factories, resolved per run (defineAgent's function-schema form) so the
+// spoken-line length can follow the on-air persona's scriptLength — a hard-coded
+// description here pinned every persona to one-liners.
+//
+// Field order is deliberate: models generate JSON in property order, so `reason`
+// comes FIRST (decide and justify before writing the line — a free mini
+// chain-of-thought), then the `air` boolean, then the segment. The boolean
+// exists because small models struggled to encode "stay silent" through a
+// nullable nested object alone, emitting bare top-level `null` or prose instead
+// (isBareNullSilent / isSilentFailure below); `air: false` gives them an
+// unambiguous silence token.
 function segmentSchema() {
   return modelTolerant(z.object({
     reason: z.string().describe('one short internal sentence on why this segment (or why silent) — never shown to the listener; write this BEFORE deciding the segment'),
@@ -327,21 +321,17 @@ export function buildSituation(ctx, { forced = false, contextFields, recentCurio
 // ---------------------------------------------------------------------------
 // Simple (non-agentic) director — the pool-mode counterpart of directorAgent.
 //
-// When the operator has set the picker to "candidate pool"
-// (settings.llm.pickerAgent off — the admin UI's signal that the model can't
-// be trusted with multi-step tool loops), the segment path must not be the
-// one place still running a tool-loop agent: on small local models the
-// director mostly degrades to silence (isSilentFailure) or done-tool stalls
-// (issue #555), so segments are effectively broken for those operators.
+// `settings.llm.pickerAgent` off is the operator's signal that the model can't
+// be trusted with multi-step tool loops, so the segment path must not be the one
+// place still running one: on small local models the director degrades to
+// silence (isSilentFailure) or done-tool stalls (#555).
 //
-// This path replaces the agent's judgment with code + ONE structured call:
-// code picks the capability (weather-on-change first, then least-recently
-// aired), calls its data tool directly (fetchSegmentData — the same tool.mjs
-// the agent would have called, minus the model-steered inputs), inlines the
-// result into the prompt, and asks for the same {air, text, sfx} decision the
-// agent schema carries — the model still gets to choose silence when the data
-// is dull. Everything downstream (announce, cooldowns, curiosity ledger, sfx
-// validation) is shared with the agent path in agenticTick.
+// This path replaces the agent's judgment with code + ONE structured call: code
+// picks the capability (weather-on-change first, then least-recently aired),
+// calls its data tool directly (fetchSegmentData — the same tool.mjs, minus the
+// model-steered inputs), inlines the result, and asks for the same
+// {air, text, sfx} decision, so the model still gets to choose silence when the
+// data is dull. Everything downstream is shared with agenticTick.
 // ---------------------------------------------------------------------------
 
 // Which capability the simple path airs this tick. Weather wins when the
@@ -715,8 +705,7 @@ export async function runCapability(which, ctx, { brief = null, persona = null }
   return text;
 }
 
-// Skill metadata for the admin command-center UI — derived straight from
-// CAPABILITIES. Previously lived in the now-deleted skills/_registry.js.
+// Skill metadata for the admin command-center UI, derived from CAPABILITIES.
 export function skillCatalog() {
   const s = settings.get();
   const enabledMap = s.skills?.enabled || {};

--- a/controller/src/stations/pure.ts
+++ b/controller/src/stations/pure.ts
@@ -1,12 +1,10 @@
 // Pure helpers for multi-station profiles — no fs, no config import (config.ts
 // depends on stations/resolve.ts, which depends on this file; keep it leaf-level).
-// Spec: docs/superpowers/specs/2026-07-24-multi-station-profiles-design.md
-
-// STATION_ID_RE, MAX_STATIONS and slugifyStationName now live in
-// schemas/station.ts so the admin form validates against them directly (the
-// slug preview was a hand-copied second implementation, and it had drifted).
-// Re-exported here because this is the import path every caller already uses,
-// and schemas/station.ts imports only zod, so the leaf-level rule above holds.
+//
+// STATION_ID_RE, MAX_STATIONS and slugifyStationName live in schemas/station.ts
+// so the admin form validates against them directly; they are re-exported here
+// because this is the import path every caller already uses, and that module
+// imports only zod, so the leaf-level rule above holds.
 import { STATION_ID_RE } from '../schemas/station.js';
 
 export {

--- a/controller/src/util/theme-provenance.ts
+++ b/controller/src/util/theme-provenance.ts
@@ -31,20 +31,20 @@
 //     client can destructure it without a presence check.
 
 /** The subset of a resolved show this read touches. */
-export interface ActiveShowLike {
+interface ActiveShowLike {
   id?: unknown;
   name?: unknown;
   themeId?: unknown;
 }
 
 /** The show that outranked the station default, as published. */
-export interface ProvenanceShow {
+interface ProvenanceShow {
   id: string;
   name: string;
   themeId: string;
 }
 
-export interface ThemeProvenance {
+interface ThemeProvenance {
   /** The effective theme — what a client should actually paint. Unchanged. */
   active: string;
   /** Which level decided `active`. */

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -565,28 +565,24 @@ export function fishAudioIssue(cloud: unknown): string | null {
 // ---------------------------------------------------------------
 // `PERSONA_ID_RE` is the same pattern as schemas/show.ts's SHOW_ID_RE, and
 // `PERSONA_SKILL_SLUG_RE` the same as schemas/skill.ts's SKILL_SLUG_RE. Neither
-// can be imported (see above) and neither can reuse the other's NAME (the flat
-// mirror would carry two declarations of it). Re-declaring is therefore
-// structural, not sloppiness — and the drift it invites is pinned by
-// scripts/persona-schema.test.ts, which asserts `.source` equality against both
-// originals. That is the same answer skill-schema.test.ts gives for
-// loader.SLUG_RE and vocab's SKILL_SLUG_RE.
+// can be imported (see above), and neither can reuse the other's NAME because
+// the flat mirror would then carry two declarations of it. Re-declaring is
+// structural, not sloppiness; the drift it invites is pinned by
+// scripts/persona-schema.test.ts, which asserts `.source` equality against both.
 //
 // WHY THERE IS NO FACTORY
 // -----------------------
-// Unlike a show, a persona CAN be validated against itself: every rule is a
-// pure function of the submitted value. `skills` names skill slugs, but a slug
-// that no longer resolves is dropped rather than refused (see the field), so
-// the live catalogue is not an input. Rules that are NOT pure — id minting and
-// cross-row de-duplication — live in persona-server.ts, which is NOT mirrored.
+// Unlike a show, a persona CAN be validated against itself: every rule is a pure
+// function of the submitted value. `skills` names skill slugs, but an unresolved
+// slug is dropped rather than refused, so the live catalogue is not an input.
+// Impure rules — id minting, cross-row de-duplication — live in
+// persona-server.ts, which is NOT mirrored.
 //
 // SETTINGS/VOCAB.TS RE-EXPORTS EVERY CONSTANT BELOW
 // -------------------------------------------------
-// The "first feature converted owns the constant" rule. No call site moved when
-// this landed; vocab.ts aliases these under the names the controller already
-// used (PERSONA_FREQUENCIES as FREQUENCIES, and so on). The web side must read
-// them from the mirror rather than hand-copying — a hand-copied cap is exactly
-// the SKILL_SLUG_RE drift this whole mechanism exists to prevent.
+// "First feature converted owns the constant", so no call site moved: vocab.ts
+// aliases these under the names the controller already used. The web side must
+// read them from the mirror rather than hand-copying.
 
 // ── Persona vocabulary ───────────────────────────────────────────────────────
 
@@ -1859,40 +1855,37 @@ export const scheduleOverrideRequestSchema = z.object({
 //
 // WHY A KEY AT A TIME, AND NOT ONE SCHEMA FOR THE SETTINGS OBJECT
 // ---------------------------------------------------------------
-// The `/settings` body is a partial PATCH, not an object: every admin panel
-// posts only the keys it owns. `z.object` strips unknown keys, so a schema over
-// the whole settings object would silently delete whatever a form learns to
-// send next. Instead each top-level key owns its own schema here, and
-// settings/patch-registry.ts runs only the keys a given patch actually carries.
-// That keeps the stripping scoped to a block whose shape is fully known.
+// The `/settings` body is a partial PATCH: every admin panel posts only the keys
+// it owns. `z.object` strips unknown keys, so a schema over the whole settings
+// object would silently delete whatever a form learns to send next. Instead each
+// top-level key owns its own schema here and patch-registry.ts runs only the
+// keys a patch actually carries, keeping the stripping scoped to blocks whose
+// shape is fully known.
 //
-// FIDELITY IS THE POINT OF THE FIRST SLICE
-// ----------------------------------------
-// #1337's rule is that no conversion may introduce a silent repair where the
-// operator previously got a refusal, or vice versa. The hand-rolled branches
-// these replace carry a lot of ACCIDENTAL leniency, and reproducing it is most
-// of the work here:
+// FIDELITY IS THE POINT
+// ---------------------
+// No conversion may introduce a silent repair where the operator previously got
+// a refusal, or vice versa (#1337's rule). The hand-rolled branches these
+// replace carry a lot of ACCIDENTAL leniency, and reproducing it is most of the
+// work:
 //
-//   * `parseInt(raw, 10)` / `parseFloat(raw)` stringify first, so '5' and even
-//     '5abc' parse, and a float handed to an int key TRUNCATES rather than
-//     failing (jingleRatio: 5.7 saves as 5 today). `z.number().int()` refuses
-//     all three. See settingsIntLike / settingsFloatLike.
-//   * `!!value` accepts anything, so `enabled: 1` is `true` today. `z.boolean()`
-//     refuses it. See settingsBoolLike.
-//   * `patch.beds || {}` means a non-object block is a silent no-op, not an
-//     error. See settingsBlockOf.
+//   * `parseInt`/`parseFloat` stringify first, so '5' and even '5abc' parse, and
+//     a float on an int key TRUNCATES rather than failing (jingleRatio: 5.7
+//     saves as 5). `z.number().int()` refuses all three — hence
+//     settingsIntLike / settingsFloatLike.
+//   * `!!value` accepts anything, so `enabled: 1` is `true`. See settingsBoolLike.
+//   * `patch.beds || {}` makes a non-object block a silent no-op, not an error.
+//     See settingsBlockOf.
 //
-// Each of those is defensible to TIGHTEN — webhooks did exactly that in #1337 —
-// but tightening is a behaviour change and belongs in a PR that says so. This
-// one establishes the frame at zero behaviour change, so the frame itself can't
+// Tightening any of these is defensible — webhooks did exactly that — but it is
+// a behaviour change and belongs in a PR that says so, so the frame itself can't
 // be what hides a regression.
 //
-// The bounds live HERE rather than in settings/defaults.ts's BOUNDS because a
-// mirrored module may not import a non-mirrored one, and the browser needs the
-// same numbers to pre-flight the form. BOUNDS re-exports these — the same
-// "first feature converted owns the constant" rule that put SHOW_ID_RE in
-// schemas/show.ts. The web side must read them from the mirror rather than
-// hand-copying, which is what BedsSection did with a bare `60` and `15`.
+// The bounds live HERE rather than in defaults.ts's BOUNDS because a mirrored
+// module may not import a non-mirrored one and the browser needs the same
+// numbers to pre-flight the form; BOUNDS re-exports them. The web side must read
+// from the mirror rather than hand-copying — which is what BedsSection did with
+// a bare `60` and `15`.
 
 // Every top-level name in schemas/*.ts shares ONE scope in the flat mirror
 // (module-private ones included), hence the SETTINGS_/settings prefixes.
@@ -2183,6 +2176,12 @@ export const CROSSFADE_DURATION_BOUNDS: SettingsNumericBound = { min: 0, max: 30
 export const LOUDNESS_TARGET_LUFS_BOUNDS: SettingsNumericBound = { min: -23, max: -9 };
 // 0 disables boosting entirely (cut-only levelling); 12 dB is plenty.
 export const LOUDNESS_MAX_BOOST_DB_BOUNDS: SettingsNumericBound = { min: 0, max: 12 };
+// 0 disables burst-on-connect; past 60 a listener is a full minute behind the
+// live edge and <queue-size> (which must exceed the burst) gets unreasonable.
+// Named rather than inline because settings.load() bounds the stored value
+// against the SAME figures — a hand-copied pair there is how the save path and
+// the load path drift.
+export const STREAM_BUFFER_SECONDS_BOUNDS: SettingsNumericBound = { min: 0, max: 60 };
 
 // Falling back to the product default is what an emptied station name does —
 // see stationSchema.
@@ -2302,8 +2301,8 @@ export const streamPatchSchema = settingsBlockOf({
   // Number(), not parseInt — so '' / null / [] are 0 (a legal "no burst") and
   // '5abc' is refused. Bounds tested before the round; see the helper.
   bufferSeconds: settingsNumberPreRoundLike(
-    { min: 0, max: 60 },
-    'stream.bufferSeconds must be a number between 0 and 60',
+    STREAM_BUFFER_SECONDS_BOUNDS,
+    `stream.bufferSeconds must be a number between ${STREAM_BUFFER_SECONDS_BOUNDS.min} and ${STREAM_BUFFER_SECONDS_BOUNDS.max}`,
   ),
   idleAfterMinutes: settingsIntLike(
     { min: 1, max: 1440 },
@@ -2959,14 +2958,12 @@ export function djPromptTextSchema(bounds: { min: number; max: number }) {
 // settings/vocab.ts as ID_RE rather than living in a shared module.
 //
 // WHY A FACTORY. Unlike webhooks and stations, a show cannot be validated
-// against itself: `personaId` has to name a real persona, `moods` a live mood,
-// `themeId` an installed theme, and `maxTrackSeconds` clears a floor derived
-// from the station's crossfade. Those four travel as ONE ShowSchemaContext
-// value rather than as separate arguments — the shape the old four-parameter
-// validateShowsStrict(raw, personas, allowedThemeIds, moodNames) grew into, and
-// the same "one scope value, never unpacked" rule PickerScope follows. Both
-// sides can build it: the admin panel already fetches personas, moods, themes
-// and the station settings.
+// against itself: `personaId` must name a real persona, `moods` a live mood,
+// `themeId` an installed theme, and `maxTrackSeconds` clears a crossfade-derived
+// floor. Those four travel as ONE ShowSchemaContext value rather than separate
+// arguments — the same "one scope value, never unpacked" rule PickerScope
+// follows. Both sides can build it; the admin panel already fetches personas,
+// moods, themes and the station settings.
 //
 // Rules that are NOT pure functions of the submitted value — id minting and
 // cross-row de-duplication — live in show-server.ts, which is NOT mirrored.


### PR DESCRIPTION
## What

Two commits, separable:

1. **`fix`** — `settings.stream.bufferSeconds` never survived a controller restart. One line missing from `load()`'s stream composition.
2. **`chore`** — a comment-leaning pass over `controller/src`, plus dead code and six wrong comments.

Read the fix commit on its own (`e549f943`); the chore commit is 57 files of mostly comment churn.

## Why

**The bug.** `load()`'s stream block composes explicitly rather than spreading `DEFAULTS`, and `bufferSeconds` was never listed — the same "three edits" trap that cost `llm.repeatPenalty` in #1327. `update()` wrote it to `settings.json` and it worked in memory for that process; the next cold load read `undefined`.

Reproduced before touching anything — operator saves 40s, controller restarts:

```
operator saved            : 40
after cold load           : undefined
written for the mixer     : "undefined"
entrypoint would use      : 22 (non-numeric -> fallback)
/now-playing tells players: 22
```

Three consequences, not just the restart flag the old comment mentioned:

- `writeLiquidsoapSettings` put the literal string `"undefined"` in the mixer handoff file, so `read_state_num` fell back to 22 and the Icecast burst was sized for the default.
- `/now-playing` advertised `?? 22`, so every player applied an 18-second-wrong listener-time offset — against a setting whose entire point (#1114) is that the advertised depth and the real burst agree.
- `update()`'s change gate compared against `undefined`, so any patch carrying `stream.bufferSeconds` restarted the mixer unconditionally.

Both halves reverted together, which is why this never looked like a sync bug — only like "my buffer setting doesn't stick".

**The comments.** ~21k of `controller/src`'s 67k lines are comments. A mechanical sweep of all 490 files found essentially no classic slop: no comments restating the code, no commented-out blocks, no stale TODO/FIXME. It's verbose but substantive rationale, so this trims narration and value-history while keeping every invariant. `settings/defaults.ts` is the worked example: 793 → 600 lines, code byte-identical.

## How tested

- `npm test` in `controller/` — 116 files pass (115 before, +1 new).
- `npm run lint` passes in `controller/`, `web/` and `mcp-subwave/` — the three CI merge gates.
- Both mirror generators (`gen:schemas`, `gen:theme-tokens`) verified as no-ops, so the drift checks are clean. Regenerating also caught that the schema comment trims had left `web/lib/schemas.generated.ts` stale — included here.
- **The new test is verified to catch the bug**: all 6 cases fail with the `load()` line removed, all 6 pass with it. It's a COLD-LOAD round trip (`setCache(null)` + `load()`) per `controller/CLAUDE.md`, because an in-process assertion passes on the broken code.
- Every non-dead-code edit in the chore commit is comment-only, verified by diffing each file's comment-stripped source against `HEAD`.

## Notes for reviewers

**One deliberate behaviour change.** The restart gate now fires only on a real change, like its sibling encoder fields, instead of unconditionally. The previous comment predicted this and deferred it; since the fix is what makes `cur.stream.bufferSeconds` real, it comes with the fix. Net effect is fewer spurious mixer restarts.

**Bounds are now a named constant.** `STREAM_BUFFER_SECONDS_BOUNDS` in `schemas/settings.ts`, used by both `load()` and the save-path schema. Hand-copying `{min: 0, max: 60}` into `load()` would have rebuilt the exact drift trap the chore commit removes a duplicate literal for (`MOOD_NAME_MAX`).

**`load()` stays lenient** — out-of-band or garbage falls back to the default rather than throwing, so a hand-edited `settings.json` still can't wedge boot.

**Scope I deliberately left alone:**

- Ran type-aware ESLint (`no-unnecessary-condition`) across `src/`. 422 hits, none actionable — they're defensive checks on data TypeScript only *believes* is typed (`parsed.likes || []` on JSON off disk). Stripping those trades a compile-time tidy for a runtime crash on a hand-edited file, against a system whose rule is that music never stops.
- ~430 files of comment long tail remain untouched. Nothing there is dense the way the top 60 were.