### PR TITLE
fix(admin): compact sidebar station selector

### DIFF
--- a/web/components/admin/AdminShell.tsx
+++ b/web/components/admin/AdminShell.tsx
@@ -527,7 +527,7 @@ function AdminSidebar({
         </SidebarMenu>
 
         {process.env.NEXT_PUBLIC_APP_VERSION ? (
-          <div className="border-t border-dashed border-[var(--separator-strong)] px-1 pt-3 text-[10px] tracking-[0.18em] text-muted uppercase group-data-[collapsible=icon]:hidden">
+          <div className="border-t border-dashed border-[var(--separator-strong)] px-1 pt-1.5 text-[10px] tracking-[0.18em] text-muted uppercase group-data-[collapsible=icon]:hidden">
             v{process.env.NEXT_PUBLIC_APP_VERSION}
           </div>
         ) : null}

--- a/web/components/admin/StationSwitcher.tsx
+++ b/web/components/admin/StationSwitcher.tsx
@@ -58,17 +58,12 @@ export default function StationSwitcher({
         <SidebarMenuItem>
           <DropdownMenu modal={false} onOpenChange={o => { if (o) void stationsQuery.refetch(); }}>
             <DropdownMenuTrigger asChild>
-              <SidebarMenuButton size="lg" tooltip="Switch station">
-                <span className="flex aspect-square size-8 shrink-0 items-center justify-center rounded-sm border border-ink">
-                  <RadioTower className="size-4" />
+              <SidebarMenuButton tooltip="Switch station">
+                <span className="flex aspect-square size-5 shrink-0 items-center justify-center rounded-sm border border-ink">
+                  <RadioTower className="size-3" />
                 </span>
-                <span className="grid min-w-0 flex-1 text-left leading-tight">
-                  <span className="truncate text-[13px] font-extrabold tracking-[0.08em] uppercase">
-                    {active.name}
-                  </span>
-                  <span className="caption truncate">
-                    {active.id ?? 'this install'} · on air
-                  </span>
+                <span className="min-w-0 flex-1 truncate text-[13px] font-extrabold tracking-[0.08em] uppercase">
+                  {active.name}
                 </span>
                 <ChevronsUpDown className="ml-auto size-4 opacity-60" />
               </SidebarMenuButton>


### PR DESCRIPTION
## Summary

- slim the admin sidebar station selector to the standard row height
- remove the station ID and on-air subtitle, and reduce the station icon size
- tighten the spacing above the sidebar version label

## Verification

- `cd web && npm run lint`
- isolated admin UI check at expanded and collapsed sidebar widths