### PR TITLE
fix(llm): give the script generators the track's actual feel

### DIFF
--- a/controller/scripts/track-feel.test.ts
+++ b/controller/scripts/track-feel.test.ts
@@ -1,0 +1,85 @@
+// Unit tests for the track feel resolver (llm/internal/prompts/track-feel.ts)
+// — the one adjective the script generators get about how a track actually
+// sounds (issue #1443).
+//
+// Two families of pins: the arousal split must read the AUDIO moods (never the
+// editorial `moods`, which is what produced the reported bug), and every
+// unknown case must degrade to '' so an un-analysed track builds a prompt
+// byte-identical to the pre-change one.
+//
+// Run: `npm test -- track-feel` (tsx scripts/track-feel.test.ts).
+
+import assert from 'node:assert/strict';
+import { trackFeel, trackFeelSuffix } from '../src/llm/internal/prompts/track-feel.js';
+
+let failures = 0;
+function test(name: string, fn: () => void | Promise<void>) {
+  return Promise.resolve()
+    .then(fn)
+    .then(() => console.log(`  ✓ ${name}`))
+    .catch((err) => { failures++; console.error(`  ✗ ${name}\n      ${err?.message || err}`); });
+}
+
+await test('the reported track reads high-energy from its audio moods', () => {
+  // Arctic Monkeys — "Balaclava", 143.6 BPM. The DJ introduced this with
+  // "slow down and let a steady groove take over".
+  const balaclava = { audioMoods: ['workout', 'festival', 'celebratory'] };
+  assert.equal(trackFeel(balaclava), 'high-energy');
+  assert.equal(trackFeelSuffix(balaclava), ' — high-energy');
+});
+
+await test('the editorial moods field is ignored, even when it disagrees', () => {
+  // Same track: `moods` says ["reflective","night"] — the tagger reading the
+  // metadata. Reading that field instead would keep the bug.
+  const balaclava = {
+    moods: ['reflective', 'night'],
+    audioMoods: ['workout', 'festival', 'celebratory'],
+  };
+  assert.equal(trackFeel(balaclava), 'high-energy');
+});
+
+await test('a genuinely quiet track reads low-key', () => {
+  assert.equal(trackFeel({ audioMoods: ['calm', 'reflective', 'night'] }), 'low-key');
+  assert.equal(trackFeelSuffix({ audioMoods: ['calm', 'night'] }), ' — low-key');
+});
+
+await test('mixed moods resolve to the dominant end', () => {
+  assert.equal(trackFeel({ audioMoods: ['workout', 'driving', 'night'] }), 'high-energy');
+  assert.equal(trackFeel({ audioMoods: ['calm', 'focus', 'energetic'] }), 'low-key');
+});
+
+await test('an even split is not a feel', () => {
+  assert.equal(trackFeel({ audioMoods: ['workout', 'calm'] }), null);
+  assert.equal(trackFeelSuffix({ audioMoods: ['workout', 'calm'] }), '');
+});
+
+await test('un-analysed and malformed tracks are a no-op', () => {
+  // Every one of these must produce '' — the prompt is then byte-identical to
+  // the pre-change one, which is the upgrade contract in CLAUDE.md.
+  for (const track of [
+    {}, null, undefined,
+    { audioMoods: [] },
+    { audioMoods: null },
+    { audioMoods: 'workout' },      // not an array
+    { moods: ['reflective'] },      // editorial moods only, no audio scoring
+  ]) {
+    assert.equal(trackFeelSuffix(track as any), '', `expected no suffix for ${JSON.stringify(track)}`);
+  }
+});
+
+await test('labels outside the vocabulary degrade rather than guess', () => {
+  // Moods are operator-editable, so a renamed or deleted label must not flip
+  // the answer — it must drop out of the count.
+  assert.equal(trackFeel({ audioMoods: ['brooding', 'wintry'] }), null);
+  assert.equal(trackFeel({ audioMoods: ['brooding', 'workout'] }), 'high-energy');
+});
+
+await test('matching is case-insensitive', () => {
+  assert.equal(trackFeel({ audioMoods: ['Workout', 'FESTIVAL'] }), 'high-energy');
+});
+
+if (failures) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log('\ntrack-feel: all tests passed');

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -10,6 +10,13 @@ import { buildContextLines, decoratePrompt, randomSeed } from './context.js';
 import { speakClockAllowed } from '../../../broadcast/clock-policy.js';
 import { isNamedRequester } from '../../../util/request-guard.js';
 import { introBudgetPhrase, introMsFor, firstVocalMsFor, bpmKeyFor } from './intro-budget.js';
+import { trackFeelSuffix } from './track-feel.js';
+
+// The feel note appended to a track line (track-feel.ts) is a STEER, not copy.
+// Without this the model reads the label out — "high-energy" spoken flat is
+// worse than the guess it replaces, and it is the same failure as speaking a
+// raw BPM.
+const FEEL_CLAUSE = ' A feel note after a track line tells you how the track actually sounds — let it steer your wording, never say it out loud.';
 
 // Real-world context the generic between-track generators are allowed to weave
 // in. Weather is deliberately EXCLUDED (issue #471): ambient weather stapled to
@@ -92,7 +99,8 @@ export async function generateIntro({ track, context, requestedBy = null, reques
   if (artistMiss) {
     ctxLines.push(`IMPORTANT: We do NOT have "${artistMiss}" in the library. The track now starting is NOT by them — it's a fitting substitute for the moment. Do not imply or claim the track is by "${artistMiss}".`);
   }
-  ctxLines.push(`Now starting: "${track.title}" by ${track.artist}${track.album ? ` from ${track.album}` : ''}${track.year ? ` (${track.year})` : ''}`);
+  const feelSuffix = trackFeelSuffix(track);
+  ctxLines.push(`Now starting: "${track.title}" by ${track.artist}${track.album ? ` from ${track.album}` : ''}${track.year ? ` (${track.year})` : ''}${feelSuffix}`);
 
   // Talk-within-the-intro (A.3 phase 1): when the track's intro runway is
   // known, budget the line to land before the vocals. Advisory + additive —
@@ -110,6 +118,7 @@ export async function generateIntro({ track, context, requestedBy = null, reques
   if (namedBy) rules.push(REQUESTER_GREETING_CLAUSE.trim() + REQUESTER_NAME_CLAUSE);
   rules.push("This is a listener request — keep the focus on what they asked for and the track now starting; don't back-announce or talk about the track that was just playing.");
   rules.push(AIR_TIME_CLAUSE.trim());
+  if (feelSuffix) rules.push(FEEL_CLAUSE.trim());
   if (artistMiss) {
     rules.push(`The listener asked for "${artistMiss}", but we don't have them — briefly own that ("no ${artistMiss} in the crates", or similar), then introduce what's actually playing as a worthy stand-in. Never pretend the track is by "${artistMiss}".`);
   }
@@ -243,7 +252,8 @@ export async function generateLink({ previous, current, context, clockIsAirTime 
   // a track one older than reality). We intro the track NOW STARTING instead, so
   // the line is always correct whatever played before it. (`previous` is still
   // accepted for the tempo/key mix nod below — a vague feel, never a name.)
-  if (current?.title) ctxLines.push(`Now playing: "${current.title}" by ${current.artist || 'unknown'}`);
+  const feelSuffix = trackFeelSuffix(current);
+  if (current?.title) ctxLines.push(`Now playing: "${current.title}" by ${current.artist || 'unknown'}${feelSuffix}`);
 
   // DJ-mode personas lean harder into teasing the track's feel / artist.
   const djMode = !!speaker?.djMode;
@@ -264,7 +274,8 @@ export async function generateLink({ previous, current, context, clockIsAirTime 
   // phrase to "skip the spoken intro" on vocals-immediate tracks — the
   // deterministic backstop would drop the line anyway; better not to write it.
   const budget = introBudgetPhrase(introMsFor(current), firstVocalMsFor(current));
-  const prompt = `Write a short DJ link to carry into the track now starting — set it up, capture its feel, weave in the moment.${teaseClause}${patterClause}${budget ? ' ' + budget : ''} ${lengthPhrase('link', speaker)}, conversational. Vary how you open — don't default to "here's", "this is", "coming up", or "that was"; find a different way in each time. Keep it forward-looking: don't back-announce, recap, or name the track that just played — focus on what's playing now.${clockClause}\n\n${ctxLines.join('\n')}`;
+  const feelClause = feelSuffix ? FEEL_CLAUSE : '';
+  const prompt = `Write a short DJ link to carry into the track now starting — set it up, capture its feel, weave in the moment.${teaseClause}${patterClause}${budget ? ' ' + budget : ''} ${lengthPhrase('link', speaker)}, conversational. Vary how you open — don't default to "here's", "this is", "coming up", or "that was"; find a different way in each time. Keep it forward-looking: don't back-announce, recap, or name the track that just played — focus on what's playing now.${clockClause}${feelClause}\n\n${ctxLines.join('\n')}`;
 
   return djText({
     system: djSystem(speaker),

--- a/controller/src/llm/internal/prompts/track-feel.ts
+++ b/controller/src/llm/internal/prompts/track-feel.ts
@@ -1,0 +1,65 @@
+// Qualitative feel for the track a script is introducing (issue #1443).
+//
+// The script generators ask the model to "capture its feel" but hand it only a
+// title and an artist, so it has to infer the sound from the words in the
+// title. That is a coin flip: "Balaclava" reads wintry, and the DJ introduced a
+// 143 BPM Arctic Monkeys track with "slow down and let a steady groove take
+// over". The library knew better the whole time — that track carries
+// audioMoods ["workout","festival","celebratory"].
+//
+// So: derive one adjective from what the AUDIO says and hand it over. No-op for
+// un-analysed tracks — same posture as introBudgetPhrase, the post is a bonus
+// when the data exists, never a precondition.
+//
+// Deliberately NOT derived from `moods`. That field is the tagger reading the
+// metadata, and on the reported track it says ["reflective","night"] — the
+// exact wrong steer. library.ts already draws this line: audioMoods is kept
+// separate "so consumers can tell 'the LLM read the metadata' from 'the audio
+// actually sounds like this'". This is a consumer that needs the second one.
+//
+// Deliberately NOT derived from bpm either, for now: #1417 has beat_track
+// reading slow material an octave high (a 76 BPM ballad stores as 152), so a
+// tempo band would be confidently wrong on exactly the slow tracks this is
+// meant to protect. Once that lands, a tempo word is a natural second signal.
+
+import * as library from '../../../music/library.js';
+import { HIGH_ENERGY_MOODS, LOW_ENERGY_MOODS } from '../../../music/audio-calibration.js';
+
+// Stored zero-shot audio moods for a track, from the track object or a library
+// lookup. [] when un-analysed or un-scored.
+function audioMoodsFor(track: any): string[] {
+  const own = track?.audioMoods;
+  if (Array.isArray(own)) return own;
+  const rec = track?.id ? library.get(track.id) : null;
+  return Array.isArray(rec?.audioMoods) ? rec.audioMoods : [];
+}
+
+/**
+ * One-word feel for a track — 'high-energy' | 'low-key' | null.
+ *
+ * Counts stored audio moods against the same arousal split the calibration
+ * layer uses, so a renamed or deleted mood degrades to null rather than
+ * flipping the answer (moods are operator-editable). A tie is null: two ends
+ * pulling equally is not a feel, and silence is always a safe output here.
+ */
+export function trackFeel(track: any): 'high-energy' | 'low-key' | null {
+  const moods = audioMoodsFor(track).map((m) => String(m).toLowerCase());
+  if (!moods.length) return null;
+  const high = moods.filter((m) => (HIGH_ENERGY_MOODS as readonly string[]).includes(m)).length;
+  const low = moods.filter((m) => (LOW_ENERGY_MOODS as readonly string[]).includes(m)).length;
+  if (high > low) return 'high-energy';
+  if (low > high) return 'low-key';
+  return null;
+}
+
+/**
+ * The feel as a prompt suffix — ' — high-energy' or '' when unknown.
+ *
+ * Returned pre-joined so a call site can append it to an existing "Now
+ * playing:" line without a conditional, and an un-analysed track produces a
+ * byte-identical prompt to before.
+ */
+export function trackFeelSuffix(track: any): string {
+  const feel = trackFeel(track);
+  return feel ? ` — ${feel}` : '';
+}


### PR DESCRIPTION
Closes #1443.

## Why

`generateLink` and `generateIntro` both ask the model to "capture its feel", and both hand it only a title and an artist. There is nothing in the prompt about how the track sounds, so the model infers the sound from the words in the title. That is a coin flip.

It lost on a 143 BPM Arctic Monkeys track called *Balaclava*, which the DJ introduced with:

> "Sometimes the best way to find your footing is to slow down and let a steady groove take over."

The library had it right the whole time: `audioMoods` on that track is `["workout","festival","celebratory"]`.

The same gap makes the constraint un-fixable from the operator side. House rules banning mood-talk end up arguing with a live instruction that sits closer to the task, and the model settles in the middle — vague mood-writing, which is worse than either extreme. An operator can counterweight the prompt but never overrule it.

## What

One adjective — `high-energy` or `low-key` — appended to the track line, plus a clause telling the model it is a steer rather than copy:

```
Now playing: "Balaclava" by Arctic Monkeys — high-energy
```

New pure module `llm/internal/prompts/track-feel.ts`, wired into both generators.

## Three decisions worth reviewing

**It reads `audioMoods`, never `moods`.** On the reported track the editorial field says `["reflective","night"]` — the exact wrong steer, and reading it would have preserved the bug. `library.ts` already draws this line ("so consumers can tell 'the LLM read the metadata' from 'the audio actually sounds like this'"); this is a consumer that needs the second one.

**It deliberately leaves `bpm` out.** #1417 has `beat_track` reading slow material an octave high, so a tempo band would be confidently wrong on exactly the slow tracks this is meant to protect. Concretely, on a real 29k-track library Leonard Cohen's *If It Be Your Will* — a hushed acoustic ballad — stores as **136 BPM**. A tempo band calls that fast; the audio-mood route calls it low-key. Once #1417 lands, tempo is a natural second signal.

**It classifies with the existing `HIGH_ENERGY_MOODS` / `LOW_ENERGY_MOODS` split** from `audio-calibration.ts` rather than a new vocabulary, so a renamed or deleted mood drops out of the count instead of flipping the answer. A tie returns null — two ends pulling equally is not a feel.

## The upgrade contract

No-op when a track carries no audio moods: the suffix is `''` and the prompt is byte-identical to before, matching `introBudgetPhrase`'s posture and the "absent or malformed coerces to pre-existing behaviour" rule in `CLAUDE.md`. The `FEEL_CLAUSE` is likewise only added when a feel was actually resolved.

## Verification

Measured against a real 29,240-track library (catalogue soul, reggae, funk, punk):

| | tracks | share |
|---|---|---|
| high-energy | 14,696 | 50.7% |
| low-key | 8,565 | 29.6% |
| tie → no feel | 5,707 | 19.7% |
| no audio data → no-op | 7 | 0.0% |

So ~80% of the library gets a usable steer and the rest degrades to silence rather than a guess. Spot checks:

```
Balaclava — Arctic Monkeys           high-energy   (moods said ["reflective","night"])
Move On Up — Curtis Mayfield         high-energy
Zombie — Fela Kuti                   high-energy
If It Be Your Will — Leonard Cohen   low-key       (stored bpm 136 — see #1417)
```

- New `scripts/track-feel.test.ts` — 8 cases, all passing: the reported track, the moods-vs-audioMoods disagreement, mixed and tied moods, out-of-vocabulary labels, case-insensitivity, and every malformed shape returning `''`.
- `npm run typecheck` clean. `npm run lint` 0 errors (the `any` in the resolver matches `bpmKeyFor` and the surrounding prompt modules).
- Full suite: this branch showed 6 failures, clean `develop` showed 23, both under Node 22 and both exiting 0 — `voice-air-events.test.ts` and friends appear flaky under the parallel runner. That suite passes alone on both. Nothing here touches it.

## Not in this PR

The clock half of #1443 — `buildContextLines` injecting `Local time:` into the same prompt, which is the same defect in a second place (the model is handed the clock, then told not to say it). Kept separate to stay focused; happy to open it once you've got a view on the shape.
