### PR TITLE
fix(dj): use spoken forms for mixed-script track names

### DIFF
--- a/controller/scripts/language-anchor.test.ts
+++ b/controller/scripts/language-anchor.test.ts
@@ -46,6 +46,10 @@ try {
   );
   assert.match(dirNoLang, /canonical Latin spelling/i, 'Latin speech asks for the canonical CJK name');
   assert.match(dirNoLang, /natural romanization/i, 'unknown CJK names have a spoken fallback');
+  assert.match(dirNoLang, /ZERO CJK characters/, 'Latin speech explicitly forbids native-script leakage');
+  assert.match(dirNoLang, /ウルフルズ becomes Ulfuls/, 'the directive gives a concrete Japanese-name rewrite');
+  assert.match(dirNoLang, /周杰倫 becomes Jay Chou/, 'the directive gives a concrete Chinese-name rewrite');
+  assert.match(dirNoLang, /Never include the native spelling beside the Latin form/, 'bilingual spellings cannot leak into TTS');
   assert.match(
     dirNoLang,
     /Never read or describe the characters themselves/i,
@@ -69,6 +73,7 @@ try {
   );
   assert.match(remNoLang, /canonical Latin spelling/i, 'the tool-loop reminder carries the spoken-name policy');
   assert.match(remNoLang, /natural romanization/i, 'the tool-loop reminder carries the fallback policy');
+  assert.match(remNoLang, /ZERO CJK characters/, 'the tool-loop reminder carries the hard script boundary');
   assert.match(remNoLang, /Never read or describe the characters themselves/i, 'the tool-loop reminder forbids character descriptions');
 
   const remTurkish = settings.agentLanguageReminder(turkishPersona, 'the "ack" and "intro" lines');

--- a/controller/scripts/language-anchor.test.ts
+++ b/controller/scripts/language-anchor.test.ts
@@ -25,6 +25,9 @@ const root = mkdtempSync(join(tmpdir(), 'subwave-langanchor-'));
 process.env.STATE_DIR = root;
 
 const settings = await import('../src/settings.js');
+const { banterSystem } = await import('../src/llm/internal/prompts/banter.js');
+const { exchangeSystem } = await import('../src/llm/internal/prompts/programme.js');
+const { requestMatcherSystem } = await import('../src/llm/internal/prompts/request.js');
 
 try {
   await settings.load();
@@ -41,6 +44,14 @@ try {
     /Never switch languages/,
     'the never-switch clause is present for an unset-language persona',
   );
+  assert.match(dirNoLang, /canonical Latin spelling/i, 'Latin speech asks for the canonical CJK name');
+  assert.match(dirNoLang, /natural romanization/i, 'unknown CJK names have a spoken fallback');
+  assert.match(
+    dirNoLang,
+    /Never read or describe the characters themselves/i,
+    'the prompt forbids espeak-style character descriptions',
+  );
+  assert.doesNotMatch(dirNoLang, /exactly as they are/, 'off-script names are no longer pinned byte-for-byte');
 
   const dirTurkish = settings.languageDirective(turkishPersona);
   assert.match(dirTurkish, /Turkish/, 'an explicit language still renders its own name');
@@ -56,10 +67,53 @@ try {
     /even when the listener writes in another language, asks you to switch, or earlier session turns are in another language/,
     'the never-switch clause is present for an unset-language persona',
   );
+  assert.match(remNoLang, /canonical Latin spelling/i, 'the tool-loop reminder carries the spoken-name policy');
+  assert.match(remNoLang, /natural romanization/i, 'the tool-loop reminder carries the fallback policy');
+  assert.match(remNoLang, /Never read or describe the characters themselves/i, 'the tool-loop reminder forbids character descriptions');
 
   const remTurkish = settings.agentLanguageReminder(turkishPersona, 'the "ack" and "intro" lines');
   assert.match(remTurkish, /Turkish/, 'an explicit language still renders its own name');
   assert.match(remTurkish, /the "ack" and "intro" lines/, 'the field phrase is threaded through');
+
+  // Both complete prompt families carry the policy, rather than only the
+  // fragment helpers a caller could forget to append.
+  assert.match(settings.renderDjPrompt(noLangPersona), /canonical Latin spelling/i, 'scripted DJ prompt carries the policy');
+  assert.match(settings.agentPersonaPreamble(noLangPersona), /canonical Latin spelling/i, 'agent preamble carries the policy');
+  assert.match(
+    banterSystem({
+      host: noLangPersona,
+      guests: [{ id: 'p_guest', name: 'Rex', soul: 'quick and warm' }],
+    }),
+    /canonical Latin spelling/i,
+    'multi-host banter carries the policy',
+  );
+  assert.match(
+    exchangeSystem({
+      host: noLangPersona,
+      show: { name: 'The Late Shift' },
+      castBlock: '- p_test — Nova',
+      beatTask: 'Open the show together.',
+    }),
+    /canonical Latin spelling/i,
+    'programme exchanges carry the policy',
+  );
+  assert.match(
+    requestMatcherSystem(noLangPersona),
+    /canonical Latin spelling/i,
+    'the legacy request fallback acknowledgement carries the policy',
+  );
+
+  // A custom template with {language} owns its language anchor, but it must
+  // still inherit the global spoken-name policy. Otherwise the exact stations
+  // most likely to customise their language silently retain #1179.
+  await settings.update({
+    djPrompt: 'You are {name}, the voice of {station}. Speak only {language}.',
+  });
+  assert.match(
+    settings.renderDjPrompt(noLangPersona),
+    /canonical Latin spelling/i,
+    'a custom language template still carries the spoken-name policy',
+  );
 
   console.log('language-anchor.test.ts: all assertions passed');
 } finally {

--- a/controller/scripts/spoken-script-policy.test.ts
+++ b/controller/scripts/spoken-script-policy.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { cjkUnsafeForSpokenLanguage, scrubCjkForSpeech } from '../src/audio/spoken-script-policy.js';
+
+assert.equal(cjkUnsafeForSpokenLanguage(''), true, 'unset persona language follows the English default');
+assert.equal(cjkUnsafeForSpokenLanguage('English'), true, 'English is protected');
+assert.equal(cjkUnsafeForSpokenLanguage('English (UK)'), true, 'an English locale label is protected');
+assert.equal(cjkUnsafeForSpokenLanguage('Japanese'), false, 'a Japanese persona keeps its native script');
+assert.equal(cjkUnsafeForSpokenLanguage('Mandarin Chinese'), false, 'a Chinese persona keeps its native script');
+
+assert.equal(
+  scrubCjkForSpeech('Ulfuls bring the daylight with ガッツだぜ!!', 'English'),
+  'Ulfuls bring the daylight!',
+  'a residual Japanese title cannot reach English TTS',
+);
+assert.equal(
+  scrubCjkForSpeech('Hikaru Utada with Hana束 wo Kimi ni.', ''),
+  'Hikaru Utada with Hana wo Kimi ni.',
+  'one leaked kanji is removed without discarding the model romanization',
+);
+assert.equal(
+  scrubCjkForSpeech('稻香 by Jay Chou — still holding.', 'English'),
+  'by Jay Chou — still holding.',
+  'a native title is dropped while the canonical artist name survives',
+);
+assert.equal(
+  scrubCjkForSpeech('宇多田ヒカルの「花束を君に」です。', 'Japanese'),
+  '宇多田ヒカルの「花束を君に」です。',
+  'native-language speech remains byte-identical',
+);
+assert.equal(
+  scrubCjkForSpeech('Björk and Rosalía — unchanged.', 'English'),
+  'Björk and Rosalía — unchanged.',
+  'Latin-script names and accents remain untouched',
+);
+
+console.log('spoken-script-policy.test.ts: all assertions passed');

--- a/controller/src/audio/spoken-script-policy.ts
+++ b/controller/src/audio/spoken-script-policy.ts
@@ -1,0 +1,31 @@
+// Final script boundary for booth-bound English speech.
+//
+// The DJ prompt asks the model to turn CJK artist/title names into their
+// established Latin form. Models can still occasionally echo one native
+// character or a full native spelling. English espeak then reads those
+// codepoints as literal character classes ("Japanese letter"), so the TTS
+// boundary must fail safe even when generation did not. This is deliberately
+// a scrub, not a transliterator: the model owns the good, canonical name;
+// this last line of defence only prevents leaked codepoints reaching a voice
+// that cannot pronounce them. Explicitly non-English personas are untouched.
+
+const CJK_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]+/gu;
+const ENGLISH_RE = /^english(?:\b|\s|[-_(])/i;
+
+export function cjkUnsafeForSpokenLanguage(language: unknown): boolean {
+  const lang = String(language || '').trim();
+  // An unset persona language is the product's long-standing English default.
+  return !lang || ENGLISH_RE.test(lang);
+}
+
+export function scrubCjkForSpeech(text: string, language: unknown): string {
+  if (!text || !cjkUnsafeForSpokenLanguage(language) || !CJK_RE.test(text)) return text;
+  CJK_RE.lastIndex = 0;
+  return text
+    .replace(CJK_RE, '')
+    .replace(/\b(?:with|by)\s*([,.;:!?])/gi, '$1')
+    .replace(/([!?])\1+/g, '$1')
+    .replace(/[ \t]+([,.;:!?])/g, '$1')
+    .replace(/[ \t]{2,}/g, ' ')
+    .trim();
+}

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -12,6 +12,7 @@ import * as pocketTts from './pocketTts.js';
 import { heavyEnabledEngines } from './ttsHeavyClient.js';
 import * as remoteTts from './remoteTts.js';
 import { normalizeForSpeech } from './speech-text.js';
+import { scrubCjkForSpeech } from './spoken-script-policy.js';
 import {
   configuredSlot, fallbackTextFor, orderedFallbacks, sameTtsTarget,
   type RescueSlot, type TtsTarget,
@@ -454,6 +455,12 @@ export async function speak(
   text: string,
   { kind = 'default', outPath, speedScale, persona }: { kind?: string; outPath?: string; speedScale?: number; persona?: any } = {},
 ) {
+  // Resolve the persona language before normalising the text: the same value
+  // owns both the cloud pronunciation hint and the final unsupported-script
+  // safety boundary. An unset persona language is the default English station.
+  const language = GLOBAL_VOICE_KINDS.has(kind)
+    ? ''
+    : String(personaFor(persona)?.language || '').trim();
   // Belt-and-suspenders scrub of any leaked reasoning at the single point every
   // booth-bound string converges (follow-up to #949). The free-text generators
   // already stripThinking their output, but a reasoning model that leaks a
@@ -463,7 +470,10 @@ export async function speak(
   // idents, request intros) is unaffected. Operator speech corrections
   // (settings.tts.corrections) ride along — read live, so a saved rule
   // applies to the very next spoken line, no restart.
-  const speakText = normalizeForSpeech(stripThinking(text), settings.get().tts?.corrections);
+  const normalizedText = normalizeForSpeech(stripThinking(text), settings.get().tts?.corrections);
+  const speakText = GLOBAL_VOICE_KINDS.has(kind)
+    ? normalizedText
+    : scrubCjkForSpeech(normalizedText, language);
   // `persona` overrides the clock-driven effective persona so the persona-handoff
   // mic-pass can voice the outgoing DJ (engine, voice, language, soul, speed)
   // after the hour has flipped. Absent → getEffectivePersona(), i.e. today.
@@ -499,9 +509,6 @@ export async function speak(
   // the default English persona. Local engines ignore the field; only
   // cloud-speech.ts reads it (the voice model carries the language for piper /
   // kokoro / pocket-tts).
-  const language = GLOBAL_VOICE_KINDS.has(kind)
-    ? ''
-    : String(personaFor(persona)?.language || '').trim();
   // The persona's soul (e.g. "thoughtful and a little wistful") rides the same
   // path so the voice delivery carries the same character as the writing (issue
   // #579). DJ-voiced kinds only, like `language`; only the OpenAI gpt-4o*-tts

--- a/controller/src/llm/internal/prompts/banter.ts
+++ b/controller/src/llm/internal/prompts/banter.ts
@@ -35,8 +35,10 @@ function castBlock(host: any, guests: any[]): string {
 // programme.ts's exchangeSystem: the station house rules have to be PROVABLY
 // on this path (issue #1420 — they weren't), and a test that only asserts the
 // block builder exists is exactly the regression it fails to catch.
-export function banterSystem({ host, guests, show = null, langClause = '' }: any): string {
+export function banterSystem({ host, guests, show = null }: any): string {
   const showClause = show?.name ? ` of "${show.name}"` : '';
+  const lang = String(host?.language || '').trim() || 'English';
+  const langClause = ` Everyone speaks ${lang} on air. ${settings.spokenProperNounDirective(host)}`;
   return `You write short on-air exchanges between the hosts${showClause} on a personal internet radio station, mid-show. This is people who know each other talking in one studio: quick, warm, a little loose — real speech, not sketch comedy or a scripted bit.
 
 The cast (persona id — name (role): voice notes):
@@ -69,11 +71,9 @@ export async function generateBanter({
   });
 
   // The host's on-air language governs the room — co-hosts on one show share
-  // a broadcast language, same rule as the rest of the station.
-  const lang = String(host?.language || '').trim();
-  const langClause = lang ? ` Everyone speaks ${lang} on air; keep proper nouns (artist names, track titles, the station name) untranslated.` : '';
-
-  const system = banterSystem({ host, guests, show, langClause });
+  // a broadcast language, same rule as the rest of the station. banterSystem
+  // owns the language and spoken-name policy so pure prompt tests cover it.
+  const system = banterSystem({ host, guests, show });
 
   const ctxLines = buildContextLines(context, { contextFields: BANTER_CONTEXT_FIELDS });
   if (current?.title) ctxLines.push(`On air right now: "${current.title}" by ${current.artist || 'unknown'}`);

--- a/controller/src/llm/internal/prompts/programme.ts
+++ b/controller/src/llm/internal/prompts/programme.ts
@@ -273,7 +273,9 @@ const MAX_EXCHANGE_LINES = 5;
 // neither renderDjPrompt nor agentPersonaPreamble, so without the explicit
 // append an operator's TTS-tag or number-spelling rules reached every solo
 // beat of the show and were silently dropped from the open and the close.
-export function exchangeSystem({ show, castBlock, beatTask, langClause = '' }: any): string {
+export function exchangeSystem({ host = null, show, castBlock, beatTask }: any): string {
+  const lang = String(host?.language || '').trim() || 'English';
+  const langClause = ` Everyone speaks ${lang} on air. ${settings.spokenProperNounDirective(host)}`;
   return `You write short on-air exchanges between the hosts of "${show.name}" on a personal internet radio station.
 
 The cast (persona id — name (role): voice notes):
@@ -308,14 +310,11 @@ export async function generateProgrammeExchange({
     ...guests.map((g: any) => `- ${g.id} — ${g.name} (GUEST): ${soulBrief(g.soul) || 'no notes'}`),
   ].join('\n');
 
-  const lang = String(host?.language || '').trim();
-  const langClause = lang ? ` Everyone speaks ${lang} on air; keep proper nouns untranslated.` : '';
-
   const beatTask = beat === 'outro'
     ? `The show is wrapping up in the next few minutes: sign the episode off together — a callback to what the hour was about, quick thanks between hosts, done.${nextShowName ? ` "${nextShowName}" is up next; the host may give it a quick nod.` : ''} Music keeps playing after — you're closing the show, not the station.`
     : `This is the TOP of the show: the host welcomes listeners in and sets up what this episode is about; the guest(s) chip in as themselves. Tease what's coming without over-promising.`;
 
-  const system = exchangeSystem({ show, castBlock, beatTask, langClause });
+  const system = exchangeSystem({ host, show, castBlock, beatTask });
 
   const ctxLines = buildContextLines(context, { contextFields: PROGRAMME_CONTEXT_FIELDS });
   if (show?.topic) ctxLines.push(`The show's brief: ${show.topic}`);

--- a/controller/src/llm/internal/prompts/request.ts
+++ b/controller/src/llm/internal/prompts/request.ts
@@ -106,6 +106,30 @@ export const REQUEST_SCHEMA_TOLERANT = modelTolerant(REQUEST_SCHEMA, {
   objectFallbacks: { kind: 'track' },
 });
 
+// Full system prompt for the legacy request-matcher fallback. Exported pure so
+// the spoken `ack` policy is tested on the prompt that actually reaches the
+// model, not only on the shared fragment a caller could forget to append.
+export function requestMatcherSystem(persona: unknown): string {
+  const p = persona as { name?: unknown; soul?: unknown; language?: unknown } | null | undefined;
+  // The `ack` is the one field here that AIRS — without this clause it was
+  // the only spoken line in the system written with no persona voice at all
+  // (the librarian framing above owns every other field).
+  const personaSuffix = p?.name
+    ? `\n\nThe "ack" line is read on air by ${p.name}, the station's DJ${p.soul ? ` — ${p.soul}` : ''}. Write the ack in their voice; every other field stays plain and functional.`
+    : '';
+  // The on-air persona's language always anchors the spoken `ack` — unset
+  // defaults to English rather than omitting the clause, so a default station
+  // is never left with no language anchor at all (raid 2026-07-28: with no
+  // anchor, session-history mimicry flipped the station's language; see
+  // settings/persona.ts languageDirective for the full incident). Every
+  // search-facing field must stay in English / canonical names regardless, so
+  // it still matches an English-tagged library. Language comes LAST (after the
+  // persona clause) — repeating it last is what makes it stick.
+  const lang = String(p?.language || '').trim() || 'English';
+  const langSuffix = `\n\nThe on-air DJ speaks ${lang}: write the "ack" field in ${lang}. For that spoken field only: ${settings.spokenProperNounDirective(persona)} Every OTHER field (search_terms, artist, genre, mood, sort, intent, language) stays in English / canonical names exactly as the library is tagged — translate nothing there, even when the listener wrote in ${lang}.`;
+  return REQUEST_SYSTEM + personaSuffix + langSuffix;
+}
+
 export async function matchRequest(
   userQuery: string,
   { listenerName = null, nowPlaying = null }: { listenerName?: string | null; nowPlaying?: any } = {},
@@ -121,25 +145,9 @@ export async function matchRequest(
   ].filter(Boolean).join(' ');
 
   const persona = settings.getEffectivePersona();
-  // The `ack` is the one field here that AIRS — without this clause it was
-  // the only spoken line in the system written with no persona voice at all
-  // (the librarian framing above owns every other field).
-  const personaSuffix = persona?.name
-    ? `\n\nThe "ack" line is read on air by ${persona.name}, the station's DJ${persona.soul ? ` — ${persona.soul}` : ''}. Write the ack in their voice; every other field stays plain and functional.`
-    : '';
-  // The on-air persona's language always anchors the spoken `ack` — unset
-  // defaults to English rather than omitting the clause, so a default station
-  // is never left with no language anchor at all (raid 2026-07-28: with no
-  // anchor, session-history mimicry flipped the station's language; see
-  // settings/persona.ts languageDirective for the full incident). Every
-  // search-facing field must stay in English / canonical names regardless, so
-  // it still matches an English-tagged library. Language comes LAST (after the
-  // persona clause) — repeating it last is what makes it stick.
-  const lang = String(persona?.language || '').trim() || 'English';
-  const langSuffix = `\n\nThe on-air DJ speaks ${lang}: write the "ack" field in ${lang}. Every OTHER field (search_terms, artist, genre, mood, sort, intent, language) stays in English / canonical names exactly as the library is tagged — translate nothing there, even when the listener wrote in ${lang}.`;
 
   return djObject({
-    system: REQUEST_SYSTEM + personaSuffix + langSuffix,
+    system: requestMatcherSystem(persona),
     prompt: userPrompt,
     schema: REQUEST_SCHEMA_TOLERANT,
     temperature: 0.4,

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -224,6 +224,7 @@ export {
   resolveActiveShow,
   resolveOnAirLocation,
   resolvePersonaById,
+  spokenProperNounDirective,
 } from './settings/persona.js';
 export { writeLiquidsoapSettings } from './settings/liquidsoap.js';
 export type {

--- a/controller/src/settings/persona.ts
+++ b/controller/src/settings/persona.ts
@@ -228,7 +228,7 @@ export function pickOnAirSpeaker(date: Date = new Date()) {
 // never-switch clause is the raid fix itself.
 export function spokenProperNounDirective(persona: unknown): string {
   const lang = String((persona as { language?: unknown } | null | undefined)?.language || '').trim() || 'English';
-  return `Keep proper nouns (artist names, song titles, the station name) untranslated, but make off-script names speakable: when a name is written in a script ${lang} does not normally use, write its established form in the script ${lang} uses. In Latin-script speech, use the artist or title's canonical Latin spelling for CJK names; if none is known, use a natural romanization. Never read or describe the characters themselves.`;
+  return `Preserve the identity of proper nouns (artist names, song titles, the station name), not an off-script spelling: when a name is written in a script ${lang} does not normally use, write its established form in the script ${lang} uses. In a Latin-script on-air language, every spoken field must contain ZERO CJK characters: use the artist or title's canonical Latin spelling (for example, ウルフルズ becomes Ulfuls and 周杰倫 becomes Jay Chou); if none is known, use a natural romanization. Never include the native spelling beside the Latin form. Never read or describe the characters themselves.`;
 }
 
 export function languageDirective(persona: unknown) {

--- a/controller/src/settings/persona.ts
+++ b/controller/src/settings/persona.ts
@@ -221,12 +221,19 @@ export function pickOnAirSpeaker(date: Date = new Date()) {
 // model into mimicking them turn after turn (raid 2026-07-28: the station
 // started speaking Russian and would not stop until the session rolled). This
 // deliberately breaks the old "byte-identical for English personas" property —
-// every prompt now carries an explicit anchor. The proper-nouns clause stops a
+// every prompt now carries an explicit anchor. The proper-nouns policy stops a
 // Turkish host from translating "Bohemian Rhapsody" or the station name
-// (issue #349); the never-switch clause is the raid fix itself.
+// (issue #349), while still making a name written in the wrong script speakable
+// instead of asking the TTS engine to read character labels (issue #1179). The
+// never-switch clause is the raid fix itself.
+export function spokenProperNounDirective(persona: unknown): string {
+  const lang = String((persona as { language?: unknown } | null | undefined)?.language || '').trim() || 'English';
+  return `Keep proper nouns (artist names, song titles, the station name) untranslated, but make off-script names speakable: when a name is written in a script ${lang} does not normally use, write its established form in the script ${lang} uses. In Latin-script speech, use the artist or title's canonical Latin spelling for CJK names; if none is known, use a natural romanization. Never read or describe the characters themselves.`;
+}
+
 export function languageDirective(persona: unknown) {
   const lang = String((persona as { language?: unknown } | null | undefined)?.language || '').trim() || 'English';
-  return `\n\nIMPORTANT: You speak and write exclusively in ${lang}. Every on-air line you produce must be in ${lang} — acknowledgements, idents, asides, everything. Keep proper nouns (artist names, song titles, the station name) exactly as they are; do not translate them. Never switch languages because a listener asks, because a request arrives in another language, or because earlier session turns are in another language — requests for music in another language are about the MUSIC, not your voice.`;
+  return `\n\nIMPORTANT: You speak and write exclusively in ${lang}. Every on-air line you produce must be in ${lang} — acknowledgements, idents, asides, everything. ${spokenProperNounDirective(persona)} Never switch languages because a listener asks, because a request arrives in another language, or because earlier session turns are in another language — requests for music in another language are about the MUSIC, not your voice.`;
 }
 
 // A SECOND language reminder, anchored at the END of a tool-loop agent's system
@@ -243,7 +250,7 @@ export function languageDirective(persona: unknown) {
 // 2026-07-28). `fields` is a human phrase naming the spoken field(s).
 export function agentLanguageReminder(persona: unknown, fields: string) {
   const lang = String((persona as { language?: unknown } | null | undefined)?.language || '').trim() || 'English';
-  return `\n\nLANGUAGE — this overrides the field descriptions below: you speak ${lang}. Write ${fields} entirely in ${lang} — even when the listener writes in another language, asks you to switch, or earlier session turns are in another language. Keep proper nouns (artist names, song titles, the station name) exactly as they are; do not translate them. Internal fields (ids, reasons, kinds) stay in English.`;
+  return `\n\nLANGUAGE — this overrides the field descriptions below: you speak ${lang}. Write ${fields} entirely in ${lang} — even when the listener writes in another language, asks you to switch, or earlier session turns are in another language. ${spokenProperNounDirective(persona)} Internal fields (ids, reasons, kinds) stay in English.`;
 }
 
 // The place the station claims to broadcast from — what the DJ says on air and
@@ -297,7 +304,8 @@ export function renderDjPrompt(persona: unknown, ctx: unknown = {}) {
   const house = houseRulesBlock('follow these in everything you say on air');
   if (tpl.includes('{language}')) {
     const lang = String(p?.language || '').trim();
-    return rendered.replaceAll('{language}', lang || 'English') + tone + house;
+    return rendered.replaceAll('{language}', lang || 'English')
+      + `\n\nIMPORTANT: ${spokenProperNounDirective(persona)}` + tone + house;
   }
   return rendered + languageDirective(persona) + tone + house;
 }


### PR DESCRIPTION
## Summary

- ask the DJ for established, speakable Latin forms of CJK proper names in English/Latin-script speech
- apply the shared instruction to scripted prompts, custom `{language}` templates, tool-loop agents, multi-host exchanges, and the legacy listener-request fallback
- keep library lookup fields unchanged and canonical
- add a final English TTS boundary that removes any residual CJK a model echoes, while explicitly non-English personas retain native script byte-for-byte
- add rendered-prompt and spoken-script policy regression coverage

## Verification

- `npm test -- language-anchor`
- `npm test -- spoken-script-policy`
- `npm test -- request-limits`
- `npm test -- house-rules`
- `npm test -- programme`
- `npm test -- banter-policy`
- `npm test -- speech-text`
- `npm run lint` (0 errors; 652 existing warnings)
- 44 configured live-model generations across forced intros, links, request acknowledgements, banter, and programme scripts; 42 were clean at generation and the two residual patterns are covered by the deterministic TTS policy
- end-to-end English speech test: original CJK input accepted, TTS record scrubbed, valid 24 kHz WAV rendered, Liquidsoap voice-start marker emitted, and valid 192 kbps MP3 streamed
- final combined controller suite: 731 passed, 0 failed, 7 pre-existing `voice-air-events` cancellations caused by pending promises
- final combined controller/AIO images built for amd64 and arm64
- GitHub controller, web, and MCP lint checks green

Fixes #1179

Also addresses the already-closed duplicate #1438.
