### PR TITLE
fix(admin): show held queue picks before mixer handoff

### DIFF
--- a/web/components/admin/DashPanel.tsx
+++ b/web/components/admin/DashPanel.tsx
@@ -46,6 +46,7 @@ import StationHeader, { type HealthMetrics } from './StationHeader';
 import { cn } from '../../lib/cn';
 import { RequestsCard } from './dash/RequestsCard';
 import { TakeoverCard } from './dash/TakeoverCard';
+import QueueHeldBadge from './dash/QueueHeldBadge';
 import { BoothTurnText, SegmentButton, SortableTh, ToggleRow, classTone } from './dash/bits';
 import type {
   ActResponse,
@@ -447,6 +448,7 @@ export default function DashPanel() {
                             Stem blend
                           </span>
                         ) : null}
+                        <QueueHeldBadge sent={t.sent} />
                         <span className="mono-num text-[10px] whitespace-nowrap text-muted">
                           {typeof t.duration === 'number' || typeof t.duration === 'string'
                             ? t.duration

--- a/web/components/admin/dash/QueueHeldBadge.test.tsx
+++ b/web/components/admin/dash/QueueHeldBadge.test.tsx
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import QueueHeldBadge from './QueueHeldBadge';
+
+test('an unsent queue row says it is held before mixer handoff', () => {
+  const html = renderToStaticMarkup(createElement(QueueHeldBadge, { sent: false }));
+  assert.match(html, />Held</);
+  assert.match(html, /title="[^"]*not handed to the mixer yet[^"]*"/);
+});
+
+test('a handed-off queue row has no held badge', () => {
+  assert.equal(renderToStaticMarkup(createElement(QueueHeldBadge, { sent: true })), '');
+});
+
+test('an omitted sent flag degrades to held instead of implying handoff', () => {
+  const html = renderToStaticMarkup(createElement(QueueHeldBadge));
+  assert.match(html, />Held</);
+});

--- a/web/components/admin/dash/QueueHeldBadge.tsx
+++ b/web/components/admin/dash/QueueHeldBadge.tsx
@@ -1,0 +1,12 @@
+export default function QueueHeldBadge({ sent }: { sent?: boolean }) {
+  if (sent === true) return null;
+
+  return (
+    <span
+      title="Held by controller — not handed to the mixer yet"
+      className="shrink-0 border border-ink/20 px-1 py-0.5 text-[8px] font-bold tracking-[0.14em] whitespace-nowrap text-muted uppercase"
+    >
+      Held
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- show a subtle `HELD` badge on admin queue rows that have not been handed to the mixer
- remove the badge as soon as the queue item reports `sent: true`
- explain the state in a tooltip without describing a sent item as playable or resolved
- degrade an omitted `sent` flag to held rather than implying a handoff that was never confirmed

## Validation

- real React server-render test: 3/3 passing
- `npm run lint` in `web` — 0 errors
- `npm run build` in `web`
- `git diff --check`

## Tracker

Implements the Bug 6 cosmetic half from #1331. The tracker checkbox should remain open until this PR merges into `develop`.