### PR TITLE
docs: pin agent PR base to develop, track .codex config

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,17 @@
+# Codex MCP wiring for the local SUB/WAVE controller.
+#
+# `args` is relative, so launch Codex from the repo root.
+
+[mcp_servers.subwave]
+command = "npx"
+args = [
+    "tsx",
+    "mcp-subwave/src/index.ts",
+]
+
+[mcp_servers.subwave.env]
+# 7701 is the controller's own port, published to the host by
+# docker-compose.dev.yml and by docker-compose.byo.yml (${CONTROLLER_PORT:-7701}).
+# Under the default prod docker-compose.yml only Caddy binds a host port, so the
+# controller is not reachable on 7701 there — use http://localhost:7700/api instead.
+SUBWAVE_API_URL = "http://localhost:7701"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,14 @@ docker compose up -d --build broadcast      # after radio.liq / icecast.xml.temp
 
 **CI does not run the test suite — run `npm test` yourself before pushing controller changes.** If `observatory-scale.test.ts` fails with `SQLITE_IOERR_WRITE`, point `TMPDIR` at real disk (it builds a 200k-track DB and `/tmp` is a 12 GB tmpfs on Arch).
 
+### Pull requests target `develop`, never `main`
+
+Open every PR against `develop`. `main` is the release branch — only `develop` (and the automated release-please branches) merge into it, and `.github/workflows/enforce-main-source.yml` fails any PR to `main` from any other head. So: `gh pr create --base develop`.
+
+**Ignore the "Main branch (you will usually use this for PRs): main" line in the session git preamble.** It is computed locally by looking for a branch named `main`/`master` and does not consult the remote default branch, which for this repo *is* `develop`. Passing `--base main` on the strength of that line is the single most common wrong-base mistake here.
+
+The one exception is the release PR itself (`develop` → `main`), which has its own procedure in [`.claude/skills/subwave-release-pr/SKILL.md`](.claude/skills/subwave-release-pr/SKILL.md) — including the merge-commit-not-squash rule that release-please depends on.
+
 ## Architecture
 
 Four cooperating processes with **file-based IPC** through a shared `state/` dir (mounted at `/var/sub-wave` in containers). This is the load-bearing fact about how the system works — there is no socket or RPC channel between controller and Liquidsoap. The shared `/var/sub-wave` mount in **both** Broadcast and Controller is what makes it work; they must always map to the same host path.


### PR DESCRIPTION
Two agent-tooling housekeeping changes.

## 1. `CLAUDE.md` — PRs target `develop`, never `main`

The repo was already configured correctly — GitHub's default branch is `develop`, `.github/PULL_REQUEST_TEMPLATE.md` asks for `develop`, and `enforce-main-source.yml` rejects any PR into `main` that isn't from `develop` or release-please.

The problem was upstream of all that: Claude Code injects a git preamble into every session containing

```
Main branch (you will usually use this for PRs): main
```

That line comes from a local branch-name lookup and never consults the remote default branch. Agents read it as instruction and passed `--base main`, and CI bounced the PR. Nothing in `CLAUDE.md` contradicted it.

The new section (next to the merge-gate section) says:

- Every PR bases on `develop` — `gh pr create --base develop`
- Ignore the preamble's "Main branch" line, with the reason it's wrong here
- The one exception is the release `develop` → `main` PR, pointing at `.claude/skills/subwave-release-pr/SKILL.md`

## 2. Track `.codex/config.toml`

Codex needs the same `mcp-subwave` wiring every contributor would otherwise hand-write. No secrets, repo-relative path, and the repo already tracks `.claude/skills/` and `AGENTS.md` — agent tooling config belongs in-tree.

Added a comment on the port, since it isn't uniform across the three compose files: `7701` is the controller's own port, published to the host by `docker-compose.dev.yml` and `docker-compose.byo.yml`, but *not* by the default prod `docker-compose.yml` where only Caddy binds a host port (use `http://localhost:7700/api` there).

No code paths touched.