### PR TITLE
fix(llm): log successful calls with generator metadata

### DIFF
--- a/controller/scripts/llm-call-log.test.ts
+++ b/controller/scripts/llm-call-log.test.ts
@@ -1,0 +1,76 @@
+// Pins the durable controller-log summary for successful LLM calls (#1435).
+// Raw request capture is intentionally separate and may contain full prompts;
+// this line is the small metadata-only record operators can grep over time.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = mkdtempSync(join(tmpdir(), 'subwave-llm-call-log-'));
+process.env.STATE_DIR = root;
+
+const { record } = await import('../src/llm/internal/telemetry/log.js');
+
+function captureLog(fn: () => void): string[] {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => lines.push(args.map(String).join(' '));
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return lines;
+}
+
+test('a successful LLM call emits one grep-friendly metadata summary', () => {
+  const lines = captureLog(() => record({
+    kind: 'generateBanter',
+    ok: true,
+    ms: 7263,
+    model: 'ollama:qwen3:8b',
+    via: 'ai-sdk:tool',
+    usage: { input: 1358, output: 33, total: 1391 },
+    system: 'private system prompt',
+    user: 'private user prompt',
+    response: 'private model response',
+  }));
+
+  assert.deepEqual(lines, [
+    '[generateBanter] ollama:qwen3:8b via ai-sdk:tool — 7263ms, 1358/33 tokens',
+  ]);
+  assert.doesNotMatch(lines[0], /private/);
+});
+
+test('a successful call does not invent zero tokens when usage is absent', () => {
+  const lines = captureLog(() => record({
+    kind: 'generateSegment',
+    ok: true,
+    ms: 804,
+    model: 'openai:gpt-5-mini',
+    via: 'ai-sdk',
+  }));
+
+  assert.deepEqual(lines, [
+    '[generateSegment] openai:gpt-5-mini via ai-sdk — 804ms, token usage unavailable',
+  ]);
+});
+
+test('failed calls do not duplicate the existing retry and failure logs', () => {
+  const lines = captureLog(() => record({
+    kind: 'pickNextTrack',
+    ok: false,
+    ms: 2000,
+    model: 'ollama:qwen3:8b',
+    via: 'ai-sdk:tool',
+    error: 'fetch failed',
+  }));
+
+  assert.deepEqual(lines, []);
+});
+
+test.after(() => {
+  rmSync(root, { recursive: true, force: true });
+});

--- a/controller/src/llm/internal/telemetry/log.ts
+++ b/controller/src/llm/internal/telemetry/log.ts
@@ -23,9 +23,21 @@ export function lifetimeTokenCount() {
   return lifetimeTokens;
 }
 
+function logSuccess(call: any) {
+  if (!call.ok) return;
+  const usage = Number.isFinite(call.usage?.input) && Number.isFinite(call.usage?.output)
+    ? `${call.usage.input}/${call.usage.output} tokens`
+    : 'token usage unavailable';
+  console.log(`[${call.kind}] ${call.model} via ${call.via} — ${call.ms}ms, ${usage}`);
+}
+
 export function record(call: any) {
   recentCalls.unshift(call);
   if (recentCalls.length > MAX_CALLS) recentCalls.length = MAX_CALLS;
+  // Metadata only: prompts and responses stay in /debug and events.jsonl.
+  // One line per success makes long-running container logs attributable by
+  // generator without enabling raw request capture (#1435).
+  logSuccess(call);
   // Mirror summarizeLlm: only successful calls that report usage contribute.
   if (call.ok && call.usage?.total) lifetimeTokens += call.usage.total;
 


### PR DESCRIPTION
## What

Adds one metadata-only controller log line for every successful LLM call. The line carries the generator kind, model, AI SDK path, latency, and input/output token counts; prompts and responses remain confined to the existing debug and event-log surfaces.

Calls from providers that do not report usage say `token usage unavailable` instead of inventing zeroes.

## Why

Successful calls currently have no call-site attribution in `docker logs`, while retry and failover messages already carry the generator name. This makes long-running station logs directly grep-able without enabling raw request capture.

Fixes #1435.

## How tested

- `npm test -- llm-call-log` — 3/3 passed
- `npm run lint` — passed (ESLint + TypeScript)
- `git diff --check` — passed
- Full controller suite — 716 passed; 7 `voice-air-events` cases cancelled with the existing pending-promise/timer behavior. The same seven cancellations reproduce on an untouched `origin/develop` checkout; there were no feature-related failures.

## Notes for reviewers

The failure recorder stays quiet here so the existing retry, failover, and raw-output failure messages are not duplicated. The durable `events-YYYY-MM-DD.jsonl` record is unchanged.
