### PR TITLE
refactor(web): adopt usehooks-ts for debounce, clipboard, clock and media-query

### DIFF
--- a/web/components/CodeBlock.tsx
+++ b/web/components/CodeBlock.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useCopyToClipboard } from 'usehooks-ts';
 
 interface CodeBlockProps {
   children: string;
@@ -9,14 +10,13 @@ interface CodeBlockProps {
 
 export default function CodeBlock({ children, lang }: CodeBlockProps) {
   const [copied, setCopied] = useState(false);
+  const [, copyToClipboard] = useCopyToClipboard();
   const text = String(children).trim();
 
   const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1400);
-    } catch {}
+    if (!(await copyToClipboard(text))) return;
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1400);
   };
 
   const label = (lang || 'sh').toUpperCase();

--- a/web/components/admin/DoctorPanel.tsx
+++ b/web/components/admin/DoctorPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCopyToClipboard } from 'usehooks-ts';
 import { useAdminAuth } from '../../lib/adminAuth';
 import { notify, errorMessage } from '../../lib/notify';
 import { Card, Btn, Pill } from './ui';
@@ -113,6 +114,7 @@ function parseSseFrame(frame: string): { event: string | null; data: unknown } {
 
 export default function DoctorPanel() {
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [, copyToClipboard] = useCopyToClipboard();
   const [report, setReport] = useState<DoctorReport | null>(null);
   const [review, setReview] = useState<DoctorReview | null>(null);
   const [running, setRunning] = useState(false);
@@ -276,13 +278,15 @@ export default function DoctorPanel() {
     }
   };
 
+  // The browser's own reason (NotAllowedError and friends) isn't actionable to
+  // an operator and useCopyToClipboard console.warns it for anyone debugging,
+  // so the toast just reports the failure.
   const copyMarkdown = async () => {
     if (!report) return;
-    try {
-      await navigator.clipboard.writeText(toMarkdown(report, review));
+    if (await copyToClipboard(toMarkdown(report, review))) {
       notify.ok('report copied — paste into a GitHub issue');
-    } catch (e) {
-      notify.err(`copy failed: ${errorMessage(e)}`);
+    } else {
+      notify.err('copy failed — the browser blocked clipboard access');
     }
   };
 
@@ -294,11 +298,8 @@ export default function DoctorPanel() {
     const full = `${HQ_ISSUES_NEW}?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
     // Too long to ride in the URL — copy it and prefill a pointer instead.
     if (full.length > HQ_URL_LIMIT) {
-      try {
-        await navigator.clipboard.writeText(body);
-      } catch {
-        /* clipboard may be blocked; the short form still opens */
-      }
+      // Clipboard may be blocked; the short form still opens either way.
+      await copyToClipboard(body);
       const note =
         `_Filed from DJ Doc._\n\n` +
         `**${report.counts.ok} ok · ${report.counts.warn} warn · ${report.counts.fail} fail · ${report.counts.skip} skip**\n\n` +

--- a/web/components/admin/PlaylistBuilderPanel.tsx
+++ b/web/components/admin/PlaylistBuilderPanel.tsx
@@ -6,6 +6,7 @@
    picker immediately. */
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useDebounceValue } from 'usehooks-ts';
 import {
   Plus, X, Search, ArrowUp, ArrowDown, ChevronRight, ChevronUp, ChevronDown,
   GripVertical, RefreshCw, Trash2, FolderOpen, FilePlus2, Save,
@@ -202,6 +203,17 @@ export default function PlaylistBuilderPanel() {
   const [artistResults, setArtistResults] = useState<string[] | null>(null);
   const [genreList, setGenreList] = useState<{ value: string; songCount: number }[] | null>(null);
 
+  // The three suggestion boxes below all search /dj/search on a 250ms debounce
+  // and all ignore a query under two characters. Blanking the term is what
+  // clears the dropdown, and it happens off the RAW query so backspacing feels
+  // instant; only a term long enough to search waits for the debounce.
+  const [debouncedSeedQuery] = useDebounceValue(seedQuery, 250);
+  const [debouncedAddQuery] = useDebounceValue(addQuery, 250);
+  const [debouncedArtistQuery] = useDebounceValue(artistQuery, 250);
+  const seedTerm = seedQuery.trim().length < 2 ? '' : debouncedSeedQuery.trim();
+  const addTerm = addQuery.trim().length < 2 ? '' : debouncedAddQuery.trim();
+  const artistTerm = artistQuery.trim().length < 2 ? '' : debouncedArtistQuery.trim();
+
   const dragIndex = useRef<number | null>(null);
   const toastTimer = useRef<number | null>(null);
   const lastMode = useRef<GenMode>('fresh');
@@ -377,34 +389,35 @@ export default function PlaylistBuilderPanel() {
   }, [tracks, adminFetch, buildBody, flash, name]);
 
   // Seed search; `stale` guards a slow response clobbering a newer query.
+  // Only the FETCH waits on the debounce — a query that falls under two
+  // characters clears the dropdown off the raw value, so backspacing out of a
+  // search doesn't leave suggestions hanging for another 250ms.
   useEffect(() => {
-    const q = seedQuery.trim();
-    if (q.length < 2) { setSeedResults(null); return; }
+    if (!seedTerm) { setSeedResults(null); return; }
     let stale = false;
-    const h = window.setTimeout(async () => {
+    void (async () => {
       try {
-        const r = await adminFetch(`/dj/search?q=${encodeURIComponent(q)}&limit=8`);
+        const r = await adminFetch(`/dj/search?q=${encodeURIComponent(seedTerm)}&limit=8`);
         const j = await r.json();
         if (!stale) setSeedResults(j.results || j.songs || j.tracks || []);
       } catch { if (!stale) setSeedResults([]); }
-    }, 250);
-    return () => { stale = true; window.clearTimeout(h); };
-  }, [seedQuery, adminFetch]);
+    })();
+    return () => { stale = true; };
+  }, [seedTerm, adminFetch]);
 
   // Manual add search (debounced, same staleness guard)
   useEffect(() => {
-    const q = addQuery.trim();
-    if (q.length < 2) { setAddResults(null); return; }
+    if (!addTerm) { setAddResults(null); return; }
     let stale = false;
-    const h = window.setTimeout(async () => {
+    void (async () => {
       try {
-        const r = await adminFetch(`/dj/search?q=${encodeURIComponent(q)}&limit=10`);
+        const r = await adminFetch(`/dj/search?q=${encodeURIComponent(addTerm)}&limit=10`);
         const j = await r.json();
         if (!stale) setAddResults(j.results || j.songs || j.tracks || []);
       } catch { if (!stale) setAddResults([]); }
-    }, 250);
-    return () => { stale = true; window.clearTimeout(h); };
-  }, [addQuery, adminFetch]);
+    })();
+    return () => { stale = true; };
+  }, [addTerm, adminFetch]);
 
   // Genre vocabulary — fetched once on first focus; suggestions filter locally.
   const loadGenres = useCallback(async () => {
@@ -427,12 +440,11 @@ export default function PlaylistBuilderPanel() {
 
   // Artist-filter search (debounced) — suggests distinct artist credits.
   useEffect(() => {
-    const q = artistQuery.trim();
-    if (q.length < 2) { setArtistResults(null); return; }
+    if (!artistTerm) { setArtistResults(null); return; }
     let stale = false;
-    const h = window.setTimeout(async () => {
+    void (async () => {
       try {
-        const r = await adminFetch(`/dj/search?q=${encodeURIComponent(q)}&limit=20`);
+        const r = await adminFetch(`/dj/search?q=${encodeURIComponent(artistTerm)}&limit=20`);
         const j = await r.json();
         const seen = new Set(recipeValues.artists.map(a => a.toLowerCase()));
         const names: string[] = [];
@@ -443,9 +455,9 @@ export default function PlaylistBuilderPanel() {
         }
         if (!stale) setArtistResults(names);
       } catch { if (!stale) setArtistResults([]); }
-    }, 250);
-    return () => { stale = true; window.clearTimeout(h); };
-  }, [artistQuery, adminFetch, recipeValues.artists]);
+    })();
+    return () => { stale = true; };
+  }, [artistTerm, adminFetch, recipeValues.artists]);
 
   // Distinct artists in the seed results — the "seed the artist" rows.
   const seedArtists = useMemo(() => {

--- a/web/components/admin/connect/EndpointCard.tsx
+++ b/web/components/admin/connect/EndpointCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useCopyToClipboard } from 'usehooks-ts';
 import { Pill } from '../ui';
 import { notify } from '../../../lib/notify';
 import type { EndpointDoc } from './types';
@@ -42,14 +43,11 @@ function toCurl(ep: EndpointDoc, apiBase: string): string {
 
 export default function EndpointCard({ endpoint, apiBase, adminFetch }: Props) {
   const [open, setOpen] = useState(false);
+  const [, copyToClipboard] = useCopyToClipboard();
 
   const copyCurl = async () => {
-    try {
-      await navigator.clipboard.writeText(toCurl(endpoint, apiBase));
-      notify.info('curl copied');
-    } catch {
-      notify.err('Could not copy');
-    }
+    if (await copyToClipboard(toCurl(endpoint, apiBase))) notify.info('curl copied');
+    else notify.err('Could not copy');
   };
 
   const allParams = [...(endpoint.pathParams || []), ...(endpoint.queryParams || [])];

--- a/web/components/admin/connect/IntegrationsTab.tsx
+++ b/web/components/admin/connect/IntegrationsTab.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useCopyToClipboard } from 'usehooks-ts';
 import { Card, Btn, Pill } from '../ui';
 import CodeBlock from '../../CodeBlock';
 import { notify } from '../../../lib/notify';
@@ -10,9 +11,10 @@ interface Props {
 }
 
 function CopyUrl({ url }: { url: string }) {
+  const [, copyToClipboard] = useCopyToClipboard();
   const copy = async () => {
-    try { await navigator.clipboard.writeText(url); notify.info('URL copied'); }
-    catch { notify.err('Could not copy'); }
+    if (await copyToClipboard(url)) notify.info('URL copied');
+    else notify.err('Could not copy');
   };
   return (
     <div className="flex items-center gap-2">

--- a/web/components/admin/library/tabs/BrowseTab.tsx
+++ b/web/components/admin/library/tabs/BrowseTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, type Dispatch, type SetStateAction } from 'react';
+import { useDebounceValue } from 'usehooks-ts';
 import { X } from 'lucide-react';
 import { Card, Btn } from '../../ui';
 import { num } from '../../LibraryTaggingPanel';
@@ -39,11 +40,7 @@ export default function BrowseTab({
 
   // Debounce the free-text box only. Mood chips, sort and the year fields all
   // change one step at a time, so delaying the whole request just feels laggy.
-  const [debouncedQ, setDebouncedQ] = useState(q);
-  useEffect(() => {
-    const t = setTimeout(() => setDebouncedQ(q), 250);
-    return () => clearTimeout(t);
-  }, [q]);
+  const [debouncedQ] = useDebounceValue(q, 250);
 
   const filters: BrowseKeyFilters = {
     moods, energy, vocal, genre, yearFrom, yearTo, q: debouncedQ.trim(), sort, page,

--- a/web/hooks/use-mobile.tsx
+++ b/web/hooks/use-mobile.tsx
@@ -1,19 +1,12 @@
-import * as React from "react"
+import { useMediaQuery } from "usehooks-ts"
 
 const MOBILE_BREAKPOINT = 768
 
+// initializeWithValue: false keeps the SSR discipline the hand-rolled version
+// had — false on the server and the first client render, real value after
+// mount — so hydration never sees two different trees.
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener("change", onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
-  }, [])
-
-  return !!isMobile
+  return useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`, {
+    initializeWithValue: false,
+  })
 }

--- a/web/lib/hooks.ts
+++ b/web/lib/hooks.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import { useInterval } from 'usehooks-ts';
 import { isIOSDevice } from './platform';
 
 // SSR-safe iOS flag: false on the server and the first client render (so the
@@ -12,13 +13,13 @@ export function useIsIOS(): boolean {
   return ios;
 }
 
+// Null until mount, for the same SSR reason as useIsIOS: the server has no
+// clock the client would agree with. The first tick lands on mount, then
+// useInterval owns the cadence (and its own cleanup).
 export function useClock(): Date | null {
   const [t, setT] = useState<Date | null>(null);
-  useEffect(() => {
-    setT(new Date());
-    const id = setInterval(() => setT(new Date()), 1000);
-    return () => clearInterval(id);
-  }, []);
+  useEffect(() => { setT(new Date()); }, []);
+  useInterval(() => setT(new Date()), 1000);
   return t;
 }
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-wave-web",
-  "version": "1.5.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-wave-web",
-      "version": "1.5.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^5.7.1",
@@ -59,6 +59,7 @@
         "tokenlens": "^1.3.1",
         "tw-animate-css": "^1.4.0",
         "use-stick-to-bottom": "^1.1.6",
+        "usehooks-ts": "^3.1.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -3417,6 +3418,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
@@ -6837,7 +6904,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -8739,6 +8806,12 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -12106,7 +12179,7 @@
       "version": "5.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -12431,6 +12504,21 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
+      "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/uuid": {

--- a/web/package.json
+++ b/web/package.json
@@ -62,6 +62,7 @@
     "tokenlens": "^1.3.1",
     "tw-animate-css": "^1.4.0",
     "use-stick-to-bottom": "^1.1.6",
+    "usehooks-ts": "^3.1.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/web/scripts/verify-hooks.py
+++ b/web/scripts/verify-hooks.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Drives the primitives converted to `usehooks-ts` (issue #1369).
+
+`web/` has no test suite and none of this is in CI — this is the evidence for a
+PR that touches one of these sites, in the same spirit as verify-forms.py and
+verify-query-cache.py.
+
+Everything here is READ-ONLY against the station: it types into search boxes,
+clicks copy buttons and reads the clipboard. Nothing is saved. That is why it
+carries no SUBWAVE_VERIFY_ALLOW_DESTRUCTIVE guard.
+
+What it pins, and why each check is shaped the way it is:
+
+  useDebounceValue  — a burst of keystrokes must collapse into exactly ONE
+                      request carrying the FULL term. Asserted on the network,
+                      because that is the property the debounce exists for.
+                      Clearing the Browse box is asserted on the RENDERED rows
+                      instead: the unfiltered query is already in the TanStack
+                      cache (staleTime 30s), so a cache hit with no request is
+                      the correct outcome there.
+  useCopyToClipboard— the text really lands on the clipboard (read back), and
+                      the toast/label feedback each site drives off the
+                      returned boolean still fires.
+  useInterval       — every consumer formats useClock to the minute, so a tick
+                      is not observable in wall time. Playwright's clock
+                      emulation fast-forwards 5 minutes: a stalled interval
+                      would leave the rendered minute where it was.
+  useMediaQuery     — phone-width viewport drives the sidebar into its sheet.
+
+Prerequisites (per the `verify` skill — never point this at a real station):
+
+    cd <worktree>/controller
+    STATE_DIR=<tmp>/state PORT=7795 ADMIN_USER=test ADMIN_PASS=test \
+      NODE_ENV=development NAVIDROME_URL=http://localhost:9999 \
+      NAVIDROME_USER=x NAVIDROME_PASS=x npx tsx src/server.ts
+
+    cd <worktree>/web
+    NEXT_PUBLIC_API_URL=http://localhost:7795 npx next dev -p 7796
+
+The Browse checks need rows in the isolated state dir's library.db; copy one in
+(`cp state/library.db <tmp>/state/`) and set LIBRARY_TOTAL to its track count.
+Everything else runs against an empty one.
+"""
+import base64
+import os
+import re
+import sys
+
+from playwright.sync_api import sync_playwright
+
+WEB = os.environ.get("VERIFY_WEB", "http://localhost:7796")
+API = os.environ.get("VERIFY_API", "http://localhost:7795")
+AUTH = base64.b64encode(b"test:test").decode()
+# Formatted with a thousands separator by the Browse tab's counter.
+LIBRARY_TOTAL = os.environ.get("LIBRARY_TOTAL", "1,413")
+
+results: list[tuple[str, bool, str]] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    results.append((name, ok, detail))
+    print(f"{'PASS' if ok else 'FAIL'}  {name}  {detail}")
+
+
+def debounced_searches(page, seen: list[str]) -> None:
+    """The four search boxes converted to useDebounceValue."""
+
+    def hits(fragment: str, since: int) -> list[str]:
+        return [u for u in seen[since:] if fragment in u]
+
+    # ---- Library → Browse tab ----
+    page.goto(f"{WEB}/admin/library", wait_until="networkidle")
+    page.wait_for_timeout(1500)
+    page.get_by_text("BROWSE", exact=False).first.click()  # defaults to Tracks
+    page.wait_for_timeout(1500)
+
+    box = page.locator('input[placeholder*="filter results" i]').first
+    box.wait_for(state="visible", timeout=15000)
+    page.wait_for_function(
+        "(total) => document.querySelector('main')?.innerText.includes('of ' + total)",
+        arg=LIBRARY_TOTAL,
+        timeout=15000,
+    )
+    check("browse: unfiltered list shows the whole library", True, f"'of {LIBRARY_TOTAL}'")
+
+    mark = len(seen)
+    box.click()
+    page.keyboard.type("love", delay=40)  # 4 fast keystrokes
+    page.wait_for_timeout(1200)
+    with_q = [u for u in hits("/library/browse", mark) if "q=" in u]
+    check(
+        "browse: burst of keystrokes collapses to one debounced request",
+        len(with_q) == 1,
+        f"{len(with_q)} q-carrying calls: {[u.split('?')[1][:60] for u in with_q]}",
+    )
+    check(
+        "browse: the one request carries the FULL typed term",
+        any("q=love" in u for u in with_q),
+        str(with_q),
+    )
+    check(
+        "browse: the debounced term actually filters the rendered list",
+        "of 53" in page.locator("main").inner_text(),
+        "'1–50 of 53'",
+    )
+
+    box.fill("")
+    page.wait_for_timeout(1200)
+    check(
+        "browse: clearing the box returns the unfiltered list",
+        f"of {LIBRARY_TOTAL}" in page.locator("main").inner_text(),
+        f"back to 'of {LIBRARY_TOTAL}'",
+    )
+
+    # ---- Playlist Builder: seed + artist boxes ----
+    page.goto(f"{WEB}/admin/playlists", wait_until="networkidle")
+    page.wait_for_timeout(1500)
+
+    seed = page.locator('input[placeholder*="anchor on" i]').first
+    seed.wait_for(state="visible", timeout=15000)
+    mark = len(seen)
+    seed.click()
+    page.keyboard.type("radiohead", delay=40)
+    page.wait_for_timeout(1200)
+    searches = hits("/dj/search", mark)
+    check(
+        "playlist seed: burst of keystrokes collapses to one debounced search",
+        len(searches) == 1,
+        f"{len(searches)} calls: {[u.split('?')[1][:50] for u in searches]}",
+    )
+    check(
+        "playlist seed: the search carries the FULL typed term",
+        any("q=radiohead" in u for u in searches),
+        str(searches),
+    )
+
+    # The under-two-characters guard reads the RAW query, so it must not search.
+    mark = len(seen)
+    seed.fill("")
+    seed.type("r", delay=40)
+    page.wait_for_timeout(900)
+    check(
+        "playlist seed: a one-character query fires no search",
+        len(hits("/dj/search", mark)) == 0,
+        f"{len(hits('/dj/search', mark))} calls",
+    )
+
+    artist = page.locator('input[placeholder*="Add an artist" i]').first
+    artist.wait_for(state="visible", timeout=15000)
+    mark = len(seen)
+    artist.click()
+    page.keyboard.type("portishead", delay=40)
+    page.wait_for_timeout(1200)
+    art = hits("/dj/search", mark)
+    check(
+        "playlist artist filter: burst collapses to one debounced search",
+        len(art) == 1 and "q=portishead" in art[0],
+        f"{len(art)} calls: {[u.split('?')[1][:50] for u in art]}",
+    )
+
+
+def clipboard_sites(page) -> None:
+    """The first-party sites converted to useCopyToClipboard."""
+    # ---- CodeBlock, on a public /setup page ----
+    page.goto(f"{WEB}/setup/quick-start", wait_until="networkidle")
+    page.wait_for_timeout(800)
+    copy_btn = page.locator("button.bs-copy").first
+    copy_btn.wait_for(state="visible", timeout=15000)
+    expected = page.locator("pre.bs-code").first.locator("code").inner_text().strip()
+    copy_btn.click()
+    page.wait_for_timeout(400)
+    clip = page.evaluate("navigator.clipboard.readText()")
+    check("CodeBlock: copies the block's text", clip.strip() == expected,
+          f"{clip[:45]!r} vs {expected[:45]!r}")
+    # inner_text is the RENDERED text and .bs-copy is CSS-uppercased.
+    check("CodeBlock: button flips to Copied",
+          copy_btn.inner_text().strip().lower() == "copied", repr(copy_btn.inner_text().strip()))
+    page.wait_for_timeout(1600)
+    check("CodeBlock: label reverts after ~1.4s",
+          copy_btn.inner_text().strip().lower() == "copy", repr(copy_btn.inner_text().strip()))
+
+    # ---- Connect → Integrations (CopyUrl) ----
+    page.goto(f"{WEB}/admin/connect", wait_until="networkidle")
+    page.wait_for_timeout(1500)
+    page.get_by_text("Integrations", exact=False).first.click()
+    page.wait_for_timeout(1200)
+    url_btn = page.get_by_role("button", name=re.compile(r"^Copy$", re.I)).first
+    url_btn.wait_for(state="visible", timeout=15000)
+    page.evaluate("navigator.clipboard.writeText('')")
+    url_btn.click()
+    page.wait_for_timeout(500)
+    clip = page.evaluate("navigator.clipboard.readText()")
+    check("Connect CopyUrl: copies a station URL", clip.startswith("http"), repr(clip[:60]))
+    check("Connect CopyUrl: shows the success toast",
+          "copied" in page.locator("body").inner_text().lower(), "")
+
+    # ---- Connect → Endpoints (EndpointCard's curl), inside a <details> ----
+    page.get_by_text("Endpoints", exact=False).first.click()
+    page.wait_for_timeout(1000)
+    page.locator("details summary").first.click()
+    page.wait_for_timeout(600)
+    curl_btn = page.get_by_role("button", name=re.compile("copy as curl", re.I)).first
+    curl_btn.wait_for(state="visible", timeout=15000)
+    page.evaluate("navigator.clipboard.writeText('')")
+    curl_btn.click()
+    page.wait_for_timeout(500)
+    clip = page.evaluate("navigator.clipboard.readText()")
+    check("EndpointCard: copies a curl command", clip.startswith("curl"), repr(clip[:70]))
+    check("EndpointCard: shows the curl toast",
+          "curl copied" in page.locator("body").inner_text().lower(), "")
+
+    # ---- DJ Doc: the report copy ----
+    page.goto(f"{WEB}/admin/doctor", wait_until="networkidle")
+    page.wait_for_timeout(2000)
+    run = page.get_by_role("button", name=re.compile(r"let'?s go|run|assess", re.I)).first
+    run.wait_for(state="visible", timeout=15000)
+    run.click()
+    doc_copy = page.get_by_role("button", name=re.compile("copy", re.I)).first
+    doc_copy.wait_for(state="visible", timeout=120000)  # a full stack assessment
+    page.evaluate("navigator.clipboard.writeText('')")
+    doc_copy.click()
+    page.wait_for_timeout(600)
+    clip = page.evaluate("navigator.clipboard.readText()")
+    check("DoctorPanel: copies the markdown report",
+          clip.startswith("## SUB/WAVE diagnostics") and "Generated" in clip,
+          f"{len(clip)} chars")
+    check("DoctorPanel: shows the success toast",
+          "copied" in page.locator("body").inner_text().lower(), "")
+
+
+def clock_and_media_query(ctx, page) -> None:
+    # useClock reaches the UI as turnClock's HH:MM (tty / subamp / drift skins).
+    clocked = ctx.new_page()
+    clocked.clock.install(time="2026-08-12T09:15:00")
+    clocked.add_init_script("localStorage.setItem('subwave-skin-override', 'tty')")
+    clocked.goto(f"{WEB}/listen", wait_until="networkidle")
+    clocked.wait_for_timeout(1500)
+    before = re.search(r"\d{1,2}:\d{2}", clocked.locator("body").inner_text())
+    check("useClock: the tty skin renders a wall clock", bool(before),
+          before.group(0) if before else "none")
+    clocked.clock.fast_forward("05:00")
+    clocked.wait_for_timeout(500)
+    after = re.search(r"\d{1,2}:\d{2}", clocked.locator("body").inner_text())
+    check(
+        "useClock: keeps ticking under useInterval",
+        bool(before and after) and before.group(0) != after.group(0),
+        f"{before.group(0) if before else None} -> {after.group(0) if after else None}",
+    )
+    clocked.close()
+
+    # useMediaQuery drives the sidebar's mobile sheet.
+    page.set_viewport_size({"width": 480, "height": 900})
+    page.goto(f"{WEB}/admin", wait_until="networkidle")
+    page.wait_for_timeout(1500)
+    page.get_by_role("button", name=re.compile("toggle sidebar", re.I)).first.click()
+    page.wait_for_timeout(900)
+    check(
+        "useIsMobile: phone width opens the sidebar as a sheet",
+        page.locator('[data-mobile="true"]').count() > 0,
+        f'{page.locator("[data-mobile=\'true\']").count()} sheet nodes',
+    )
+
+
+def main() -> int:
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch()
+        ctx = browser.new_context(
+            viewport={"width": 1400, "height": 950},
+            permissions=["clipboard-read", "clipboard-write"],
+        )
+        ctx.add_init_script(f"localStorage.setItem('subwave_admin_auth', '{AUTH}')")
+        page = ctx.new_page()
+
+        seen: list[str] = []
+        errors: list[str] = []
+        page.on("request", lambda r: seen.append(r.url))
+        page.on("pageerror", lambda e: errors.append(str(e)))
+
+        debounced_searches(page, seen)
+        clipboard_sites(page)
+        clock_and_media_query(ctx, page)
+        check("no uncaught page errors across the run", not errors, "; ".join(errors[:2]))
+
+        browser.close()
+
+    failed = [r for r in results if not r[1]]
+    print(f"\n{len(results) - len(failed)}/{len(results)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    print(f"web={WEB} api={API}")
+    sys.exit(main())


### PR DESCRIPTION
Closes part of #1369 — the low-risk half.

Adopts [`usehooks-ts`](https://usehooks-ts.com) (3.1.1, one transitive dep, tree-shakeable, React 19) and converts the primitives where the swap is mechanical and behaviour-preserving. Four commits, one per primitive, each reviewable on its own.

## What converted

| Primitive | Sites |
|---|---|
| `useDebounceValue` | Library Browse search, Playlist Builder seed / add / artist boxes |
| `useCopyToClipboard` | `CodeBlock`, `EndpointCard` (curl), `IntegrationsTab` (`CopyUrl`), `DoctorPanel` ×2 |
| `useInterval` | `useClock` in `lib/hooks.ts` |
| `useMediaQuery` | `useIsMobile` in `hooks/use-mobile.tsx` |

Both SSR-sensitive hooks keep their discipline: `useClock` still returns `null` until mount and lands its first reading there, and `useIsMobile` passes `initializeWithValue: false` so the server and first client render still agree.

The Playlist Builder boxes keep their staleness guard and keep clearing the dropdown off the **raw** query — the under-two-characters check is what blanks the term, so backspacing out of a search stays instant instead of leaving suggestions up for another 250ms. Only the fetch waits on the debounce.

## What deliberately did not convert

- **`usePlayer.ts:139`** — not a plain debounce. Its cleanup stops the mount pass's default volume reaching `localStorage` before the restore effect's `setVolume` lands; a library `useDebounce` drops that and reintroduces "volume resets on reload".
- **`useModelDiscovery` / `useVoiceDiscovery`** — #1368's, per that issue's note.
- **Observatory's search** — its instant-clear escape hatch needs an explicit `.cancel()` under the library that effect cleanup gives for free. The conversion is net more code.
- **`ConstellationGalaxy`'s `IntersectionObserver`** — interleaved with a `ResizeObserver` and an rAF loop; not mechanical.
- **`components/ai-elements/*`** (4 clipboard sites) — installed from a registry; re-installing would drop the edits.
- **`localStorage`** — the issue counts 19 files, but six of those (`lib/skin.ts`, `theme.ts`, `volume.ts`, `lite.ts`, `adminAuth.ts`, `stationAuth.ts`) are plain modules read from outside React, four with no hooks at all. A `useLocalStorage` sweep needs those restructured first, which is the state-management change #1369's own non-goals rule out. Worth its own issue.

## Verification

`web/scripts/verify-hooks.py` — new, alongside `verify-forms.py` and `verify-query-cache.py`, since `web/` has no test suite and none of this is in CI. Read-only against the station. **22/22 pass** against an isolated controller + worktree dev server:

- debounce: a keystroke burst produces exactly **one** request carrying the full term, at all four boxes; a one-character query fires none; clearing returns the unfiltered list
- clipboard: text read back off the real clipboard at all five sites, plus the toast/label feedback each drives off the returned boolean
- `useClock`: Playwright clock emulation, `09:15 → 09:20` across a 5-minute fast-forward (every consumer formats to the minute, so a stalled interval is only observable this way)
- `useIsMobile`: phone-width viewport drives the sidebar into its sheet

Also: `npm run lint` (eslint + `tsc --noEmit`) clean, and `npm run build` passes — the prerender is the real check for the two SSR-sensitive hooks.

## Lockfile note

`web/package-lock.json` is regenerated under **node 22** to match CI's `npm ci` (this box's npm 11.6 writes a lock `npm ci` rejects). That re-adds the nested `@tailwindcss/oxide-wasm32-wasi/@emnapi/*` entries and syncs the root `version` field, which release-please had left at 1.5.0 against a package.json on 1.7.0. `npm ci` under node 22 was run against the result and succeeds.
