### PR TITLE
feat(llm): allow five-minute agent deadlines

### DIFF
--- a/controller/scripts/agent-timeout.test.ts
+++ b/controller/scripts/agent-timeout.test.ts
@@ -1,0 +1,41 @@
+// settings.llm.agentTimeoutMs — the shared wall-clock budget for DJ-agent
+// picks, listener requests, and the segment director.
+//
+// Exercise both persistence paths: update() is what the admin UI uses, while a
+// cold load is what proves the saved value survives a controller restart.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const stateRoot = mkdtempSync(path.join(tmpdir(), 'subwave-agent-timeout-'));
+process.env.STATE_DIR = stateRoot;
+
+const { setCache } = await import('../src/settings/store.js');
+const settings = await import('../src/settings.js');
+
+const SETTINGS_PATH = path.join(stateRoot, 'settings.json');
+
+async function coldLoad(agentTimeoutMs: unknown) {
+  writeFileSync(SETTINGS_PATH, JSON.stringify({ llm: { agentTimeoutMs } }));
+  setCache(null);
+  await settings.load();
+  return settings.get().llm.agentTimeoutMs;
+}
+
+test('the admin save path accepts a five-minute agent deadline across a restart', async () => {
+  await coldLoad(45_000);
+  await settings.update({ llm: { agentTimeoutMs: 300_000 } } as never);
+  assert.equal(settings.get().llm.agentTimeoutMs, 300_000, 'applies immediately');
+
+  setCache(null);
+  await settings.load();
+  assert.equal(settings.get().llm.agentTimeoutMs, 300_000, 'survives a controller restart');
+});
+
+test('a hand-edited deadline is capped at five minutes on cold load', async () => {
+  assert.equal(await coldLoad(300_000), 300_000, 'the documented ceiling is accepted');
+  assert.equal(await coldLoad(600_000), 300_000, 'values above the ceiling are contained');
+});

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -804,7 +804,7 @@ export async function load() {
         typeof stored.llm?.requestWebResolve === 'boolean'
           ? stored.llm.requestWebResolve
           : DEFAULTS.llm.requestWebResolve,
-      // Clamped to [5s, 180s]; settings.json files from before the field
+      // Clamped to [5s, 300s]; settings.json files from before the field
       // existed pick up the default.
       agentTimeoutMs: clampAgentTimeout(stored.llm?.agentTimeoutMs, DEFAULTS.llm.agentTimeoutMs),
       pauseWhenEmpty:

--- a/controller/src/settings/vocab.ts
+++ b/controller/src/settings/vocab.ts
@@ -316,13 +316,13 @@ export function clampRepeatPenalty(raw: unknown, def: number): number {
   return Math.min(2.0, Math.max(1.0, raw));
 }
 
-// Coerce a stored agent-deadline value (ms). Clamped to [5s, 180s] and floored
+// Coerce a stored agent-deadline value (ms). Clamped to [5s, 300s] and floored
 // to an integer; non-numeric/NaN falls back to `def`. The lower bound keeps a
 // fat-fingered save from making every agent pick fail instantly; the upper
 // bound keeps a stalling model from tying up an inference slot for minutes.
 export function clampAgentTimeout(raw: unknown, def: number): number {
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return def;
-  return Math.min(180_000, Math.max(5_000, Math.floor(raw)));
+  return Math.min(300_000, Math.max(5_000, Math.floor(raw)));
 }
 
 // Daily LLM token cap. 0 disables (the default — never cap a free local box);
@@ -1147,4 +1147,3 @@ export const AAC_BITRATES = SETTINGS_AAC_BITRATES;
 // the analyzer's measured LUFS, or tag-with-measured-fallback (the default).
 export const LOUDNESS_SOURCES = SETTINGS_LOUDNESS_SOURCES;
 export type LoudnessSource = (typeof LOUDNESS_SOURCES)[number];
-

--- a/web/components/admin/settings/LlmSection.tsx
+++ b/web/components/admin/settings/LlmSection.tsx
@@ -1007,7 +1007,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
             <Input
               type="number"
               min={5}
-              max={180}
+              max={300}
               step={5}
               value={Math.round(form.llm.agentTimeoutMs / 1000)}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
@@ -1020,7 +1020,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
               How long an agent pick or listener request may run before falling
               back to the stateless picker. Slow reasoning models often need
               20&ndash;40s per pick; lower it for snappier fallbacks on a fast
-              model. 5&ndash;180s.
+              model. 5&ndash;300s.
             </div>
           </div>
         )}


### PR DESCRIPTION
## What

Raise the configurable DJ-agent deadline ceiling from 180 seconds to 300 seconds in both controller normalization and the admin UI. Add regression coverage for the settings update path, controller restart persistence, and cold-load clamping above the new ceiling.

## Why

Slow local models can produce valid completions just beyond the old three-minute cap. Keeping the existing 45-second default and a finite five-minute ceiling gives personal stations more headroom without removing the stall safeguard.

Closes #1428.

## How tested

- `PATH=/tmp/subwave-agent-timeout-venv-ppxSTk/bin:$PATH mise exec node@25.2.1 -- npm test` — 722 passed
- `cd controller && npm run lint` — 0 errors
- `cd web && npm run lint` — 0 errors
- `git diff --check origin/develop...HEAD`

## Notes for reviewers

The default remains 45 seconds. Only the operator-selectable maximum changes.