### PR TITLE
feat(web): sort persona roster by on-air status and name

### DIFF
--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -35,6 +35,7 @@ import {
 import { PersonaHero } from './personas/PersonaHero';
 import { SystemPromptModal } from './personas/SystemPromptModal';
 import { PersonaRoster } from './personas/PersonaRoster';
+import { orderPersonaRoster } from './personas/roster-order';
 import { PersonaEditor } from './personas/PersonaEditor';
 
 // The RHF resolver is the two shared schemas the controller validates against,
@@ -466,6 +467,11 @@ export default function PersonasPanel() {
   const onAirPersonaId = data?.onAir?.personaId || activePersonaId;
   const onAirPersona = personas.find(p => p.id === onAirPersonaId) || activePersona;
   const onAirShow = data?.onAir?.show || null;
+  // Display order for the roster AND the editor's counter, so both name the
+  // same slot. Sits below the loading guards rather than in a useMemo, and at
+  // PERSONA_MAX rows the sort per render costs nothing.
+  const roster = orderPersonaRoster(personas, onAirPersonaId);
+  const focusedPosition = roster.find(e => e.index === safeIdx)?.position ?? safeIdx + 1;
   const focusedOk = !isPersonaInvalid(safeIdx);
   // Drives the confirm on ×/Escape: closing the editor keeps edits pending in
   // `personas`, which is how unsaved state used to ride along on the next save.
@@ -509,7 +515,7 @@ export default function PersonasPanel() {
       />
 
       <PersonaRoster
-        personas={personas}
+        roster={roster}
         activePersonaId={activePersonaId}
         onAirPersonaId={onAirPersonaId}
         avatarTick={avatarTick}
@@ -607,6 +613,7 @@ export default function PersonasPanel() {
       <PersonaEditor
         persona={focused}
         index={safeIdx}
+        position={focusedPosition}
         control={control}
         personaCount={personas.length}
         activePersonaId={activePersonaId}

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -4,7 +4,7 @@
 // override who is on air for its hour); the system prompt is a library of
 // global templates, '' = the built-in default. Everything POSTs to /settings
 // and applies live — no mixer restart.
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { z } from 'zod';
 import {
   useFieldArray,
@@ -295,6 +295,21 @@ export default function PersonasPanel() {
   const personas = watch('personas');
   const djPrompts = watch('djPrompts');
 
+  // A scheduled show can override the default; fall back to the default
+  // selection on controllers predating the onAir field.
+  const onAirPersonaId = data?.onAir?.personaId || activePersonaId;
+  // Display order for the roster AND the editor's counter, so both name the
+  // same slot. The memo is load-bearing, not an optimisation: removing a
+  // persona hands `watch` one frame where the dropped index is still counted
+  // but holds only the editor's registered fields — no `skills`, no `id`.
+  // Recomputing on that frame renders a card for it and throws on
+  // `p.skills.length`; the memo re-uses the last good order until the array
+  // settles. Sits above the loading guards so the hook order never varies.
+  const roster = useMemo(
+    () => orderPersonaRoster(personas, onAirPersonaId),
+    [personas, onAirPersonaId],
+  );
+
   // The textarea's maxLength already enforces the house-rules cap; this guards
   // a pasted-over-limit edge.
   const promptsOk = !form.formState.errors.djPrompts
@@ -462,15 +477,8 @@ export default function PersonasPanel() {
   }
 
   const activePersona = personas.find(p => p.id === activePersonaId);
-  // A scheduled show can override the default; fall back to the default
-  // selection on controllers predating the onAir field.
-  const onAirPersonaId = data?.onAir?.personaId || activePersonaId;
   const onAirPersona = personas.find(p => p.id === onAirPersonaId) || activePersona;
   const onAirShow = data?.onAir?.show || null;
-  // Display order for the roster AND the editor's counter, so both name the
-  // same slot. Sits below the loading guards rather than in a useMemo, and at
-  // PERSONA_MAX rows the sort per render costs nothing.
-  const roster = orderPersonaRoster(personas, onAirPersonaId);
   const focusedPosition = roster.find(e => e.index === safeIdx)?.position ?? safeIdx + 1;
   const focusedOk = !isPersonaInvalid(safeIdx);
   // Drives the confirm on ×/Escape: closing the editor keeps edits pending in
@@ -615,7 +623,7 @@ export default function PersonasPanel() {
         index={safeIdx}
         position={focusedPosition}
         control={control}
-        personaCount={personas.length}
+        personaCount={roster.length}
         activePersonaId={activePersonaId}
         onAirPersonaId={onAirPersonaId}
         data={data}

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -19,6 +19,9 @@ import { PersonaSkillsCard } from './PersonaSkillsCard';
 interface PersonaEditorProps {
   persona: Persona;
   index: number;
+  // 1-based slot in the DISPLAYED roster, not in the form array — the header
+  // counter has to name the position the operator just clicked.
+  position: number;
   control: Control<PersonasFormValues>;
   personaCount: number;
   activePersonaId: string;
@@ -52,7 +55,7 @@ interface PersonaEditorProps {
 }
 
 export function PersonaEditor({
-  persona, index, control, personaCount, activePersonaId, onAirPersonaId, data, adminFetch, avatarTick, uploadingId,
+  persona, index, position, control, personaCount, activePersonaId, onAirPersonaId, data, adminFetch, avatarTick, uploadingId,
   defaultEngine, cloudIssueText, skillCatalog, editorRef, open, isNew, onClose,
   onUpdate,
   onUploadAvatar, onGenerateAvatar, onClearAvatar, onSetActive, onRemove,
@@ -91,7 +94,7 @@ export function PersonaEditor({
         // width to bite: capped on phones (a 40-char name would push the close
         // button off the edge), unbounded on desktop.
         <span className="caption block max-w-[42vw] truncate sm:max-w-none">
-          {persona.name.trim() || `Persona ${index + 1}`} · {index + 1} of {personaCount}
+          {persona.name.trim() || `Persona ${position}`} · {position} of {personaCount}
         </span>
       )}
       footer={

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -1,12 +1,10 @@
 'use client';
 // One "broadcast slate" card per persona, matching the show cards on /admin/shows.
 // The whole card is the edit target; adding lives in the hero's "+ Add persona".
-import { useMemo } from 'react';
 import { Users } from 'lucide-react';
-import type { Persona } from './types';
 import { API_BASE, PERSONA_MAX } from './constants';
 import { initialsFor } from './helpers';
-import { orderPersonaRoster } from './roster-order';
+import type { PersonaRosterEntry } from './roster-order';
 import { cn } from '../../../lib/cn';
 import { useRosterView } from '../../../lib/adminView';
 import { Btn, Pill, MetaChip } from '../ui';
@@ -14,7 +12,9 @@ import PersonaTable from './PersonaTable';
 import RosterViewToggle from '../RosterViewToggle';
 
 interface PersonaRosterProps {
-  personas: Persona[];
+  // Already in display order — the panel owns the ordering so the editor's
+  // "n of m" counter can name the same position the operator clicked.
+  roster: PersonaRosterEntry[];
   // The admin-selected default — gets the "default" pill.
   activePersonaId: string;
   // Equals activePersonaId unless a show overrides it.
@@ -33,15 +33,11 @@ interface PersonaRosterProps {
 }
 
 export function PersonaRoster({
-  personas, activePersonaId, onAirPersonaId, avatarTick, isPersonaInvalid,
+  roster, activePersonaId, onAirPersonaId, avatarTick, isPersonaInvalid,
   onOpenPrompt, onAdd, onSelect, communityCount, onCommunity,
 }: PersonaRosterProps) {
   // Cards (default) or a dense table. Remembered per surface in localStorage.
   const [view, setView] = useRosterView('personas');
-  const roster = useMemo(
-    () => orderPersonaRoster(personas, onAirPersonaId),
-    [personas, onAirPersonaId],
-  );
 
   return (
     <section className="grid gap-4">
@@ -49,7 +45,7 @@ export function PersonaRoster({
           squeezed onto the count's line they run past the right edge. */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <span className="caption">
-          roster · {personas.length} / {PERSONA_MAX} · on air first · then A–Z
+          roster · {roster.length} / {PERSONA_MAX} · on air first · then A–Z
         </span>
         <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
           <RosterViewToggle view={view} onChange={setView} />
@@ -65,12 +61,12 @@ export function PersonaRoster({
             )}
           </Btn>
           <Btn className="min-h-9 sm:min-h-0" onClick={onOpenPrompt}>System prompt</Btn>
-          <Btn className="min-h-9 sm:min-h-0" tone="accent" onClick={onAdd} disabled={personas.length >= PERSONA_MAX}>
+          <Btn className="min-h-9 sm:min-h-0" tone="accent" onClick={onAdd} disabled={roster.length >= PERSONA_MAX}>
             + Add persona
           </Btn>
         </div>
       </div>
-      {view === 'list' && personas.length > 0 && (
+      {view === 'list' && roster.length > 0 && (
         <PersonaTable
           entries={roster}
           activePersonaId={activePersonaId}
@@ -81,7 +77,7 @@ export function PersonaRoster({
         />
       )}
 
-      {view === 'cards' && roster.map(({ persona: p, index: i }) => {
+      {view === 'cards' && roster.map(({ persona: p, index: i, position }) => {
         const isOnAir = p.id === onAirPersonaId;
         const isDefault = p.id === activePersonaId;
         const valid = !isPersonaInvalid(i);
@@ -102,7 +98,7 @@ export function PersonaRoster({
             key={p.id}
             role="button"
             tabIndex={0}
-            aria-label={`Edit ${p.name.trim() || `Persona ${i + 1}`}`}
+            aria-label={`Edit ${p.name.trim() || `Persona ${position}`}`}
             onClick={() => onSelect(i)}
             onKeyDown={(e) => {
               if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(i); }
@@ -145,7 +141,7 @@ export function PersonaRoster({
                       </div>
                     )}
                     <div className="truncate text-[17px] font-extrabold tracking-[-0.01em] text-ink">
-                      {p.name.trim() || `Persona ${i + 1}`}
+                      {p.name.trim() || `Persona ${position}`}
                     </div>
                   </div>
 

--- a/web/components/admin/personas/PersonaRoster.tsx
+++ b/web/components/admin/personas/PersonaRoster.tsx
@@ -1,10 +1,12 @@
 'use client';
 // One "broadcast slate" card per persona, matching the show cards on /admin/shows.
 // The whole card is the edit target; adding lives in the hero's "+ Add persona".
+import { useMemo } from 'react';
 import { Users } from 'lucide-react';
 import type { Persona } from './types';
 import { API_BASE, PERSONA_MAX } from './constants';
 import { initialsFor } from './helpers';
+import { orderPersonaRoster } from './roster-order';
 import { cn } from '../../../lib/cn';
 import { useRosterView } from '../../../lib/adminView';
 import { Btn, Pill, MetaChip } from '../ui';
@@ -36,13 +38,19 @@ export function PersonaRoster({
 }: PersonaRosterProps) {
   // Cards (default) or a dense table. Remembered per surface in localStorage.
   const [view, setView] = useRosterView('personas');
+  const roster = useMemo(
+    () => orderPersonaRoster(personas, onAirPersonaId),
+    [personas, onAirPersonaId],
+  );
 
   return (
     <section className="grid gap-4">
       {/* On phones the actions take a full row of their own under the count:
           squeezed onto the count's line they run past the right edge. */}
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <span className="caption">roster · {personas.length} / {PERSONA_MAX}</span>
+        <span className="caption">
+          roster · {personas.length} / {PERSONA_MAX} · on air first · then A–Z
+        </span>
         <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
           <RosterViewToggle view={view} onChange={setView} />
           <Btn
@@ -64,7 +72,7 @@ export function PersonaRoster({
       </div>
       {view === 'list' && personas.length > 0 && (
         <PersonaTable
-          personas={personas}
+          entries={roster}
           activePersonaId={activePersonaId}
           onAirPersonaId={onAirPersonaId}
           avatarTick={avatarTick}
@@ -73,7 +81,7 @@ export function PersonaRoster({
         />
       )}
 
-      {view === 'cards' && personas.map((p, i) => {
+      {view === 'cards' && roster.map(({ persona: p, index: i }) => {
         const isOnAir = p.id === onAirPersonaId;
         const isDefault = p.id === activePersonaId;
         const valid = !isPersonaInvalid(i);
@@ -102,6 +110,7 @@ export function PersonaRoster({
             className={cn(
               'group card relative cursor-pointer transition-colors hover:bg-[var(--ink-softer)]',
               'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--accent)]',
+              isOnAir && roster.length > 1 && 'mb-1',
             )}
           >
             <span

--- a/web/components/admin/personas/PersonaTable.tsx
+++ b/web/components/admin/personas/PersonaTable.tsx
@@ -45,13 +45,13 @@ export function PersonaTable({
       key: 'name',
       label: 'DJ',
       className: 'whitespace-nowrap',
-      render: ({ persona: p, index }) => {
+      render: ({ persona: p, position }) => {
         const isOnAir = p.id === onAirPersonaId;
         const isDefault = p.id === activePersonaId;
         return (
           <span className="flex min-w-0 items-center gap-1.5">
             <span className="truncate font-extrabold text-ink">
-              {p.name.trim() || `Persona ${index + 1}`}
+              {p.name.trim() || `Persona ${position}`}
             </span>
             {isOnAir && <Pill tone="accent" dot>on air</Pill>}
             {isDefault && !isOnAir && <Pill>default</Pill>}
@@ -126,7 +126,7 @@ export function PersonaTable({
       cols={cols}
       rows={entries}
       rowKey={r => r.persona.id}
-      rowLabel={r => `Edit ${r.persona.name.trim() || `Persona ${r.index + 1}`}`}
+      rowLabel={r => `Edit ${r.persona.name.trim() || `Persona ${r.position}`}`}
       rowSpine={spineFor}
       onRowClick={r => onSelect(r.index)}
     />

--- a/web/components/admin/personas/PersonaTable.tsx
+++ b/web/components/admin/personas/PersonaTable.tsx
@@ -5,16 +5,16 @@
 // colour.
 
 import { useMemo } from 'react';
-import type { Persona } from './types';
 import { API_BASE } from './constants';
 import { initialsFor } from './helpers';
+import type { PersonaRosterEntry } from './roster-order';
 import { Pill, MetaChip } from '../ui';
 import { RosterTable } from '../RosterTable';
 import type { RosterColumn } from '../RosterTable';
 import { RosterAvatar } from '../RosterAvatar';
 
 interface PersonaTableProps {
-  personas: Persona[];
+  entries: PersonaRosterEntry[];
   // The admin-selected default — gets the "default" pill.
   activePersonaId: string;
   // The persona actually broadcasting now (show override aware).
@@ -26,21 +26,10 @@ interface PersonaTableProps {
   onSelect: (idx: number) => void;
 }
 
-// The roster is index-keyed (onSelect(i)), so the row carries its position.
-interface PersonaRow {
-  persona: Persona;
-  index: number;
-}
-
 export function PersonaTable({
-  personas, activePersonaId, onAirPersonaId, avatarTick, isPersonaInvalid, onSelect,
+  entries, activePersonaId, onAirPersonaId, avatarTick, isPersonaInvalid, onSelect,
 }: PersonaTableProps) {
-  const rows = useMemo<PersonaRow[]>(
-    () => personas.map((persona, index) => ({ persona, index })),
-    [personas],
-  );
-
-  const cols = useMemo<RosterColumn<PersonaRow>[]>(() => [
+  const cols = useMemo<RosterColumn<PersonaRosterEntry>[]>(() => [
     {
       key: 'face',
       label: '',
@@ -124,7 +113,7 @@ export function PersonaTable({
   ], [activePersonaId, onAirPersonaId, avatarTick, isPersonaInvalid]);
 
   // Same status priority as the card spine.
-  const spineFor = ({ persona: p, index }: PersonaRow): string => {
+  const spineFor = ({ persona: p, index }: PersonaRosterEntry): string => {
     if (p.id === onAirPersonaId) return 'var(--accent)';
     if (p.id === activePersonaId) return 'var(--ink)';
     if (isPersonaInvalid(index)) return 'var(--danger)';
@@ -135,7 +124,7 @@ export function PersonaTable({
     <RosterTable
       caption="DJ roster"
       cols={cols}
-      rows={rows}
+      rows={entries}
       rowKey={r => r.persona.id}
       rowLabel={r => `Edit ${r.persona.name.trim() || `Persona ${r.index + 1}`}`}
       rowSpine={spineFor}

--- a/web/components/admin/personas/roster-order.ts
+++ b/web/components/admin/personas/roster-order.ts
@@ -2,7 +2,13 @@ import type { Persona } from './types';
 
 export interface PersonaRosterEntry {
   persona: Persona;
+  // Position in the form array. RHF field paths, validation, deletion and
+  // editing all key off this — never off display order.
   index: number;
+  // 1-based position in the DISPLAYED roster. Human-facing counters and the
+  // unnamed-persona placeholder read this, so what the operator is told
+  // matches what they are looking at.
+  position: number;
 }
 
 const PERSONA_NAME_COLLATOR = new Intl.Collator(undefined, {
@@ -31,5 +37,6 @@ export function orderPersonaRoster(
 
       const byName = PERSONA_NAME_COLLATOR.compare(leftName, rightName);
       return byName || left.index - right.index;
-    });
+    })
+    .map((entry, position) => ({ ...entry, position: position + 1 }));
 }

--- a/web/components/admin/personas/roster-order.ts
+++ b/web/components/admin/personas/roster-order.ts
@@ -1,0 +1,35 @@
+import type { Persona } from './types';
+
+export interface PersonaRosterEntry {
+  persona: Persona;
+  index: number;
+}
+
+const PERSONA_NAME_COLLATOR = new Intl.Collator(undefined, {
+  sensitivity: 'base',
+  numeric: true,
+});
+
+// Display order only: callers retain `index` for RHF field paths, validation,
+// deletion and editing. Reordering the form array itself would turn a visual
+// navigation aid into a persisted settings change.
+export function orderPersonaRoster(
+  personas: Persona[],
+  onAirPersonaId: string,
+): PersonaRosterEntry[] {
+  return personas
+    .map((persona, index) => ({ persona, index }))
+    .sort((left, right) => {
+      const leftOnAir = left.persona.id === onAirPersonaId;
+      const rightOnAir = right.persona.id === onAirPersonaId;
+      if (leftOnAir !== rightOnAir) return leftOnAir ? -1 : 1;
+
+      const leftName = left.persona.name.trim();
+      const rightName = right.persona.name.trim();
+      if (!leftName && rightName) return 1;
+      if (leftName && !rightName) return -1;
+
+      const byName = PERSONA_NAME_COLLATOR.compare(leftName, rightName);
+      return byName || left.index - right.index;
+    });
+}


### PR DESCRIPTION
## What changed

- pins the persona currently on air to the top of the Personas roster
- sorts the remaining personas alphabetically by display name
- applies the same ordering to both card and table views
- preserves each persona's original form index so editing, validation, and deletion continue to target the correct record

## Why

Persona rosters currently follow creation order, which becomes difficult to navigate on stations with many DJs. Putting the live presenter first and the rest in alphabetical order makes the page easier to scan without changing stored persona order.

The order is calculated from the page's existing on-air snapshot, so it updates naturally on page refresh and adds no polling.

## Validation

- web ESLint and TypeScript checks
- focused ordering checks covering on-air priority, case-insensitive alphabetical order, stable duplicate names, blank names, missing on-air IDs, and preserved form indices
- `git diff --check`
