### PR TITLE
fix(library): store album/artist ids so album blocks actually hold

### DIFF
--- a/controller/scripts/blocklist-album-id.test.ts
+++ b/controller/scripts/blocklist-album-id.test.ts
@@ -26,9 +26,10 @@ const stateDir = mkdtempSync(join(tmpdir(), 'subwave-blocklist-album-id-'));
 process.env.STATE_DIR = stateDir;
 
 const db = await import('../src/music/library-db.js');
+const library = await import('../src/music/library.js');
 const blocklist = await import('../src/music/blocklist.js');
 
-await db.open({ embeddingDim: 768 });
+await library.load();
 await blocklist.load();
 
 // One various-artists compilation: same album, same album id, DIFFERENT artist
@@ -42,6 +43,8 @@ db.upsertTrackMeta('t2', {
   title: 'Second', artist: 'Second Act', album: 'Sunshine Sampler',
   albumId: COMP_ALBUM_ID, artistId: 'art-second',
 });
+db.upsertTrackTags('t1', { moods: ['sunny'], energy: 'medium', source: 'manual' });
+db.upsertTrackTags('t2', { moods: ['sunny'], energy: 'medium', source: 'manual' });
 
 test("the walk's album/artist ids round-trip through library.db", () => {
   const rec = db.getTrack('t2');
@@ -81,6 +84,11 @@ test('blocking a compilation album blocks EVERY track on it, not just the one it
   const hit = blocklist.hitOf(t2);
   assert.equal(hit?.kind, 'entry');
   assert.equal(hit?.kind === 'entry' && hit.type, 'album');
+});
+
+test('the public mood source filters a compilation sibling by its album id', () => {
+  const ids = library.songsByMood('sunny').map((track) => track.id);
+  assert.equal(ids.includes('t2'), false, 'the differently credited sibling never reaches a mood candidate pool');
 });
 
 test('an artist block matches by id through a credit the name fallback cannot normalise', async () => {

--- a/controller/scripts/blocklist-album-id.test.ts
+++ b/controller/scripts/blocklist-album-id.test.ts
@@ -1,0 +1,104 @@
+// Album/artist blocks must reach their EXACT id tiers on LIBRARY-sourced
+// candidates, not just on raw Subsonic songs.
+//
+// The reported failure: an operator blocks an album, and the station keeps
+// playing it — on a compilation, the whole thing back to back. Cause: the
+// `tracks` table carried only free-text `album`/`artist`, so blocklist.matchOf
+// could only reach an album entry through its normalised-name fallback, which
+// keys on (album name, THAT TRACK'S artist). A compilation gives every track a
+// different artist string, so every track but the one the block was created
+// from missed the key and aired. (Nothing catches the clustering either — the
+// pool builders cap by artist, and on a various-artists album every artist is
+// different.)
+//
+// These tests pin the fix from both ends: the walk's ids survive the round trip
+// through library.db, and a blocked album's OTHER tracks are blocked by id even
+// though the name fallback cannot see them.
+//
+// Run: npx tsx scripts/blocklist-album-id.test.ts (auto-discovered by npm test).
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const stateDir = mkdtempSync(join(tmpdir(), 'subwave-blocklist-album-id-'));
+process.env.STATE_DIR = stateDir;
+
+const db = await import('../src/music/library-db.js');
+const blocklist = await import('../src/music/blocklist.js');
+
+await db.open({ embeddingDim: 768 });
+await blocklist.load();
+
+// One various-artists compilation: same album, same album id, DIFFERENT artist
+// strings — the shape the name fallback cannot match across.
+const COMP_ALBUM_ID = 'alb-comp-1';
+db.upsertTrackMeta('t1', {
+  title: 'Opener', artist: 'First Act', album: 'Sunshine Sampler',
+  albumId: COMP_ALBUM_ID, artistId: 'art-first',
+});
+db.upsertTrackMeta('t2', {
+  title: 'Second', artist: 'Second Act', album: 'Sunshine Sampler',
+  albumId: COMP_ALBUM_ID, artistId: 'art-second',
+});
+
+test("the walk's album/artist ids round-trip through library.db", () => {
+  const rec = db.getTrack('t2');
+  assert.ok(rec);
+  assert.equal(rec.albumId, COMP_ALBUM_ID);
+  assert.equal(rec.artistId, 'art-second');
+});
+
+test('a metadata write without ids never clears the walked ones', () => {
+  // The manual tag editor and the analyzer's top-up both write TrackMeta with
+  // no ids to offer. COALESCE, not overwrite.
+  db.upsertTrackMeta('t2', { title: 'Second (Remaster)' });
+  const rec = db.getTrack('t2');
+  assert.equal(rec?.title, 'Second (Remaster)');
+  assert.equal(rec?.albumId, COMP_ALBUM_ID, 'album id survived a partial write');
+  assert.equal(rec?.artistId, 'art-second');
+});
+
+test('blocking a compilation album blocks EVERY track on it, not just the one it was created from', async () => {
+  // The route resolves an album block from one track row, so the entry carries
+  // that track's artist — 'First Act' here.
+  await blocklist.add({
+    type: 'album', id: COMP_ALBUM_ID, name: 'Sunshine Sampler', artist: 'First Act',
+  });
+
+  const t1 = db.getTrack('t1');
+  const t2 = db.getTrack('t2');
+  assert.equal(blocklist.isBlocked(t1), true);
+  assert.equal(blocklist.isBlocked(t2), true, 'the other artists on the compilation are blocked too');
+
+  // ...and the id tier is what did it: strip the ids and the name fallback
+  // misses t2 exactly as it did before the fix. This is the regression.
+  const nameOnly = (r: any) => ({ id: r.id, title: r.title, artist: r.artist, album: r.album });
+  assert.equal(blocklist.isBlocked(nameOnly(t1)), true, "name fallback still catches the block's own artist");
+  assert.equal(blocklist.isBlocked(nameOnly(t2)), false, 'name fallback alone cannot see it — the id tier is load-bearing');
+
+  const hit = blocklist.hitOf(t2);
+  assert.equal(hit?.kind, 'entry');
+  assert.equal(hit?.kind === 'entry' && hit.type, 'album');
+});
+
+test('an artist block matches by id through a credit the name fallback cannot normalise', async () => {
+  db.upsertTrackMeta('t3', {
+    title: 'Guest Spot', artist: 'Second Act feat. Somebody Else', album: 'Elsewhere',
+    albumId: 'alb-other', artistId: 'art-second',
+  });
+  await blocklist.add({ type: 'artist', id: 'art-second', name: 'Second Act' });
+
+  const t3 = db.getTrack('t3');
+  assert.equal(blocklist.isBlocked(t3), true);
+  assert.equal(
+    blocklist.isBlocked({ id: 't3', artist: 'Second Act feat. Somebody Else' }),
+    false,
+    'the exact-name fallback cannot match a featured credit — the id tier is what does',
+  );
+});
+
+test.after(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+});

--- a/controller/scripts/manual-original-year.test.ts
+++ b/controller/scripts/manual-original-year.test.ts
@@ -410,7 +410,14 @@ test('migration 22 backfills the refresh marker ONLY where the era text changed'
   // Recreate the on-disk shape an installation already running PR #1431 can
   // have: schema 21, a populated vec index, and no dirty-marker column yet.
   const d = db.requireDb();
-  d.prepare(`ALTER TABLE tracks DROP COLUMN text_vector_dirty`).run();
+  // Every column added after schema 21 has to come off, not just v22's — the
+  // point is a genuine v21 shape, and migrate() re-runs each block from there.
+  d.prepare(`ALTER TABLE tracks DROP COLUMN text_vector_dirty`).run();  // v22
+  // v23 — the indexes reference the columns, so they go first.
+  d.prepare(`DROP INDEX IF EXISTS idx_tracks_album_id`).run();
+  d.prepare(`DROP INDEX IF EXISTS idx_tracks_artist_id`).run();
+  d.prepare(`ALTER TABLE tracks DROP COLUMN album_id`).run();
+  d.prepare(`ALTER TABLE tracks DROP COLUMN artist_id`).run();
   d.pragma('user_version = 21');
   db.close();
   await db.open({ embeddingDim: 768, adoptStoredDim: true });

--- a/controller/src/music/analyze-library.ts
+++ b/controller/src/music/analyze-library.ts
@@ -131,6 +131,11 @@ async function main() {
         title: song.title,
         artist: song.artist,
         album: song.album,
+        // Same ids the tagger's walk records — this walk writes the
+        // same rows, so it must not leave them NULL on a catalogue that only
+        // ever runs the analyzer's pass.
+        albumId: song.albumId ?? null,
+        artistId: song.artistId ?? null,
         year: song.year,
         genres: subsonic.songGenres(song),
         duration: song.duration,

--- a/controller/src/music/library-db/rows.ts
+++ b/controller/src/music/library-db/rows.ts
@@ -14,6 +14,8 @@ export function rowToTrack(row: TrackRow): TrackRecord {
     title: row.title,
     artist: row.artist,
     album: row.album,
+    albumId: row.album_id ?? null,
+    artistId: row.artist_id ?? null,
     year: row.year,
     originalYear: row.original_year ?? null,
     originalYearSource: row.original_year_source ?? null,

--- a/controller/src/music/library-db/schema.ts
+++ b/controller/src/music/library-db/schema.ts
@@ -466,6 +466,30 @@ export async function migrate(embeddingDim: number, reseed = false, adoptStoredD
     d.pragma('user_version = 22');
   }
 
+  if (userVersion < 23) {
+    // Subsonic album/artist ids on the track row. Until now `tracks`
+    // carried only free-text `album`/`artist`, so an ALBUM or ARTIST blocklist
+    // entry could only be enforced against a library-sourced candidate through
+    // matchOf()'s normalised-name fallback — and that fallback keys an album on
+    // (album name, THAT TRACK'S artist). On a compilation or any split credit
+    // ("Artist feat. Guest") every other track on the blocked album carries a
+    // different artist string, misses the key, and airs. The id tiers already
+    // in matchOf() are exact; they were simply unreachable from the pools the
+    // picker actually draws from. Storing the ids makes them reachable.
+    //
+    // No backfill is possible here — the ids live in Navidrome, not in this
+    // file. NULL is the pre-existing behaviour (name fallback only), so an
+    // upgraded station is byte-identical until its next library walk fills
+    // them in.
+    runDdl(d, `
+      ALTER TABLE tracks ADD COLUMN album_id  TEXT;
+      ALTER TABLE tracks ADD COLUMN artist_id TEXT;
+      CREATE INDEX IF NOT EXISTS idx_tracks_album_id  ON tracks(album_id);
+      CREATE INDEX IF NOT EXISTS idx_tracks_artist_id ON tracks(artist_id);
+    `);
+    d.pragma('user_version = 23');
+  }
+
   // Reconcile the requested embedding dim against what physically exists.
   //
   // The vec0 table's `FLOAT[N]` schema is the authority for what inserts accept —

--- a/controller/src/music/library-db/tracks.ts
+++ b/controller/src/music/library-db/tracks.ts
@@ -144,12 +144,17 @@ export function upsertTrackMeta(id: string, meta: TrackMeta): void {
   requireDb()
     .prepare(
       `
-      INSERT INTO tracks (id, title, artist, album, year, original_year, original_year_source, is_compilation, era_untrusted, genres, duration_sec)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO tracks (id, title, artist, album, album_id, artist_id, year, original_year, original_year_source, is_compilation, era_untrusted, genres, duration_sec)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(id) DO UPDATE SET
         title        = COALESCE(excluded.title, tracks.title),
         artist       = COALESCE(excluded.artist, tracks.artist),
         album        = COALESCE(excluded.album, tracks.album),
+        -- COALESCE, like every other column here: the walk is the only writer
+        -- that HAS these ids, so a manual tag edit or an analyzer metadata
+        -- top-up passing undefined must not blank a walked row.
+        album_id     = COALESCE(excluded.album_id, tracks.album_id),
+        artist_id    = COALESCE(excluded.artist_id, tracks.artist_id),
         year         = COALESCE(excluded.year, tracks.year),
         -- Walk-time 'album-tag' years never clobber a per-track 'musicbrainz'
         -- resolution — the MB lookup is the more specific signal (issue #842) —
@@ -187,6 +192,8 @@ export function upsertTrackMeta(id: string, meta: TrackMeta): void {
       meta.title ?? null,
       meta.artist ?? null,
       meta.album ?? null,
+      meta.albumId ?? null,
+      meta.artistId ?? null,
       normaliseYear(meta.year),
       normaliseYear(meta.originalYear),
       normaliseYear(meta.originalYear) != null ? 'album-tag' : null,

--- a/controller/src/music/library-db/types.ts
+++ b/controller/src/music/library-db/types.ts
@@ -13,6 +13,12 @@ export interface TrackRecord {
   title: string | null;
   artist: string | null;
   album: string | null;
+  // Subsonic album/artist ids — what lets the never-play blocklist match an
+  // ALBUM or ARTIST entry EXACTLY on a library-sourced candidate, instead of
+  // through the normalised-name fallback that a compilation or a "feat."
+  // credit defeats. null = not walked since the migration that added them.
+  albumId: string | null;
+  artistId: string | null;
   year: number | null;
   // Original-release-year surface (issue #842): the track's TRUE first-release
   // year when it differs from the file's `year` tag (reissues, compilation
@@ -132,6 +138,11 @@ export interface TrackRow {
   title: string | null;
   artist: string | null;
   album: string | null;
+  // Subsonic ids for the track's album and artist. NULL on any row not walked
+  // since the migration that added them — every consumer treats that as
+  // "unknown" and falls back to the name it already had.
+  album_id: string | null;
+  artist_id: string | null;
   year: number | null;
   original_year: number | null;
   original_year_source: string | null;
@@ -176,6 +187,11 @@ export interface TrackMeta {
   title?: string | null;
   artist?: string | null;
   album?: string | null;
+  /** Subsonic album/artist ids. Omitted by the non-walk writers (manual tag
+   *  edits, the analyzer's metadata top-up), which have no id to offer —
+   *  upsertTrackMeta COALESCEs, so an omitted id never clears a stored one. */
+  albumId?: string | null;
+  artistId?: string | null;
   year?: number | string | null;
   genres?: string[] | null;
   duration?: number | null;

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -275,6 +275,8 @@ export function songsByMood(mood: string | null | undefined): any[] {
       title: r.title,
       artist: r.artist,
       album: r.album,
+      albumId: r.albumId,
+      artistId: r.artistId,
       year: r.year,
       genres: r.genres,
       genre: r.genre,

--- a/controller/src/music/library.ts
+++ b/controller/src/music/library.ts
@@ -186,6 +186,8 @@ export function set(songId: string, data: any) {
     title: data.title,
     artist: data.artist,
     album: data.album,
+    albumId: data.albumId ?? null,
+    artistId: data.artistId ?? null,
     year: data.year,
     genres: Array.isArray(data.genres) && data.genres.length
       ? data.genres
@@ -324,6 +326,14 @@ function slimTrack(r: db.TrackRecord) {
     title: r.title,
     artist: r.artist,
     album: r.album,
+    // Subsonic album/artist ids. Carried so blocklist.matchOf can reach
+    // its EXACT id tiers on library-sourced candidates — every rejectBlocked()
+    // below filters these rows, and without the ids an album entry falls back
+    // to (album name, that track's artist), which a compilation defeats. Not
+    // part of the LLM candidate surface: llm/.../picker/slim.ts whitelists its
+    // own fields, so this stays out of the model's context.
+    albumId: r.albumId,
+    artistId: r.artistId,
     year: r.year,
     // Era-year surface (issues #842, #1418) — carried inline so show-filter's
     // era checks on library-sourced pools never need a per-track DB lookup.

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -750,6 +750,10 @@ export async function* iterateAllSongs() {
         for (const s of songs) {
           yield {
             ...s,
+            // The album we are ITERATING is the authoritative id — a Child's
+            // own albumId is normally the same, but it is optional in the
+            // Subsonic spec, and this loop always knows the answer.
+            albumId: s.albumId ?? r.album?.id ?? album.id ?? null,
             albumIsCompilation: isCompilation,
             albumOriginalYear: originalYear,
             albumEraUntrusted: suspicion.suspect,

--- a/controller/src/music/tag-library/flags.ts
+++ b/controller/src/music/tag-library/flags.ts
@@ -130,6 +130,11 @@ export async function walkNavidrome(): Promise<{ walked: number; liveIds: Set<st
       title: song.title,
       artist: song.artist,
       album: song.album,
+      // Subsonic album/artist ids. The walk is the only writer that has
+      // them, and they are what lets an ALBUM/ARTIST blocklist entry match a
+      // library-sourced candidate exactly rather than by name.
+      albumId: song.albumId ?? null,
+      artistId: song.artistId ?? null,
       year: song.year,
       // Album-level era signals (issues #842, #1418). The album's
       // originalReleaseDate is a track's original year only when it is


### PR DESCRIPTION
Reported on Discord: https://discord.com/channels/1514647956333002812/1534208297459257344 — *"All tracks from this album were previously blocked; now the radio is just playing the whole album in a row."*

## The bug

`tracks` carried only free-text `album` / `artist` — no `album_id`, no `artist_id`. So on a **library-sourced** candidate (the mood / vector / energy / deep-cut pools the picker actually draws from, via `library.slimTrack`) `blocklist.matchOf` could never reach its exact id tiers. It fell through to the normalised-name fallback, which keys an album on `(album name, THAT TRACK'S artist)`.

The album entry is resolved from **one** track row (`routes/library.ts`, the `type === 'album'` branch stores `artist: song.artist`). So on a various-artists compilation — or any split / `"Artist feat. Guest"` credit — every other track on the blocked album carries a different artist string, misses the key, and airs.

The same shape explains the *"in a row"* half: nothing caps consecutive tracks from one album. `auto-pool.ts` and `playlist-gen-pure.ts` both cap by **artist**, and on a various-artists album every artist is different.

## The fix

Store the Subsonic album and artist ids on the row and carry them onto the candidate, so the exact tiers become reachable. **`blocklist.ts` is untouched** — those tiers were always there, just unreachable from the pools that matter.

- **schema** — migration 23 adds indexed `album_id` / `artist_id`. No backfill is possible (the ids live in Navidrome), and NULL is exactly today's behaviour, so an upgraded station is byte-identical until its next library walk.
- **write** — `TrackMeta` gains the ids; `upsertTrackMeta` `COALESCE`s them, so the writers that *don't* have ids (manual tag edits, the analyzer's metadata top-up) can never blank a walked row. Both walks pass them (`tag-library/flags.ts`, `analyze-library.ts`), and `subsonic.iterateAllSongs()` fills `albumId` from the album it's iterating when the Child omits its own.
- **read** — `rowToTrack` maps them; `library.slimTrack` carries them. They stay **out of the model's context**: `llm/internal/tools/picker/slim.ts` whitelists its own fields.

## Tests

New `controller/scripts/blocklist-album-id.test.ts` (4 tests) pins the round trip, the `COALESCE` guarantee, and the bug from both ends — a compilation album block now catches every track on it, *and* stripping the ids off the same rows reproduces the old miss, so the id tier is provably what's doing the work. Same for an artist block reaching through a `"feat."` credit.

`manual-original-year.test.ts` rewinds a DB to schema 21 to re-run migration 22, so it now drops the v23 indexes and columns too — a real v21 database has neither.

`npm run lint`: 0 errors. Full suite green except `analyzer-python.test.ts` (a Python `vocal_gate_test.py` sub-suite) and `voice-air-events.test.ts`, both confirmed failing identically on a clean baseline with these changes stashed.

## Two caveats

1. **This needs a library walk to take effect.** Existing rows have NULL ids until tagging/analysis re-walks, so until then the old name fallback is all there is and the reported album keeps leaking.
2. **The clustering is not fixed here.** An album-level cap alongside `maxPerArtist` in the pool builders is a separate change.