### PR TITLE
ci: stagger image pushes so GHCR stops rate-limiting releases

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -37,6 +37,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      # Stagger the pushes. All 11 images push 4 tags each to ghcr.io, and when
+      # several finish their layer uploads in the same window GHCR answers the
+      # manifest PUT with a 403 "secondary rate limit" (hit on the v1.7.0 run —
+      # subwave-analyzer-heavy failed at `exporting to image` after the layers
+      # were already up, and a re-run of that job alone passed unchanged). The
+      # builds have very different durations, so capping concurrency spreads the
+      # completions out. Costs wall-clock on a release run; tag pushes are rare.
+      max-parallel: 4
       matrix:
         include:
           - image: subwave-caddy
@@ -183,7 +191,11 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=sha,prefix=sha-,format=short
+            # Only on an ad-hoc dispatch, where the ref is a branch and nothing
+            # else pins the commit. A tag push already has {{version}} pointing
+            # at exactly one commit, so the sha tag is a redundant fourth
+            # manifest push per image (11 of the 44 a release run makes).
+            type=sha,prefix=sha-,format=short,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - uses: docker/build-push-action@v6
         with:


### PR DESCRIPTION
## Summary

The v1.7.0 publish run lost `subwave-analyzer-heavy` to a GHCR secondary rate limit. The build was fine and the layers uploaded (`pushing layers 4.1s done`); the manifest PUT came back `403 permission_denied: You have exceeded a secondary rate limit`. Re-running that one job on its own passed with no other change, which is what identifies it as contention rather than a build defect.

All 11 matrix jobs start together and each pushes **4 tags**, so a release fires ~44 manifest pushes into a few-minute window. Two changes, both in `.github/workflows/publish-images.yml`:

- **`max-parallel: 4`** on the build matrix. The builds have very different durations (caddy finishes in ~30s, aio-cuda spends 90s reclaiming disk before it even starts), so capping concurrency staggers the completions instead of letting several multi-GB pushes land together. `fail-fast: false` is unchanged, so one failure still never takes the others down.
- **The `sha-` tag is now dispatch-only.** That is 11 of the 44 manifest pushes. On a tag push `{{version}}` already pins the exact commit, so the sha tag is redundant there; it stays on `workflow_dispatch`, where the ref is a branch and nothing else identifies the build.

**Cost:** wall-clock on a release run goes up, since the three heavy images no longer overlap with everything else. Tag pushes are rare, so that is the cheaper side of the trade. If release speed matters more, `6` still halves the peak push pressure.

**Deliberately not done**, both recorded in the commit message so the next person hitting this doesn't redo the analysis:
- Splitting heavy and lean images into two `needs:`-gated jobs would duplicate the entire shared `steps:` block (checkout, disk reclaim, QEMU, buildx, login, metadata, build-push) or need a reusable workflow, which is real structure for a failure that costs one `gh run rerun --failed`.
- A retry wrapper around `build-push-action` is worse than it looks: `subwave-aio-cuda` exports no cache by design (its multi-GB torch layer would evict the rest of the 10GB GHA budget), so a retry there is a full cold rebuild rather than a cheap re-push.

## Test plan
- [ ] YAML parses and the matrix still has all 11 entries (checked locally with `yaml.safe_load`).
- [ ] On the next `v*` tag push, all 11 images publish in one run with no manual re-run.
- [ ] That run pushes 3 tags per image (`X.Y.Z`, `X.Y`, `latest`) and no `sha-` tag.
- [ ] A manual `workflow_dispatch` from a branch still produces a `sha-<short>` tag.