### PR TITLE
feat(shows): add matching-track availability diagnostic

### DIFF
--- a/controller/scripts/show-candidate-display.test.ts
+++ b/controller/scripts/show-candidate-display.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const displayModulePath = '../../web/components/admin/shows/' + 'candidate-diagnostic.js';
+const display = await import(displayModulePath).catch(() => null);
+
+test('strict diagnostics display the effective playlist pool instead of library-wide matches', () => {
+  const report = {
+    strict: true,
+    library: { indexed: 4, matchingFilters: 2, afterExclusions: 1, effective: 0 },
+    playlist: { total: 2, matchingFilters: 1, afterExclusions: 0, effective: 0 },
+    warnings: [],
+  };
+
+  assert.equal(display?.displayedMatchingTracks?.(report), 0);
+});
+
+test('soft diagnostics keep the filter-fit count visible', () => {
+  const report = {
+    strict: false,
+    library: { indexed: 4, matchingFilters: 2, afterExclusions: 2, effective: 4 },
+    playlist: null,
+    warnings: [],
+  };
+
+  assert.equal(display?.displayedMatchingTracks?.(report), 2);
+});

--- a/controller/scripts/show-candidate-projection.test.ts
+++ b/controller/scripts/show-candidate-projection.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, test } from 'node:test';
+
+const stateDir = mkdtempSync(join(tmpdir(), 'subwave-show-candidates-'));
+process.env.STATE_DIR = stateDir;
+
+const db = await import('../src/music/library-db.js');
+const { trackInstrumental } = await import('../src/music/show-filter.js');
+const { candidateCoverage } = await import('../src/music/show-candidates.js');
+
+await db.open({ embeddingDim: 768 });
+
+after(() => {
+  db.close();
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+test('candidate projection preserves vocal analysis as unknown, instrumental, or vocal', () => {
+  const insert = db.requireDb().prepare(
+    `INSERT INTO tracks (id, title, artist, audio_moods, energy, vocal_ranges_json)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  );
+  insert.run('unknown', 'Unknown', 'A', JSON.stringify(['calm']), null, null);
+  insert.run('instrumental', 'Instrumental', 'B', null, null, '[]');
+  insert.run('vocal', 'Vocal', 'C', null, 'medium', JSON.stringify([{ startMs: 1_000, endMs: 9_000 }]));
+
+  const rows = new Map(db.candidateFilterTracks().map((row) => [row.id, row]));
+  assert.equal(trackInstrumental(rows.get('unknown')), null);
+  assert.equal(trackInstrumental(rows.get('instrumental')), true);
+  assert.equal(trackInstrumental(rows.get('vocal')), false);
+  assert.deepEqual(candidateCoverage([...rows.values()]), { mood: true, energy: true, vocal: true });
+});

--- a/controller/scripts/show-candidates.test.ts
+++ b/controller/scripts/show-candidates.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { buildShowCandidateDiagnostic } from '../src/music/show-candidates.js';
+
+const rows = [
+  { id: 'jazz-calm', title: 'One', artist: 'A', genre: 'Jazz', year: 1994, moods: ['calm'], audioMoods: [], energy: 'low' },
+  { id: 'jazz-loud', title: 'Two', artist: 'B', genre: 'Jazz', year: 1994, moods: ['calm'], audioMoods: [], energy: 'high' },
+  { id: 'rock-calm', title: 'Three', artist: 'C', genre: 'Rock', year: 1994, moods: ['calm'], audioMoods: [], energy: 'low' },
+];
+const locks = { genres: ['Jazz'], eras: [], moods: ['calm'], energies: ['low'], vocals: null };
+
+test('candidate funnel shows the strict playlist intersection and exclusions', () => {
+  const result = buildShowCandidateDiagnostic({
+    show: { filtersStrict: true, genres: ['Jazz'], playlistStrict: true },
+    libraryRows: rows,
+    playlistRows: [rows[0]!, rows[1]!],
+    excludedIds: new Set(['jazz-calm']),
+    locks,
+  });
+  assert.equal(result.strict, true);
+  assert.deepEqual(result.library, { indexed: 3, matchingFilters: 1, afterExclusions: 0, effective: 0 });
+  assert.deepEqual(result.playlist, { total: 2, matchingFilters: 1, afterExclusions: 0, effective: 0 });
+});
+
+test('soft filters remain advisory while the filter-fit count stays visible', () => {
+  const result = buildShowCandidateDiagnostic({
+    show: { filtersStrict: false, genres: ['Jazz'], playlistStrict: false },
+    libraryRows: rows,
+    playlistRows: [rows[0]!, rows[1]!],
+    excludedIds: new Set(['rock-calm']),
+    locks,
+  });
+  assert.equal(result.library.matchingFilters, 1);
+  assert.equal(result.library.effective, 2);
+  assert.equal(result.playlist?.effective, 2);
+});

--- a/controller/scripts/show-candidates.test.ts
+++ b/controller/scripts/show-candidates.test.ts
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { buildShowCandidateDiagnostic } from '../src/music/show-candidates.js';
+import * as showCandidates from '../src/music/show-candidates.js';
+
+const { buildShowCandidateDiagnostic } = showCandidates;
 
 const rows = [
   { id: 'jazz-calm', title: 'One', artist: 'A', genre: 'Jazz', year: 1994, moods: ['calm'], audioMoods: [], energy: 'low' },
   { id: 'jazz-loud', title: 'Two', artist: 'B', genre: 'Jazz', year: 1994, moods: ['calm'], audioMoods: [], energy: 'high' },
   { id: 'rock-calm', title: 'Three', artist: 'C', genre: 'Rock', year: 1994, moods: ['calm'], audioMoods: [], energy: 'low' },
+  { id: 'jazz-calm-2', title: 'Four', artist: 'D', genre: 'Jazz', year: 1994, moods: ['calm'], audioMoods: [], energy: 'low' },
 ];
 const locks = { genres: ['Jazz'], eras: [], moods: ['calm'], energies: ['low'], vocals: null };
 
@@ -18,7 +21,7 @@ test('candidate funnel shows the strict playlist intersection and exclusions', (
     locks,
   });
   assert.equal(result.strict, true);
-  assert.deepEqual(result.library, { indexed: 3, matchingFilters: 1, afterExclusions: 0, effective: 0 });
+  assert.deepEqual(result.library, { indexed: 4, matchingFilters: 2, afterExclusions: 1, effective: 0 });
   assert.deepEqual(result.playlist, { total: 2, matchingFilters: 1, afterExclusions: 0, effective: 0 });
 });
 
@@ -30,7 +33,16 @@ test('soft filters remain advisory while the filter-fit count stays visible', ()
     excludedIds: new Set(['rock-calm']),
     locks,
   });
-  assert.equal(result.library.matchingFilters, 1);
-  assert.equal(result.library.effective, 2);
+  assert.equal(result.library.matchingFilters, 2);
+  assert.equal(result.library.effective, 3);
   assert.equal(result.playlist?.effective, 2);
+});
+
+test('candidate coverage includes audio-derived moods and preserves vocal tri-state', () => {
+  const coverage = showCandidates.candidateCoverage([
+    { id: 'audio-calm', moods: [], audioMoods: ['calm'], energy: null, vocalRanges: null },
+    { id: 'sung', moods: [], audioMoods: [], energy: 'medium', vocalRanges: [{ startMs: 1_000, endMs: 9_000 }] },
+  ]);
+
+  assert.deepEqual(coverage, { mood: true, energy: true, vocal: true });
 });

--- a/controller/src/music/library-db/queries.ts
+++ b/controller/src/music/library-db/queries.ts
@@ -216,3 +216,38 @@ export function genreCentroids(): Array<{ genre: string; count: number; centroid
 }
 
 
+
+// Lean, whole-library projection for the explicit Show-editor candidate
+// diagnostic. It avoids the heavyweight analysis JSON that full track reads
+// carry while retaining every field used by the strict show locks.
+export function candidateFilterTracks(): Array<{
+  id: string;
+  title: string | null;
+  artist: string | null;
+  year: number | null;
+  originalYear: number | null;
+  isCompilation: boolean | null;
+  genres: string[];
+  genre: string | null;
+  moods: string[];
+  audioMoods: string[];
+  energy: EnergyValue;
+  vocalRanges: unknown[] | null;
+}> {
+  const rows = requireDb().prepare(`SELECT id, title, artist, year, original_year,
+    is_compilation, genres, genre, moods, audio_moods, energy, vocal_ranges_json FROM tracks`).all() as Array<Record<string, any>>;
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title ?? null,
+    artist: row.artist ?? null,
+    year: row.year ?? null,
+    originalYear: row.original_year ?? null,
+    isCompilation: row.is_compilation == null ? null : !!row.is_compilation,
+    genres: row.genres ? safeParseArray(row.genres) : [],
+    genre: row.genre ?? null,
+    moods: row.moods ? safeParseArray(row.moods) : [],
+    audioMoods: row.audio_moods ? safeParseArray(row.audio_moods) : [],
+    energy: row.energy ?? null,
+    vocalRanges: row.vocal_ranges_json == null ? null : safeParseArray(row.vocal_ranges_json),
+  }));
+}

--- a/controller/src/music/library-db/queries.ts
+++ b/controller/src/music/library-db/queries.ts
@@ -234,8 +234,29 @@ export function candidateFilterTracks(): Array<{
   energy: EnergyValue;
   vocalRanges: unknown[] | null;
 }> {
+  type CandidateFilterRow = {
+    id: string;
+    title: string | null;
+    artist: string | null;
+    year: number | null;
+    original_year: number | null;
+    is_compilation: number | null;
+    genres: string | null;
+    genre: string | null;
+    moods: string | null;
+    audio_moods: string | null;
+    energy: EnergyValue;
+    vocal_range_count: number | null;
+  };
   const rows = requireDb().prepare(`SELECT id, title, artist, year, original_year,
-    is_compilation, genres, genre, moods, audio_moods, energy, vocal_ranges_json FROM tracks`).all() as Array<Record<string, any>>;
+    is_compilation, genres, genre, moods, audio_moods, energy,
+    CASE
+      WHEN vocal_ranges_json IS NULL THEN NULL
+      WHEN json_valid(vocal_ranges_json) AND json_type(vocal_ranges_json) = 'array'
+        THEN json_array_length(vocal_ranges_json)
+      ELSE NULL
+    END AS vocal_range_count
+    FROM tracks`).all() as CandidateFilterRow[];
   return rows.map((row) => ({
     id: row.id,
     title: row.title ?? null,
@@ -248,6 +269,11 @@ export function candidateFilterTracks(): Array<{
     moods: row.moods ? safeParseArray(row.moods) : [],
     audioMoods: row.audio_moods ? safeParseArray(row.audio_moods) : [],
     energy: row.energy ?? null,
-    vocalRanges: row.vocal_ranges_json == null ? null : safeParseArray(row.vocal_ranges_json),
+    // The show filter only reads this field's tri-state: null = unmeasured,
+    // [] = instrumental, non-empty = vocal. Keep the projection lean by
+    // carrying presence rather than parsing every stored span object.
+    vocalRanges: row.vocal_range_count == null
+      ? null
+      : row.vocal_range_count === 0 ? [] : [{}],
   }));
 }

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -209,6 +209,11 @@ export function countTagged(): number {
   return loaded ? db.countTagged() : 0;
 }
 
+// Lean whole-library projection for the explicitly requested Show-editor candidate diagnostic.
+export function candidateFilterTracks() {
+  return loaded ? db.candidateFilterTracks() : [];
+}
+
 // Lean metadata for the /now-playing hot path — only the fields the player's
 // metadata strip renders (genre · BPM · key · mood · energy · year). Backed by
 // db.getTrackLite so a per-listener poll never SELECTs or JSON.parses the heavy

--- a/controller/src/music/show-candidates.ts
+++ b/controller/src/music/show-candidates.ts
@@ -3,13 +3,27 @@ import * as subsonic from './subsonic.js';
 import { applyStrictLocks, hasEraBound, type VocalMode } from './show-filter.js';
 import { resolveExcludedPlaylistIds, resolveShowPlaylistPool } from './show-playlist.js';
 
-type Candidate = { id?: string; title?: string | null; artist?: string | null; year?: number | null; originalYear?: number | null; isCompilation?: boolean | null; genres?: string[] | null; genre?: string | null; moods?: string[] | null; audioMoods?: string[] | null; energy?: string | null; vocalRanges?: unknown[] | null };
+export type Candidate = { id?: string; title?: string | null; artist?: string | null; year?: number | null; originalYear?: number | null; isCompilation?: boolean | null; genres?: string[] | null; genre?: string | null; moods?: string[] | null; audioMoods?: string[] | null; energy?: string | null; vocalRanges?: unknown[] | null };
 type Locks = { genres: string[]; eras: Array<{ fromYear?: number | null; toYear?: number | null }>; moods: string[]; energies: string[]; vocals: VocalMode | null };
 export interface ShowCandidateDiagnostic { strict: boolean; library: { indexed: number; matchingFilters: number; afterExclusions: number; effective: number }; playlist: null | { total: number; matchingFilters: number; afterExclusions: number; effective: number }; warnings: string[] }
+export type CandidateCoverage = { mood: boolean; energy: boolean; vocal: boolean };
 
 function hasMusicFilter(show: any): boolean { return !!(show?.genres?.length || show?.moods?.length || show?.energies?.length || show?.vocals || hasEraBound(show?.eras)); }
 function filtered(rows: Candidate[], locks: Locks): Candidate[] { return applyStrictLocks(rows, locks, { starve: true }); }
 function exclude(rows: Candidate[], ids: Set<string> | null): Candidate[] { return ids?.size ? rows.filter(row => row.id && !ids.has(row.id)) : rows; }
+
+export function candidateCoverage(rows: Candidate[]): CandidateCoverage {
+  let mood = false;
+  let energy = false;
+  let vocal = false;
+  for (const row of rows) {
+    mood ||= !!(row.moods?.length || row.audioMoods?.length);
+    energy ||= !!row.energy;
+    vocal ||= row.vocalRanges != null;
+    if (mood && energy && vocal) break;
+  }
+  return { mood, energy, vocal };
+}
 
 // Pure count funnel. It deliberately excludes recency and journey state: those
 // are transient discovery constraints, not properties of a show configuration.
@@ -30,16 +44,17 @@ export function buildShowCandidateDiagnostic({ show, libraryRows, playlistRows, 
 
 export async function diagnoseShowCandidates(show: any): Promise<ShowCandidateDiagnostic> {
   await library.load();
-  const stats = library.stats();
+  const libraryRows = library.candidateFilterTracks();
+  const coverage = candidateCoverage(libraryRows);
   const warnings: string[] = [];
   const genres: string[] = [];
   for (const requested of show?.genres ?? []) {
     try { const resolved = await subsonic.resolveGenreName(requested); if (resolved) genres.push(resolved); else warnings.push(`Genre “${requested}” is not present in the library, so it is not an active lock.`); }
     catch { warnings.push(`Could not resolve genre “${requested}”; it is not counted as an active lock.`); }
   }
-  const moodCovered = Object.keys(stats.byMood ?? {}).length > 0;
-  const energyCovered = Object.keys(stats.byEnergy ?? {}).length > 0;
-  const vocalCovered = library.vocalAnalyzedCount() > 0;
+  const moodCovered = coverage.mood;
+  const energyCovered = coverage.energy;
+  const vocalCovered = coverage.vocal;
   if (show?.moods?.length && !moodCovered) warnings.push('Mood tags have no library coverage, so the mood filter is not active.');
   if (show?.energies?.length && !energyCovered) warnings.push('Energy tags have no library coverage, so the energy filter is not active.');
   if (show?.vocals && !vocalCovered) warnings.push('Vocal analysis has no library coverage, so the vocal filter is not active.');
@@ -47,5 +62,5 @@ export async function diagnoseShowCandidates(show: any): Promise<ShowCandidateDi
   const [playlistPool, excludedIds] = await Promise.all([resolveShowPlaylistPool(show), resolveExcludedPlaylistIds(show)]);
   if (show?.playlistIds?.length && !playlistPool) warnings.push('None of the pinned playlists could be resolved to tracks.');
   if (show?.filtersStrict !== true && hasMusicFilter(show)) warnings.push('Strict filter is off: matching filters is advisory; the show may draw from the wider library.');
-  return buildShowCandidateDiagnostic({ show, libraryRows: library.candidateFilterTracks(), playlistRows: playlistPool?.tracks ?? null, excludedIds, locks, warnings });
+  return buildShowCandidateDiagnostic({ show, libraryRows, playlistRows: playlistPool?.tracks ?? null, excludedIds, locks, warnings });
 }

--- a/controller/src/music/show-candidates.ts
+++ b/controller/src/music/show-candidates.ts
@@ -1,0 +1,51 @@
+import * as library from './library.js';
+import * as subsonic from './subsonic.js';
+import { applyStrictLocks, hasEraBound, type VocalMode } from './show-filter.js';
+import { resolveExcludedPlaylistIds, resolveShowPlaylistPool } from './show-playlist.js';
+
+type Candidate = { id?: string; title?: string | null; artist?: string | null; year?: number | null; originalYear?: number | null; isCompilation?: boolean | null; genres?: string[] | null; genre?: string | null; moods?: string[] | null; audioMoods?: string[] | null; energy?: string | null; vocalRanges?: unknown[] | null };
+type Locks = { genres: string[]; eras: Array<{ fromYear?: number | null; toYear?: number | null }>; moods: string[]; energies: string[]; vocals: VocalMode | null };
+export interface ShowCandidateDiagnostic { strict: boolean; library: { indexed: number; matchingFilters: number; afterExclusions: number; effective: number }; playlist: null | { total: number; matchingFilters: number; afterExclusions: number; effective: number }; warnings: string[] }
+
+function hasMusicFilter(show: any): boolean { return !!(show?.genres?.length || show?.moods?.length || show?.energies?.length || show?.vocals || hasEraBound(show?.eras)); }
+function filtered(rows: Candidate[], locks: Locks): Candidate[] { return applyStrictLocks(rows, locks, { starve: true }); }
+function exclude(rows: Candidate[], ids: Set<string> | null): Candidate[] { return ids?.size ? rows.filter(row => row.id && !ids.has(row.id)) : rows; }
+
+// Pure count funnel. It deliberately excludes recency and journey state: those
+// are transient discovery constraints, not properties of a show configuration.
+export function buildShowCandidateDiagnostic({ show, libraryRows, playlistRows, excludedIds, locks, warnings = [] }: { show: any; libraryRows: Candidate[]; playlistRows: Candidate[] | null; excludedIds: Set<string> | null; locks: Locks; warnings?: string[] }): ShowCandidateDiagnostic {
+  const strict = show?.filtersStrict === true && hasMusicFilter(show);
+  const libraryFiltered = filtered(libraryRows, locks);
+  const playlistFiltered = playlistRows ? filtered(playlistRows, locks) : null;
+  const libraryEffective = exclude(strict ? libraryFiltered : libraryRows, excludedIds);
+  const playlistEffective = playlistFiltered == null ? null : exclude(strict ? playlistFiltered : playlistRows!, excludedIds);
+  const playlistStrict = !!(show?.playlistStrict && playlistRows);
+  return {
+    strict,
+    library: { indexed: libraryRows.length, matchingFilters: libraryFiltered.length, afterExclusions: exclude(libraryFiltered, excludedIds).length, effective: playlistStrict ? (playlistEffective?.length ?? 0) : libraryEffective.length },
+    playlist: playlistRows == null ? null : { total: playlistRows.length, matchingFilters: playlistFiltered!.length, afterExclusions: exclude(playlistFiltered!, excludedIds).length, effective: playlistEffective!.length },
+    warnings,
+  };
+}
+
+export async function diagnoseShowCandidates(show: any): Promise<ShowCandidateDiagnostic> {
+  await library.load();
+  const stats = library.stats();
+  const warnings: string[] = [];
+  const genres: string[] = [];
+  for (const requested of show?.genres ?? []) {
+    try { const resolved = await subsonic.resolveGenreName(requested); if (resolved) genres.push(resolved); else warnings.push(`Genre “${requested}” is not present in the library, so it is not an active lock.`); }
+    catch { warnings.push(`Could not resolve genre “${requested}”; it is not counted as an active lock.`); }
+  }
+  const moodCovered = Object.keys(stats.byMood ?? {}).length > 0;
+  const energyCovered = Object.keys(stats.byEnergy ?? {}).length > 0;
+  const vocalCovered = library.vocalAnalyzedCount() > 0;
+  if (show?.moods?.length && !moodCovered) warnings.push('Mood tags have no library coverage, so the mood filter is not active.');
+  if (show?.energies?.length && !energyCovered) warnings.push('Energy tags have no library coverage, so the energy filter is not active.');
+  if (show?.vocals && !vocalCovered) warnings.push('Vocal analysis has no library coverage, so the vocal filter is not active.');
+  const locks: Locks = { genres, eras: hasEraBound(show?.eras) ? show.eras : [], moods: moodCovered ? (show?.moods ?? []) : [], energies: energyCovered ? (show?.energies ?? []) : [], vocals: vocalCovered ? (show?.vocals ?? null) : null };
+  const [playlistPool, excludedIds] = await Promise.all([resolveShowPlaylistPool(show), resolveExcludedPlaylistIds(show)]);
+  if (show?.playlistIds?.length && !playlistPool) warnings.push('None of the pinned playlists could be resolved to tracks.');
+  if (show?.filtersStrict !== true && hasMusicFilter(show)) warnings.push('Strict filter is off: matching filters is advisory; the show may draw from the wider library.');
+  return buildShowCandidateDiagnostic({ show, libraryRows: library.candidateFilterTracks(), playlistRows: playlistPool?.tracks ?? null, excludedIds, locks, warnings });
+}

--- a/controller/src/routes/shows.ts
+++ b/controller/src/routes/shows.ts
@@ -28,6 +28,7 @@ import { readCommunityShow } from '../shows/community.js';
 import { SLUG_RE } from '../skills/loader.js';
 import { queue } from '../broadcast/queue.js';
 import { rollSessionNow } from '../broadcast/scheduler.js';
+import { diagnoseShowCandidates } from '../music/show-candidates.js';
 
 export const router = express.Router();
 
@@ -45,6 +46,12 @@ async function showPostContext() {
     minTrackSeconds: settings.minTrackSeconds(),
   });
 }
+
+// Read-only: accepts the editor draft but never persists or schedules it.
+router.post('/shows/candidates', requireAdmin, validateBodyAsync(showPostContext), async (req, res) => {
+  try { res.json(await diagnoseShowCandidates(req.body.show)); }
+  catch (err: any) { queue.log('error', 'POST /shows/candidates failed: ' + err.message); res.status(500).json({ error: err.message }); }
+});
 
 router.post('/shows/community/:slug/install', requireAdmin, async (req, res) => {
   const slug = String(req.params.slug);

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -43,7 +43,7 @@ import {
   sameEra,
 } from './types';
 import type { EraWindow, Persona, PlaylistIndexStatus, Show, ShowsFormValues, SkillOption, ThemeOption } from './types';
-import { hasAnyMusicFilter } from './lib';
+import { hasAnyMusicFilter, showPayload } from './lib';
 import { ChipRow } from './ChipRow';
 
 // The footer names the field the schema objected to; the schema's own keys are
@@ -158,6 +158,23 @@ export function ShowEditor({
   const vocalsCtl = useController({ control, name: path('vocals') });
   const genresCtl = useController({ control, name: path('genres') });
   const maxTrackSecondsCtl = useController({ control, name: path('maxTrackSeconds') });
+
+  type CandidateDiagnostic = { strict: boolean; library: { indexed: number; matchingFilters: number; afterExclusions: number; effective: number }; playlist: null | { total: number; matchingFilters: number; afterExclusions: number; effective: number }; warnings: string[] };
+  const candidateKey = JSON.stringify(showPayload(show));
+  const [candidateBusy, setCandidateBusy] = useState(false);
+  const [candidateError, setCandidateError] = useState<string | null>(null);
+  const [candidateReport, setCandidateReport] = useState<{ key: string; value: CandidateDiagnostic } | null>(null);
+  const visibleCandidateReport = candidateReport?.key === candidateKey ? candidateReport.value : null;
+  const calculateCandidates = async () => {
+    setCandidateBusy(true); setCandidateError(null);
+    try {
+      const r = await adminFetch('/shows/candidates', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ show: showPayload(show) }) });
+      const j = await r.json().catch(() => ({})) as CandidateDiagnostic & { error?: string };
+      if (!r.ok) throw new Error(j.error || 'failed (' + r.status + ')');
+      setCandidateReport({ key: candidateKey, value: j });
+    } catch (err) { setCandidateError(err instanceof Error ? err.message : String(err)); }
+    finally { setCandidateBusy(false); }
+  };
 
   // The editor is remounted per show (keyed by id at the call site), so this
   // resets on switch — it's a text buffer, not form data.
@@ -567,6 +584,30 @@ export function ShowEditor({
             flow; Strict filter above makes them hard rules. Mood set to Any
             (auto) follows the station&apos;s own mood instead of pinning one.
           </span>
+
+          <Field>
+            <FieldTitle>candidate availability</FieldTitle>
+            <FieldDescription>
+              Check the current draft against the local library and any pinned playlists. This is a configuration audit: it does not include no-repeat protection, the current track, or a sonic journey.
+            </FieldDescription>
+            <div className="mt-2 flex items-center gap-2">
+              <Btn className="min-h-9 sm:min-h-0" onClick={calculateCandidates} disabled={!valid || candidateBusy}>
+                {candidateBusy ? 'Calculating…' : 'Calculate candidates'}
+              </Btn>
+              {!valid && <span className="field-hint">Finish the required show fields first.</span>}
+            </div>
+            {candidateError && <span role="alert" className="field-hint text-vermilion">Could not calculate candidates: {candidateError}</span>}
+            {visibleCandidateReport && (
+              <div className="mt-2 grid gap-1 border border-ink bg-[var(--muted)] p-3 text-sm">
+                <span><strong>{visibleCandidateReport.library.effective.toLocaleString()}</strong> tracks in this show’s current candidate universe</span>
+                <span className="field-hint">{visibleCandidateReport.library.matchingFilters.toLocaleString()} match the configured music filters · {visibleCandidateReport.library.afterExclusions.toLocaleString()} remain after excluded playlists</span>
+                {visibleCandidateReport.playlist && (
+                  <span className="field-hint">Pinned playlists: {visibleCandidateReport.playlist.total.toLocaleString()} tracks · {visibleCandidateReport.playlist.matchingFilters.toLocaleString()} match filters · {visibleCandidateReport.playlist.afterExclusions.toLocaleString()} after exclusions</span>
+                )}
+                {visibleCandidateReport.warnings.map(warning => <span key={warning} className="field-hint text-vermilion">{warning}</span>)}
+              </div>
+            )}
+          </Field>
 
           <Field>
             <PlaylistIdsField

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -599,8 +599,18 @@ export function ShowEditor({
             {candidateError && <span role="alert" className="field-hint text-vermilion">Could not calculate candidates: {candidateError}</span>}
             {visibleCandidateReport && (
               <div className="mt-2 grid gap-1 border border-ink bg-[var(--muted)] p-3 text-sm">
-                <span><strong>{visibleCandidateReport.library.effective.toLocaleString()}</strong> tracks in this show’s current candidate universe</span>
-                <span className="field-hint">{visibleCandidateReport.library.matchingFilters.toLocaleString()} match the configured music filters · {visibleCandidateReport.library.afterExclusions.toLocaleString()} remain after excluded playlists</span>
+                {hasAnyMusicFilter(show) ? (
+                  <>
+                    <span><strong>{visibleCandidateReport.library.matchingFilters.toLocaleString()}</strong> tracks match this show’s music filters</span>
+                    {visibleCandidateReport.strict ? (
+                      <span className="field-hint">{visibleCandidateReport.library.effective.toLocaleString()} remain available under this show’s strict rules after excluded playlists</span>
+                    ) : (
+                      <span className="field-hint">Soft filter is on: this is a filter-fit count, not a hard candidate limit. {visibleCandidateReport.library.afterExclusions.toLocaleString()} matching tracks remain after excluded playlists.</span>
+                    )}
+                  </>
+                ) : (
+                  <span className="field-hint">No music filters are configured for this show.</span>
+                )}
                 {visibleCandidateReport.playlist && (
                   <span className="field-hint">Pinned playlists: {visibleCandidateReport.playlist.total.toLocaleString()} tracks · {visibleCandidateReport.playlist.matchingFilters.toLocaleString()} match filters · {visibleCandidateReport.playlist.afterExclusions.toLocaleString()} after exclusions</span>
                 )}

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -648,12 +648,11 @@ export function ShowEditor({
               <div className="mt-2 grid gap-1 border border-ink bg-[var(--muted)] p-3 text-sm">
                 {hasAnyMusicFilter(show) ? (
                   <>
-                    <span><strong>{visibleCandidateReport.library.matchingFilters.toLocaleString()}</strong> tracks match these music filters.</span>
-                    <span className="field-hint">{visibleCandidateReport.library.afterExclusions.toLocaleString()} remain after excluded playlists.</span>
-                    <span className="field-hint">
-                      {visibleCandidateReport.strict
-                        ? 'Strict filter keeps the DJ within these results, except as a last resort.'
-                        : 'With Strict filter off, the DJ can go outside these results for flow.'}
+                    <span>
+                      <strong>{visibleCandidateReport.library.afterExclusions.toLocaleString()}</strong>{' '}
+                      tracks match these music filters after excluded playlists{visibleCandidateReport.strict
+                        ? ', and form this show’s selection pool.'
+                        : '. With Strict filter off, the DJ prefers them but can go outside them for flow.'}
                     </span>
                   </>
                 ) : (

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -585,39 +585,6 @@ export function ShowEditor({
             (auto) follows the station&apos;s own mood instead of pinning one.
           </span>
 
-          <Field>
-            <FieldTitle>candidate availability</FieldTitle>
-            <FieldDescription>
-              Check the current draft against the local library and any pinned playlists. This is a configuration audit: it does not include no-repeat protection, the current track, or a sonic journey.
-            </FieldDescription>
-            <div className="mt-2 flex items-center gap-2">
-              <Btn className="min-h-9 sm:min-h-0" onClick={calculateCandidates} disabled={!valid || candidateBusy}>
-                {candidateBusy ? 'Calculating…' : 'Calculate candidates'}
-              </Btn>
-              {!valid && <span className="field-hint">Finish the required show fields first.</span>}
-            </div>
-            {candidateError && <span role="alert" className="field-hint text-vermilion">Could not calculate candidates: {candidateError}</span>}
-            {visibleCandidateReport && (
-              <div className="mt-2 grid gap-1 border border-ink bg-[var(--muted)] p-3 text-sm">
-                {hasAnyMusicFilter(show) ? (
-                  <>
-                    <span><strong>{visibleCandidateReport.library.matchingFilters.toLocaleString()}</strong> tracks match this show’s music filters</span>
-                    {visibleCandidateReport.strict ? (
-                      <span className="field-hint">{visibleCandidateReport.library.effective.toLocaleString()} remain available under this show’s strict rules after excluded playlists</span>
-                    ) : (
-                      <span className="field-hint">Soft filter is on: this is a filter-fit count, not a hard candidate limit. {visibleCandidateReport.library.afterExclusions.toLocaleString()} matching tracks remain after excluded playlists.</span>
-                    )}
-                  </>
-                ) : (
-                  <span className="field-hint">No music filters are configured for this show.</span>
-                )}
-                {visibleCandidateReport.playlist && (
-                  <span className="field-hint">Pinned playlists: {visibleCandidateReport.playlist.total.toLocaleString()} tracks · {visibleCandidateReport.playlist.matchingFilters.toLocaleString()} match filters · {visibleCandidateReport.playlist.afterExclusions.toLocaleString()} after exclusions</span>
-                )}
-                {visibleCandidateReport.warnings.map(warning => <span key={warning} className="field-hint text-vermilion">{warning}</span>)}
-              </div>
-            )}
-          </Field>
 
           <Field>
             <PlaylistIdsField
@@ -662,6 +629,42 @@ export function ShowEditor({
                 here (up to 10).
               </span>
             </PlaylistIdsField>
+          </Field>
+          <Field>
+            <FieldTitle>matching tracks</FieldTitle>
+            <FieldDescription>
+              See how many tracks fit the music filters above. Excluded playlists
+              are already removed from the count. Live picks also account for
+              recent plays and the track already on air.
+            </FieldDescription>
+            <div className="mt-2 flex items-center gap-2">
+              <Btn className="min-h-9 sm:min-h-0" onClick={calculateCandidates} disabled={!valid || candidateBusy}>
+                {candidateBusy ? 'Counting…' : 'Count matching tracks'}
+              </Btn>
+              {!valid && <span className="field-hint">Finish the required show fields first.</span>}
+            </div>
+            {candidateError && <span role="alert" className="field-hint text-vermilion">Could not count matching tracks: {candidateError}</span>}
+            {visibleCandidateReport && (
+              <div className="mt-2 grid gap-1 border border-ink bg-[var(--muted)] p-3 text-sm">
+                {hasAnyMusicFilter(show) ? (
+                  <>
+                    <span><strong>{visibleCandidateReport.library.matchingFilters.toLocaleString()}</strong> tracks match these music filters.</span>
+                    <span className="field-hint">{visibleCandidateReport.library.afterExclusions.toLocaleString()} remain after excluded playlists.</span>
+                    <span className="field-hint">
+                      {visibleCandidateReport.strict
+                        ? 'Strict filter keeps the DJ within these results, except as a last resort.'
+                        : 'With Strict filter off, the DJ can go outside these results for flow.'}
+                    </span>
+                  </>
+                ) : (
+                  <span className="field-hint">No music filters selected. Add a mood, era, energy, vocal type, or genre to count matches.</span>
+                )}
+                {visibleCandidateReport.playlist && (
+                  <span className="field-hint">Playlist anchor: {visibleCandidateReport.playlist.total.toLocaleString()} tracks · {visibleCandidateReport.playlist.matchingFilters.toLocaleString()} match these filters · {visibleCandidateReport.playlist.afterExclusions.toLocaleString()} after exclusions</span>
+                )}
+                {visibleCandidateReport.warnings.map(warning => <span key={warning} className="field-hint text-vermilion">{warning}</span>)}
+              </div>
+            )}
           </Field>
 
           {scopedRuleCount > 0 && (

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -45,6 +45,7 @@ import {
 import type { EraWindow, Persona, PlaylistIndexStatus, Show, ShowsFormValues, SkillOption, ThemeOption } from './types';
 import { hasAnyMusicFilter, showPayload } from './lib';
 import { ChipRow } from './ChipRow';
+import { displayedMatchingTracks, type CandidateDiagnostic } from './candidate-diagnostic';
 
 // The footer names the field the schema objected to; the schema's own keys are
 // developer-facing, so the common ones get an operator-facing label.
@@ -159,7 +160,6 @@ export function ShowEditor({
   const genresCtl = useController({ control, name: path('genres') });
   const maxTrackSecondsCtl = useController({ control, name: path('maxTrackSeconds') });
 
-  type CandidateDiagnostic = { strict: boolean; library: { indexed: number; matchingFilters: number; afterExclusions: number; effective: number }; playlist: null | { total: number; matchingFilters: number; afterExclusions: number; effective: number }; warnings: string[] };
   const candidateKey = JSON.stringify(showPayload(show));
   const [candidateBusy, setCandidateBusy] = useState(false);
   const [candidateError, setCandidateError] = useState<string | null>(null);
@@ -649,7 +649,7 @@ export function ShowEditor({
                 {hasAnyMusicFilter(show) ? (
                   <>
                     <span>
-                      <strong>{visibleCandidateReport.library.afterExclusions.toLocaleString()}</strong>{' '}
+                      <strong>{displayedMatchingTracks(visibleCandidateReport).toLocaleString()}</strong>{' '}
                       tracks match these music filters after excluded playlists{visibleCandidateReport.strict
                         ? ', and form this show’s selection pool.'
                         : '. With Strict filter off, the DJ prefers them but can go outside them for flow.'}

--- a/web/components/admin/shows/candidate-diagnostic.ts
+++ b/web/components/admin/shows/candidate-diagnostic.ts
@@ -1,0 +1,13 @@
+export type CandidateDiagnostic = {
+  strict: boolean;
+  library: { indexed: number; matchingFilters: number; afterExclusions: number; effective: number };
+  playlist: null | { total: number; matchingFilters: number; afterExclusions: number; effective: number };
+  warnings: string[];
+};
+
+// A strict report names the configured selection pool, which can be the
+// playlist intersection rather than every library-wide filter match. Soft
+// reports keep showing filter fit because the wider pool is only a fallback.
+export function displayedMatchingTracks(report: CandidateDiagnostic): number {
+  return report.strict ? report.library.effective : report.library.afterExclusions;
+}


### PR DESCRIPTION
## Summary

- Add an on-demand matching-track count to Edit Show, positioned with excluded playlists.
- Validate the current unsaved show draft before calculating.
- Distinguish the strict selection pool from the soft-filter preference pool.
- Show pinned-playlist and excluded-playlist effects without presenting the broad soft-filter fallback as the useful count.
- Follow the existing Show editor’s operator-facing copy and layout conventions.

## Validation

- Controller focused candidate tests passed.
- Controller type check passed.
- Web lint and type check passed.

## Station assessment

Tested on the live station. The currently on-air show reports 3,727 matching tracks; with Strict filter enabled this is its post-exclusion selection pool, while with it disabled it remains the DJ’s preferred pool.
