### PR TITLE
feat(web): move playlist reorder onto dnd-kit (touch + keyboard)

### DIFF
--- a/web/components/admin/PlaylistBuilderPanel.tsx
+++ b/web/components/admin/PlaylistBuilderPanel.tsx
@@ -7,9 +7,25 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  Plus, X, Search, ArrowUp, ArrowDown, ChevronRight, ChevronUp, ChevronDown,
-  GripVertical, RefreshCw, Trash2, FolderOpen, FilePlus2, Save,
+  Plus, X, Search, ChevronRight, ChevronUp, ChevronDown,
+  RefreshCw, Trash2, FolderOpen, FilePlus2, Save,
 } from 'lucide-react';
+import {
+  DndContext,
+  KeyboardSensor,
+  MouseSensor,
+  TouchSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core';
+import type { Announcements, DragEndEvent } from '@dnd-kit/core';
+import { restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import { Controller, useWatch } from 'react-hook-form';
 import type { z } from 'zod';
 import { useAdminAuth } from '../../lib/adminAuth';
@@ -28,9 +44,8 @@ import {
   Eyeb,
   IconBtn,
   Tog,
-  energyBgClass,
-  energyLabel,
 } from './playlist-builder/bits';
+import { TrackRow } from './playlist-builder/TrackRow';
 import { runGenerationJob } from './playlist-builder/generate';
 import type {
   ArcShape,
@@ -42,7 +57,6 @@ import type {
   View,
 } from './playlist-builder/types';
 import {
-  API,
   ARCS,
   BPM_MAX,
   BPM_MIN,
@@ -202,7 +216,6 @@ export default function PlaylistBuilderPanel() {
   const [artistResults, setArtistResults] = useState<string[] | null>(null);
   const [genreList, setGenreList] = useState<{ value: string; songCount: number }[] | null>(null);
 
-  const dragIndex = useRef<number | null>(null);
   const toastTimer = useRef<number | null>(null);
   const lastMode = useRef<GenMode>('fresh');
   const generatingRef = useRef(false);
@@ -471,6 +484,59 @@ export default function PlaylistBuilderPanel() {
     });
   };
   const removeAt = (i: number) => setTracks(prev => prev.filter((_, idx) => idx !== i));
+
+  // A sortable id has to be unique and survive a reorder, and a track id is
+  // neither: the same song can legitimately sit in the deck twice (that is what
+  // the DUPLICATE badge marks), and an index-derived id renames every row below
+  // the one that moved. The deck's own objects are the stable identity — a move
+  // splices them, it doesn't rebuild them — so the uid is minted per object and
+  // parked in a WeakMap. It doubles as the React key, which is why a reorder no
+  // longer remounts the rows below it and re-fetches their artwork.
+  const uids = useRef(new WeakMap<DraftTrack, string>());
+  const nextUid = useRef(0);
+  const uidOf = (t: DraftTrack): string => {
+    let u = uids.current.get(t);
+    if (!u) { u = `row-${nextUid.current++}`; uids.current.set(t, u); }
+    return u;
+  };
+  const rowIds = tracks.map(uidOf);
+
+  // Mouse and touch are separate sensors on purpose. One PointerSensor would
+  // have to claim the touch gesture the moment a finger lands to be able to
+  // drag, which costs the list its scroll; the delay makes a press-and-hold the
+  // drag and leaves a plain swipe scrolling.
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 220, tolerance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const onDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    const from = rowIds.indexOf(String(active.id));
+    const to = rowIds.indexOf(String(over.id));
+    if (from < 0 || to < 0) return;
+    move(from, to);
+  };
+
+  // dnd-kit announces "item 3" by default; a deck of songs should say which
+  // song. Positions are 1-based to match the number column on screen.
+  const announce = (id: string, at: number | null): string => {
+    const i = rowIds.indexOf(id);
+    const name = tracks[i]?.title || 'Track';
+    return at == null ? name : `${name}, position ${at + 1} of ${tracks.length}`;
+  };
+  const announcements: Announcements = {
+    onDragStart: ({ active }) => `Picked up ${announce(String(active.id), rowIds.indexOf(String(active.id)))}.`,
+    onDragOver: ({ active, over }) => (over
+      ? `${announce(String(active.id), null)} moved to position ${rowIds.indexOf(String(over.id)) + 1} of ${tracks.length}.`
+      : undefined),
+    onDragEnd: ({ active, over }) => (over
+      ? `${announce(String(active.id), null)} dropped at position ${rowIds.indexOf(String(over.id)) + 1} of ${tracks.length}.`
+      : `${announce(String(active.id), null)} returned to its place.`),
+    onDragCancel: ({ active }) => `Reordering cancelled. ${announce(String(active.id), null)} returned to its place.`,
+  };
+
   const addTrack = (t: RawTrackRow) => {
     setTracks(prev => [...prev, rowToDraft(t)]);
     setAddQuery('');
@@ -1185,71 +1251,30 @@ export default function PlaylistBuilderPanel() {
 
                 <ScrollArea ref={listRef} className="flex-1">
                   <div className="pb-8">
-                  {tracks.map((t, i) => (
-                    <div
-                      key={`${t.id}-${i}`}
-                      data-row={i}
-                      draggable
-                      onDragStart={() => { dragIndex.current = i; }}
-                      onDragOver={e => e.preventDefault()}
-                      onDrop={() => { if (dragIndex.current != null) move(dragIndex.current, i); dragIndex.current = null; }}
-                      className={cn(
-                        'group grid grid-cols-[24px_44px_minmax(0,1fr)_auto] items-center gap-3 border-b border-separator-soft px-4 py-[9px] transition-colors hover:bg-ink-soft sm:grid-cols-[18px_24px_44px_minmax(0,1fr)_auto] sm:px-6',
-                        hotRow === i && 'bg-vermilion/10',
-                      )}
+                    <DndContext
+                      sensors={sensors}
+                      collisionDetection={closestCenter}
+                      modifiers={[restrictToVerticalAxis]}
+                      onDragEnd={onDragEnd}
+                      accessibility={{ announcements }}
                     >
-                      <div className="hidden cursor-grab place-items-center text-muted sm:grid">
-                        <GripVertical className="size-4" />
-                      </div>
-                      <div className="text-right font-mono text-xs text-muted">{i + 1}</div>
-                      <img
-                        src={`${API}/cover/${encodeURIComponent(t.id)}`}
-                        alt=""
-                        loading="lazy"
-                        className="size-11 border border-ink bg-ink-soft object-cover"
-                      />
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="truncate text-sm font-semibold">{t.title}</span>
-                          {dupeIds.has(t.id) && (
-                            <span className="flex-none border border-[var(--accent)] px-1 py-px font-mono text-[9px] font-bold tracking-[0.08em] text-vermilion">DUPLICATE</span>
-                          )}
-                        </div>
-                        <div className="mt-[3px] truncate font-mono text-[11px] text-muted">
-                          {t.artist}{t.album ? ` · ${t.album}` : ''}
-                        </div>
-                        {((t.moods && t.moods.length > 0) || t.instrumental === true) && (
-                          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-                            {(t.moods || []).slice(0, 2).map(m => (
-                              <span key={m} className="border border-separator-soft px-[5px] py-px font-mono text-[9px] tracking-[0.04em] text-muted uppercase">{m}</span>
-                            ))}
-                            {t.instrumental === true && (
-                              <span className="border border-separator-soft px-[5px] py-px font-mono text-[9px] tracking-[0.04em] text-muted uppercase">instrumental</span>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                      {/* Beside three 30px icon buttons this block is ~170px;
-                          stacked it costs 90px and the title keeps the rest. */}
-                      <div className="flex flex-col items-end gap-1 sm:flex-row sm:items-center sm:gap-2">
-                        <div className="flex flex-col items-end gap-[3px]">
-                          <span className="font-mono text-xs text-ink">{fmtDur(t.durationSec || 0)}</span>
-                          <span className="flex items-center gap-[5px] font-mono text-[10px] text-muted">
-                            <span className={cn('inline-block size-[7px]', energyBgClass(t.energy))} />
-                            {energyLabel(t.energy)}{t.year ? ` · ${t.year}` : ''}
-                          </span>
-                        </div>
-                        <div className="flex items-center gap-0.5 transition-opacity lg:opacity-0 lg:group-hover:opacity-100">
-                          {/* The drag grip is `sm:` only, so on mobile these are
-                              the only way to move a row: size them for a thumb. */}
-                          <IconBtn className="size-9 sm:size-[30px]" onClick={() => move(i, i - 1)} disabled={i === 0} title="Move up"><ArrowUp className="size-[15px]" /></IconBtn>
-                          <IconBtn className="size-9 sm:size-[30px]" onClick={() => move(i, i + 1)} disabled={i === tracks.length - 1} title="Move down"><ArrowDown className="size-[15px]" /></IconBtn>
-                          <IconBtn className="size-9 sm:size-[30px]" onClick={() => removeAt(i)} title="Remove"><X className="size-[15px]" /></IconBtn>
-                        </div>
-                      </div>
-                    </div>
-                  ))}
-                </div>
+                      <SortableContext items={rowIds} strategy={verticalListSortingStrategy}>
+                        {tracks.map((t, i) => (
+                          <TrackRow
+                            key={uidOf(t)}
+                            id={uidOf(t)}
+                            track={t}
+                            index={i}
+                            total={tracks.length}
+                            duplicate={dupeIds.has(t.id)}
+                            hot={hotRow === i}
+                            onMove={move}
+                            onRemove={removeAt}
+                          />
+                        ))}
+                      </SortableContext>
+                    </DndContext>
+                  </div>
                 </ScrollArea>
               </div>
             )}

--- a/web/components/admin/playlist-builder/TrackRow.tsx
+++ b/web/components/admin/playlist-builder/TrackRow.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+// One row of the deck, sortable via dnd-kit (#1370).
+//
+// The row was HTML5-`draggable` for its whole life, which meant mouse only:
+// `dragstart` never fires on touch, and there was no keyboard path at all. Now
+// the grip is a real focusable handle carrying the sensor listeners, so the same
+// gesture works with a mouse, a finger (long-press — see the sensor setup in
+// PlaylistBuilderPanel) and the arrow keys.
+//
+// The grip is no longer `sm:`-only: it is the touch affordance, so it has to
+// exist at the width where touch is likeliest. The up/down buttons stay — a
+// keyboard user who never discovers the handle still has an explicit path.
+
+import { useCallback, useRef } from 'react';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { ArrowDown, ArrowUp, GripVertical, X } from 'lucide-react';
+import { useDynamicStyle } from '../../../hooks/useDynamicStyle';
+import { cn } from '../../../lib/cn';
+import { IconBtn, energyBgClass, energyLabel } from './bits';
+import type { DraftTrack } from './types';
+import { API, fmtDur } from './types';
+
+export function TrackRow({
+  id, track: t, index: i, total, duplicate, hot, onMove, onRemove,
+}: {
+  id: string;
+  track: DraftTrack;
+  index: number;
+  total: number;
+  duplicate: boolean;
+  hot: boolean;
+  onMove: (from: number, to: number) => void;
+  onRemove: (i: number) => void;
+}) {
+  const {
+    attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition, isDragging,
+  } = useSortable({ id });
+
+  // dnd-kit owns the node ref; useDynamicStyle needs one of its own, because
+  // inline `style={…}` is lint-forbidden here (#50).
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  const setRefs = useCallback((node: HTMLDivElement | null) => {
+    rowRef.current = node;
+    setNodeRef(node);
+  }, [setNodeRef]);
+  useDynamicStyle(rowRef, {
+    // Translate, not Transform: the sortable transform carries a scale factor
+    // for size-mismatched neighbours and rows here are uniform, so scaling only
+    // shimmers the artwork.
+    transform: CSS.Translate.toString(transform),
+    transition,
+    zIndex: isDragging ? 20 : null,
+  });
+
+  return (
+    <div
+      ref={setRefs}
+      data-row={i}
+      className={cn(
+        'group relative grid grid-cols-[28px_24px_44px_minmax(0,1fr)_auto] items-center gap-3 border-b border-separator-soft px-4 py-[9px] transition-colors hover:bg-ink-soft sm:grid-cols-[18px_24px_44px_minmax(0,1fr)_auto] sm:px-6',
+        hot && 'bg-vermilion/10',
+        // Dragging: lift it off the list rather than hiding it, so the keyboard
+        // user can still see what they are carrying.
+        isDragging && 'bg-bg opacity-90 shadow-drawer',
+      )}
+    >
+      {/* `touch-none` is load-bearing, not styling. Without it the browser keeps
+          the touch gesture for itself and scrolls the page alongside the drag,
+          and that scroll is invisible to the sensor's delta — measured on a
+          430px viewport, a one-row drag landed THREE rows down, reproducibly,
+          and landed exactly right with the property on. The cost is that this
+          28px strip no longer scrolls the list; the other ~93% of the row
+          still does. */}
+      <button
+        type="button"
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        aria-label={`Reorder ${t.title || 'track'}`}
+        className="grid h-full cursor-grab touch-none place-items-center self-stretch text-muted focus-visible:ring-1 focus-visible:ring-[var(--accent)] focus-visible:outline-none active:cursor-grabbing"
+      >
+        <GripVertical className="size-4" />
+      </button>
+      <div className="text-right font-mono text-xs text-muted">{i + 1}</div>
+      <img
+        src={`${API}/cover/${encodeURIComponent(t.id)}`}
+        alt=""
+        loading="lazy"
+        className="size-11 border border-ink bg-ink-soft object-cover"
+      />
+      <div className="min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-semibold">{t.title}</span>
+          {duplicate && (
+            <span className="flex-none border border-[var(--accent)] px-1 py-px font-mono text-[9px] font-bold tracking-[0.08em] text-vermilion">DUPLICATE</span>
+          )}
+        </div>
+        <div className="mt-[3px] truncate font-mono text-[11px] text-muted">
+          {t.artist}{t.album ? ` · ${t.album}` : ''}
+        </div>
+        {((t.moods && t.moods.length > 0) || t.instrumental === true) && (
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            {(t.moods || []).slice(0, 2).map(m => (
+              <span key={m} className="border border-separator-soft px-[5px] py-px font-mono text-[9px] tracking-[0.04em] text-muted uppercase">{m}</span>
+            ))}
+            {t.instrumental === true && (
+              <span className="border border-separator-soft px-[5px] py-px font-mono text-[9px] tracking-[0.04em] text-muted uppercase">instrumental</span>
+            )}
+          </div>
+        )}
+      </div>
+      {/* Beside three 30px icon buttons this block is ~170px;
+          stacked it costs 90px and the title keeps the rest. */}
+      <div className="flex flex-col items-end gap-1 sm:flex-row sm:items-center sm:gap-2">
+        <div className="flex flex-col items-end gap-[3px]">
+          <span className="font-mono text-xs text-ink">{fmtDur(t.durationSec || 0)}</span>
+          <span className="flex items-center gap-[5px] font-mono text-[10px] text-muted">
+            <span className={cn('inline-block size-[7px]', energyBgClass(t.energy))} />
+            {energyLabel(t.energy)}{t.year ? ` · ${t.year}` : ''}
+          </span>
+        </div>
+        <div className="flex items-center gap-0.5 transition-opacity lg:opacity-0 lg:group-hover:opacity-100">
+          {/* The grip drags; these are the explicit one-step path, and on mobile
+              they stay thumb-sized. */}
+          <IconBtn className="size-9 sm:size-[30px]" onClick={() => onMove(i, i - 1)} disabled={i === 0} title="Move up"><ArrowUp className="size-[15px]" /></IconBtn>
+          <IconBtn className="size-9 sm:size-[30px]" onClick={() => onMove(i, i + 1)} disabled={i === total - 1} title="Move down"><ArrowDown className="size-[15px]" /></IconBtn>
+          <IconBtn className="size-9 sm:size-[30px]" onClick={() => onRemove(i)} title="Remove"><X className="size-[15px]" /></IconBtn>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/admin/playlist-builder/TrackRow.tsx
+++ b/web/components/admin/playlist-builder/TrackRow.tsx
@@ -121,7 +121,12 @@ export function TrackRow({
             {energyLabel(t.energy)}{t.year ? ` · ${t.year}` : ''}
           </span>
         </div>
-        <div className="flex items-center gap-0.5 transition-opacity lg:opacity-0 lg:group-hover:opacity-100">
+        {/* `group-focus-within` is not decoration: at lg the cluster is hidden
+            until the row is hovered, and a keyboard user never hovers — without
+            it, tabbing lands on a button that is fully transparent, focus ring
+            and all. Hover reveals it for the mouse; focus reveals it for the
+            keyboard the same way. */}
+        <div className="flex items-center gap-0.5 transition-opacity lg:opacity-0 lg:group-focus-within:opacity-100 lg:group-hover:opacity-100">
           {/* The grip drags; these are the explicit one-step path, and on mobile
               they stay thumb-sized. */}
           <IconBtn className="size-9 sm:size-[30px]" onClick={() => onMove(i, i - 1)} disabled={i === 0} title="Move up"><ArrowUp className="size-[15px]" /></IconBtn>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,14 +1,18 @@
 {
   "name": "sub-wave-web",
-  "version": "1.5.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-wave-web",
-      "version": "1.5.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.7.1",
         "@next/third-parties": "^16.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -409,6 +413,73 @@
       "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -6837,7 +6908,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -12106,7 +12177,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.7.1",
     "@next/third-parties": "^16.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/web/scripts/verify-playlist-dnd.py
+++ b/web/scripts/verify-playlist-dnd.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+"""web/scripts/verify-playlist-dnd.py
+
+Evidence for the Playlist Builder's dnd-kit reorder (#1370): the three input
+paths the HTML5 drag API could not serve — mouse, touch and keyboard — plus the
+paths that already existed and must not regress. Not part of CI: web/ has no
+test suite and the merge gate is lint.
+
+Usage: python3 web/scripts/verify-playlist-dnd.py
+
+STACK. The isolated verify stack from the `verify` skill — controller on :7791,
+web dev server on :7793, admin creds test:test. Unlike the other verify-*
+scripts this one needs NO seeded library and NO music server, and it writes
+nothing anywhere: /playlists and /cover are stubbed in the browser, and a deck
+reorder is local state until Save, which this never clicks.
+
+TWO MEASUREMENT TRAPS, both learned the hard way and both guarded below.
+ 1. Route globs. A bare `**/playlists` also matches the page's own document
+    request at /admin/playlists and serves the HTML request JSON. Scope every
+    stub to the controller ORIGIN.
+ 2. Scrolling under a synthetic finger. A scripted drag follows fixed
+    coordinates; it cannot watch the list move and adjust the way a real finger
+    does, so any scroll during the drag reads as an overshoot. Two separate
+    sources: dnd-kit's auto-scroll near the viewport edges (correct behaviour —
+    it is how you reach a row below the fold, so drags here stay in the
+    band-free middle), and a one-off ~176px document growth on the FIRST focus
+    of any control in the deck, which is pre-existing (measured identically on
+    the old "Move down" button) and is taken as a warm-up before measuring.
+"""
+import base64, json, os, sys, tempfile
+from playwright.sync_api import sync_playwright
+
+WEB = "http://localhost:7793"
+AUTH = base64.b64encode(b"test:test").decode()
+OUT = os.environ.get("VERIFY_SHOTS") or os.path.join(tempfile.gettempdir(), "subwave-dnd-shots")
+os.makedirs(OUT, exist_ok=True)
+
+# 6 tracks; #2 and #5 are the SAME song id — the duplicate case that rules out
+# a track-id sortable id.
+TRACKS = [
+    {"id": "s1", "title": "Alpha",   "artist": "A1", "durationSec": 200, "energy": "low"},
+    {"id": "dup", "title": "Bravo",  "artist": "A2", "durationSec": 210, "energy": "medium"},
+    {"id": "s3", "title": "Charlie", "artist": "A3", "durationSec": 220, "energy": "high"},
+    {"id": "s4", "title": "Delta",   "artist": "A4", "durationSec": 230, "energy": "low"},
+    {"id": "dup", "title": "Bravo",  "artist": "A2", "durationSec": 210, "energy": "medium"},
+    {"id": "s6", "title": "Foxtrot", "artist": "A6", "durationSec": 240, "energy": "high"},
+]
+PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+fails = []
+
+
+def check(name, ok, detail=""):
+    print(("  PASS  " if ok else "  FAIL  ") + name + ((" — " + detail) if detail else ""))
+    if not ok:
+        fails.append(name)
+
+
+def titles(page):
+    return page.eval_on_selector_all(
+        "[data-row] .truncate.text-sm.font-semibold", "els => els.map(e => e.textContent.trim())"
+    )
+
+
+API = "http://localhost:7791"
+
+
+def stub(page):
+    # Scope to the CONTROLLER origin: a bare `**/playlists` also matches the
+    # page's own document request at /admin/playlists and serves it JSON.
+    page.route(API + "/playlists", lambda r: r.fulfill(
+        status=200, content_type="application/json",
+        body=json.dumps({"playlists": [{"id": "p1", "name": "Verify Deck", "songCount": len(TRACKS)}]})))
+    page.route(API + "/playlists/p1", lambda r: r.fulfill(
+        status=200, content_type="application/json",
+        body=json.dumps({"id": "p1", "name": "Verify Deck", "entries": TRACKS})))
+    page.route(API + "/cover/**", lambda r: r.fulfill(status=200, content_type="image/png", body=PNG))
+
+
+def load_deck(page):
+    page.goto(WEB + "/admin/playlists", wait_until="domcontentloaded")
+    page.wait_for_selector("text=Browse", timeout=45000)
+    page.click("text=Browse")
+    page.wait_for_selector("text=Verify Deck", timeout=15000)
+    page.click("text=Verify Deck")
+    page.wait_for_selector("[data-row='0']", timeout=15000)
+    page.wait_for_timeout(400)
+
+
+def grip(page, i):
+    return page.locator(f"[data-row='{i}'] button[aria-label^='Reorder']").first
+
+
+def box_center(loc):
+    b = loc.bounding_box()
+    return b["x"] + b["width"] / 2, b["y"] + b["height"] / 2
+
+
+def mouse_drag(page, frm, to):
+    x0, y0 = box_center(grip(page, frm))
+    x1, y1 = box_center(grip(page, to))
+    page.mouse.move(x0, y0)
+    page.mouse.down()
+    for k in range(1, 13):  # small steps: the MouseSensor needs 4px before it starts
+        page.mouse.move(x0 + (x1 - x0) * k / 12, y0 + (y1 - y0) * k / 12)
+        page.wait_for_timeout(20)
+    page.mouse.up()
+    page.wait_for_timeout(500)
+
+
+def settle(page):
+    """A scroll still in flight moves the rows under a synthetic finger and
+    fakes an overshoot — wait for window.scrollY to stop changing."""
+    last = None
+    for _ in range(40):
+        y = page.evaluate("window.scrollY")
+        if y == last:
+            return y
+        last = y
+        page.wait_for_timeout(100)
+    return last
+
+
+def touch_drag(page, cdp, frm, to):
+    """Playwright has no touch-drag helper, so drive raw CDP touch events.
+    The TouchSensor arms on a 220ms press, hence the hold before moving."""
+    x0, y0 = box_center(grip(page, frm))
+    x1, y1 = box_center(grip(page, to))
+    s0 = page.evaluate("window.scrollY")
+    print(f"    [touch] from y={y0:.0f} to y={y1:.0f} scrollY={s0} "
+          f"rows={page.eval_on_selector_all('[data-row]', 'els => els.map(e => Math.round(e.getBoundingClientRect().y))')}")
+    cdp.send("Input.dispatchTouchEvent", {"type": "touchStart", "touchPoints": [{"x": x0, "y": y0}]})
+    page.wait_for_timeout(400)  # > the 220ms activation delay
+    for k in range(1, 13):
+        cdp.send("Input.dispatchTouchEvent", {"type": "touchMove", "touchPoints": [
+            {"x": x0 + (x1 - x0) * k / 12, "y": y0 + (y1 - y0) * k / 12}]})
+        page.wait_for_timeout(25)
+    cdp.send("Input.dispatchTouchEvent", {"type": "touchEnd", "touchPoints": []})
+    page.wait_for_timeout(500)
+    print(f"    [touch] scroll delta during drag: {page.evaluate('window.scrollY') - s0}")
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+
+    # ---------- mouse + keyboard (desktop) ----------
+    ctx = browser.new_context(viewport={"width": 1400, "height": 950})
+    ctx.add_init_script(f"localStorage.setItem('subwave_admin_auth', '{AUTH}')")
+    page = ctx.new_page()
+    errs = []
+    page.on("pageerror", lambda e: errs.append(str(e)))
+    stub(page)
+    load_deck(page)
+
+    start = titles(page)
+    print("\nDECK:", start)
+    check("deck loaded with 6 rows", len(start) == 6, str(start))
+    check("duplicate song rendered twice", start.count("Bravo") == 2)
+    check("DUPLICATE badge present", page.locator("text=DUPLICATE").count() == 2)
+    page.screenshot(path=OUT + "/1-deck.png")
+
+    print("\nMOUSE")
+    mouse_drag(page, 0, 3)
+    after = titles(page)
+    check("mouse drag row1 -> row4", after == ["Bravo", "Charlie", "Delta", "Alpha", "Bravo", "Foxtrot"], str(after))
+    page.screenshot(path=OUT + "/2-after-mouse.png")
+
+    print("\nDUPLICATE IDENTITY (drag the 2nd copy of the duplicate song)")
+    before = titles(page)
+    dup_rows = [i for i, t in enumerate(before) if t == "Bravo"]
+    mouse_drag(page, dup_rows[1], dup_rows[1] - 1)  # 2nd Bravo up one
+    moved = titles(page)
+    check("2nd duplicate copy moved, 1st stayed put",
+          moved == ["Bravo", "Charlie", "Delta", "Bravo", "Alpha", "Foxtrot"], str(moved))
+
+    print("\nKEYBOARD")
+    page.reload()  # the deck is local state — reload gives a clean order
+    load_deck(page)
+    base = titles(page)
+    grip(page, 0).focus()
+    focused = page.evaluate("document.activeElement.getAttribute('aria-label')")
+    check("grip is focusable", (focused or "").startswith("Reorder"), str(focused))
+    page.keyboard.press("Space")
+    page.wait_for_timeout(250)
+    live = page.locator("[role='status'], [aria-live]").all_inner_texts()
+    picked = " ".join(live)
+    check("screen-reader announcement names the track", "Alpha" in picked, picked.strip()[:120])
+    page.screenshot(path=OUT + "/3-keyboard-picked-up.png")
+    page.keyboard.press("ArrowDown")
+    page.wait_for_timeout(200)
+    page.keyboard.press("ArrowDown")
+    page.wait_for_timeout(200)
+    page.keyboard.press("Space")
+    page.wait_for_timeout(500)
+    kb = titles(page)
+    check("keyboard reorder moved row1 down two",
+          kb == [base[1], base[2], base[0], base[3], base[4], base[5]], f"{base} -> {kb}")
+    page.screenshot(path=OUT + "/4-after-keyboard.png")
+
+    print("\nESCAPE CANCELS")
+    pre = titles(page)
+    grip(page, 0).focus()
+    page.keyboard.press("Space")
+    page.wait_for_timeout(200)
+    page.keyboard.press("ArrowDown")
+    page.wait_for_timeout(200)
+    page.keyboard.press("Escape")
+    page.wait_for_timeout(400)
+    check("Escape leaves the order untouched", titles(page) == pre, str(titles(page)))
+
+    print("\nEXISTING PATHS STILL WORK")
+    pre = titles(page)
+    page.locator("[data-row='0'] button[title='Move down']").first.click()
+    page.wait_for_timeout(300)
+    check("Move down button still reorders",
+          titles(page) == [pre[1], pre[0]] + pre[2:], str(titles(page)))
+    page.locator("[data-row='0'] button[title='Remove']").first.click()
+    page.wait_for_timeout(300)
+    check("Remove button still removes", len(titles(page)) == 5, str(titles(page)))
+
+    check("no page errors", not errs, "; ".join(errs[:3]))
+    ctx.close()
+
+    # ---------- touch (mobile emulation) ----------
+    print("\nTOUCH (iPhone-sized viewport, hasTouch)")
+    mctx = browser.new_context(viewport={"width": 430, "height": 900}, has_touch=True,
+                               is_mobile=True, device_scale_factor=2)
+    mctx.add_init_script(f"localStorage.setItem('subwave_admin_auth', '{AUTH}')")
+    mp = mctx.new_page()
+    merrs = []
+    mp.on("pageerror", lambda e: merrs.append(str(e)))
+    stub(mp)
+    load_deck(mp)
+    cdp = mctx.new_cdp_session(mp)
+    check("grip visible on a phone viewport", grip(mp, 0).is_visible())
+    mp.screenshot(path=OUT + "/5-mobile-deck.png")
+
+    # Both ends of the drag must sit clear of dnd-kit's auto-scroll bands (the
+    # outer ~20% of the viewport). Auto-scroll is not a bug to assert against —
+    # it is how a finger reaches a row below the fold — but it makes a SCRIPTED
+    # drag non-deterministic: fixed coordinates can't watch the list move and
+    # adjust the way a real finger does. Inside the band-free middle the drop
+    # position is exact, which is what these two checks pin.
+    def safe_rows(page, n):
+        h = page.evaluate("window.innerHeight")
+        lo, hi = h * 0.28, h * 0.68
+        out = []
+        for i in range(n):
+            b = grip(page, i).bounding_box()
+            if b and lo <= b["y"] + b["height"] / 2 <= hi:
+                out.append(i)
+        return out
+
+    # Warm-up: the FIRST focus of any control in the deck grows the document by
+    # ~176px on a narrow viewport and the page scrolls to match — measured
+    # identically on the pre-existing "Move down" button, so it predates dnd-kit
+    # and is not what is under test here. It happens once; take it before
+    # measuring, or it lands in the middle of the first drag.
+    mp.eval_on_selector("[data-row='0'] button[title='Move down']", "e => e.focus()")
+    mp.wait_for_timeout(800)
+    mp.eval_on_selector("[data-row='2']", "e => e.scrollIntoView({block:'center'})")
+    settle(mp)
+    rows = safe_rows(mp, 6)
+    print("    band-free rows:", rows)
+    check("at least two rows clear of the auto-scroll bands", len(rows) >= 2, str(rows))
+
+    a, b = rows[0], rows[1]
+    mstart = titles(mp)
+    touch_drag(mp, cdp, a, b)               # downward, one slot
+    mafter = titles(mp)
+    exp = mstart[:a] + mstart[a + 1:]
+    exp = exp[:b] + [mstart[a]] + exp[b:]
+    check(f"touch drag row{a + 1} -> row{b + 1} (down)", mafter == exp, f"{mstart} -> {mafter}")
+
+    mstart = titles(mp)
+    touch_drag(mp, cdp, b, a)               # and back up
+    mafter = titles(mp)
+    exp = mstart[:b] + mstart[b + 1:]
+    exp = exp[:a] + [mstart[b]] + exp[a:]
+    check(f"touch drag row{b + 1} -> row{a + 1} (up)", mafter == exp, f"{mstart} -> {mafter}")
+    mp.screenshot(path=OUT + "/6-after-touch.png")
+
+    # A plain quick swipe must still scroll, not drag.
+    pre = titles(mp)
+    x, y = box_center(grip(mp, 0))
+    cdp.send("Input.dispatchTouchEvent", {"type": "touchStart", "touchPoints": [{"x": x, "y": y}]})
+    for k in range(1, 6):
+        cdp.send("Input.dispatchTouchEvent", {"type": "touchMove", "touchPoints": [{"x": x, "y": y - k * 30}]})
+        mp.wait_for_timeout(10)
+    cdp.send("Input.dispatchTouchEvent", {"type": "touchEnd", "touchPoints": []})
+    mp.wait_for_timeout(400)
+    check("quick swipe on the grip does not reorder", titles(mp) == pre, str(titles(mp)))
+    check("no page errors (mobile)", not merrs, "; ".join(merrs[:3]))
+
+    mctx.close()
+    browser.close()
+
+print("\n" + ("ALL CHECKS PASSED" if not fails else "FAILED: " + ", ".join(fails)))
+print("screenshots:", OUT)
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
Closes half of #1370 — the Playlist Builder, which the issue suggests doing first. The schedule board follows in its own PR.

## What

The deck rows were HTML5-`draggable`. That is mouse-only: `dragstart` never fires on touch, and there is no keyboard path at all, so reordering a playlist was unreachable on a tablet and unreachable without a pointer.

The row moves into its own `TrackRow` component and the grip becomes a real focusable `<button>` carrying the sensor listeners, so one affordance serves mouse, finger and arrow keys. It is no longer `sm:`-only — it *is* the touch target, so it has to exist at the width where touch is likeliest. The up/down buttons stay: they are the explicit one-step path, and a keyboard user who never discovers the handle still has one.

## Three decisions worth reviewing

**Sortable ids come from a `WeakMap` keyed on the track object** — not the track id, not the row index. The same song can legitimately sit in the deck twice (that is what the DUPLICATE badge marks), so the id is not unique; and an index-derived id renames every row below the one that moved. The deck's own objects are already the stable identity, since a move splices them rather than rebuilding them. It doubles as the React key, so a reorder no longer remounts the rows below it and re-fetches their artwork.

**Mouse and touch get separate sensors.** One `PointerSensor` would have to claim the gesture the moment a finger lands to be able to drag, which costs the list its scroll. A 220ms `TouchSensor` delay makes press-and-hold the drag and leaves a plain swipe scrolling.

**`touch-none` on the grip is load-bearing, not styling.** Without it the browser keeps the touch gesture and scrolls the page alongside the drag, and that scroll is invisible to the sensor's delta — measured on a 430px viewport, a one-row drag landed **three rows down**, reproducibly, and landed exactly right with the property on. The cost is that the 28px grip strip no longer scrolls the list; the other ~93% of the row still does.

## Verification

Done in a browser against the isolated verify stack, not assumed. `web/scripts/verify-playlist-dnd.py` ships with the PR — it needs no music server and no seeded library (the `/playlists` and `/cover` reads are stubbed at the browser) and it never clicks Save, so it writes nothing anywhere. All checks pass on two consecutive runs:

- mouse drag across three rows
- **duplicate identity** — dragging the *second* copy of a duplicated song moves that copy and leaves the first alone
- touch drag, both directions, under device emulation on a 430px viewport
- full keyboard reorder, with the live region announcing `Alpha moved to position 1 of 6` — announcements name the *track*, since dnd-kit's default says "item 3"
- Escape cancels without changing the order
- the pre-existing move-up / move-down / remove buttons still work

The script documents two measurement traps it guards against, both of which cost me real time: a bare `**/playlists` route glob also swallows the page's own document request, and any scroll during a *scripted* drag reads as an overshoot, since fixed coordinates cannot watch the list move the way a finger does.

## One pre-existing quirk found, deliberately not fixed here

On a narrow viewport the **first** focus of any control in the deck grows the document by ~176px and the page scrolls to match, once. It is not from dnd-kit: I measured it identically on the old "Move down" button, so it predates this change — most likely the panel's frame-height measurement settling. It is invisible in normal use (a one-time nudge) but it perturbs the first scripted drag, which is why the verify script takes it as a warm-up. Worth its own issue rather than smuggling a layout change in here.

## Notes

- `web/` lint + typecheck clean; the three remaining warnings are pre-existing in `playlist-builder/generate.ts`, untouched.
- `package-lock.json` was regenerated under Node 22 to match CI.
