### PR TITLE
fix(dj): keep daypart context aligned

### DIFF
--- a/controller/scripts/daypart-context.test.ts
+++ b/controller/scripts/daypart-context.test.ts
@@ -1,0 +1,24 @@
+// Issue #1411: a midday DJ link was prompted to address people working at
+// night. The shared link-angle list feeds both the session agent and the pool
+// fallback, so a time-specific suggestion here must be supported by the
+// context the model actually receives.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { decoratePrompt } from '../src/llm/internal/prompts/context.js';
+
+test('a midday link prompt does not suggest an unsupported late-shift moment', () => {
+  const originalRandom = Math.random;
+  // Select the listener-moment angle deterministically (index 6 of 9).
+  Math.random = () => 0.7;
+  try {
+    const prompt = decoratePrompt(
+      'Local time: 12:45 pm\nPeriod: midday (lunch hour)',
+      { kind: 'link' },
+    );
+    assert.doesNotMatch(prompt, /commute|late shift|weekend|midweek lull/i);
+  } finally {
+    Math.random = originalRandom;
+  }
+});

--- a/controller/scripts/weather-settings-live.test.ts
+++ b/controller/scripts/weather-settings-live.test.ts
@@ -1,0 +1,58 @@
+// Issue #1411: onboarding persisted the station timezone and weather location
+// through settings.update(), but only the timezone reached the running process.
+// The settings page then showed Buenos Aires while context.ts kept querying the
+// boot-time Chandigarh coordinates until a restart.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const stateRoot = mkdtempSync(join(tmpdir(), 'subwave-weather-live-'));
+process.env.STATE_DIR = stateRoot;
+
+const settings = await import('../src/settings.js');
+const { getWeather, invalidateWeatherCache } = await import('../src/context.js');
+
+test('a settings.update weather change reaches the next context fetch without a restart', async () => {
+  await settings.load();
+  invalidateWeatherCache();
+
+  const originalFetch = globalThis.fetch;
+  const urls: string[] = [];
+  globalThis.fetch = (async (input: string | URL | Request) => {
+    urls.push(String(input));
+    return new Response(JSON.stringify({
+      current: { temperature_2m: 25, weather_code: 0, is_day: 1 },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }) as typeof fetch;
+
+  try {
+    const before = await getWeather();
+    assert.equal(before.location, 'Punjab');
+
+    await settings.update({
+      weather: {
+        lat: -34.6037,
+        lng: -58.3816,
+        locationName: 'Buenos Aires, Buenos Aires F.D., Argentina',
+        units: 'metric',
+      },
+    });
+
+    const after = await getWeather();
+    assert.equal(after.location, 'Buenos Aires, Buenos Aires F.D., Argentina');
+    assert.equal(urls.length, 2, 'the changed coordinates bypass the old 30-minute cache entry');
+    assert.match(urls[1], /latitude=-34\.6037&longitude=-58\.3816/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test.after(() => {
+  rmSync(stateRoot, { recursive: true, force: true });
+});

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -57,13 +57,36 @@ export function getFestivalContext(date = new Date()) {
 }
 
 // Weather via Open-Meteo (no API key required)
-let weatherCache: { data: any; fetchedAt: number } = { data: null, fetchedAt: 0 };
+let weatherCache: { data: any; fetchedAt: number; configKey: string } = {
+  data: null,
+  fetchedAt: 0,
+  configKey: '',
+};
 const WEATHER_TTL_MS = 30 * 60 * 1000;
+
+// Weather is settings-layer state, so read the live settings cache directly.
+// The old config.weather mirror was refreshed by POST /settings and at boot,
+// but not by onboarding or backup restore — both of which call settings.update()
+// directly. That left the saved location and the running forecast out of sync
+// until a controller restart.
+function weatherConfig() {
+  return getSettings().weather || config.weather;
+}
+
+function weatherConfigKey(weather: ReturnType<typeof weatherConfig>) {
+  return [
+    weather.lat,
+    weather.lng,
+    weather.units,
+    weather.locationName,
+    weather.onAirLocation,
+  ].join('\u0000');
+}
 
 // Force the next getWeather() call to re-fetch — used when the user changes
 // their location in /settings.
 export function invalidateWeatherCache() {
-  weatherCache = { data: null, fetchedAt: 0 };
+  weatherCache = { data: null, fetchedAt: 0, configKey: '' };
 }
 
 // The place the weather readout is ATTRIBUTED to — the broad on-air location,
@@ -74,21 +97,27 @@ export function invalidateWeatherCache() {
 // Keeping the precise locationName out of it is what stops a station's public
 // URL from naming its operator's town.
 //
-// Fed config.weather rather than the settings cache so this module keeps
-// deriving weather from the same mirrored block as lat/lng/units.
-function attributedLocation() {
-  return resolveOnAirLocation({ weather: config.weather });
+// Fed the same live weather block as the forecast query so its attributed
+// location and coordinates cannot drift across settings writers.
+function attributedLocation(weather = weatherConfig()) {
+  return resolveOnAirLocation({ weather });
 }
 
 export async function getWeather() {
-  if (weatherCache.data && Date.now() - weatherCache.fetchedAt < WEATHER_TTL_MS) {
+  const weather = weatherConfig();
+  const configKey = weatherConfigKey(weather);
+  if (
+    weatherCache.data &&
+    weatherCache.configKey === configKey &&
+    Date.now() - weatherCache.fetchedAt < WEATHER_TTL_MS
+  ) {
     return weatherCache.data;
   }
-  const imperial = config.weather.units === 'imperial';
+  const imperial = weather.units === 'imperial';
   const tempUnit = imperial ? 'F' : 'C';
   try {
     const unitParam = imperial ? '&temperature_unit=fahrenheit' : '';
-    const url = `https://api.open-meteo.com/v1/forecast?latitude=${config.weather.lat}&longitude=${config.weather.lng}&current=temperature_2m,weather_code,is_day${unitParam}`;
+    const url = `https://api.open-meteo.com/v1/forecast?latitude=${weather.lat}&longitude=${weather.lng}&current=temperature_2m,weather_code,is_day${unitParam}`;
     const res = await fetchWithTimeout(url, { timeoutMs: 10_000 });
     const data = await res.json() as any;
     const code = data.current.weather_code;
@@ -99,12 +128,12 @@ export async function getWeather() {
       temp: Math.round(data.current.temperature_2m),
       tempUnit,
       isDay: data.current.is_day === 1,
-      location: attributedLocation(),
+      location: attributedLocation(weather),
     };
-    weatherCache = { data: result, fetchedAt: Date.now() };
+    weatherCache = { data: result, fetchedAt: Date.now(), configKey };
     return result;
   } catch {
-    return { condition: 'unknown', mood: null, temp: null, tempUnit, location: attributedLocation() };
+    return { condition: 'unknown', mood: null, temp: null, tempUnit, location: attributedLocation(weather) };
   }
 }
 
@@ -204,7 +233,7 @@ const MONTH_LABELS = ['January', 'February', 'March', 'April', 'May', 'June',
 // latitude, so a southern-hemisphere station (negative lat) reads July as
 // winter, not summer (issue: Buenos Aires DJ talking about "summer" and "heat"
 // in July). The southern seasons are the northern ones shifted six months.
-function seasonFor(month /* 1-12 */, lat = config.weather.lat) {
+function seasonFor(month /* 1-12 */, lat = weatherConfig().lat) {
   const m = lat < 0 ? ((month + 5) % 12) + 1 : month;
   if (m === 12 || m <= 2) return 'winter';
   if (m <= 5) return 'spring';

--- a/controller/src/llm/internal/prompts/context.ts
+++ b/controller/src/llm/internal/prompts/context.ts
@@ -37,7 +37,7 @@ export const ANGLES = {
     'Make one small, true observation that has nothing to do with music, then let the song pick it up.',
     'Name the artist only in passing, folded into a thought — never "this is X by Y".',
     'Pose a tiny question or thought and let the track be the answer.',
-    'Acknowledge a listener-shaped moment (commute, late shift, weekend, midweek lull) without naming anyone, then ease in.',
+    'Acknowledge what this point in the day might feel like for a listener, using only the supplied current context, then ease in.',
     'Say one honest sentence about how this track lands right now, and get out of the way.',
     'React to the shift in the room as it comes on — how it lifts, settles, darkens, or opens things up.',
   ],

--- a/controller/src/routes/settings/core.ts
+++ b/controller/src/routes/settings/core.ts
@@ -21,7 +21,6 @@ import * as piper from '../../audio/piper.js';
 import * as llmProvider from '../../llm/provider.js';
 import { queue } from '../../broadcast/queue.js';
 import { streamStatus } from '../../broadcast/liquidsoap-control.js';
-import { invalidateWeatherCache } from '../../context.js';
 import { requireAdmin } from '../../middleware/auth.js';
 import { validateSettingsBody } from '../../middleware/validate.js';
 import { saveSecrets, SECRET_ENV_KEYS } from '../../setup/secrets.js';
@@ -227,18 +226,10 @@ router.get('/settings', requireAdmin, async (req, res) => {
 router.post('/settings', requireAdmin, validateSettingsBody(), async (req, res) => {
   try {
     const result = await settings.update(req.body || {});
-    // Apply live: weather location flows through config.weather to context.js
+    // context.ts reads the live settings cache and keys its forecast cache by
+    // this block, so every settings.update() writer applies immediately — the
+    // route only owns the operator-facing log.
     if ('weather' in (req.body || {})) {
-      config.weather.lat = result.saved.weather.lat;
-      config.weather.lng = result.saved.weather.lng;
-      config.weather.locationName = result.saved.weather.locationName;
-      config.weather.onAirLocation = result.saved.weather.onAirLocation;
-      config.weather.units = result.saved.weather.units;
-      // Not optional for onAirLocation: getWeather() bakes the attributed
-      // location into its cached result, so without this the DJ keeps naming
-      // the old place — and /now-playing keeps publishing it — for a full
-      // cache TTL after the operator changes it.
-      invalidateWeatherCache();
       queue.log(
         'scheduler',
         `weather location → ${result.saved.weather.locationName} (${result.saved.weather.units}) · on air → ${settings.resolveOnAirLocation(result.saved)}`,
@@ -377,5 +368,4 @@ router.post('/settings/navidrome/test', requireAdmin, async (req, res) => {
   }
   res.json(await subsonic.pingWith({ url, user, pass, client: 'sub-wave-admin' }));
 });
-
 

--- a/controller/src/server.ts
+++ b/controller/src/server.ts
@@ -226,11 +226,6 @@ app.listen(config.server.port, async () => {
   try {
     await settings.load();
     const s = settings.get();
-    config.weather.lat = s.weather.lat;
-    config.weather.lng = s.weather.lng;
-    config.weather.locationName = s.weather.locationName;
-    config.weather.onAirLocation = s.weather.onAirLocation;
-    config.weather.units = s.weather.units;
     await settings.ensureLiquidsoapSettingsFile();
     console.log(
       `[settings] loaded. jingleRatio=${s.jingleRatio} crossfadeDuration=${s.crossfadeDuration} location=${s.weather.locationName} onAir=${settings.resolveOnAirLocation(s)}`,

--- a/controller/src/settings/persona.ts
+++ b/controller/src/settings/persona.ts
@@ -252,8 +252,8 @@ export function agentLanguageReminder(persona: unknown, fields: string) {
 // operator-facing label for the coordinates and is never spoken or published;
 // weather.lat/lng never leave the Open-Meteo call.
 //
-// context.ts passes { weather: config.weather } instead of the cache default so
-// its weather block stays the single source it derives lat/lng/units from.
+// context.ts passes the exact live weather block used for its forecast query so
+// the public/spoken location and the private coordinates cannot drift.
 export function resolveOnAirLocation(s: unknown = peek()) {
   const w = (s as { weather?: { onAirLocation?: unknown; locationName?: unknown } } | null | undefined)?.weather;
   return (
@@ -376,4 +376,3 @@ export function onAirRosterClause(persona: unknown, date: Date = new Date()): st
   }
   return '';
 }
-


### PR DESCRIPTION
## What

Keep generated DJ links grounded in the supplied local-time context, and make weather context follow saved settings immediately across the admin route, onboarding, and backup restore paths.

## Why

A daytime broadcast could be framed as a late shift because the prompt supplied unsupported examples. Separately, non-admin settings writers could persist a new weather location without updating the controller's in-memory context.

Closes #1411.

## How tested

- `cd controller && npm run lint`
- `cd controller && npm test -- daypart-context`
- `cd controller && npm test -- weather-settings-live`
- Full controller suite with its NumPy and real-disk temp prerequisites: 735 passed, 0 failed, 0 cancelled across 146 files

## Notes for reviewers

The weather cache is keyed by the complete live weather settings block, so every settings writer gets the same invalidation behavior without route-specific mutation.

The isolated `voice-air-events` worker needs a referenced test-only keepalive to exercise its timeout path because both production marker timers are deliberately unref'd. With that harness condition, all 15 voice-air tests and the complete suite finish cleanly; production code is unchanged.
