### PR TITLE
fix(tts): distinguish cloud fallback providers

### DIFF
--- a/controller/scripts/tts-fallback.test.ts
+++ b/controller/scripts/tts-fallback.test.ts
@@ -10,7 +10,7 @@
 
 import assert from 'node:assert/strict';
 import {
-  configuredSlot, fallbackTextFor, orderedFallbacks, type RescueSlot,
+  configuredSlot, fallbackTextFor, orderedFallbacks, sameTtsTarget, type RescueSlot,
 } from '../src/audio/tts-fallback.js';
 
 const allUsable = () => true;
@@ -214,6 +214,49 @@ const cloudFb = configuredSlot(
   { enabled: true, engine: 'cloud', voice: 'nova', cloudProvider: 'elevenlabs' },
   ENGINES,
 );
+
+// A failed Cloud provider must not blacklist the whole Cloud engine. This is
+// the live #1345 shape: a local OpenAI-compatible/Fish service fails, while the
+// operator's configured ElevenLabs rescue is healthy and should be attempted
+// before Piper.
+const crossProviderCloud = orderedFallbacks(
+  { engine: 'cloud', cloudProvider: 'openai-compatible' },
+  cloudFb,
+  'piper',
+  allUsable,
+  'openai-compatible',
+);
+assert.deepEqual(
+  engines(crossProviderCloud),
+  ['cloud', 'piper', 'kokoro'],
+  'a different Cloud provider remains a valid rescue target',
+);
+assert.equal(
+  crossProviderCloud[0]?.personaTts?.cloudProvider,
+  'elevenlabs',
+  'the first rescue carries the configured ElevenLabs provider',
+);
+assert.equal(
+  sameTtsTarget(
+    { engine: 'cloud', cloudProvider: 'elevenlabs' },
+    { engine: 'cloud', cloudProvider: 'elevenlabs' },
+    'openai-compatible',
+  ),
+  true,
+  'the same Cloud provider is still the same failed target',
+);
+assert.deepEqual(
+  engines(orderedFallbacks(
+    { engine: 'cloud', cloudProvider: 'elevenlabs' },
+    cloudFb,
+    'piper',
+    allUsable,
+    'openai-compatible',
+  )),
+  ['piper', 'kokoro'],
+  'the failed Cloud provider is not immediately retried',
+);
+
 const seen: Array<[string, string | null | undefined]> = [];
 orderedFallbacks('piper', cloudFb, 'cloud', (e, p) => { seen.push([e, p]); return true; });
 assert.deepEqual(

--- a/controller/src/audio/tts-fallback.ts
+++ b/controller/src/audio/tts-fallback.ts
@@ -24,6 +24,33 @@ export interface RescueSlot {
   personaTts: { engine: string; voice: string; cloudProvider: string } | null;
 }
 
+export interface TtsTarget {
+  engine: string;
+  cloudProvider?: string | null;
+}
+
+function slotTarget(slot: RescueSlot): TtsTarget {
+  return {
+    engine: slot.engine,
+    cloudProvider: slot.personaTts?.cloudProvider ?? null,
+  };
+}
+
+// Engines normally identify a render target on their own. Cloud is the one
+// exception: OpenAI-compatible/Fish, ElevenLabs, and OpenAI share the `cloud`
+// dispatcher but are independent failure domains. A failed provider must not
+// blacklist a healthy provider configured as the operator's rescue.
+export function sameTtsTarget(
+  left: TtsTarget,
+  right: TtsTarget,
+  defaultCloudProvider: string | null | undefined = null,
+): boolean {
+  if (left.engine !== right.engine) return false;
+  if (left.engine !== 'cloud') return true;
+  const provider = (target: TtsTarget) => target.cloudProvider || defaultCloudProvider || null;
+  return provider(left) === provider(right);
+}
+
 export interface TtsFallbackConfig {
   enabled?: boolean;
   engine?: string;
@@ -76,11 +103,15 @@ export function configuredSlot(
 // null for the hardcoded ones — the probe must agree with the call, and a
 // hardcoded cloud rung speaks with the station default's credentials.
 export function orderedFallbacks(
-  primary: string,
+  primary: string | TtsTarget,
   configured: RescueSlot | null,
   defaultEngine: string | null | undefined,
   usable: (engine: string, cloudProvider?: string | null) => boolean,
+  defaultCloudProvider: string | null | undefined = null,
 ): RescueSlot[] {
+  const primaryTarget: TtsTarget = typeof primary === 'string'
+    ? { engine: primary }
+    : primary;
   const candidates: RescueSlot[] = [
     ...(configured ? [configured] : []),
     ...[defaultEngine, 'piper', 'kokoro'].map((engine) => ({
@@ -91,7 +122,12 @@ export function orderedFallbacks(
   const out: RescueSlot[] = [];
   for (const slot of candidates) {
     const { engine } = slot;
-    if (!engine || engine === primary || out.some((s) => s.engine === engine)) continue;
+    const target = slotTarget(slot);
+    if (
+      !engine
+      || sameTtsTarget(target, primaryTarget, defaultCloudProvider)
+      || out.some((s) => s.engine === engine)
+    ) continue;
     if (!usable(engine, slot.personaTts?.cloudProvider ?? null)) continue;
     out.push(slot);
   }

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -13,7 +13,8 @@ import { heavyEnabledEngines } from './ttsHeavyClient.js';
 import * as remoteTts from './remoteTts.js';
 import { normalizeForSpeech } from './speech-text.js';
 import {
-  configuredSlot, fallbackTextFor, orderedFallbacks, type RescueSlot,
+  configuredSlot, fallbackTextFor, orderedFallbacks, sameTtsTarget,
+  type RescueSlot, type TtsTarget,
 } from './tts-fallback.js';
 import { localizedPreviewText } from './preview-text.js';
 import * as cloud from '../llm/speech.js';
@@ -108,6 +109,23 @@ function plainSlot(engine: string): RescueSlot {
   return { engine, personaTts: null };
 }
 
+function ttsTarget(
+  engine: string,
+  personaTts: { engine?: unknown; cloudProvider?: unknown } | null | undefined,
+): TtsTarget {
+  const globalCloudProvider = settings.get().tts?.cloud?.provider ?? null;
+  const personaCloudProvider = personaTts?.engine === 'cloud'
+    && typeof personaTts.cloudProvider === 'string'
+    ? personaTts.cloudProvider
+    : null;
+  return {
+    engine,
+    cloudProvider: engine === 'cloud'
+      ? (personaCloudProvider || globalCloudProvider)
+      : null,
+  };
+}
+
 // Which engine — and which VOICE — actually speaks a segment of `kind`.
 // Returns a slot rather than an engine string because a reroute can now carry
 // the operator's chosen fallback voice, which an engine id alone can't express.
@@ -135,7 +153,11 @@ function resolveEngine(kind: string, personaTts: any): RescueSlot {
     const configured = fallbackSlot();
     if (
       configured
-      && configured.engine !== chosen
+      && !sameTtsTarget(
+        ttsTarget(configured.engine, configured.personaTts),
+        ttsTarget(chosen, personaTts),
+        tts.cloud?.provider,
+      )
       && engineUsable(configured.engine, configured.personaTts?.cloudProvider ?? null)
     ) {
       return configured;
@@ -164,12 +186,13 @@ function resolveEngine(kind: string, personaTts: any): RescueSlot {
 //
 // At most four attempts; the ordering is pure and pinned by
 // scripts/tts-fallback.test.ts.
-function fallbackChain(primary: string): RescueSlot[] {
+function fallbackChain(primary: TtsTarget): RescueSlot[] {
   return orderedFallbacks(
     primary,
     fallbackSlot(),
     settings.get().tts?.defaultEngine,
     (engine, cloudProvider) => engineUsable(engine, cloudProvider ?? null),
+    settings.get().tts?.cloud?.provider,
   );
 }
 
@@ -477,7 +500,7 @@ export async function speak(
     // The primary passed the pre-flight gate but threw mid-render. Walk the
     // rescue chain — configured default engine, then Piper, then Kokoro — so
     // the DJ never goes silent because one provider hiccuped.
-    const chain = fallbackChain(primary);
+    const chain = fallbackChain(ttsTarget(primary, primaryPersonaTts));
     if (!chain.length) {
       recordTts({
         ...callBase, engine: primary, fellBack: requested !== primary,


### PR DESCRIPTION
## Summary

- distinguish Cloud TTS rescue targets by provider, not only by the shared `cloud` engine name
- allow a configured ElevenLabs fallback after an OpenAI-compatible/Fish provider fails
- preserve the existing engine-level deduplication between fallback rungs
- add regression coverage for both cross-provider rescue and same-provider suppression

## Root cause

The TTS rescue chain excluded any fallback whose engine matched the failed primary engine. OpenAI-compatible Fish and ElevenLabs both use Subwave's `cloud` engine, so a healthy configured ElevenLabs fallback was mistaken for the failed Fish target and skipped. The chain then continued to Piper.

The dispatcher now treats a Cloud target as the combination of engine and provider. Other engines retain their existing engine-only identity.

## Verification

- `tsx scripts/tts-fallback.test.ts`
- `npm run lint` (0 errors; existing repository warnings only)
- live Docker test: stopped the configured OpenAI-compatible Fish service and triggered `generateHourlyTime`; the request used the configured ElevenLabs fallback voice instead of Piper

Fixes #1345
