### PR TITLE
fix(web): confirm a schedule booking, the one board write that said nothing

### DIFF
--- a/web/components/admin/schedule/SchedulePanel.tsx
+++ b/web/components/admin/schedule/SchedulePanel.tsx
@@ -264,12 +264,21 @@ export default function SchedulePanel() {
     setSchedule(setRange(schedule, days, line.start, line.end, value));
   };
 
+  // Booking was the one write on this board that confirmed nothing. Filling a
+  // day, filling an hour, resizing and removing all toast; the single most
+  // common action did not, so the brush — the only booking path a finger or a
+  // keyboard has — landed silently. Sonner's toast is also the live region, so
+  // that silence was a screen reader hearing nothing at all for the write it is
+  // most likely to make. Same sentence shape as its siblings, deliberately.
   const dropShow = (b: Block, showId: string) => {
     if (!schedule || !showById(showId)) return;
     setSchedule(setRange(schedule, [b.day], b.start, b.start + b.span, showId));
     setLine({ day: b.day, start: b.start, end: b.start + b.span });
     setLineDays([b.day]);
     setLineShowId(showId);
+    notify.ok(
+      `“${showById(showId)?.name ?? 'show'}” now ${dayName(b.day)} ${hhmm(b.start)} – ${hhmm(b.start + b.span)} — unsaved until you save the week.`,
+    );
   };
 
   // Vacated hours fall silent; gained ones overwrite whatever was there, so a run

--- a/web/scripts/verify-schedule-booking.py
+++ b/web/scripts/verify-schedule-booking.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""web/scripts/verify-schedule-booking.py
+
+Evidence that every write on the weekly schedule board confirms itself — the
+gap this script was written for is that BOOKING did not. Filling a day, filling
+an hour, resizing and removing all called `notify.ok`; `dropShow` did not, so
+the brush (the only booking path a finger or a keyboard has) landed silently.
+Sonner's toast is also the aria-live region, so that silence was a screen reader
+hearing nothing for the write an operator makes most often.
+
+Usage: python3 web/scripts/verify-schedule-booking.py
+
+STACK. Defaults to the isolated verify stack from the `verify` skill (web on
+:7793, admin test:test). Point it elsewhere with SUBWAVE_VERIFY_WEB and
+SUBWAVE_VERIFY_AUTH ("user:pass") — e.g. a worktree dev stack on :7700.
+
+SAFE BY CONSTRUCTION. It frees one run and books it straight back, and the board
+is local state until Save — which this never clicks. Nothing is written to the
+station.
+
+TWO TRAPS, both hit while writing this:
+ 1. `button[aria-pressed]` is not the show palette. The day-group toggles in the
+    order desk carry it too, and they sort first, so arming "WEEKDAYS" armed
+    nothing at all and the slot silently fell through to its dropdown. Select
+    the palette by its title ("Click to arm"), not by the ARIA attribute.
+ 2. Arming REWRITES that title, so a locator built from it re-resolves to a
+    different show on the next call. Assert on the armed button, not the stale
+    locator, or the check reads a neighbour's aria-pressed and fails a passing
+    app.
+"""
+import base64, os, re, sys
+from playwright.sync_api import sync_playwright
+
+WEB = os.environ.get("SUBWAVE_VERIFY_WEB", "http://localhost:7793")
+AUTH = base64.b64encode(
+    os.environ.get("SUBWAVE_VERIFY_AUTH", "test:test").encode()
+).decode()
+
+fails = []
+
+
+def check(name, ok, detail=""):
+    print(("PASS " if ok else "FAIL ") + name + ((" — " + detail) if detail else ""))
+    if not ok:
+        fails.append(name)
+
+
+def toasts(pg):
+    return " | ".join(pg.locator("[data-sonner-toast]").all_inner_texts()).strip()
+
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    pg = browser.new_page(viewport={"width": 1440, "height": 900})
+    pg.add_init_script(f"localStorage.setItem('subwave_admin_auth','{AUTH}')")
+    pg.goto(f"{WEB}/admin/shows/schedule", wait_until="networkidle")
+    pg.wait_for_timeout(3000)
+
+    # A seeded week can be fully booked, so free one run to get a silent slot.
+    pg.locator("button", has_text=re.compile(r"^×$")).first.click()
+    pg.wait_for_timeout(1200)
+    check("removing a run announces (control: worked before this change)",
+          "unsaved until you save the week" in toasts(pg), toasts(pg)[:140])
+
+    # Let it clear, so the booking assertion can only be seeing a NEW toast.
+    pg.wait_for_timeout(4800)
+    check("toast area clear before the booking", toasts(pg) == "", toasts(pg)[:120] or "(clear)")
+
+    brush = pg.locator('button[title*="Click to arm"]').first
+    check("show palette found", brush.count() > 0)
+    name = brush.inner_text().strip().split("\n")[0]
+    brush.click()
+    pg.wait_for_timeout(500)
+    armed = pg.locator('button[aria-pressed="true"][title*="is armed"]')
+    check("show armed", armed.count() == 1, f"armed={name}, matches={armed.count()}")
+
+    slot = pg.locator("button", has_text=re.compile(r"^\+\s")).first
+    check("the silent slot shows the armed brush",
+          "add a show" not in slot.inner_text().strip().lower(),
+          f"slot={slot.inner_text().strip()!r}")
+    slot.click()
+    pg.wait_for_timeout(1200)
+
+    check("no menu opened — an armed click writes directly",
+          pg.locator("[role=menu]").count() == 0)
+
+    t = toasts(pg)
+    check("booking a single run announces",
+          "unsaved until you save the week" in t, t[:220] or "(SILENT)")
+    check("the announcement names the show and its hours",
+          name.split()[0].lower() in t.lower() and "–" in t, t[:200])
+
+    region = pg.locator("[aria-live]").first
+    check("it lands in an aria-live region a screen reader reads",
+          region.count() > 0 and region.get_attribute("aria-live") in ("polite", "assertive"),
+          f"aria-live={region.get_attribute('aria-live') if region.count() else 'none'}")
+
+    browser.close()
+
+sys.exit(1 if fails else 0)


### PR DESCRIPTION
Follow-up to #1387. Part of the assessment for the schedule-board half of #1370 — see "Why not dnd-kit" below, which is the substantive finding here.

## What

`dropShow` was the only write on the weekly board that confirmed nothing. Its four siblings all toast:

| Write | Announced before this PR |
|---|---|
| Fill a day (`fillDay`) | yes |
| Fill an hour all week (`fillHour`) | yes |
| Resize a run (`resizeRun`) | yes |
| Remove a run (`removeRun`) | yes |
| **Book a run (`dropShow`)** | **no** |

Booking is the write an operator makes most often, and `notify` is Sonner, whose toast viewport *is* the `aria-live="polite"` region — so this was not just a missing visual confirmation, it was a screen reader hearing nothing for the most common action on the page.

One call in the shared handler covers all three entry points that reach it — the armed brush (the only booking path a finger or a keyboard has), the per-slot dropdown, and a mouse drag — using the same sentence shape its siblings already use.

## Why not dnd-kit

#1370 scopes the board as the second surface to port, on the premise that it is mouse-only with no keyboard path. Reading `Board.tsx`, that premise does not hold for the board the way it did for the playlist:

- **Booking** — the palette items are real `<button>`s with `aria-pressed` that arm a brush; a click on any hour, day header or gutter hour books it. Unarmed, the slot is a Radix `DropdownMenu` listing every show. Both are touch- and keyboard-usable today.
- **Resizing** — `onPointerDown/Move/Up` with `setPointerCapture` (so touch works) plus `onKeyDown` arrow-key stepping.
- **Removing / editing** — plain buttons.

Nothing on the board is mouse-only; the HTML5 `dataTransfer` code is a redundant shortcut for booking that is already covered three other ways. Porting it would trade a working model for no new capability, against real risk: ~168 droppable cells per week, day folding, a gutter column, and resize sharing pointer events with a drag sensor.

**Assessed and deliberately not fixed:** the 7px resize handles are a poor fingertip target (WCAG 2.5.8 wants 24px). I tried to size this up and backed out — the handles sit inside the card, so expanding inward swallows a one-hour card's own tap target (22px at compact density) and expanding outward collides with the neighbouring card's handle. It needs a redesign, not a media query, and touch users can already extend a run by booking the adjacent hour with the brush. Flagging rather than shipping a change that breaks short cards.

I'd suggest closing the board half of #1370 on this basis rather than leaving it open for someone to re-derive from a `grep dataTransfer`.

## Verification

`web/scripts/verify-schedule-booking.py` — 9/9 against a worktree dev stack. It asserts the removal toast as a control, waits for the toast area to clear so the booking assertion can only see a *new* toast, and checks the announcement lands in a `polite` live region. It frees one run and books it straight back, and the board is local state until Save, which it never clicks — nothing is written to the station.

It also pins two selector traps that made an earlier run report a passing app as broken: `button[aria-pressed]` also matches the order desk's day-group toggles (so "WEEKDAYS" gets armed and nothing happens), and arming rewrites the palette button's `title`, so a locator built from it re-resolves to a different show on the next call.

`npm run lint` (eslint + tsc) clean.
