### PR TITLE
fix(tts): use native CJK phonemizers for Kokoro

### DIFF
--- a/controller/scripts/kokoro-g2p.test.ts
+++ b/controller/scripts/kokoro-g2p.test.ts
@@ -1,0 +1,52 @@
+// Regression coverage for native CJK Kokoro speech (#1437).
+//
+// The worker used to feed every advertised language through EspeakG2P. That
+// can map kana, but it cannot resolve context-dependent kanji readings and
+// falls back to spoken character descriptions. The dispatch itself is pure;
+// exercise it with tiny constructor doubles so this contributor test needs no
+// Kokoro model or Python TTS environment. Docker build smoke checks exercise
+// the real Misaki Japanese and Chinese implementations.
+
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const worker = fileURLToPath(new URL('./kokoro_worker.py', import.meta.url));
+const probe = String.raw`
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("kokoro_worker", sys.argv[1])
+worker = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(worker)
+
+class Espeak:
+    class EspeakG2P:
+        def __init__(self, language):
+            self.kind = f"espeak:{language}"
+
+class Japanese:
+    class JAG2P:
+        def __init__(self, version):
+            assert version == "pyopenjtalk"
+            self.kind = "japanese"
+
+        def __call__(self, text):
+            return "kanajjjj", []
+
+class Chinese:
+    class ZHG2P:
+        def __init__(self):
+            self.kind = "chinese"
+
+japanese = worker.build_g2p("ja", Espeak, Japanese, Chinese)
+phonemes, _ = japanese("仮名")
+assert phonemes == "kana"
+assert worker.build_g2p("cmn", Espeak, Japanese, Chinese).kind == "chinese"
+assert worker.build_g2p("en-gb", Espeak, Japanese, Chinese).kind == "espeak:en-gb"
+`;
+
+const out = spawnSync('python3', ['-c', probe, worker], { encoding: 'utf8' });
+assert.equal(out.status, 0, out.stderr || out.stdout);
+
+console.log('kokoro-g2p: native CJK dispatch passed');

--- a/controller/scripts/kokoro_worker.py
+++ b/controller/scripts/kokoro_worker.py
@@ -39,12 +39,42 @@ def log(msg):
     sys.stderr.flush()
 
 
+class JapaneseG2P:
+    """Adapt Misaki's phoneme+pitch output for kokoro-onnx v1.0."""
+
+    def __init__(self, frontend):
+        self.frontend = frontend
+
+    def __call__(self, text):
+        annotated, tokens = self.frontend(text)
+        if len(annotated) % 2:
+            raise ValueError("Japanese G2P returned mismatched phoneme and pitch lengths")
+        return annotated[: len(annotated) // 2], tokens
+
+
+def build_g2p(lang, espeak, japanese, chinese):
+    """Build the phonemizer that actually understands ``lang``.
+
+    espeak-ng can pronounce kana but has no morphological dictionary for
+    context-dependent kanji readings; for those codepoints it falls back to
+    spoken character descriptions. Misaki's native frontends carry the
+    language-specific segmentation and dictionaries Kokoro expects.
+    """
+    if lang == "ja":
+        # pyopenjtalk-plus ships the Open JTalk dictionary inside amd64 and
+        # arm64 wheels, so kanji works offline without a first-use download.
+        return JapaneseG2P(japanese.JAG2P(version="pyopenjtalk"))
+    if lang == "cmn":
+        return chinese.ZHG2P()
+    return espeak.EspeakG2P(language=lang)
+
+
 def main():
     try:
         from kokoro_onnx import Kokoro
         import soundfile as sf
         import misaki
-        from misaki import espeak
+        from misaki import espeak, ja, zh
     except Exception as e:
         emit({"id": None, "ok": False, "fatal": True, "error": f"import failed: {e}"})
         sys.exit(1)
@@ -96,7 +126,7 @@ def main():
             lang = lang_mapping.get(voice_code[0], "en-gb")  # british english fallback
         g2p = g2p_cache.get(lang)
         if g2p is None:
-            g2p = espeak.EspeakG2P(language=lang)
+            g2p = build_g2p(lang, espeak, ja, zh)
             g2p_cache[lang] = g2p
         return g2p
 

--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -91,13 +91,18 @@ RUN mkdir -p /opt/piper/voices && \
 # this base (Debian trixie) ships 3.13 — so provision a standalone CPython 3.12
 # via uv for THIS venv only (the analyzer venv stays on system python3). The
 # import check mirrors the worker's import block so a broken combo fails the
-# build instead of silently falling back to Piper at runtime.
+# build instead of silently falling back to Piper at runtime. pyopenjtalk-plus
+# provides Python 3.12 wheels for amd64 and arm64 with its dictionary bundled,
+# so Japanese synthesis needs neither a compiler nor a first-use download.
 COPY --from=ghcr.io/astral-sh/uv:0.11.27 /uv /usr/local/bin/uv
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python
 RUN uv venv --python 3.12 /opt/kokoro/venv && \
     uv pip install --python /opt/kokoro/venv/bin/python --no-cache \
-      kokoro-onnx==0.5.0 soundfile==0.12.1 misaki==0.9.4 && \
-    /opt/kokoro/venv/bin/python -c "import kokoro_onnx, misaki; from misaki import espeak"
+      kokoro-onnx==0.5.0 soundfile==0.12.1 misaki==0.9.4 \
+      pyopenjtalk-plus==0.4.1.post8 \
+      cn2an==0.5.24 jieba==0.42.1 ordered-set==4.1.0 pypinyin==0.55.0 pypinyin-dict==0.9.0 && \
+    /opt/kokoro/venv/bin/python -c \
+      "import kokoro_onnx, misaki; from misaki import espeak; from misaki.ja import JAG2P; from misaki.zh import ZHG2P; assert JAG2P(version='pyopenjtalk')('生ビール')[0]; assert ZHG2P()('中文')[0]"
 RUN mkdir -p /opt/kokoro/models && \
     wget -q ${WGET_RETRY} -O /opt/kokoro/models/kokoro-v1.0.onnx \
       https://github.com/thewh1teagle/kokoro-onnx/releases/download/model-files-v1.0/kokoro-v1.0.onnx && \
@@ -165,6 +170,8 @@ COPY controller/package*.json controller/.npmrc ./
 RUN npm ci --omit=dev
 COPY controller/src ./src
 COPY controller/scripts ./scripts
+RUN /opt/kokoro/venv/bin/python -c \
+      "from scripts.kokoro_worker import build_g2p; from misaki import espeak, ja, zh; raw, _ = ja.JAG2P(version='pyopenjtalk')('生ビール'); phonemes, _ = build_g2p('ja', espeak, ja, zh)('生ビール'); assert phonemes == raw[:len(raw) // 2]"
 
 # --- Web app (standalone build from the webbuild stage) ---------------------
 # Mirrors web/Dockerfile's runner layout, rooted at /web instead of /app.

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -36,11 +36,17 @@ RUN mkdir -p /opt/piper/voices && \
 
 # --- Kokoro (optional second TTS — slower, more natural) --------------------
 # Isolated venv; the worker loads the model once and stays resident
-# (controller/scripts/kokoro_worker.py).
+# (controller/scripts/kokoro_worker.py). pyopenjtalk-plus provides CPython 3.11
+# wheels for amd64 and arm64 with its dictionary bundled, so Japanese synthesis
+# needs neither a compiler nor a first-use download.
 RUN python3 -m venv /opt/kokoro/venv && \
     /opt/kokoro/venv/bin/pip install --no-cache-dir --upgrade pip && \
     /opt/kokoro/venv/bin/pip install --no-cache-dir \
-      kokoro-onnx==0.5.0 soundfile==0.12.1 misaki==0.9.4
+      kokoro-onnx==0.5.0 soundfile==0.12.1 misaki==0.9.4 \
+      pyopenjtalk-plus==0.4.1.post8 \
+      cn2an==0.5.24 jieba==0.42.1 ordered-set==4.1.0 pypinyin==0.55.0 pypinyin-dict==0.9.0 && \
+    /opt/kokoro/venv/bin/python -c \
+      "from misaki.ja import JAG2P; from misaki.zh import ZHG2P; assert JAG2P(version='pyopenjtalk')('生ビール')[0]; assert ZHG2P()('中文')[0]"
 
 RUN mkdir -p /opt/kokoro/models && \
     wget -q ${WGET_RETRY} -O /opt/kokoro/models/kokoro-v1.0.onnx \
@@ -136,6 +142,8 @@ COPY controller/package*.json controller/.npmrc ./
 RUN npm ci --omit=dev
 COPY controller/src ./src
 COPY controller/scripts ./scripts
+RUN /opt/kokoro/venv/bin/python -c \
+      "from scripts.kokoro_worker import build_g2p; from misaki import espeak, ja, zh; raw, _ = ja.JAG2P(version='pyopenjtalk')('生ビール'); phonemes, _ = build_g2p('ja', espeak, ja, zh)('生ビール'); assert phonemes == raw[:len(raw) // 2]"
 
 # Version reported by the controller (backup manifest). Set from `git describe`
 # by scripts/update.sh + CI; unset → controller/package.json (routes/backup.ts).


### PR DESCRIPTION
## Summary

- route Kokoro Japanese through Misaki JAG2P/Open JTalk and Mandarin through ZHG2P
- strip Misaki's paired pitch annotations before kokoro-onnx tokenization
- package offline, multi-architecture phonemizer dependencies in controller and AIO images
- add CJK dispatch/adapter regression coverage and image smoke checks

## Verification

- `npm test -- kokoro-g2p`
- `npm test -- kokoro-lang`
- `npm run lint` (0 errors; 652 existing warnings)
- amd64 and arm64 controller image builds
- amd64 and arm64 AIO image builds
- real Japanese and Mandarin worker synthesis on amd64 and emulated arm64
- final combined tree with #1455: focused suites and lint/typecheck green
- final combined controller suite: 731 passed, 0 failed, 7 pre-existing `voice-air-events` cancellations caused by pending promises
- isolated controller/broadcast stack: both services healthy, valid 192 kbps MP3 output
- GitHub controller, web, and MCP lint checks green

Fixes #1437
