### PR TITLE
fix(llm): support newer GPT-5 reasoning floors

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -374,8 +374,15 @@ async function main() {
   await test('openai: effort level only on o-series/gpt-5 (sent verbatim as reasoning_effort — gpt-4-class 400s on it)', () => {
     assert.equal(reasoningFor({ provider: 'openai', model: 'o3', reasoning: false }), 'minimal');
     assert.equal(reasoningFor({ provider: 'openai', model: 'o3', reasoning: true }), 'medium');
+    assert.equal(reasoningFor({ provider: 'openai', model: 'gpt-5-mini', reasoning: false }), 'minimal');
     assert.equal(reasoningFor({ provider: 'openai', model: 'gpt-5-mini', reasoning: true }), 'medium');
     assert.equal(reasoningFor({ provider: 'openai', model: 'gpt-4.1-mini', reasoning: false }), undefined);
+  });
+  await test('openai: dotted GPT-5 generations use none when reasoning is off', () => {
+    for (const model of ['gpt-5.1', 'gpt-5.2', 'gpt-5.4-mini', 'gpt-5.6-luna']) {
+      assert.equal(reasoningFor({ provider: 'openai', model, reasoning: false }), 'none');
+    }
+    assert.equal(reasoningFor({ provider: 'openai', model: 'gpt-5.6-luna', reasoning: true }), 'medium');
   });
   await test('requesty: minimal when suppressing — same wire bytes as the old providerOptions.requesty block', () => {
     assert.equal(reasoningFor({ provider: 'requesty', model: 'openai/gpt-4o-mini', reasoning: true }), undefined);

--- a/controller/src/llm/internal/provider/capabilities.ts
+++ b/controller/src/llm/internal/provider/capabilities.ts
@@ -113,13 +113,16 @@ const CAPS: Record<string, ProviderCapabilities> = {
   openai: {
     objectStrategy: 'native',
     repeatPenaltyApplies: false,
-    // o-series / gpt-5 always reason; only effort is tunable — 'minimal' is the
-    // floor ('none' is rejected). The model-id gate must stay: the provider
-    // forwards the level as reasoning_effort VERBATIM, and gpt-4-class models
-    // 400 on receiving it. forceNoThink not factored — these models permit
-    // forced tools while reasoning.
+    // OpenAI forwards the level as reasoning_effort VERBATIM. Original gpt-5
+    // and o-series use 'minimal' as their floor ('none' is rejected), while the
+    // dotted GPT-5 generations (5.1+) replaced 'minimal' with 'none'. Keep the
+    // model-id gate: gpt-4-class models 400 on receiving any reasoning effort.
+    // forceNoThink is not factored — these models permit forced tools while
+    // reasoning.
     reasoningLevel: ({ modelId, reasoning }) =>
-      /^(o\d|gpt-5)/i.test(modelId) ? (reasoning ? 'medium' : 'minimal') : undefined,
+      /^(o\d|gpt-5)/i.test(modelId)
+        ? (reasoning ? 'medium' : /^gpt-5\.\d/i.test(modelId) ? 'none' : 'minimal')
+        : undefined,
     discoverySteps: NATIVE_DISCOVERY_STEPS,
   },
   // openai-compatible targets self-hosted llama.cpp / vLLM / LM Studio — the


### PR DESCRIPTION
## What

Map OpenAI's dotted GPT-5 generations (5.1+) to `reasoning_effort: none` when SUB/WAVE reasoning is off. Preserve `minimal` for original GPT-5/o-series models and `medium` when reasoning is on.

## Why

GPT-5.6 Luna rejects `minimal`, so library tagging fails at both the batch and per-track fallback paths. Closes #1445.

## How tested

- `cd controller && npm run test:llm`
- `cd controller && npm test -- track-feel`
- `cd controller && npm run lint` — 0 errors (existing warnings only)
- `git diff --check`
- Full controller suite: 692 passed, 0 failed, 7 cancelled in the pre-existing `voice-air-events.test.ts`; that file and its production sources are unchanged from `origin/develop`, and the cancellation reproduces in isolation on Node 22.23.2 because its timeout is unref'd.

## Notes for reviewers

The regression assertion was run red first (`minimal !== none`) and then green after the capability mapping changed.
