### PR TITLE
Add a genre-lock quick control to the admin Dash

### DIFF
--- a/controller/scripts/schedule-schema.test.ts
+++ b/controller/scripts/schedule-schema.test.ts
@@ -19,11 +19,14 @@ import test from 'node:test';
 process.env.STATE_DIR = mkdtempSync(join(tmpdir(), 'subwave-schedule-schema-'));
 
 const {
+  GENRE_LOCK_GENRES_MAX,
+  GENRE_LOCK_SHOW_ID,
   OVERRIDE_MAX_MINUTES,
   OVERRIDE_MIN_MINUTES,
   SCHEDULE_DAYS,
   SCHEDULE_HOURS,
   emptyWeek,
+  genreLockRequestSchema,
   repairScheduleForLoad,
   resolveScheduleSlots,
   scheduleOverrideRequestSchema,
@@ -333,4 +336,49 @@ test('override request: the minutes message names the real bounds', () => {
     r.error!.issues[0]!.message,
     new RegExp(`between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}`),
   );
+});
+
+// --- POST /schedule/genre-lock ----------------------------------------------
+
+test('genre lock: the reserved show id is a valid show id', () => {
+  // SHOW_ID_RE (schemas/show.ts) is 3-32 chars of lowercase letters, digits or
+  // underscores — asserted structurally here rather than by importing show.ts,
+  // which schedule.ts may not do (see the header).
+  assert.match(GENRE_LOCK_SHOW_ID, /^[a-z0-9_]{3,32}$/);
+});
+
+test('genre lock request: accepts one or more genres and coerces minutes', () => {
+  const r = genreLockRequestSchema.parse({ genres: ['Jazz'], minutes: '90' });
+  assert.deepEqual(r.genres, ['Jazz']);
+  assert.equal(r.minutes, 90);
+});
+
+test('genre lock request: genres de-duplicate case-insensitively, in first-seen order', () => {
+  const r = genreLockRequestSchema.parse({ genres: ['Jazz', 'jazz', 'Soul', 'JAZZ'], minutes: 60 });
+  assert.deepEqual(r.genres, ['Jazz', 'Soul']);
+});
+
+test('genre lock request: refuses an empty genre list', () => {
+  assert.equal(genreLockRequestSchema.safeParse({ genres: [], minutes: 60 }).success, false);
+});
+
+test('genre lock request: caps the genre list at GENRE_LOCK_GENRES_MAX', () => {
+  const genres = Array.from({ length: GENRE_LOCK_GENRES_MAX + 1 }, (_, i) => `genre-${i}`);
+  assert.equal(genreLockRequestSchema.safeParse({ genres, minutes: 60 }).success, false);
+  assert.equal(
+    genreLockRequestSchema.safeParse({ genres: genres.slice(0, GENRE_LOCK_GENRES_MAX), minutes: 60 }).success,
+    true,
+  );
+});
+
+test('genre lock request: same minute bounds as the takeover request', () => {
+  for (const minutes of [OVERRIDE_MIN_MINUTES - 1, OVERRIDE_MAX_MINUTES + 1, 30.5, 'soon']) {
+    assert.equal(
+      genreLockRequestSchema.safeParse({ genres: ['Jazz'], minutes }).success,
+      false,
+      `minutes=${String(minutes)} should be refused`,
+    );
+  }
+  assert.equal(genreLockRequestSchema.safeParse({ genres: ['Jazz'], minutes: OVERRIDE_MIN_MINUTES }).success, true);
+  assert.equal(genreLockRequestSchema.safeParse({ genres: ['Jazz'], minutes: OVERRIDE_MAX_MINUTES }).success, true);
 });

--- a/controller/src/routes/shows.ts
+++ b/controller/src/routes/shows.ts
@@ -18,6 +18,8 @@ import * as settings from '../settings.js';
 import { requireAdmin } from '../middleware/auth.js';
 import { validateBody, validateBodyAsync } from '../middleware/validate.js';
 import {
+  GENRE_LOCK_SHOW_ID,
+  genreLockRequestSchema,
   resolveScheduleSlots,
   scheduleOverrideRequestSchema,
   scheduleSaveSchema,
@@ -217,6 +219,76 @@ router.post('/schedule/override', requireAdmin, validateBody(scheduleOverrideReq
     res.json({ override });
   } catch (err: any) {
     queue.log('error', `POST /schedule/override failed: ${err.message}`);
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /schedule/genre-lock — the quick "only this genre, for N minutes"
+// control: one reserved show (GENRE_LOCK_SHOW_ID) carries the genre filter,
+// upserted here, then pinned exactly like POST /schedule/override. Re-hitting
+// this route while a lock is live replaces the genre list and/or extends the
+// window — same "re-POST to replace" contract the takeover route itself
+// documents.
+//
+// The reserved show is a NORMAL show — it lists at /admin/shows, can be
+// hand-edited (a different host, an extra mood/era), and is not deleted when
+// the lock ends. That is deliberate: hidden state an operator can't see or
+// fix is worse than one more row in the roster, and re-locking just updates
+// this same row rather than accumulating a new show per lock.
+//
+// Host persona: kept from a previous lock if one exists (so relocking doesn't
+// jump the DJ's voice mid-window), else the station's active persona — same
+// default the community show install route uses.
+// ---------------------------------------------------------------------------
+router.post('/schedule/genre-lock', requireAdmin, validateBody(genreLockRequestSchema), async (req, res) => {
+  const { genres, minutes } = req.body as { genres: string[]; minutes: number };
+
+  await settings.load();
+  const s = settings.get();
+  const shows = s.shows || [];
+  const existing = shows.find((sh: any) => sh.id === GENRE_LOCK_SHOW_ID);
+
+  const personaId = existing?.personaId || s.activePersonaId || s.personas?.[0]?.id;
+  if (!personaId) {
+    return res.status(409).json({ error: 'no persona in the roster to host the genre lock — add a persona first' });
+  }
+  if (!existing && shows.length >= settings.SHOWS_LIMIT) {
+    return res.status(409).json({ error: `the show list is full (${settings.SHOWS_LIMIT} shows max) — remove one first` });
+  }
+
+  const label = genres.length > 2 ? `${genres.slice(0, 2).join(', ')} +${genres.length - 2}` : genres.join(', ');
+  // Spread the existing row first so a hand-edited field (a mood, an era, a
+  // different host) survives a relock — only what this control owns is
+  // overwritten. A brand-new lock has no `existing` to spread, so it starts
+  // from the show schema's own defaults via settings.update()'s validator.
+  const lockShow = {
+    ...existing,
+    id: GENRE_LOCK_SHOW_ID,
+    name: `🔒 ${label}`,
+    personaId,
+    genres,
+    filtersStrict: true,
+  };
+  const nextShows = existing
+    ? shows.map((sh: any) => (sh.id === GENRE_LOCK_SHOW_ID ? lockShow : sh))
+    : [...shows, lockShow];
+
+  const startedAt = Date.now();
+  const override = { showId: GENRE_LOCK_SHOW_ID, startedAt, expiresAt: startedAt + minutes * 60_000 };
+  try {
+    // Both keys in ONE update() call: settings.ts validates shows before
+    // scheduleOverride (see settings.ts's patch handling) and checks the
+    // override's showId against the just-validated shows array, so the
+    // brand-new/updated lock show is already "real" by the time the override
+    // is checked — no two-step save where the second call could 404.
+    await settings.update({ shows: nextShows, scheduleOverride: override });
+    queue.log('scheduler', `[genre lock] "${label}" pinned for ${minutes} min via admin UI`);
+    void rollSessionNow();
+    const saved = settings.get().shows?.find((sh: any) => sh.id === GENRE_LOCK_SHOW_ID) || null;
+    res.json({ override, show: saved });
+  } catch (err: any) {
+    queue.log('error', `POST /schedule/genre-lock failed: ${err.message}`);
     res.status(400).json({ error: err.message });
   }
 });

--- a/controller/src/schemas/schedule.ts
+++ b/controller/src/schemas/schedule.ts
@@ -1,10 +1,12 @@
-// Shared schedule schema — the weekly grid (#shows) and the timed takeover
-// (#930), executed on BOTH sides. The controller runs it in
-// settings.validate.validateScheduleStrict / validateScheduleOverrideStrict
-// (the update() chokepoint), in settings.normalize.normalizeSchedule /
-// normalizeScheduleOverride (the lenient load path) and in the PUT /schedule +
-// POST /schedule/override route middleware; the browser runs the mirrored copy
-// (web/lib/schemas.generated.ts) for the takeover dialog's minute bounds.
+// Shared schedule schema — the weekly grid (#shows), the timed takeover
+// (#930), and the genre lock quick-control, executed on BOTH sides. The
+// controller runs it in settings.validate.validateScheduleStrict /
+// validateScheduleOverrideStrict (the update() chokepoint),
+// settings.normalize.normalizeSchedule / normalizeScheduleOverride (the
+// lenient load path), and the PUT /schedule + POST /schedule/override +
+// POST /schedule/genre-lock route middleware; the browser runs the mirrored
+// copy (web/lib/schemas.generated.ts) for the takeover/genre-lock dialogs'
+// bounds.
 //
 // HARD RULE: this file may import ONLY from 'zod'. It is copied verbatim into
 // the web bundle, so a project import or a node builtin here breaks the mirror.
@@ -308,6 +310,64 @@ export function scheduleOverrideSchema(ctx: ScheduleOverrideContext) {
  */
 export const scheduleOverrideRequestSchema = z.object({
   showId: z.string({ error: 'pick a show to pin' }).min(1, 'pick a show to pin'),
+  minutes: z.coerce
+    .number({ error: `must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}` })
+    .int(`must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}`)
+    .min(OVERRIDE_MIN_MINUTES, `must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}`)
+    .max(OVERRIDE_MAX_MINUTES, `must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}`),
+});
+
+// ── Genre lock (quick "only this genre, for N minutes") ─────────────────────
+//
+// A one-control shortcut over the show + takeover machinery above: rather than
+// building a show and placing it in the grid, the operator picks genre(s) and
+// a duration and this reserved show id carries the filter. routes/shows.ts's
+// POST /schedule/genre-lock upserts a show at this id (genres + filtersStrict,
+// host = the active persona) and pins it exactly like POST /schedule/override.
+// It stays a normal, visible, editable show — not hidden state — so an
+// operator who wants to hand-tune it (a different host, an added mood) isn't
+// stuck. Reserved rather than random so re-locking updates the SAME show
+// instead of accumulating one new show per lock.
+export const GENRE_LOCK_SHOW_ID = 'genre_lock';
+
+// This module may only import 'zod' (see header), so these duplicate
+// schemas/show.ts's SHOW_GENRE_MAX and SHOW_FILTER_VALUES_MAX rather than
+// importing them. Both bound the same free-text genre list a show's own
+// `genres` field accepts; a change to either pair should change both.
+// Exported (not just used locally) so the admin form can cap the chip input
+// and grey out "Add" at the same limit the server enforces, the same way
+// components/admin/shows/types.ts's FILTER_VALUES_MAX mirrors show.ts's.
+export const GENRE_LOCK_GENRE_MAX = 64;
+export const GENRE_LOCK_GENRES_MAX = 15;
+
+/**
+ * POST /schedule/genre-lock's body. Genres are free text, resolved fuzzily
+ * against the library at pick time — same contract as a show's own `genres`
+ * field, never checked against Subsonic here. Deduplicated case-insensitively,
+ * in first-seen order, like showStringList's genre list above.
+ */
+export const genreLockRequestSchema = z.object({
+  genres: z
+    .array(
+      z
+        .string({ error: 'must be a string' })
+        .trim()
+        .min(1, `must be ${GENRE_LOCK_GENRE_MAX} characters or fewer`)
+        .max(GENRE_LOCK_GENRE_MAX, `must be ${GENRE_LOCK_GENRE_MAX} characters or fewer`),
+    )
+    .min(1, 'pick at least one genre')
+    .max(GENRE_LOCK_GENRES_MAX, `must have at most ${GENRE_LOCK_GENRES_MAX} entries`)
+    .transform((xs) => {
+      const seen = new Set<string>();
+      const out: string[] = [];
+      for (const v of xs) {
+        const k = v.toLowerCase();
+        if (seen.has(k)) continue;
+        seen.add(k);
+        out.push(v);
+      }
+      return out;
+    }),
   minutes: z.coerce
     .number({ error: `must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}` })
     .int(`must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}`)

--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -46,6 +46,7 @@ import StationHeader, { type HealthMetrics } from './StationHeader';
 import { cn } from '../../lib/cn';
 import { RequestsCard } from './dash/RequestsCard';
 import { TakeoverCard } from './dash/TakeoverCard';
+import { GenreLockCard } from './dash/GenreLockCard';
 import { BoothTurnText, SegmentButton, SortableTh, ToggleRow, classTone } from './dash/bits';
 import type {
   ActResponse,
@@ -664,6 +665,8 @@ export default function DashPanel() {
           </Card>
 
           <TakeoverCard tz={tz} locale={locale} />
+
+          <GenreLockCard tz={tz} locale={locale} />
 
           <Card title="Broadcast">
             <div className="grid gap-2.5">

--- a/web/components/admin/dash/GenreLockCard.tsx
+++ b/web/components/admin/dash/GenreLockCard.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+// Genre lock — the quick "only this genre, for N minutes" control. A sibling
+// of TakeoverCard (#930): where that card pins an EXISTING show, this one
+// skips the show-builder detour entirely — pick genre(s) and a duration, and
+// POST /schedule/genre-lock upserts one reserved show (GENRE_LOCK_SHOW_ID)
+// with those genres + a hard filter, then pins it exactly like a takeover.
+// The reserved show is a normal, visible show (it lists at /admin/shows,
+// editable like any other), so this card never needs its own copy of the
+// show's fields — the pinned show's NAME already carries the genre label
+// ("🔒 Jazz, Soul"), because the route names it that way.
+//
+// Like TakeoverCard, this fetches for itself: GET /schedule is the read both
+// cards share, and each POSTs/DELETEs the one mutation it owns.
+
+import { useEffect, useState } from 'react';
+import { Controller, useController } from 'react-hook-form';
+import { useAdminAuth } from '../../../lib/adminAuth';
+import { notify, errorMessage } from '../../../lib/notify';
+import { fmtClock } from '../../../lib/format';
+import type { StationLocale } from '../../../lib/types';
+import { cn } from '../../../lib/cn';
+import { useZodForm, applyServerFieldErrors } from '@/lib/form';
+import { TextField } from '@/lib/form-fields';
+import { Input } from '../../ui/input';
+import { Card, Btn, Pill, Seg } from '../ui';
+import GenreSuggest from '../GenreSuggest';
+import {
+  genreLockRequestSchema,
+  GENRE_LOCK_SHOW_ID,
+  GENRE_LOCK_GENRE_MAX,
+  GENRE_LOCK_GENRES_MAX,
+  OVERRIDE_MIN_MINUTES,
+  OVERRIDE_MAX_MINUTES,
+  type ScheduleOverride,
+} from '@/lib/schemas.generated';
+
+interface LockedShow {
+  id: string;
+  name: string;
+}
+
+const PRESETS = [
+  { minutes: 60, label: '1h' },
+  { minutes: 120, label: '2h' },
+  { minutes: 180, label: '3h' },
+];
+
+export function GenreLockCard({ tz, locale }: { tz?: string; locale?: StationLocale }) {
+  const { adminFetch, needsAuth, hydrated } = useAdminAuth();
+  const [shows, setShows] = useState<LockedShow[]>([]);
+  const [override, setOverride] = useState<ScheduleOverride | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+  const [genreDraft, setGenreDraft] = useState('');
+
+  const form = useZodForm(genreLockRequestSchema, { genres: [], minutes: 60 });
+  // Array field — a raw Controller, like ShowEditor's own genresCtl, rather
+  // than TextField/SwitchField (neither covers a chip list).
+  const genresCtl = useController({ control: form.control, name: 'genres' });
+  const genres: string[] = genresCtl.field.value ?? [];
+
+  // Same 30s poll TakeoverCard runs, on the same endpoint — a lock made here,
+  // in another tab, or lapsing on its own lands on screen without a reload.
+  // Never touches the form: a poll mid-type must not clobber a half-built
+  // genre list.
+  useEffect(() => {
+    if (!hydrated || needsAuth) return;
+    let cancelled = false;
+    const tick = async () => {
+      setNow(Date.now());
+      try {
+        const r = await adminFetch('/schedule');
+        if (!r.ok || cancelled) return;
+        const j = (await r.json()) as { shows?: LockedShow[]; override?: ScheduleOverride | null };
+        setShows(
+          Array.isArray(j.shows)
+            ? j.shows.filter(s => s && typeof s.id === 'string' && s.id)
+            : [],
+        );
+        setOverride(j.override ?? null);
+      } catch {}
+    };
+    tick();
+    const id = setInterval(tick, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [hydrated, needsAuth]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Only OUR concern: a live override that isn't the genre-lock show is
+  // someone else's takeover (TakeoverCard already renders that state) — this
+  // card stays on the picker so a fresh lock can still be pinned over it,
+  // same "re-POST replaces" contract the override route documents.
+  const live = override && override.expiresAt > now && override.showId === GENRE_LOCK_SHOW_ID ? override : null;
+  const lockedShow = live ? shows.find(s => s.id === GENRE_LOCK_SHOW_ID) ?? null : null;
+  const minutesLeft = live ? Math.max(1, Math.ceil((live.expiresAt - now) / 60_000)) : 0;
+  // The route names the reserved show "🔒 <genres>" — strip the emoji back
+  // off for display here since the card already has its own "on air" pill.
+  const lockedLabel = lockedShow?.name.replace(/^🔒\s*/, '') ?? '';
+
+  const addGenre = (g: string) => {
+    const v = g.trim().slice(0, GENRE_LOCK_GENRE_MAX);
+    if (!v || genres.length >= GENRE_LOCK_GENRES_MAX) return;
+    if (genres.some(x => x.toLowerCase() === v.toLowerCase())) {
+      setGenreDraft('');
+      return;
+    }
+    genresCtl.field.onChange([...genres, v]);
+    setGenreDraft('');
+  };
+  const removeGenre = (g: string) => genresCtl.field.onChange(genres.filter(x => x !== g));
+
+  const lock = form.handleSubmit(async (values) => {
+    setBusy(true);
+    try {
+      const r = await adminFetch('/schedule/genre-lock', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values),
+      });
+      const j = (await r.json().catch(() => ({}))) as {
+        error?: string;
+        fieldErrors?: Record<string, string>;
+        override?: ScheduleOverride;
+        show?: LockedShow;
+      };
+      if (!r.ok) {
+        applyServerFieldErrors(form, j.fieldErrors);
+        throw new Error(j.error || `failed (${r.status})`);
+      }
+      setOverride(j.override ?? null);
+      if (j.show) setShows(prev => [...prev.filter(s => s.id !== j.show!.id), j.show!]);
+      // eslint-disable-next-line react-hooks/purity
+      setNow(Date.now());
+      notify.ok(`genre locked to ${values.genres.join(', ')} — the switch airs on the next track.`);
+      form.reset({ genres: [], minutes: values.minutes });
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  });
+
+  const cancel = async () => {
+    setBusy(true);
+    try {
+      const r = await adminFetch('/schedule/override', { method: 'DELETE' });
+      const j = (await r.json().catch(() => ({}))) as { error?: string };
+      if (!r.ok) throw new Error(j.error || `failed (${r.status})`);
+      setOverride(null);
+      notify.ok('Genre lock cancelled — back to the weekly schedule.');
+    } catch (e) {
+      notify.err(errorMessage(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onAir = !!live;
+
+  return (
+    <Card
+      title="Genre lock"
+      sub={onAir ? undefined : 'only this genre, for a while'}
+      className={cn(onAir && 'shadow-[0_0_0_2px_color-mix(in_oklab,var(--accent)_28%,transparent)]')}
+      right={onAir ? <Pill tone="accent" dot>on air</Pill> : undefined}
+    >
+      {onAir ? (
+        <div className="grid gap-2.5">
+          <div className="grid gap-1 border border-[color-mix(in_oklab,var(--accent)_35%,transparent)] bg-[var(--accent-soft)] px-2.5 py-2">
+            <div className="flex items-baseline gap-2">
+              <span className="min-w-0 truncate text-[13px] font-bold text-ink">🔒 {lockedLabel}</span>
+              <span className="mono-num ml-auto flex-none text-[10px] whitespace-nowrap text-muted">
+                ends {fmtClock(live!.expiresAt, tz, locale)}
+              </span>
+            </div>
+            <div className="text-[10px] text-muted">only this genre plays · {minutesLeft} min left</div>
+          </div>
+          <Btn sm className="w-full" disabled={busy} onClick={cancel}>
+            {busy ? 'cancelling…' : 'Cancel lock'}
+          </Btn>
+        </div>
+      ) : (
+        <div className="grid gap-2.5">
+          <div className="grid gap-1.5">
+            {genres.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {genres.map(g => (
+                  <button
+                    key={g}
+                    type="button"
+                    onClick={() => removeGenre(g)}
+                    className="min-h-9 border border-ink bg-ink px-2 py-0.5 text-[12px] text-bg sm:min-h-0"
+                    title="Remove this genre"
+                  >
+                    {g} ×
+                  </button>
+                ))}
+              </div>
+            )}
+            <div className="flex min-w-0 gap-2">
+              <Input
+                type="text"
+                value={genreDraft}
+                maxLength={GENRE_LOCK_GENRE_MAX}
+                onChange={e => setGenreDraft(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addGenre(genreDraft); } }}
+                placeholder={genres.length ? 'add another genre' : 'e.g. Jazz'}
+                disabled={genres.length >= GENRE_LOCK_GENRES_MAX}
+                aria-label="Genre"
+              />
+              <Btn
+                className="min-h-9 flex-none sm:min-h-0"
+                onClick={() => addGenre(genreDraft)}
+                disabled={!genreDraft.trim() || genres.length >= GENRE_LOCK_GENRES_MAX}
+              >
+                Add
+              </Btn>
+            </div>
+            <GenreSuggest adminFetch={adminFetch} value={genreDraft} onSelect={addGenre} />
+          </div>
+          <div className="flex flex-wrap items-center gap-2.5">
+            <Controller
+              control={form.control}
+              name="minutes"
+              render={({ field }) => (
+                <Seg
+                  value={String(field.value)}
+                  options={PRESETS.map(p => ({ id: String(p.minutes), label: p.label }))}
+                  onChange={id => field.onChange(Number(id))}
+                />
+              )}
+            />
+            <TextField
+              control={form.control}
+              name="minutes"
+              label="Lock minutes"
+              numeric
+              className="max-w-32"
+              min={OVERRIDE_MIN_MINUTES}
+              max={OVERRIDE_MAX_MINUTES}
+            />
+          </div>
+          <Btn
+            tone="accent"
+            sm
+            className="w-full"
+            disabled={busy || genres.length === 0 || !form.formState.isValid}
+            onClick={lock}
+          >
+            {busy ? 'locking…' : 'Lock it in →'}
+          </Btn>
+          <div className="text-[10px] text-muted">
+            hard-filters to these genres · the switch airs on the next track · the schedule picks up again after
+          </div>
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -1528,13 +1528,15 @@ export const listenerRequestSchema = z.object({
 
 // ─── from controller/src/schemas/schedule.ts ─────────────────────────────
 
-// Shared schedule schema — the weekly grid (#shows) and the timed takeover
-// (#930), executed on BOTH sides. The controller runs it in
-// settings.validate.validateScheduleStrict / validateScheduleOverrideStrict
-// (the update() chokepoint), in settings.normalize.normalizeSchedule /
-// normalizeScheduleOverride (the lenient load path) and in the PUT /schedule +
-// POST /schedule/override route middleware; the browser runs the mirrored copy
-// (web/lib/schemas.generated.ts) for the takeover dialog's minute bounds.
+// Shared schedule schema — the weekly grid (#shows), the timed takeover
+// (#930), and the genre lock quick-control, executed on BOTH sides. The
+// controller runs it in settings.validate.validateScheduleStrict /
+// validateScheduleOverrideStrict (the update() chokepoint),
+// settings.normalize.normalizeSchedule / normalizeScheduleOverride (the
+// lenient load path), and the PUT /schedule + POST /schedule/override +
+// POST /schedule/genre-lock route middleware; the browser runs the mirrored
+// copy (web/lib/schemas.generated.ts) for the takeover/genre-lock dialogs'
+// bounds.
 //
 // HARD RULE: this file may import ONLY from 'zod'. It is copied verbatim into
 // the web bundle, so a project import or a node builtin here breaks the mirror.
@@ -1837,6 +1839,64 @@ export function scheduleOverrideSchema(ctx: ScheduleOverrideContext) {
  */
 export const scheduleOverrideRequestSchema = z.object({
   showId: z.string({ error: 'pick a show to pin' }).min(1, 'pick a show to pin'),
+  minutes: z.coerce
+    .number({ error: `must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}` })
+    .int(`must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}`)
+    .min(OVERRIDE_MIN_MINUTES, `must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}`)
+    .max(OVERRIDE_MAX_MINUTES, `must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}`),
+});
+
+// ── Genre lock (quick "only this genre, for N minutes") ─────────────────────
+//
+// A one-control shortcut over the show + takeover machinery above: rather than
+// building a show and placing it in the grid, the operator picks genre(s) and
+// a duration and this reserved show id carries the filter. routes/shows.ts's
+// POST /schedule/genre-lock upserts a show at this id (genres + filtersStrict,
+// host = the active persona) and pins it exactly like POST /schedule/override.
+// It stays a normal, visible, editable show — not hidden state — so an
+// operator who wants to hand-tune it (a different host, an added mood) isn't
+// stuck. Reserved rather than random so re-locking updates the SAME show
+// instead of accumulating one new show per lock.
+export const GENRE_LOCK_SHOW_ID = 'genre_lock';
+
+// This module may only import 'zod' (see header), so these duplicate
+// schemas/show.ts's SHOW_GENRE_MAX and SHOW_FILTER_VALUES_MAX rather than
+// importing them. Both bound the same free-text genre list a show's own
+// `genres` field accepts; a change to either pair should change both.
+// Exported (not just used locally) so the admin form can cap the chip input
+// and grey out "Add" at the same limit the server enforces, the same way
+// components/admin/shows/types.ts's FILTER_VALUES_MAX mirrors show.ts's.
+export const GENRE_LOCK_GENRE_MAX = 64;
+export const GENRE_LOCK_GENRES_MAX = 15;
+
+/**
+ * POST /schedule/genre-lock's body. Genres are free text, resolved fuzzily
+ * against the library at pick time — same contract as a show's own `genres`
+ * field, never checked against Subsonic here. Deduplicated case-insensitively,
+ * in first-seen order, like showStringList's genre list above.
+ */
+export const genreLockRequestSchema = z.object({
+  genres: z
+    .array(
+      z
+        .string({ error: 'must be a string' })
+        .trim()
+        .min(1, `must be ${GENRE_LOCK_GENRE_MAX} characters or fewer`)
+        .max(GENRE_LOCK_GENRE_MAX, `must be ${GENRE_LOCK_GENRE_MAX} characters or fewer`),
+    )
+    .min(1, 'pick at least one genre')
+    .max(GENRE_LOCK_GENRES_MAX, `must have at most ${GENRE_LOCK_GENRES_MAX} entries`)
+    .transform((xs) => {
+      const seen = new Set<string>();
+      const out: string[] = [];
+      for (const v of xs) {
+        const k = v.toLowerCase();
+        if (seen.has(k)) continue;
+        seen.add(k);
+        out.push(v);
+      }
+      return out;
+    }),
   minutes: z.coerce
     .number({ error: `must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}` })
     .int(`must be an integer between ${OVERRIDE_MIN_MINUTES} and ${OVERRIDE_MAX_MINUTES}`)


### PR DESCRIPTION
Lets an operator hard-filter the station to one or more genres for a bounded window (e.g. "only Jazz for the next 2 hours") without going through the show-builder + weekly-grid detour first.

Reuses the existing show/genre-filter and timed-takeover machinery rather than adding a parallel music-selection path: POST /schedule/genre-lock upserts one reserved show (genres + filtersStrict) and pins it exactly like the existing POST /schedule/override. The reserved show stays a normal, visible show at /admin/shows rather than hidden state.

- controller/src/schemas/schedule.ts: genreLockRequestSchema + GENRE_LOCK_SHOW_ID/GENRE_LOCK_GENRE_MAX/GENRE_LOCK_GENRES_MAX, mirrored into web/lib/schemas.generated.ts.
- controller/src/routes/shows.ts: POST /schedule/genre-lock.
- web/components/admin/dash/GenreLockCard.tsx: the Dash control, wired into DashPanel.tsx next to TakeoverCard.
- controller/scripts/schedule-schema.test.ts: coverage for the new request schema.