### PR TITLE
fix(admin): keep the genre filter after picking a suggestion

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -4227,6 +4227,11 @@ html:has(.admin-root.paper) {
 }
 .admin-root .lib-chip:hover { border-color: var(--ink); color: var(--ink); }
 .admin-root .lib-chip.on { background: var(--ink); border-color: var(--ink); color: var(--bg); }
+/* a chip that is already picked stays on screen as feedback, not as a target */
+.admin-root .lib-chip:disabled { cursor: default; }
+.admin-root .lib-chip:disabled:not(.on) { opacity: 0.5; }
+.admin-root .lib-chip:disabled:not(.on):hover { border-color: var(--separator-strong); color: var(--muted); }
+.admin-root .lib-chip.on:disabled:hover { border-color: var(--ink); color: var(--bg); }
 .admin-root .lib-chip .n { font-size: 9px; opacity: 0.6; font-variant-numeric: tabular-nums; }
 .admin-root .lib-chip-more { border-style: dashed; }
 

--- a/web/components/admin/GenreSuggest.tsx
+++ b/web/components/admin/GenreSuggest.tsx
@@ -34,6 +34,7 @@ interface Props {
 const POPULAR = 12;
 const MATCHES = 10;
 const norm = (s: string) => s.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+export const genreSelectionKey = (s: string) => s.trim().toLowerCase();
 
 export default function GenreSuggest({ adminFetch, value, onSelect, selected, disabled }: Props) {
   const query = useAdminQuery<SuggestData>({
@@ -49,8 +50,8 @@ export default function GenreSuggest({ adminFetch, value, onSelect, selected, di
     () => new Map((data?.genres || []).map((genre) => [norm(genre.value), genre])),
     [data],
   );
-  const selectedNorm = useMemo(
-    () => new Set((selected || []).map(norm)),
+  const selectedKeys = useMemo(
+    () => new Set((selected || []).map(genreSelectionKey)),
     [selected],
   );
 
@@ -90,7 +91,7 @@ export default function GenreSuggest({ adminFetch, value, onSelect, selected, di
       </span>
       <div className="flex flex-wrap gap-1.5">
         {chips.map((g) => {
-          const isSelected = selectedNorm.has(norm(g.value));
+          const isSelected = selectedKeys.has(genreSelectionKey(g.value));
           const tracks = `${g.songCount} track${g.songCount === 1 ? '' : 's'}`;
           return (
             <button

--- a/web/components/admin/GenreSuggest.tsx
+++ b/web/components/admin/GenreSuggest.tsx
@@ -24,13 +24,18 @@ interface Props {
   adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
   value: string;
   onSelect: (genre: string) => void;
+  // Genres already picked. The caller keeps the typed filter in place across
+  // picks, so the same chip list stays on screen — without marking what's
+  // already in it, a chip gives no feedback when clicked.
+  selected?: string[];
+  disabled?: boolean;
 }
 
 const POPULAR = 12;
 const MATCHES = 10;
 const norm = (s: string) => s.trim().toLowerCase().replace(/[^a-z0-9]/g, '');
 
-export default function GenreSuggest({ adminFetch, value, onSelect }: Props) {
+export default function GenreSuggest({ adminFetch, value, onSelect, selected, disabled }: Props) {
   const query = useAdminQuery<SuggestData>({
     key: settingsKeys.genreSuggestions(),
     adminFetch,
@@ -43,6 +48,10 @@ export default function GenreSuggest({ adminFetch, value, onSelect }: Props) {
   const byNorm = useMemo(
     () => new Map((data?.genres || []).map((genre) => [norm(genre.value), genre])),
     [data],
+  );
+  const selectedNorm = useMemo(
+    () => new Set((selected || []).map(norm)),
+    [selected],
   );
 
   if (query.error || !data || data.genres.length === 0) return null;
@@ -80,18 +89,24 @@ export default function GenreSuggest({ adminFetch, value, onSelect }: Props) {
         {match && !data.hasEmbeddings ? ' — tag your library with embeddings for related genres' : ''}
       </span>
       <div className="flex flex-wrap gap-1.5">
-        {chips.map((g) => (
-          <button
-            key={g.value}
-            type="button"
-            className={cn('lib-chip', norm(g.value) === nv && nv !== '' && 'on')}
-            onClick={() => onSelect(g.value)}
-            title={`${g.songCount} track${g.songCount === 1 ? '' : 's'}`}
-          >
-            {g.value}
-            {g.songCount > 0 && <span className="n">{g.songCount}</span>}
-          </button>
-        ))}
+        {chips.map((g) => {
+          const isSelected = selectedNorm.has(norm(g.value));
+          const tracks = `${g.songCount} track${g.songCount === 1 ? '' : 's'}`;
+          return (
+            <button
+              key={g.value}
+              type="button"
+              className={cn('lib-chip', (isSelected || (norm(g.value) === nv && nv !== '')) && 'on')}
+              onClick={() => onSelect(g.value)}
+              disabled={isSelected || disabled}
+              aria-pressed={isSelected}
+              title={isSelected ? `${tracks} — already added` : tracks}
+            >
+              {g.value}
+              {g.songCount > 0 && <span className="n">{g.songCount}</span>}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -178,14 +178,22 @@ export function ShowEditor({
   // The editor is remounted per show (keyed by id at the call site), so this
   // resets on switch — it's a text buffer, not form data.
   const [genreDraft, setGenreDraft] = useState('');
-  const addGenre = (g: string) => {
+  const addGenre = (g: string, { keepDraft = false } = {}) => {
     const v = g.trim().slice(0, 64);
     const current = genresCtl.field.value ?? [];
     if (!v || current.length >= FILTER_VALUES_MAX) return;
-    if (current.some((x: string) => x.toLowerCase() === v.toLowerCase())) { setGenreDraft(''); return; }
+    if (current.some((x: string) => x.toLowerCase() === v.toLowerCase())) {
+      if (!keepDraft) setGenreDraft('');
+      return;
+    }
     genresCtl.field.onChange([...current, v]);
-    setGenreDraft('');
+    if (!keepDraft) setGenreDraft('');
   };
+  // A suggestion chip narrows the list it came from, so clearing the draft on
+  // click would throw the user back to "popular genres" after every pick —
+  // retyping "trance" once per trance sub-genre. Committing the typed
+  // text (Enter/Add) still clears: there the draft *is* the thing consumed.
+  const addGenreFromSuggestion = (g: string) => addGenre(g, { keepDraft: true });
   // Genres no track carries. The controller resolves free text onto the nearest
   // library tag, silently broadening the show ("Pop Punk" → "Pop") or dropping the
   // filter — invisible on air unless said here. Mirrors show-filter.normGenre so UI
@@ -555,7 +563,9 @@ export function ShowEditor({
           <GenreSuggest
             adminFetch={adminFetch}
             value={genreDraft}
-            onSelect={addGenre}
+            selected={showGenres}
+            onSelect={addGenreFromSuggestion}
+            disabled={showGenres.length >= FILTER_VALUES_MAX}
           />
 
           <SwitchField

--- a/web/tests/genre-suggest.test.ts
+++ b/web/tests/genre-suggest.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as genreSuggest from '../components/admin/GenreSuggest';
+
+type GenreSelectionKey = (value: string) => string;
+
+function selectionKey(): GenreSelectionKey {
+  const key = (genreSuggest as { genreSelectionKey?: GenreSelectionKey }).genreSelectionKey;
+  if (typeof key !== 'function') {
+    throw new TypeError('GenreSuggest must expose its selected-value identity');
+  }
+  return key;
+}
+
+test('selected genre identity preserves distinct non-Latin tags', () => {
+  const key = selectionKey();
+
+  assert.notEqual(key('演歌'), key('歌謡曲'));
+});
+
+test('selected genre identity ignores surrounding whitespace and case', () => {
+  const key = selectionKey();
+
+  assert.equal(key(' Trance '), key('trance'));
+});


### PR DESCRIPTION
Reported on Discord (["Genre Leans within shows"](https://discord.com/channels/1514647956333002812/1538883985097097246)): in a show's **genre leans** field, typing a search term and clicking a suggestion chip snapped the list back to the default "popular genres". Picking several sub-genres of one family meant retyping the filter between every pick — type "trance", click progressive trance, type "trance" again, click uplifting trance.

## Change

- `addGenre(g, { keepDraft })` in `ShowEditor` — the suggestion path passes `keepDraft: true`, so a chip click adds the genre and leaves the typed filter in the input. Committing the typed text (Enter / Add) still clears it: there the draft *is* what was consumed.
- `GenreSuggest` takes `selected` and `disabled`. Because the chip list no longer resets after a pick, chips already added render `on` / `aria-pressed` / disabled, titled "already added" — a sticky list with no marking gives no feedback when clicked. `disabled` also covers the at-`FILTER_VALUES_MAX` case.
- Disabled `.lib-chip` styling in `globals.css`: no pointer cursor, no hover shift, dimmed only in the at-max case rather than the already-picked one.

Result: type "trance" once, then click progressive trance, uplifting trance, psytrance in a row, each turning solid as it's added. The filter clears when the operator clears the field.

## Testing

`npm run lint` in `web/` (eslint + `tsc --noEmit`) is clean apart from pre-existing warnings in unrelated files. Not yet exercised in a browser.