### PR TITLE
fix(analyzer): accelerate CUDA sounds-like backfills

### DIFF
--- a/controller/scripts/analyze-mode.test.ts
+++ b/controller/scripts/analyze-mode.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { analysisModeForTrack } from '../src/music/analyze-capability.js';
+
+test('an already-current track missing only its sounds-like vector uses embedding-only work', () => {
+  assert.equal(analysisModeForTrack('audio-only', new Set(['stale', 'vocal', 'stems']), true), 'embedding-only');
+});
+
+test('baseline, vocal, and stem scopes retain full acoustic analysis', () => {
+  const full = new Set(['stale', 'vocal', 'stems']);
+  for (const id of full) assert.equal(analysisModeForTrack(id, full, true), 'full', id);
+  assert.equal(analysisModeForTrack('ordinary', full, false), 'full');
+});

--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -681,6 +681,15 @@ def estimate_sections(y, sr, librosa, chroma=None):
 # so a worker with embeddings DISABLED never needs torch/transformers/onnx and
 # the librosa-only venv keeps working.
 # ---------------------------------------------------------------------------
+def clap_batch_enabled(mode, device):
+    """Only the published CUDA transformers path benefits from window batching.
+
+    CPU torch keeps the old one-window memory envelope, and arbitrary ONNX
+    exports may not have a dynamic batch axis.
+    """
+    return mode == "transformers" and device == "cuda"
+
+
 class ClapEmbedder:
     def __init__(self):
         self.mode = None
@@ -725,41 +734,29 @@ class ClapEmbedder:
             self.mode = "transformers"
             log(f"CLAP transformers model loaded: {hf_id}")
 
-    def embed(self, y48, sr):
+    def _embed_onnx(self, y48, sr):
         import numpy as np
 
-        return_tensors = "np" if self.mode == "onnx" else "pt"
         # transformers renamed the ClapProcessor audio kwarg `audios` → `audio`
         # and turned the old name into a hard error (not just a warning) in
         # recent releases. Try the new name, fall back to the old one so this
         # works against whatever transformers the analyzer venv resolved.
         try:
             inputs = self.processor(
-                audio=y48, sampling_rate=sr, return_tensors=return_tensors
+                audio=y48, sampling_rate=sr, return_tensors="np"
             )
         except (TypeError, ValueError):
             inputs = self.processor(
-                audios=y48, sampling_rate=sr, return_tensors=return_tensors
+                audios=y48, sampling_rate=sr, return_tensors="np"
             )
         feats = inputs["input_features"]
+        feats_np = np.asarray(feats, dtype=np.float32)
+        out = self.session.run(None, {self.input_name: feats_np})
+        return np.asarray(out[0]).reshape(-1)
 
-        if self.mode == "onnx":
-            feats_np = np.asarray(feats, dtype=np.float32)
-            out = self.session.run(None, {self.input_name: feats_np})
-            vec = np.asarray(out[0]).reshape(-1)
-        else:
-            import torch
-
-            feats = feats.to(resolve_device())
-            with torch.no_grad():
-                emb = self.model.get_audio_features(input_features=feats)
-            # transformers ≤4.x returns the projected 512-d audio-features
-            # tensor directly; 5.x returns a BaseModelOutputWithPooling whose
-            # .pooler_output is that same projected embedding. Unwrap the new
-            # shape so this works against whatever the analyzer venv resolved.
-            if hasattr(emb, "pooler_output"):
-                emb = emb.pooler_output
-            vec = emb.cpu().numpy().reshape(-1)
+    @staticmethod
+    def _normalise(vec):
+        import numpy as np
 
         if vec.shape[0] != CLAP_EMBED_DIM:
             raise RuntimeError(
@@ -770,6 +767,65 @@ class ClapEmbedder:
         if norm > 0:
             vec = vec / norm
         return [float(x) for x in vec]
+
+    def _embed_transformers(self, windows, sr):
+        import numpy as np
+        import torch
+
+        audio = list(windows)
+        try:
+            inputs = self.processor(
+                audio=audio, sampling_rate=sr, return_tensors="pt"
+            )
+        except (TypeError, ValueError):
+            inputs = self.processor(
+                audios=audio, sampling_rate=sr, return_tensors="pt"
+            )
+        feats = inputs["input_features"].to(resolve_device())
+        with torch.no_grad():
+            emb = self.model.get_audio_features(input_features=feats)
+        # transformers ≤4.x returns the projected tensor directly; 5.x wraps
+        # it in BaseModelOutputWithPooling.
+        if hasattr(emb, "pooler_output"):
+            emb = emb.pooler_output
+        rows = np.asarray(emb.cpu().numpy())
+        if rows.ndim == 1:
+            rows = rows.reshape(1, -1)
+        if rows.shape[0] != len(audio):
+            raise RuntimeError(
+                f"unexpected CLAP embedding batch {rows.shape[0]} (want {len(audio)})"
+            )
+        return [self._normalise(row) for row in rows]
+
+    def embed_many(self, windows, sr):
+        """Embed one track's windows, batching only the CUDA model forward."""
+        if not windows:
+            return []
+        if self.mode == "onnx":
+            return [self._normalise(self._embed_onnx(window, sr)) for window in windows]
+        if not self.batches_windows():
+            return [self._embed_transformers([window], sr)[0] for window in windows]
+        try:
+            return self._embed_transformers(windows, sr)
+        except Exception as ex:  # noqa: BLE001 - preserve the old memory envelope
+            log(f"CLAP window batch failed ({ex}); retrying sequentially")
+            try:
+                import torch
+
+                torch.cuda.empty_cache()
+            except Exception:  # noqa: BLE001 - cache release is best-effort
+                pass
+            return [self._embed_transformers([window], sr)[0] for window in windows]
+
+    def batches_windows(self):
+        """Whether decoded windows should be retained for one model batch."""
+        return self.mode == "transformers" and clap_batch_enabled(
+            self.mode, resolve_device()
+        )
+
+    def embed(self, y48, sr):
+        """Compatibility surface for callers that genuinely have one window."""
+        return self.embed_many([y48], sr)[0]
 
     def _resolve_text_model(self):
         """The CLAP text tower. In transformers mode it's the loaded ClapModel;
@@ -854,6 +910,8 @@ def embed_windows(embedder, path, librosa, duration_s):
     header-duration probe (0.0 = unknown → leading window only)."""
     import numpy as np
 
+    batch_windows = embedder.batches_windows()
+    windows = []
     vecs = []
     for offset in clap_window_offsets(duration_s, ANALYZE_SECONDS):
         try:
@@ -867,7 +925,17 @@ def embed_windows(embedder, path, librosa, duration_s):
             continue
         if offset > 0 and len(y48) < CLAP_SR * 5:
             continue  # truncated tail of a byte-capped download
-        vecs.append(np.asarray(embedder.embed(y48, CLAP_SR), dtype=np.float64))
+        if batch_windows:
+            windows.append(y48)
+        else:
+            # Preserve the CPU/ONNX one-window memory envelope: decode, embed,
+            # and release each window before moving to the next offset.
+            vecs.append(np.asarray(embedder.embed(y48, CLAP_SR), dtype=np.float64))
+    if batch_windows:
+        vecs = [
+            np.asarray(vec, dtype=np.float64)
+            for vec in embedder.embed_many(windows, CLAP_SR)
+        ]
     if not vecs:
         return None
     mean = np.mean(vecs, axis=0)
@@ -1551,7 +1619,10 @@ def measure_loudness(y, sr):
         return None, None
 
 
-def analyze(librosa, url=None, path=None, embed=None, vocal=None, complete=None, stems_dir=None):
+def analyze(
+    librosa, url=None, path=None, embed=None, vocal=None, complete=None,
+    stems_dir=None, embedding_only=False,
+):
     import numpy as np
 
     # A controller-provided path is pre-fetched onto the shared volume and
@@ -1583,11 +1654,6 @@ def analyze(librosa, url=None, path=None, embed=None, vocal=None, complete=None,
             log(f"duration probe failed ({e})")
             duration_s = 0.0
 
-        # Decode once WITH channels (a mono file still comes back 1-D): the
-        # loudness meter needs real stereo for a correct BS.1770 channel sum
-        # (issue #998); every other feature works off the mono downmix.
-        y_src, sr = load_audio(librosa, path, sr=ANALYZE_SR, mono=False, duration=ANALYZE_SECONDS)
-        y = librosa.to_mono(y_src)
         # CLAP wants 48 kHz mono — decode fresh copies at that rate from the
         # SAME file (still present here, before the finally removes owned
         # temps), windowed across the track (see embed_windows). A model/
@@ -1603,6 +1669,20 @@ def analyze(librosa, url=None, path=None, embed=None, vocal=None, complete=None,
             except Exception as e:  # noqa: BLE001 — embedding is best-effort
                 log(f"audio embedding failed: {e}")
                 audio_embedding = None
+        # A sounds-like backfill over an otherwise-current track needs only the
+        # CLAP vector. Returning here avoids re-running every CPU acoustic
+        # feature (and Demucs via an env default) merely to fill that one column.
+        if embedding_only:
+            return {"audio_embedding": audio_embedding} if audio_embedding is not None else {}
+        # Decode once WITH channels (a mono file still comes back 1-D): the
+        # loudness meter needs real stereo for a correct BS.1770 channel sum
+        # (issue #998); every other baseline feature works off the mono downmix.
+        # This deliberately follows the embedding-only return above: a CLAP
+        # backfill must not pay for the baseline window it will not consume.
+        y_src, sr = load_audio(
+            librosa, path, sr=ANALYZE_SR, mono=False, duration=ANALYZE_SECONDS
+        )
+        y = librosa.to_mono(y_src)
         # Outro (tail) features — only meaningful off a complete file; a
         # byte-capped download's "tail" is mid-song. Best-effort like the rest.
         # With an UNKNOWN completeness (old caller) the original path's
@@ -1916,6 +1996,7 @@ def main():
                     librosa, url=url, path=path,
                     embed=req.get("embed"), vocal=req.get("vocal"),
                     complete=req.get("complete"), stems_dir=req.get("stems_dir"),
+                    embedding_only=req.get("embedding_only") is True,
                 )
                 # If a getter stamped the clock, this request DID use a model —
                 # re-stamp so the countdown starts from the end of the work, not

--- a/controller/scripts/analyzer-python.test.ts
+++ b/controller/scripts/analyzer-python.test.ts
@@ -13,6 +13,7 @@ import { fileURLToPath } from 'node:url';
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 
 const SUITES = [
+  'analyzer_embedding_test.py', // batched CLAP + embedding-only backfills (#1426)
   'idle_release_test.py', // idle model release + heavy clock (#1099/#1204)
   'vocal_gate_test.py', // vocal-stem gate thresholds (#1125)
   'test_chatterbox_chunk.py', // chatterbox chunk_text (#1130)

--- a/controller/scripts/analyzer_embedding_test.py
+++ b/controller/scripts/analyzer_embedding_test.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Pure-stdlib regression tests for CLAP batching and embedding-only passes.
+
+The production worker imports numpy lazily.  This suite supplies the tiny
+vector surface these tests exercise so it stays runnable from a contributor's
+plain system Python, matching the other analyzer Python suites.
+"""
+
+import io
+import math
+import os
+import sys
+import types
+
+
+class Vector(list):
+    @property
+    def shape(self):
+        return (len(self),)
+
+    def __truediv__(self, value):
+        return Vector(x / value for x in self)
+
+
+fake_numpy = types.ModuleType("numpy")
+fake_numpy.float64 = float
+
+
+def fake_asarray(value, dtype=None):
+    return value if hasattr(value, "ndim") else Vector(value)
+
+
+fake_numpy.asarray = fake_asarray
+fake_numpy.mean = lambda rows, axis=0: Vector(
+    sum(row[i] for row in rows) / len(rows) for i in range(len(rows[0]))
+)
+fake_numpy.linalg = types.SimpleNamespace(
+    norm=lambda row: math.sqrt(sum(x * x for x in row))
+)
+sys.modules.setdefault("numpy", fake_numpy)
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import analyze_worker as aw  # noqa: E402
+
+
+failures = 0
+
+
+def test(name, fn):
+    global failures
+    try:
+        fn()
+        print(f"  ✓ {name}")
+    except Exception as err:  # noqa: BLE001 - a failed assert is a reported case
+        failures += 1
+        print(f"  ✗ {name}\n      {err}")
+
+
+class FakeLibrosa:
+    def __init__(self):
+        self.offsets = []
+
+    def load(self, _path, **kwargs):
+        self.offsets.append(kwargs.get("offset", 0.0))
+        class AudioWindow:
+            def __init__(self, marker):
+                self.marker = marker
+
+            def __len__(self):
+                return kwargs["sr"] * 40
+
+        return AudioWindow(kwargs.get("offset", 0.0) + 1.0), kwargs["sr"]
+
+    def get_duration(self, **_kwargs):
+        return 200.0
+
+
+def test_clap_windows_share_one_model_forward():
+    librosa = FakeLibrosa()
+
+    class Embedder:
+        def __init__(self):
+            self.calls = []
+
+        def batches_windows(self):
+            return True
+
+        def embed_many(self, windows, sr):
+            self.calls.append((windows, sr))
+            return [[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]
+
+    embedder = Embedder()
+    vector = aw.embed_windows(embedder, "/music/track.flac", librosa, 200.0)
+
+    assert len(embedder.calls) == 1, "three CLAP windows must use one batched model forward"
+    windows, sr = embedder.calls[0]
+    assert len(windows) == 3, windows
+    assert sr == aw.CLAP_SR, sr
+    assert librosa.offsets == [0.0, 80.0, 128.0], librosa.offsets
+    assert len(vector) == 2
+    assert abs(math.sqrt(sum(x * x for x in vector)) - 1.0) < 1e-9, vector
+
+
+def test_embedding_only_skips_baseline_acoustic_work():
+    original = (aw.ensure_fast_decode, aw.get_embedder, aw.embed_windows, aw.load_audio)
+    try:
+        aw.ensure_fast_decode = lambda path: (path, None)
+        aw.get_embedder = lambda force=False: object()
+        aw.embed_windows = lambda embedder, path, librosa, duration: [0.25, 0.75]
+
+        def baseline_decode(*_args, **_kwargs):
+            raise AssertionError("embedding-only analysis decoded the baseline acoustic window")
+
+        aw.load_audio = baseline_decode
+        result = aw.analyze(
+            FakeLibrosa(), path="/music/track.flac", embed=True, embedding_only=True
+        )
+    finally:
+        aw.ensure_fast_decode, aw.get_embedder, aw.embed_windows, aw.load_audio = original
+
+    assert result == {"audio_embedding": [0.25, 0.75]}, result
+
+
+def test_onnx_exports_keep_the_safe_sequential_fallback():
+    embedder = aw.ClapEmbedder()
+    embedder.mode = "onnx"
+    calls = []
+
+    def embed_one(window, sr):
+        calls.append((window, sr))
+        vector = Vector([0.0] * aw.CLAP_EMBED_DIM)
+        vector[0] = float(window)
+        return vector
+
+    embedder._embed_onnx = embed_one
+    vectors = embedder.embed_many([1.0, 2.0], aw.CLAP_SR)
+
+    assert calls == [(1.0, aw.CLAP_SR), (2.0, aw.CLAP_SR)], calls
+    assert len(vectors) == 2
+    assert vectors[0][0] == 1.0 and vectors[1][0] == 1.0, vectors
+
+
+def test_non_cuda_windows_decode_and_embed_one_at_a_time():
+    events = []
+
+    class Librosa(FakeLibrosa):
+        def load(self, path, **kwargs):
+            window, sr = super().load(path, **kwargs)
+            events.append(("decode", window.marker))
+            return window, sr
+
+    class Embedder:
+        def batches_windows(self):
+            return False
+
+        def embed(self, window, _sr):
+            events.append(("embed", window.marker))
+            return [1.0, 0.0]
+
+    aw.embed_windows(Embedder(), "/music/track.flac", Librosa(), 200.0)
+
+    assert events == [
+        ("decode", 1.0), ("embed", 1.0),
+        ("decode", 81.0), ("embed", 81.0),
+        ("decode", 129.0), ("embed", 129.0),
+    ], events
+
+
+def test_only_cuda_transformers_batches_windows():
+    decide = getattr(aw, "clap_batch_enabled", None)
+    assert callable(decide), "clap_batch_enabled must define the batching boundary"
+    assert decide("transformers", "cuda") is True
+    assert decide("transformers", "cpu") is False
+    assert decide("onnx", "cuda") is False
+
+
+def test_cuda_transformers_runs_one_processor_and_model_batch():
+    class Features:
+        def __init__(self, audio):
+            self.audio = audio
+            self.device = None
+
+        def to(self, device):
+            self.device = device
+            return self
+
+    class Rows:
+        ndim = 2
+
+        def __init__(self, count):
+            self.values = [Vector([1.0] + [0.0] * (aw.CLAP_EMBED_DIM - 1)) for _ in range(count)]
+            self.shape = (count, aw.CLAP_EMBED_DIM)
+
+        def __iter__(self):
+            return iter(self.values)
+
+    class Tensor:
+        def __init__(self, count):
+            self.rows = Rows(count)
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return self.rows
+
+    class Processor:
+        def __init__(self):
+            self.calls = []
+
+        def __call__(self, **kwargs):
+            self.calls.append(kwargs)
+            return {"input_features": Features(kwargs.get("audio") or kwargs["audios"])}
+
+    class Model:
+        def __init__(self):
+            self.calls = []
+
+        def get_audio_features(self, input_features):
+            self.calls.append(input_features)
+            return Tensor(len(input_features.audio))
+
+    class NoGrad:
+        def __enter__(self):
+            return None
+
+        def __exit__(self, *_args):
+            return False
+
+    fake_torch = types.ModuleType("torch")
+    fake_torch.no_grad = lambda: NoGrad()
+    original_torch = sys.modules.get("torch")
+    original_resolve = aw.resolve_device
+    try:
+        sys.modules["torch"] = fake_torch
+        aw.resolve_device = lambda: "cuda"
+        embedder = aw.ClapEmbedder()
+        embedder.mode = "transformers"
+        embedder.processor = Processor()
+        embedder.model = Model()
+        vectors = embedder.embed_many([[1.0], [2.0], [3.0]], aw.CLAP_SR)
+    finally:
+        aw.resolve_device = original_resolve
+        if original_torch is None:
+            sys.modules.pop("torch", None)
+        else:
+            sys.modules["torch"] = original_torch
+
+    assert len(embedder.processor.calls) == 1, embedder.processor.calls
+    assert len(embedder.model.calls) == 1, embedder.model.calls
+    assert embedder.model.calls[0].device == "cuda"
+    assert len(vectors) == 3
+
+
+def test_cuda_batch_failure_retries_windows_sequentially():
+    original_resolve = aw.resolve_device
+    original_stderr = sys.stderr
+    log_output = io.StringIO()
+    try:
+        aw.resolve_device = lambda: "cuda"
+        sys.stderr = log_output
+        embedder = aw.ClapEmbedder()
+        embedder.mode = "transformers"
+        calls = []
+
+        def run(windows, _sr):
+            calls.append(len(windows))
+            if len(windows) > 1:
+                raise RuntimeError("CUDA out of memory")
+            return [[1.0, 0.0]]
+
+        embedder._embed_transformers = run
+        vectors = embedder.embed_many([1.0, 2.0, 3.0], aw.CLAP_SR)
+    finally:
+        aw.resolve_device = original_resolve
+        sys.stderr = original_stderr
+
+    assert calls == [3, 1, 1, 1], calls
+    assert vectors == [[1.0, 0.0]] * 3, vectors
+    assert "retrying sequentially" in log_output.getvalue()
+
+
+print("analyzer embedding efficiency:")
+test("CLAP windows share one model forward", test_clap_windows_share_one_model_forward)
+test("embedding-only skips baseline acoustic work", test_embedding_only_skips_baseline_acoustic_work)
+test("ONNX exports retain sequential fallback", test_onnx_exports_keep_the_safe_sequential_fallback)
+test("non-CUDA windows decode and embed one at a time", test_non_cuda_windows_decode_and_embed_one_at_a_time)
+test("only CUDA transformers batch windows", test_only_cuda_transformers_batches_windows)
+test("CUDA transformers run one processor/model batch", test_cuda_transformers_runs_one_processor_and_model_batch)
+test("CUDA batch failure retries sequentially", test_cuda_batch_failure_retries_windows_sequentially)
+
+if failures:
+    print(f"✗ analyzer_embedding_test.py: {failures} failure(s)")
+    sys.exit(1)
+print("✓ analyzer_embedding_test.py passed")

--- a/controller/src/music/analyze-capability.ts
+++ b/controller/src/music/analyze-capability.ts
@@ -117,6 +117,18 @@ export function backfillDecision(x: CapabilityInputs): CapabilityDecision {
   };
 }
 
+// Tracks pulled in only because their CLAP vector is missing do not need the
+// baseline acoustic pass repeated. Any baseline/vocal/stem scope membership
+// keeps the full path; audioBackfill is explicit so ordinary analysis never
+// becomes embedding-only by accident.
+export function analysisModeForTrack(
+  id: string,
+  fullAnalysisIds: ReadonlySet<string>,
+  audioBackfill: boolean,
+): 'full' | 'embedding-only' {
+  return audioBackfill && !fullAnalysisIds.has(id) ? 'embedding-only' : 'full';
+}
+
 // How many tracks in a row may fail before the pass stops treating a throw as
 // evidence about the FILE. Five: a run of five consecutive failures is not five
 // bad files landing next to each other in id order, it is the thing they share

--- a/controller/src/music/analyze.ts
+++ b/controller/src/music/analyze.ts
@@ -21,7 +21,12 @@ import { runAudioMoodPass } from './audio-moods.js';
 import { runPropagatedEnergyPass } from './propagated-energy.js';
 import { reportProgress, makeEventLogger } from './tagger-progress.js';
 import { quietGateDecision, type QuietState } from './analyze-quiet-pure.js';
-import { backfillDecision, failureCountsAgainstTrack, SYSTEMIC_FAILURE_RUN } from './analyze-capability.js';
+import {
+  analysisModeForTrack,
+  backfillDecision,
+  failureCountsAgainstTrack,
+  SYSTEMIC_FAILURE_RUN,
+} from './analyze-capability.js';
 import { probeListenerCount } from '../broadcast/listeners.js';
 
 // Structured status events for the panel, mirrored to the terse `[analyze] …`
@@ -286,8 +291,8 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
 
   // Audio backfill: also target already-analysed tracks lacking a CLAP vector,
   // so enabling embeddings on an analysed library fills in without a full
-  // --re-analyze. Re-running recomputes bpm/key (same values, harmless) and
-  // stores the vector from the same call.
+  // --re-analyze. Tracks selected only by this widening skip the already-current
+  // baseline features and ask the worker for their CLAP vector alone.
   //
   // Two gates, both narrow. NOT under a fixed re-scan scope: that already covers
   // the previously-analysed set and re-embeds via embed:true, so widening would
@@ -421,6 +426,14 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     logEvent(analyzer.vocalActivityError() ? 'warning' : 'info', stemDecision.notice);
   }
 
+  // Only ids pulled in solely by the CLAP widening may take the fast path. A
+  // baseline/re-analysis id needs every acoustic feature. Vocal and stem work
+  // currently applies to every id in its pass, so those runs stay full too.
+  const fullAnalysisIds = new Set(bpmIds);
+  if (vocalBackfill || stemCache) {
+    for (const id of ids) fullAnalysisIds.add(id);
+  }
+
   // Say how many tracks the scope is deliberately leaving out. Silence here is
   // what made the old behaviour so confusing in reverse: "all tracks current"
   // is true of a library with 90 files that can never be analysed, and reads as
@@ -516,6 +529,7 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
     // doesn't keep pulling audio for a queue it isn't going to compute yet.
     await waitForQuiet(quietGate, { done: i, total: ids.length });
     const id = ids[i];
+    const embeddingOnly = analysisModeForTrack(id, fullAnalysisIds, audioBackfill) === 'embedding-only';
     const downloadPromise = inflight;
     // Kick off the NEXT download before awaiting this one's analysis so the
     // fetch overlaps the compute.
@@ -589,76 +603,89 @@ export async function runAnalysisPass(opts: AnalyzeOptions = {}): Promise<Analyz
       // Lyrics still override the stored ranges below either way.
       const vocal = vocalBackfill ? (lyricVocal && !stems_dir ? false : true) : undefined;
       const a = localPath
-        ? await analyzer.analyzePath(localPath, { embed, vocal, complete: localComplete, stems_dir })
-        : await analyzer.analyze(id, { embed, vocal, stems_dir });
-      // Lyrics win over the worker's vocal output when present: the ranges are
-      // ground truth, and a synced onset is a truer intro than the energy
-      // heuristic the worker returns once Demucs is skipped. An instrumental
-      // marker (introMs null) keeps the energy-based intro.
-      const vocalRanges = lyricVocal ? lyricVocal.vocalRanges : a.vocalRanges;
-      // Tail ranges for lyric-decided tracks (feature: vocal-aware
-      // transitions): vocal:false above skips the worker's tail Demucs pass,
-      // so a.outro comes back with NO vocalRanges — and without a fill here
-      // the sung tracks the feature exists for never get tail data
-      // (mix.vocalTailFor stays null) while the tail-widened backfill
-      // re-targets them on every pass, forever — the same churn class as the
-      // "275/7093" report. Lyrics are tail ground truth exactly as they are
-      // for the head: clip the whole-track ranges into the outro window
-      // (20s mirrors the worker's ANALYZE_OUTRO_SECONDS default; the
-      // wind-down start bounds it when the tagged duration is unknown).
-      // Lyric-decided ⇒ override, matching vocalRanges above — a
-      // stems-forced Demucs tail is still trumped by synced timing.
-      let outro = a.outro;
-      if (lyricVocal && outro) {
-        const durMs = (Number(db.getTrack(id)?.durationSec) || 0) * 1000;
-        const windowStartMs = durMs > 0 ? Math.min(outro.startMs, durMs - 20_000) : outro.startMs;
-        outro = {
-          ...outro,
-          vocalRanges: clipRangesToTail(lyricVocal.vocalRanges, windowStartMs, durMs > 0 ? durMs : null),
-        };
-      }
-      db.upsertTrackAnalysis(id, {
-        bpm: a.bpm,
-        musicalKey: a.musicalKey,
-        introMs: lyricVocal?.introMs != null ? lyricVocal.introMs : a.introMs,
-        confidence: a.confidence,
-        loudnessLufs: a.loudnessLufs,
-        peakDb: a.peakDb,
-        sections: a.sections,
-        pace: a.paceCurve,
-        beats: a.beats,
-        bars: a.bars,
-        keyRanges: a.keyRanges,
-        vocalRanges,
-        outro,
-        // Stamp the stem attempt whenever the worker actually reached the
-        // stem-writing step — true (written) OR false (the write failed for
-        // this track). Both are settled outcomes, and stamping the miss is
-        // what stops a track that can never produce stems from being
-        // re-targeted on every pass forever. null means the worker never got
-        // that far (no stems_dir requested, or no Demucs), so the track stays
-        // in scope for a later, better-equipped pass.
-        stemsAttempted: a.stemsCached !== null,
-      });
-      if (vocalRanges != null) vocalAnalyzed += 1;
-      // Stuck-case telemetry (vocal-aware transitions): a vocal pass that
-      // produced head ranges but NO outro (incomplete download — the file
-      // grew past ANALYZE_MAX_BYTES since its outro was stored) can't write
-      // tail vocal data, and the upsert's COALESCE keeps the old tail-missing
-      // outro — so the widened backfill will re-target this track every pass.
-      // Say so instead of churning silently. Lyric-decided tracks hit the
-      // same wall (no outro → nothing for the lyric fill above to clip into);
-      // otherwise keyed off the WORKER's ranges, not the lyric-resolved ones:
-      // it's the Demucs tail pass that's stuck.
-      if (a.outro == null && (lyricVocal != null || (vocal && a.vocalRanges != null))) {
-        const prior = db.getTrack(id);
-        if (prior?.outro && prior.outro.vocalRanges == null) {
-          console.log(`[analyze] ${id}: tail vocals not computable (incomplete download; stored outro predates tail detection) — stays in the vocal backfill scope`);
+        ? await analyzer.analyzePath(localPath, {
+            embed,
+            vocal,
+            complete: localComplete,
+            stems_dir,
+            embedding_only: embeddingOnly || undefined,
+          })
+        : await analyzer.analyze(id, {
+            embed,
+            vocal,
+            stems_dir,
+            embedding_only: embeddingOnly || undefined,
+          });
+      if (!embeddingOnly) {
+        // Lyrics win over the worker's vocal output when present: the ranges are
+        // ground truth, and a synced onset is a truer intro than the energy
+        // heuristic the worker returns once Demucs is skipped. An instrumental
+        // marker (introMs null) keeps the energy-based intro.
+        const vocalRanges = lyricVocal ? lyricVocal.vocalRanges : a.vocalRanges;
+        // Tail ranges for lyric-decided tracks (feature: vocal-aware
+        // transitions): vocal:false above skips the worker's tail Demucs pass,
+        // so a.outro comes back with NO vocalRanges — and without a fill here
+        // the sung tracks the feature exists for never get tail data
+        // (mix.vocalTailFor stays null) while the tail-widened backfill
+        // re-targets them on every pass, forever — the same churn class as the
+        // "275/7093" report. Lyrics are tail ground truth exactly as they are
+        // for the head: clip the whole-track ranges into the outro window
+        // (20s mirrors the worker's ANALYZE_OUTRO_SECONDS default; the
+        // wind-down start bounds it when the tagged duration is unknown).
+        // Lyric-decided ⇒ override, matching vocalRanges above — a
+        // stems-forced Demucs tail is still trumped by synced timing.
+        let outro = a.outro;
+        if (lyricVocal && outro) {
+          const durMs = (Number(db.getTrack(id)?.durationSec) || 0) * 1000;
+          const windowStartMs = durMs > 0 ? Math.min(outro.startMs, durMs - 20_000) : outro.startMs;
+          outro = {
+            ...outro,
+            vocalRanges: clipRangesToTail(lyricVocal.vocalRanges, windowStartMs, durMs > 0 ? durMs : null),
+          };
+        }
+        db.upsertTrackAnalysis(id, {
+          bpm: a.bpm,
+          musicalKey: a.musicalKey,
+          introMs: lyricVocal?.introMs != null ? lyricVocal.introMs : a.introMs,
+          confidence: a.confidence,
+          loudnessLufs: a.loudnessLufs,
+          peakDb: a.peakDb,
+          sections: a.sections,
+          pace: a.paceCurve,
+          beats: a.beats,
+          bars: a.bars,
+          keyRanges: a.keyRanges,
+          vocalRanges,
+          outro,
+          // Stamp the stem attempt whenever the worker actually reached the
+          // stem-writing step — true (written) OR false (the write failed for
+          // this track). Both are settled outcomes, and stamping the miss is
+          // what stops a track that can never produce stems from being
+          // re-targeted on every pass forever. null means the worker never got
+          // that far (no stems_dir requested, or no Demucs), so the track stays
+          // in scope for a later, better-equipped pass.
+          stemsAttempted: a.stemsCached !== null,
+        });
+        if (vocalRanges != null) vocalAnalyzed += 1;
+        // Stuck-case telemetry (vocal-aware transitions): a vocal pass that
+        // produced head ranges but NO outro (incomplete download — the file
+        // grew past ANALYZE_MAX_BYTES since its outro was stored) can't write
+        // tail vocal data, and the upsert's COALESCE keeps the old tail-missing
+        // outro — so the widened backfill will re-target this track every pass.
+        // Say so instead of churning silently. Lyric-decided tracks hit the
+        // same wall (no outro → nothing for the lyric fill above to clip into);
+        // otherwise keyed off the WORKER's ranges, not the lyric-resolved ones:
+        // it's the Demucs tail pass that's stuck.
+        if (a.outro == null && (lyricVocal != null || (vocal && a.vocalRanges != null))) {
+          const prior = db.getTrack(id);
+          if (prior?.outro && prior.outro.vocalRanges == null) {
+            console.log(`[analyze] ${id}: tail vocals not computable (incomplete download; stored outro predates tail detection) — stays in the vocal backfill scope`);
+          }
         }
       }
       // Opportunistically store the CLAP audio vector whenever the backend
-      // carried one. Independent of the bpm/key write above: a track analysed
-      // before CLAP was enabled simply gets its vector on the next pass once
+      // carried one. Independent of the baseline write above: a track analysed
+      // before CLAP was enabled can take the embedding-only path once
       // unanalysedAudioIds re-targets it. The first vector written stamps the
       // audio-embedding provenance row.
       if (a.audioEmbedding && a.audioEmbedding.length === db.AUDIO_EMBEDDING_DIM) {

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -414,6 +414,9 @@ export interface AnalyzeRequestOpts {
   // worker persists its Demucs stems (head + tail) as FLAC into this dir on
   // the shared volume; implies the separation even without `vocal`.
   stems_dir?: string;
+  // The track's baseline analysis is already current; compute only its CLAP
+  // vector. Wire-named because both backends receive the options verbatim.
+  embedding_only?: boolean;
 }
 
 // Write a request to the local stdio worker and resolve its response. The

--- a/docker/analyzer/server.py
+++ b/docker/analyzer/server.py
@@ -441,6 +441,9 @@ class AnalyzeRequest(BaseModel):
     # persists the Demucs stems it already computes as FLAC into this dir —
     # implies the separation pass even when `vocal` wasn't requested.
     stems_dir: str | None = None
+    # CLAP backfill for a track whose baseline analysis is already current.
+    # Skips every non-embedding feature in the worker.
+    embedding_only: bool = False
 
 
 @app.post("/analyze")
@@ -459,6 +462,8 @@ async def analyze(req: AnalyzeRequest):
         payload["complete"] = req.complete
     if req.stems_dir is not None:
         payload["stems_dir"] = req.stems_dir
+    if req.embedding_only:
+        payload["embedding_only"] = True
     msg = await analyzer_worker.request(payload)
     if not msg.get("ok"):
         raise HTTPException(500, msg.get("error") or "analyze failed")

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -143,7 +143,12 @@ depends on your install, and the admin panel names the right one for yours:
 ### Heavy analysis on an NVIDIA GPU (CUDA)
 
 On a host with an NVIDIA card, the heavy stack can run CLAP + Demucs on the GPU
-instead of pinning your CPU cores — a big speed-up on deep library ingestion.
+— a big speed-up on deep library ingestion. Audio decode/resampling and the
+baseline bpm/key/loudness/structure pass remain CPU work; CUDA accelerates the
+model stages rather than replacing the whole analyzer. A sounds-like backfill
+over tracks whose baseline analysis is already current skips those baseline
+features, and batches each track's CLAP windows into one CUDA model call.
+
 It's a compose overlay, not an `.env` toggle (a GPU device reservation can't be
 switched from `.env`):
 

--- a/web/components/manual/AcousticAnalysis.tsx
+++ b/web/components/manual/AcousticAnalysis.tsx
@@ -146,8 +146,11 @@ ANALYZER_HEAVY=1`}</CodeBlock>
         <p className="bs-eyebrow">ON AN NVIDIA GPU</p>
         <h2>The CUDA flavour — same features, much faster.</h2>
         <p>
-          Hosts with an NVIDIA card can run the heavy stack on the GPU instead of pinning
-          CPU cores, a big speed-up on deep library ingestion. It&rsquo;s a compose{' '}
+          Hosts with an NVIDIA card can run CLAP and Demucs on the GPU, a big speed-up on
+          deep library ingestion. Decode, resampling, and the baseline acoustic features
+          still use the CPU; CUDA accelerates the model stages rather than replacing the
+          whole analyzer. Sounds-like backfills skip already-current baseline features and
+          batch each track&rsquo;s CLAP windows into one CUDA model call. It&rsquo;s a compose{' '}
           <em>overlay</em>, not an <code className="bs-code-inline">.env</code> toggle (a
           GPU reservation can&rsquo;t be switched from <code className="bs-code-inline">.env</code>):
         </p>

--- a/web/content/news/2026-07-21-analyzer-on-the-gpu.md
+++ b/web/content/news/2026-07-21-analyzer-on-the-gpu.md
@@ -30,6 +30,6 @@ Open the [Library page](/news/your-dj-knows-your-library) in admin. Next to the 
 
 ## Why it helps
 
-A big collection gets its fingerprints without a week of pegged cores, and the scan never steals cycles from the broadcast. Turn on quiet times, kick off a full rescan, and the station does the homework in its own gaps. It is the same trade [Chatterbox made a month ago](/news/chatterbox-on-the-gpu), this time for the analysis side.
+A big collection gets its model-heavy fingerprint and vocal work off the CPU. Decode and the baseline acoustic measurements still use CPU time, so quiet times remains the way to keep a full rescan from competing with the broadcast. Sounds-like-only backfills skip those already-current baseline measurements and feed each track's windows to CUDA together. It is the same trade [Chatterbox made a month ago](/news/chatterbox-on-the-gpu), this time for the analysis side.
 
 *Update: running the all-in-one image instead of the compose stack? It got [the same CUDA path](/news/one-click-on-the-gpu) a few days later.*


### PR DESCRIPTION
## What

- Add an embedding-only worker path for already-analysed tracks missing only their CLAP sounds-like vector.
- Batch each track start/middle/late CLAP windows into one CUDA transformers forward, while keeping CPU and ONNX sequential and falling back to sequential CUDA inference if the batch fails.
- Keep new, stale, re-analysis, vocal, and stem work on the full acoustic path, and clarify the CPU/GPU split in the operator docs.

## Why

The CUDA analyzer was selected correctly, but a sounds-like backfill still repeated CPU baseline analysis and ran each CLAP window as a separate model call. That saturated the CPU and left long idle gaps between short GPU bursts.

Closes #1426

## How tested

- `cd controller && npm run lint`
- `cd web && npm run lint`
- `cd mcp-subwave && npm run lint`
- `cd controller && npm run gen:themes` plus generated-mirror diff check
- `cd controller && npm run gen:schemas` plus generated-mirror diff check
- `cd controller && npm test -- analyze-mode`
- `cd controller && PATH=<venv-with-numpy> npm test -- analyzer-python`
- Python bytecode compilation for the worker, regression suite, and sidecar server
- Full controller suite: 728 passed; 7 existing `voice-air-events.test.ts` cases were cancelled because their pending promise outlives the unref timer. The focused file reproduces the same 8 passed / 7 cancelled result and this PR does not touch that path.

## Notes for reviewers

No NVIDIA GPU is available in this checkout. The regression suite exercises the CUDA processor/model batch boundary with a fake tensor surface, verifies one processor/model call for three windows, and verifies the sequential fallback after a simulated CUDA OOM.