### PR TITLE
fix(broadcast): keep music commitment off the intro-render critical path

### DIFF
--- a/controller/scripts/drain-policy.test.ts
+++ b/controller/scripts/drain-policy.test.ts
@@ -5,8 +5,9 @@
 
 import assert from 'node:assert/strict';
 import {
-  remainingSec, drainAction, shouldDeadlinePick,
+  remainingSec, drainAction, shouldDeadlinePick, introRenderBudgetSec,
   DRAIN_DEADLINE_SEC, HARD_DEADLINE_SEC, DEADLINE_PICK_COOLDOWN_SEC,
+  DRAIN_COMMIT_RESERVE_SEC, MIN_PRERENDER_BUDGET_SEC,
 } from '../src/broadcast/drain-policy.js';
 
 // ── remainingSec ─────────────────────────────────────────────────────────────
@@ -100,5 +101,58 @@ assert.ok(
   (DRAIN_DEADLINE_SEC - HARD_DEADLINE_SEC) / DEADLINE_PICK_COOLDOWN_SEC >= 2,
   'pick window fits at least two attempts',
 );
+
+// ── introRenderBudgetSec ─────────────────────────────────────────────────────
+// The drain verdict only decides "send"; the intro pre-render sits between the
+// verdict and the next.txt write, and on a slow local TTS engine it can outlast
+// the runway (#1409). The budget is what keeps music commitment off the speech
+// critical path.
+
+// Unknowable clock → unbounded, exactly today's behaviour. No seam is known to
+// be at risk, so there is no basis for cutting a render short.
+assert.equal(introRenderBudgetSec(null), null, 'unknown clock → unbounded render');
+
+// Plenty of runway → render freely, minus the commit reserve.
+assert.equal(introRenderBudgetSec(300), 300 - DRAIN_COMMIT_RESERVE_SEC, 'long runway → runway minus reserve');
+
+// The boundary: a budget of exactly the minimum still renders.
+assert.equal(
+  introRenderBudgetSec(DRAIN_COMMIT_RESERVE_SEC + MIN_PRERENDER_BUDGET_SEC),
+  MIN_PRERENDER_BUDGET_SEC,
+  'exactly the minimum window still renders',
+);
+// One second under it → skip. A render that cannot finish only delays the music.
+assert.equal(
+  introRenderBudgetSec(DRAIN_COMMIT_RESERVE_SEC + MIN_PRERENDER_BUDGET_SEC - 1),
+  0,
+  'below the minimum window → skip the pre-render',
+);
+
+// The reserve itself is never spent on speech: at exactly the reserve, and
+// anywhere below it, the answer is skip — including an expired clock, where the
+// seam has already passed and the only useful act is committing the music.
+assert.equal(introRenderBudgetSec(DRAIN_COMMIT_RESERVE_SEC), 0, 'no runway past the reserve → skip');
+assert.equal(introRenderBudgetSec(5), 0, 'almost no runway → skip');
+assert.equal(introRenderBudgetSec(0), 0, 'seam is now → skip');
+assert.equal(introRenderBudgetSec(-30), 0, 'expired clock → skip, never a negative budget');
+
+// A budget is never negative — the call site feeds it to setTimeout.
+for (const r of [-100, -1, 0, 1, 11, 12, 17, 18, 60, 600]) {
+  const b = introRenderBudgetSec(r);
+  assert.ok(b != null && b >= 0, `budget for remaining=${r} is non-negative`);
+}
+
+// The hard-deadline drain is the emergency path — the pick did NOT land in time
+// and Liquidsoap must have the track resolved before the crossfade. Whatever
+// render window survives there must leave the commit reserve intact.
+const atHardDeadline = introRenderBudgetSec(HARD_DEADLINE_SEC);
+assert.ok(
+  atHardDeadline != null && atHardDeadline <= HARD_DEADLINE_SEC - DRAIN_COMMIT_RESERVE_SEC,
+  'a hard-deadline drain still reserves the commit tail',
+);
+
+// The reserve must cover the commit tail it is named for: two writeHandoff
+// waits (5s each) plus slack. Shrinking it below that reintroduces #1409.
+assert.ok(DRAIN_COMMIT_RESERVE_SEC >= 10, 'reserve covers both 5s handoff waits');
 
 console.log('drain-policy: all assertions passed');

--- a/controller/scripts/intro-render.test.ts
+++ b/controller/scripts/intro-render.test.ts
@@ -1,0 +1,45 @@
+// Intro pre-render lifecycle (#1409 follow-up).
+//
+// A render that outlives the drain budget must stay reusable at track start:
+// starting the same TTS job again doubles local-worker latency and cloud cost.
+// A render that fails before the budget expires is a failure, not an overrun.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { awaitIntroRender, IntroRenderTracker } from '../src/broadcast/queue/intro-render.js';
+
+test('a timed-out pre-render remains available at air time without a second render', async () => {
+  const tracker = new IntroRenderTracker<object>();
+  const item = {};
+  let calls = 0;
+  let finish!: (wav: string) => void;
+
+  const pending = tracker.start(item, () => {
+    calls += 1;
+    return new Promise<string>(resolve => { finish = resolve; });
+  });
+
+  const drainResult = await awaitIntroRender(pending, 5);
+  assert.deepEqual(drainResult, { status: 'timed-out' });
+
+  // onTrackStarted spreads the queued item into a new `current` object before
+  // calling airIntro, so the lifecycle must follow that identity hand-off.
+  const current = { ...item };
+  tracker.transfer(item, current);
+  const atAir = tracker.get(current);
+  assert.equal(atAir, pending, 'air time reuses the render that exceeded the drain budget');
+
+  finish('/tmp/intro.wav');
+  assert.deepEqual(await atAir, { status: 'rendered', wav: '/tmp/intro.wav' });
+  assert.equal(calls, 1, 'the script is rendered exactly once');
+});
+
+test('a render rejection is reported as failure rather than timeout', async () => {
+  const tracker = new IntroRenderTracker<object>();
+  const failure = new Error('engine unavailable');
+  const pending = tracker.start({}, async () => { throw failure; });
+
+  const result = await awaitIntroRender(pending, 50);
+  assert.equal(result.status, 'failed');
+  if (result.status === 'failed') assert.equal(result.error, failure);
+});

--- a/controller/src/broadcast/drain-policy.ts
+++ b/controller/src/broadcast/drain-policy.ts
@@ -52,6 +52,41 @@ export function remainingSec(
   return (startedAtMs + effective * 1000 - nowMs) / 1000;
 }
 
+// Runway the drain keeps for the commit tail that follows the intro render
+// inside ONE drain pass: the bed's handoff write and the track URI's own
+// (writeHandoff waits up to 5s each for Liquidsoap's 1.0s poll to consume the
+// file), plus the loudness lookup and the annotate. The pre-render is an
+// optimisation and must never eat into it.
+export const DRAIN_COMMIT_RESERVE_SEC = 12;
+
+// Below this there is no honest render window left — starting a TTS call that
+// cannot finish only delays the music commit for a WAV nobody will use.
+export const MIN_PRERENDER_BUDGET_SEC = 5;
+
+// How long the drain may spend pre-rendering a queued item's intro/link WAV
+// before it MUST commit the music instead (#1409). The hard deadline governs
+// the drain VERDICT; everything between that verdict and the `next.txt` write
+// is optional work, and on a slow local TTS engine the render alone can
+// outlast the remaining runway — Liquidsoap then falls through to `auto.m3u`
+// and the pick airs one track late.
+//
+// Returns:
+//   null  — unbounded, today's behaviour. The clock is unknowable (boot,
+//           recover, untracked auto play), so there is no seam to miss and
+//           no basis for a budget.
+//   0     — skip the pre-render entirely; commit the music now. `airIntro`
+//           renders from `introScript` at air time, the path that already
+//           covers a reaped WAV or a voice switch flipped back on.
+//   >0    — seconds the render may take before the drain moves on without it.
+//
+// Skipping is cheap precisely because the render is recoverable at air time;
+// a missed seam is not.
+export function introRenderBudgetSec(remaining: number | null): number | null {
+  if (remaining == null) return null;
+  const budget = remaining - DRAIN_COMMIT_RESERVE_SEC;
+  return budget >= MIN_PRERENDER_BUDGET_SEC ? budget : 0;
+}
+
 type DrainAction = 'send-pair' | 'send-intrinsic' | 'hold';
 
 // Decide what the drain loop does with the FIRST unsent item:

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -91,6 +91,7 @@ import {
   type QueuedVoice,
   type VoiceHandoff,
 } from './queue/voice-io.js';
+import { awaitIntroRender, IntroRenderTracker } from './queue/intro-render.js';
 import { notifyQueued, notifySpoken } from './voice-events.js';
 
 // Everything the outside world is told about ONE spoken segment, held in a
@@ -142,6 +143,7 @@ class Queue {
   _emptyDjQueueStreak = 0;      // consecutive reconcile checks seeing an empty dj_queue while sent items remain — see reconcileWithDjQueue
   _deadlinePickAt = 0;          // last deadline-pick ATTEMPT (ms epoch) — failure-retry cooldown, see maybeDeadlinePick
   _pendingVoice: { text: string; kind: string; wavPath: string; persona: Persona | null; meta: TurnMeta; t: number } | null = null; // one boundary-deferred segment awaiting the next track start — see announceAtNextTrack
+  _introRenders = new IntroRenderTracker<QueueItem>(); // timed-out pre-renders stay reusable by airIntro
 
   // Snapshot upcoming/current/history to disk. The queue is otherwise purely
   // in-memory, so a controller restart (every `--build controller` rebuild)
@@ -1086,29 +1088,29 @@ class Queue {
             // the race: a render that lands after the budget still reaches the
             // item (airIntro then finds a WAV instead of re-rendering), and a
             // late rejection can never surface as an unhandled rejection.
-            const render = speak(item.introScript, {
+            const render = this._introRenders.start(item, () => speak(item.introScript!, {
               kind: item.introKind || 'dj-speak',
               // Voice it as whoever wrote it. Without this, speak() falls back
               // to getEffectivePersona() at DRAIN time — minutes after the line
               // was written, possibly the other side of a show boundary.
               persona: item.introPersona || null,
-            });
-            const settled = render.then(
-              wav => { if (!item.introAired) item.introWav = wav; },
-              err => { this.log('error', `TTS failed: ${(err as Error).message}`); },
-            );
-            if (budgetSec == null) {
-              await settled;
-            } else {
-              let timer: NodeJS.Timeout | undefined;
-              await Promise.race([
-                settled,
-                new Promise<void>(resolve => { timer = setTimeout(resolve, budgetSec * 1000); }),
-              ]);
-              clearTimeout(timer);
-              if (!item.introWav) {
-                this.log('mix', `Intro render overran its ${Math.round(budgetSec)}s window — committing "${item.track.title}" now, voice follows at air time`);
+            }));
+            // The tracker turns rejection into a result so a late failure can
+            // never surface unhandled. This observer owns the item mutation and
+            // error log even after the drain stops waiting.
+            void render.then(result => {
+              if (result.status === 'rendered') {
+                if (!item.introAired) item.introWav = result.wav;
+              } else {
+                this.log('error', `TTS failed: ${(result.error as Error).message}`);
               }
+            });
+            const result = await awaitIntroRender(
+              render,
+              budgetSec == null ? null : budgetSec * 1000,
+            );
+            if (result.status === 'timed-out') {
+              this.log('mix', `Intro render overran its ${Math.round(budgetSec!)}s window — committing "${item.track.title}" now, voice follows at air time`);
             }
           }
         }
@@ -1598,6 +1600,18 @@ class Queue {
     // set above, so this can't double-air.
     if (!item.introWav || !existsSync(item.introWav)) {
       if (!item.introScript) return;
+      // The drain may have stopped WAITING for this pre-render to protect the
+      // music seam. Reuse that one TTS job at air time: local workers process
+      // requests serially, so starting it again would queue a duplicate behind
+      // the original; cloud engines would bill the same line twice.
+      const pending = this._introRenders.get(item);
+      if (pending) {
+        const result = await pending;
+        if (result.status === 'rendered') item.introWav = result.wav;
+      }
+    }
+    if (!item.introWav || !existsSync(item.introWav)) {
+      if (!item.introScript) return;
       try {
         item.introWav = await speak(item.introScript, {
           kind: item.introKind || 'dj-speak',
@@ -1749,6 +1763,10 @@ class Queue {
       const item = consumed[consumed.length - 1];
       const source = item.aiPicked ? 'ai' : 'request';
       this.current = { ...item, startedAt: new Date().toISOString(), source };
+      // A timed-out intro pre-render is keyed by the queued item. The current
+      // item is a spread clone, so carry the lifecycle across that identity
+      // hand-off before airIntro tries to reuse it.
+      this._introRenders.transfer(item, this.current);
       this.log('playing', `${np.title} — ${np.artist}`, { requestedBy: item.requestedBy, source });
       // A tracked item matched → controller and Liquidsoap are in sync; clear any
       // dj_queue-empty desync streak accumulated from prior untracked plays.

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -40,6 +40,7 @@ import * as scrobble from './scrobble.js';
 import * as liquidsoapControl from './liquidsoap-control.js';
 import {
   drainAction,
+  introRenderBudgetSec,
   remainingSec,
   shouldDeadlinePick,
   DEADLINE_PICK_COOLDOWN_SEC,
@@ -1062,17 +1063,53 @@ class Queue {
         // WAV (the script predates the flip), so the render is pure waste — and
         // if the switch comes back on before the track airs, airIntro renders
         // from the script itself.
+        //
+        // The render is BUDGETED against the same clock the drain verdict used
+        // (#1409). The verdict only decides "send"; the music isn't committed
+        // until the writeHandoff far below, and a slow local TTS engine can
+        // burn the whole remaining runway right here — the seam then falls to
+        // auto.m3u and this pick airs one track late. Music commitment is not
+        // allowed to sit behind optional speech: past the budget the drain
+        // moves on and airIntro renders from the script at air time.
+        //
+        // A deferred render also costs this link its bed — maybePushBed needs
+        // a WAV to measure the line against, so it no-ops and a long link airs
+        // over the song's intro under the light duck (pre-bed behaviour). That
+        // is the accepted price of the trade: a naked link is a garnish lost,
+        // a missed seam is the wrong track on air.
         if (item.introScript && !item.introWav && autoVoiceAllowed()) {
-          try {
-            item.introWav = await speak(item.introScript, {
+          const budgetSec = introRenderBudgetSec(this.remainingUntilItemAirs(item));
+          if (budgetSec === 0) {
+            this.log('mix', `Intro render deferred to air time — "${item.track.title}" airs too soon to render ahead`);
+          } else {
+            // Settle handlers are attached to the render promise ITSELF, not to
+            // the race: a render that lands after the budget still reaches the
+            // item (airIntro then finds a WAV instead of re-rendering), and a
+            // late rejection can never surface as an unhandled rejection.
+            const render = speak(item.introScript, {
               kind: item.introKind || 'dj-speak',
               // Voice it as whoever wrote it. Without this, speak() falls back
               // to getEffectivePersona() at DRAIN time — minutes after the line
               // was written, possibly the other side of a show boundary.
               persona: item.introPersona || null,
             });
-          } catch (err) {
-            this.log('error', `TTS failed: ${(err as Error).message}`);
+            const settled = render.then(
+              wav => { if (!item.introAired) item.introWav = wav; },
+              err => { this.log('error', `TTS failed: ${(err as Error).message}`); },
+            );
+            if (budgetSec == null) {
+              await settled;
+            } else {
+              let timer: NodeJS.Timeout | undefined;
+              await Promise.race([
+                settled,
+                new Promise<void>(resolve => { timer = setTimeout(resolve, budgetSec * 1000); }),
+              ]);
+              clearTimeout(timer);
+              if (!item.introWav) {
+                this.log('mix', `Intro render overran its ${Math.round(budgetSec)}s window — committing "${item.track.title}" now, voice follows at air time`);
+              }
+            }
           }
         }
 

--- a/controller/src/broadcast/queue/intro-render.ts
+++ b/controller/src/broadcast/queue/intro-render.ts
@@ -1,0 +1,64 @@
+// Lifecycle for a queued track's optional intro/link pre-render.
+//
+// The drain may stop WAITING for TTS when its runway expires, but the render
+// itself cannot be cancelled. Keep that one in-flight promise addressable so
+// airIntro can reuse it instead of starting the same expensive job again.
+
+export type IntroRenderResult =
+  | { status: 'rendered'; wav: string }
+  | { status: 'failed'; error: unknown };
+
+export type IntroRenderWaitResult = IntroRenderResult | { status: 'timed-out' };
+
+export class IntroRenderTracker<Item extends object> {
+  private active = new WeakMap<Item, Promise<IntroRenderResult>>();
+
+  private track(item: Item, pending: Promise<IntroRenderResult>): void {
+    this.active.set(item, pending);
+    void pending.then(() => {
+      if (this.active.get(item) === pending) this.active.delete(item);
+    });
+  }
+
+  start(item: Item, render: () => Promise<string>): Promise<IntroRenderResult> {
+    const existing = this.active.get(item);
+    if (existing) return existing;
+
+    const pending: Promise<IntroRenderResult> = Promise.resolve()
+      .then(render)
+      .then(
+        wav => ({ status: 'rendered' as const, wav }),
+        error => ({ status: 'failed' as const, error }),
+      );
+    this.track(item, pending);
+    return pending;
+  }
+
+  get(item: Item): Promise<IntroRenderResult> | null {
+    return this.active.get(item) ?? null;
+  }
+
+  transfer(from: Item, to: Item): void {
+    const pending = this.active.get(from);
+    if (!pending) return;
+    this.active.delete(from);
+    this.track(to, pending);
+  }
+}
+
+export async function awaitIntroRender(
+  pending: Promise<IntroRenderResult>,
+  budgetMs: number | null,
+): Promise<IntroRenderWaitResult> {
+  if (budgetMs == null) return pending;
+
+  let timer: NodeJS.Timeout | undefined;
+  const result = await Promise.race<IntroRenderWaitResult>([
+    pending,
+    new Promise<{ status: 'timed-out' }>(resolve => {
+      timer = setTimeout(() => resolve({ status: 'timed-out' }), budgetMs);
+    }),
+  ]);
+  clearTimeout(timer);
+  return result;
+}


### PR DESCRIPTION
Fixes #1409.

## The problem

The pair-drain hard deadline (`HARD_DEADLINE_SEC`, 45s) governs the drain **verdict**, not the handoff. Everything between that verdict and the `next.txt` write is optional work, and the intro/link TTS pre-render (`queue.ts`, just after `if (action === 'hold') break`) is unbounded. On a slow local engine it can outlast the remaining runway — Liquidsoap falls through to `auto.m3u`, and the selected track airs one track late with the visible queue and the broadcast diverging for a seam.

`senderBusy` compounds it: the 1.5s watcher tick calls `drainToLiquidsoap()` unforced, which returns immediately while the first drain is stuck in the render, so nothing can shortcut.

The reporter's timeline fits exactly — `pair blend` (logged *after* the render) landed 11s past the seam auto.m3u had already won.

Not dead air, and the now-wrong link was correctly dropped by `linkClockDrifted`. Low severity, but the intended transition is lost.

## The fix

New pure `introRenderBudgetSec(remaining)` in `drain-policy.ts` — the decision belongs in the policy module, not inlined at the call site:

- `null` (unknowable clock — boot, recover, untracked auto play) → unbounded, byte-identical to today. No seam is known to be at risk, so there is no basis for a budget.
- runway minus a 12s commit reserve, when that leaves at least 5s → that is the render's window.
- otherwise `0` → skip the pre-render and commit the music now.

The reserve covers the commit tail that follows the render inside one drain pass: the bed's handoff write and the track URI's own (`writeHandoff` waits up to 5s each for Liquidsoap's 1.0s poll), plus the loudness lookup and the annotate.

At the call site the render is skipped or raced, and either way the music commits on time. Skipping is cheap precisely because the render is recoverable: `airIntro` already renders from `introScript` at air time, the path that covers a reaped WAV or a voice switch flipped back on.

The settle handlers ride the render promise **itself**, not the race — a render that lands after the budget still reaches the item (so `airIntro` finds a WAV instead of re-rendering), and a late rejection can never surface as an unhandled rejection.

This is the same reasoning the stem-blend render already carries a few lines below (`queue.ts`: "the TTS await between them can run tens of seconds on a slow engine, and a stale window would let the render overrun the drain's hard fallback"). That guard just never applied to the TTS render sitting in front of it.

## Trade-off

A deferred render costs that link its bed — `maybePushBed` needs a WAV to measure the line against, so it no-ops and a long link airs over the song's intro under the light duck (pre-bed behaviour). Documented at the call site: a garnish lost beats the wrong track on air.

## Related, deliberately out of scope

`commitBeforeSkip()` force-drains before an operator skip, but a force drain enters the same render and its budget comes from the on-air clock, which can be minutes. So an operator skip can still stall behind a TTS render and lose the same race (the #1300 bug 6 class). Uniform budgeting does not make it worse and does not fix it. The fix is one line — treat `force` as budget `0`, since "force" means commit now — but it is a behaviour change on a second path and belongs in its own PR.

## Verification

- `npm run lint` — 0 errors.
- `npm test` — 657/658. The single failure is `analyzer-python.test.ts` (`ModuleNotFoundError: No module named 'numpy'`), which fails identically on `develop` on this machine.
- New assertions in `scripts/drain-policy.test.ts`: boundaries either side of the minimum window, expired clock, non-negative budget across the range, that a hard-deadline drain still reserves the commit tail, and that the reserve stays large enough to cover both 5s handoff waits.
