### PR TITLE
fix(broadcast): don't start a jingle while a DJ clip is on air

### DIFF
--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -869,6 +869,30 @@ bed_on_air = ref(false)
 # the future cannot latch — at worst it is already in the past.
 voice_until = ref(0.)
 
+# Hard ceiling on how far ahead voice_marker may push that deadline. The gate
+# fails toward SERVING jingles, deliberately: a measured duration that comes back
+# wrong (corrupt header, a filename that resolved to some other media) would
+# otherwise silence the rotate for as long as that number says, and unlike the
+# collision the gate fixes, that failure is inaudible — nothing in the log says
+# why the stingers stopped.
+VOICE_GATE_MAX_SEC = 120.
+
+# Two things this gate deliberately does NOT do:
+#
+#   - It arms at the clip's on_metadata, i.e. after the 0.5s say.txt poll and the
+#     silent lead-in. waitForJingleClear (voice-io.ts) covers a jingle already
+#     handed out when the controller writes say.txt; a jingle handed to the rotate
+#     inside that ~1s seam is covered by neither side. Arming optimistically at
+#     handoff would close it, but the controller has no channel to Liquidsoap
+#     other than the handoff files themselves — it would need a new one, for a
+#     window narrower than the poll that creates it.
+#   - intro_queue arms it too, not just voice_queue. A talk-over link is written
+#     for the INCOMING song, so if the rotate served a stinger at that seam the
+#     link would talk over the stinger instead — same collision, quieter. The
+#     cost is that links land on the rotate's decision point by construction, so
+#     a chatty persona (speech every 1-5 tracks) will skip some jingles and run
+#     slightly under the configured ratio. Skipping a jingle is the cheaper miss.
+
 # JINGLES & STATION ID — rotate a jingle in every N tracks.
 #
 # CRITICAL: this rotate MUST sit here, on the raw pre-cross / pre-duck music
@@ -965,24 +989,48 @@ def voice_marker(channel, tmp_dir) =
     begin
       voice_id = m["subwave_voice"]
       if voice_id != "" then
-        # Arm the jingle gate (see voice_until above). request.duration is
-        # documented as expensive, but this hook is synchronous=false and so
-        # runs off the streaming thread. The 30s fallback keeps the guard useful
-        # when the clip cannot be measured, and stays bounded by construction.
-        dur = request.duration(m["filename"])
-        voice_until := time() + (null.get(default=30., dur)) + 2.
+        # ONE clock read for both jobs, taken before either. `startedAt` is the
+        # live-edge stamp the controller treats as the moment the words begin
+        # (#1382) — re-reading time() after the work below would skew it by
+        # however long that work took.
+        now = time()
+        fname = m["filename"]
 
+        # The marker goes out FIRST. Arming the jingle gate needs request.duration,
+        # which decodes a header and can raise on an unreadable/empty filename; if
+        # that ran first, a raise would cost the marker entirely, and because the
+        # file is never deleted awaitVoiceAir would not degrade instantly — it
+        # would burn its full 20s timeout against the PREVIOUS clip's voiceId.
         file.write(
           data=json.stringify(compact=true, {
             voiceId = voice_id,
             channel = channel,
-            filename = m["filename"],
-            startedAt = time()
+            filename = fname,
+            startedAt = now
           }),
           atomic=true,
           temp_dir=tmp_dir,
           "#{state_dir}/voice-playing.json"
         )
+
+        # Arm the jingle gate (see voice_until above). request.duration is
+        # documented as expensive, but this hook is synchronous=false and so runs
+        # off the streaming thread. Two bounds, because an over-long deadline
+        # silently starves the rotate with nothing in the log to explain it: the
+        # 30s fallback covers a clip that cannot be measured at all, and the cap
+        # covers one that measures WRONG (corrupt header, or a filename that
+        # resolved to some other media). No script is a legitimate two minutes.
+        dur =
+          try
+            null.get(default=30., request.duration(fname))
+          catch err do
+            log(
+              label="subwave",
+              "voice duration unavailable for #{fname} (#{err}); jingle gate falls back to 30s"
+            )
+            30.
+          end
+        voice_until := now + min(dur, VOICE_GATE_MAX_SEC) + 2.
       end
     end
 end

--- a/liquidsoap/radio.liq
+++ b/liquidsoap/radio.liq
@@ -856,6 +856,19 @@ music_meta = music
 # and the rotate defers to the next real boundary.
 bed_on_air = ref(false)
 
+# Voice-on-air deadline for the jingle gate below. #997 solved one direction —
+# a voice handoff waits out a jingle that is already feeding (jingle-playing.json
+# + waitForJingleClear in the controller). The other direction was unguarded: the
+# rotate could hand a stinger to the music chain WHILE a DJ clip is on air, and
+# the jingle simply plays over the voice.
+#
+# A deadline, not a boolean. `source.is_ready(voice_queue)` looks like the
+# obvious predicate and is a trap: on a request.queue it latches true forever
+# after the first push (measured: still true 24s after a 6.4s clip finished,
+# queue empty), which would starve the jingle rotate permanently. An instant in
+# the future cannot latch — at worst it is already in the past.
+voice_until = ref(0.)
+
 # JINGLES & STATION ID — rotate a jingle in every N tracks.
 #
 # CRITICAL: this rotate MUST sit here, on the raw pre-cross / pre-duck music
@@ -892,10 +905,11 @@ music =
       )
     )
     # A bed on air makes jingles unavailable (bed_on_air above) so the rotate
-    # can't split a bed from the song it ramps into; a starved music chain does
-    # the same so the rotate can't serve stingers forever over dead air (see the
-    # MUSIC STARVE GUARD below).
-    jingles = source.available(jingles, {not bed_on_air() and not music_starved()})
+    # can't split a bed from the song it ramps into; a voice clip on air does
+    # the same so a stinger can't be handed over the DJ (voice_until above); and
+    # a starved music chain does the same so the rotate can't serve stingers
+    # forever over dead air (see the MUSIC STARVE GUARD below).
+    jingles = source.available(jingles, {not bed_on_air() and time() > voice_until() and not music_starved()})
     rotate(weights=[1, jingle_ratio()], [jingles, music])
   else
     music
@@ -951,6 +965,13 @@ def voice_marker(channel, tmp_dir) =
     begin
       voice_id = m["subwave_voice"]
       if voice_id != "" then
+        # Arm the jingle gate (see voice_until above). request.duration is
+        # documented as expensive, but this hook is synchronous=false and so
+        # runs off the streaming thread. The 30s fallback keeps the guard useful
+        # when the clip cannot be measured, and stays bounded by construction.
+        dur = request.duration(m["filename"])
+        voice_until := time() + (null.get(default=30., dur)) + 2.
+
         file.write(
           data=json.stringify(compact=true, {
             voiceId = voice_id,


### PR DESCRIPTION
### The gap

#997 guarded one direction: a voice handoff waits out a jingle that is already feeding, via `jingle-playing.json` and `waitForJingleClear` in the controller.

The other direction was unguarded. The jingle rotate can hand a stinger to the music chain **while a DJ clip is on air**, and the stinger simply plays over the voice. The gate already knew about beds:

```liquidsoap
jingles = source.available(jingles, {not bed_on_air() and not music_starved()})
```

A bed on air makes jingles unavailable; a voice on air did not.

### Why it may not have shown up

It is only audible on stations that actually rotate jingles. Ours ran with `jingleRatio: 0` for months, so nothing ever collided. Raising it to 12 surfaced the overlap within a day — most often on shows with chatty personas and `extended` scripts, where a clip can hold the voice chain for 15-60s and a track boundary lands inside that window.

### Implementation — a deadline, not a boolean

`source.is_ready(voice_queue)` looks like the obvious predicate and is a trap: on a `request.queue` it latches `true` forever after the first push. Measured on Liquidsoap 2.4.5, one 6.4s clip pushed at t=2s, queue drained and empty afterwards:

```
t=2s   is_ready=false  queue=0
t=6s   is_ready=true   queue=0
t=12s  is_ready=true   queue=0
t=24s  is_ready=true   queue=0   <-- still
```

Gating the rotate on that would starve jingles permanently after the first segment — worse than the bug it fixes. A timestamp cannot latch: at worst it is already in the past and the gate opens.

`voice_until` is armed from `voice_marker`, which already fires on every clip and carries the filename. `request.duration` is documented as expensive, but that hook is `synchronous=false` and runs off the streaming thread. The 30s fallback keeps the guard useful when a clip cannot be measured, and stays bounded by construction.

### Verification

- `liquidsoap --check` passes
- Running in production on a 24/7 station since 2026-08-14, no dead air, jingles still rotating (`jingleRatio: 12`)
- The `is_ready` measurements above are reproducible with a short script against any `request.queue`

Happy to adjust naming or comment density to taste.