### PR TITLE
fix(web): remove duplicate skill name label

### DIFF
--- a/web/components/admin/skills/SkillEditModal.tsx
+++ b/web/components/admin/skills/SkillEditModal.tsx
@@ -673,13 +673,11 @@ export default function SkillEditModal({ mode, skill, personas, tagSuggestions, 
         <div style={{ opacity: isEdit && !enabled ? 0.6 : 1, transition: 'opacity .2s ease' }}>
 
             <div className="sw-section">
-              <div style={sectionLabel}>SKILL NAME</div>
               <TextField
                 control={control}
                 name="label"
                 label="Skill name"
                 placeholder={displayName}
-                className="mt-4"
               />
               {mode === 'create' && (
                 <Controller


### PR DESCRIPTION
## Why

The skill editor rendered both a `SKILL NAME` section heading and a `Skill name` field label for the same input. This made the edit screen look duplicated and added no extra context for operators.

## What changed

- remove the redundant section heading
- keep the bound field label so the input remains clearly named and accessible
- remove the spacing that existed only between the duplicate labels

## Verification

- `npx eslint components/admin/skills/SkillEditModal.tsx`
- `git diff --check`

Full `npm run lint` currently reaches TypeScript and then stops on existing missing `@dnd-kit/*` modules in the playlist builder; the changed component passes targeted ESLint.