### PR TITLE
feat(admin): search, group and defer the settings surface

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -3368,6 +3368,31 @@ html:has(.admin-root.paper) {
     }
 }
 
+/* Settings search jumped to this card — a two-and-a-bit second accent ring so
+   the operator can see WHICH of six near-identical cards the result landed on.
+   Set as a DOM attribute rather than React state: the flash outlives the scroll
+   animation and belongs to no component's data. Respects reduced motion by
+   holding the ring steady instead of fading it. */
+.admin-root .card[data-flash] {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    animation: settings-card-flash 2.6s ease-out forwards;
+}
+@keyframes settings-card-flash {
+    0%,
+    70% {
+        outline-color: var(--accent);
+    }
+    100% {
+        outline-color: transparent;
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    .admin-root .card[data-flash] {
+        animation: none;
+    }
+}
+
 /* Card */
 .admin-root .card {
     border: 1px solid var(--ink);

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ChangeEvent } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { notify, errorMessage } from '../../lib/notify';
 import { normalizeStationLocale } from '../../lib/format';
@@ -27,15 +27,17 @@ import {
   SETTINGS_MP3_BITRATES,
   SETTINGS_OPUS_BITRATES,
 } from '@/lib/schemas.generated';
+import { AlertTriangle } from 'lucide-react';
 import {
-  Radio, Palette, Cpu, Mic, Library, Search,
-  Activity, Archive, Save, AlertTriangle, Heart, Music2,
-} from 'lucide-react';
-import {
-  SectionHeader, SettingsFieldError, ELEVENLABS_VS_DEFAULTS, FISH_TTS_DEFAULTS,
+  SectionHeader, SaveBar, SettingsFieldError, ELEVENLABS_VS_DEFAULTS, FISH_TTS_DEFAULTS,
   type FormState, type FormUpdater, type SettingsData, type SaveSettings,
   type LoudnessSource, type LlmForm, type LlmFallbackForm,
 } from './settings/shared';
+import {
+  SECTIONS, SECTION_GROUPS, RESTART_PATHS, sectionById, type SectionId,
+} from './settings/registry';
+import { Advanced, SectionChromeProvider } from './settings/section-chrome';
+import { SettingsSearch, type SettingsJump } from './settings/SettingsSearch';
 import { TtsSection } from './settings/TtsSection';
 import { LlmSection } from './settings/LlmSection';
 import { SearchSection } from './settings/SearchSection';
@@ -50,22 +52,59 @@ import {
   useSettingsQuery,
 } from './settings/queries';
 
-const SECTIONS = [
-  { id: 'station',  label: 'Station', hint: 'name · location · locale', icon: Radio },
-  { id: 'music',    label: 'Music source', hint: 'navidrome · subsonic', icon: Music2 },
-  { id: 'theme',    label: 'Skin & Themes', hint: 'player skin · palette', icon: Palette },
-  { id: 'llm',      label: 'LLM provider', hint: 'model routing', icon: Cpu },
-  { id: 'tts',      label: 'TTS voice', hint: 'default engine', icon: Mic },
-  { id: 'library',  label: 'Library tagger', hint: 'embedding · propagation', icon: Library },
-  { id: 'search',   label: 'Web search', hint: 'live-facts backend', icon: Search },
-  { id: 'scrobble', label: 'Scrobbling', hint: 'last.fm · listenbrainz', icon: Activity },
-  { id: 'likes',    label: 'Likes', hint: 'heart button · navidrome stars', icon: Heart },
-  { id: 'archives', label: 'Archives', hint: 'hourly recordings', icon: Archive },
-  { id: 'backup',   label: 'Backup', hint: 'export · restore', icon: Save },
-  { id: 'danger',   label: 'Danger zone', hint: 'broadcast control', icon: AlertTriangle },
-] as const;
+/**
+ * Read one dotted path out of the form. Returns undefined for a missing branch
+ * rather than throwing, so a path that names a key a given settings.json has
+ * never carried compares equal on both sides and reads as clean.
+ */
+function atPath(form: FormState | null, path: string): unknown {
+  let node: unknown = form;
+  for (const key of path.split('.')) {
+    if (!node || typeof node !== 'object') return undefined;
+    node = (node as Record<string, unknown>)[key];
+  }
+  return node;
+}
 
-type SectionId = (typeof SECTIONS)[number]['id'];
+const samePath = (a: FormState | null, b: FormState | null, path: string) =>
+  JSON.stringify(atPath(a, path) ?? null) === JSON.stringify(atPath(b, path) ?? null);
+
+/**
+ * How many individual controls differ between two form branches.
+ *
+ * Counting LEAVES, not top-level keys: `requests` is one key holding seven
+ * fields, and "1 unsaved change" under a card where the operator just edited
+ * three of them reads as a bug in the counter.
+ */
+function countLeafDiffs(a: unknown, b: unknown): number {
+  if (JSON.stringify(a ?? null) === JSON.stringify(b ?? null)) return 0;
+  const plain = (v: unknown): v is Record<string, unknown> =>
+    !!v && typeof v === 'object' && !Array.isArray(v);
+  // An array is one control (the TTS corrections list, the compat params
+  // table), not one control per row.
+  if (!plain(a) || !plain(b)) return 1;
+  let n = 0;
+  for (const key of new Set([...Object.keys(a), ...Object.keys(b)])) {
+    n += countLeafDiffs(a[key], b[key]);
+  }
+  return n;
+}
+
+/**
+ * The paths a section owns that differ from the last saved baseline.
+ *
+ * Diffing against the BASELINE rather than the server's current values is what
+ * makes the count survive the 3s refetch: the baseline only moves when a save
+ * succeeds, so an operator mid-edit keeps seeing their own change count.
+ */
+function dirtyPaths(
+  form: FormState | null,
+  baseline: FormState | null,
+  paths: readonly string[],
+): string[] {
+  if (!form || !baseline) return [];
+  return paths.filter(path => !samePath(form, baseline, path));
+}
 
 // The three encoder vocabularies, from the mirror rather than re-typed. radio.liq
 // has a literal `%mp3(bitrate=…)` branch per value, so each set is genuinely
@@ -173,7 +212,19 @@ export default function SettingsPanel() {
   const [confirmStop, setConfirmStop] = useState(false);
   const [activeSection, setActiveSection] = useState<SectionId>('station');
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  // Portal target for the one sticky save bar. Null while nothing is unsaved,
+  // which is what makes every section's SaveBar render nothing when clean.
+  const [saveSlot, setSaveSlot] = useState<HTMLElement | null>(null);
+  // Dirtiness reported by a section whose state does not ride FormState.
+  const [localDirty, setLocalDirty] = useState<Record<string, boolean>>({});
+  // Advanced disclosure, per section — remembered while the panel is open so
+  // flipping away to check another section and back does not re-collapse it.
+  const [advOpen, setAdvOpen] = useState<Record<string, boolean>>({});
   const router = useRouter();
+
+  const reportDirty = useCallback((id: string, dirty: boolean) => {
+    setLocalDirty(prev => (!!prev[id] === dirty ? prev : { ...prev, [id]: dirty }));
+  }, []);
 
   const refresh = async () => { await settingsQuery.refetch(); };
 
@@ -513,37 +564,180 @@ export default function SettingsPanel() {
     } finally { setBusy(false); }
   };
 
+  /**
+   * Archives and the danger zone used to carry a Save button per card — one for
+   * the bitrate, one for the retention window, one for each stream mount. Each
+   * now folds into the section's one save.
+   *
+   * Posting the whole block is safe rather than noisy: `settings.update()`
+   * change-gates every field in these two blocks against the CURRENT value
+   * before deciding it changed, so an untouched field posted alongside an
+   * edited one neither writes nor flags a restart.
+   */
+  const saveArchives = () => {
+    if (!form) return;
+    saveSettings({
+      archive: {
+        enabled: form.archive.enabled,
+        bitrate: parseInt(form.archive.bitrate, 10),
+        retentionDays: parseInt(form.archive.retentionDays, 10),
+      },
+    });
+  };
+
+  const saveDanger = () => {
+    if (!form) return;
+    saveSettings({
+      crossfadeDuration: parseFloat(form.crossfadeDuration),
+      maxTrackSeconds: parseInt(form.maxTrackSeconds, 10) || 0,
+      silenceTrim: {
+        enabled: form.silenceTrim.enabled,
+        minGapMs: parseInt(form.silenceTrim.minGapMs, 10) || 1500,
+      },
+      transitions: {
+        pairDrain: form.transitions.pairDrain,
+        stemBlends: form.transitions.stemBlends,
+      },
+      audio: {
+        stemCache: form.transitions.stemCache,
+        stemCacheGb: Number(form.transitions.stemCacheGb),
+      },
+      loudness: {
+        targetLufs: parseFloat(form.loudness.targetLufs),
+        maxBoostDb: parseFloat(form.loudness.maxBoostDb),
+        source: form.loudness.source,
+      },
+      stream: {
+        idleWhenEmpty: form.stream.idleWhenEmpty,
+        idleAfterMinutes: parseInt(form.stream.idleAfterMinutes, 10),
+        opusEnabled: form.stream.opusEnabled,
+        opusBitrate: parseInt(form.stream.opusBitrate, 10),
+        flacEnabled: form.stream.flacEnabled,
+        oggIcyMetadata: form.stream.oggIcyMetadata,
+        aacEnabled: form.stream.aacEnabled,
+        aacBitrate: parseInt(form.stream.aacBitrate, 10),
+        bitrate: parseInt(form.stream.bitrate, 10),
+        bufferSeconds: Number(form.stream.bufferSeconds),
+      },
+    });
+  };
+
+  const activeSpec = sectionById(activeSection);
+  const baseline = formBaselineRef.current;
+  const changedPaths = dirtyPaths(form, baseline, activeSpec?.formKeys ?? []);
+  const changedCount = changedPaths.reduce(
+    (n, path) => n + countLeafDiffs(atPath(form, path), atPath(baseline, path)),
+    0,
+  );
+  // A section can be dirty in either currency: form paths the panel diffs, or a
+  // section-local edit it cannot see (Navidrome creds, which live in
+  // setup-config.json rather than settings.json).
+  const hasLocalDirty = Object.values(localDirty).some(Boolean);
+  const sectionDirty = changedCount > 0 || hasLocalDirty;
+  // Warn BEFORE the save, from the mirrored path list. The controller stays the
+  // authority afterwards — its `requiresRestart` is what raises the persistent
+  // banner above.
+  const restartWarn = RESTART_PATHS.some(path =>
+    (activeSpec?.formKeys ?? []).some(key => path === key || path.startsWith(`${key}.`))
+    && !samePath(form, baseline, path));
+
+  const dirtyLabel = changedCount > 0
+    ? `${changedCount} unsaved change${changedCount === 1 ? '' : 's'} in ${activeSpec?.label.toLowerCase() ?? 'this section'}`
+    : `unsaved changes in ${activeSpec?.label.toLowerCase() ?? 'this section'}`;
+
+  /** Roll this section's fields back to the last saved baseline, nothing else. */
+  const discardSection = () => {
+    if (!form || !baseline || !activeSpec) return;
+    const next = JSON.parse(JSON.stringify(form)) as Record<string, unknown>;
+    const from = baseline as unknown as Record<string, unknown>;
+    for (const key of activeSpec.formKeys) {
+      if (key in from) next[key] = JSON.parse(JSON.stringify(from[key] ?? null));
+    }
+    setForm(next as unknown as FormState);
+    // The errors belonged to values that no longer exist — same ownership rule
+    // the save path uses, so an unrelated section's message survives.
+    setFieldErrors(prev => {
+      const out: Record<string, string> = {};
+      for (const [path, message] of Object.entries(prev)) {
+        const owned = activeSpec.formKeys.some(k => path === k || path.startsWith(`${k}.`));
+        if (!owned) out[path] = message;
+      }
+      return out;
+    });
+  };
+
+  /** Search result → switch section, open Advanced if needed, scroll and flash. */
+  const jumpTo = useCallback(({ section, anchor, advanced }: SettingsJump) => {
+    setActiveSection(section);
+    if (advanced) setAdvOpen(prev => ({ ...prev, [section]: true }));
+    // The section swap and the disclosure both have to commit before the target
+    // card exists to scroll to, so this waits a beat rather than a frame.
+    window.setTimeout(() => {
+      const el = document.querySelector(`[data-card="${anchor}"]`);
+      if (!(el instanceof HTMLElement)) return;
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      el.setAttribute('data-flash', '');
+      window.setTimeout(() => el.removeAttribute('data-flash'), 2600);
+    }, 90);
+  }, []);
+
+  const chrome = useMemo(() => ({
+    saveSlot,
+    reportDirty,
+    advOpen: !!advOpen[activeSection],
+    setAdvOpen: (open: boolean) =>
+      setAdvOpen(prev => ({ ...prev, [activeSection]: open })),
+  }), [saveSlot, reportDirty, advOpen, activeSection]);
+
   return (
     <div className="stack-mobile grid grid-cols-[240px_1fr] items-start gap-6">
-      <aside className="grid gap-1 sm:sticky sm:top-6">
-        <span className="caption pb-2">settings</span>
-        {SECTIONS.map(s => {
-          const isActive = activeSection === s.id;
-          const Icon = s.icon;
-          return (
-            <button
-              key={s.id}
-              onClick={() => setActiveSection(s.id)}
-              className={cn(
-                'flex cursor-pointer items-center gap-2.5 border border-ink px-3 py-2.5 text-left font-[inherit] transition-colors',
-                isActive ? 'bg-ink text-bg' : 'bg-[var(--ink-soft)] text-ink hover:bg-ink/10',
-              )}
-            >
-              <Icon className="size-4 shrink-0 opacity-80" strokeWidth={2} aria-hidden />
-              <span className="grid min-w-0 gap-1">
-                <span className="text-[11px] font-bold tracking-[0.2em] uppercase">
-                  {s.label}
-                </span>
-                <span className="text-[9px] tracking-[0.18em] uppercase opacity-70">
-                  {s.hint}
-                </span>
-              </span>
-            </button>
-          );
-        })}
+      <aside className="grid gap-3.5 sm:sticky sm:top-6">
+        {SECTION_GROUPS.map(group => (
+          <div key={group} className="grid gap-1">
+            <span className="caption pb-1">{group}</span>
+            {SECTIONS.filter(s => s.group === group).map(s => {
+              const isActive = activeSection === s.id;
+              const Icon = s.icon;
+              // A section not on screen can only be dirty in form paths — its
+              // own component is unmounted, so a section-local edit (music)
+              // shows a dot on the active section alone. That is accurate
+              // rather than approximate: leaving those sections discards them.
+              const dirty = dirtyPaths(form, baseline, s.formKeys).length > 0
+                || (isActive && hasLocalDirty);
+              return (
+                <button
+                  key={s.id}
+                  onClick={() => setActiveSection(s.id)}
+                  className={cn(
+                    'flex cursor-pointer items-center gap-2.5 border border-ink px-3 py-2.5 text-left font-[inherit] transition-colors',
+                    isActive ? 'bg-ink text-bg' : 'bg-[var(--ink-soft)] text-ink hover:bg-ink/10',
+                  )}
+                >
+                  <Icon className="size-4 shrink-0 opacity-80" strokeWidth={2} aria-hidden />
+                  <span className="grid min-w-0 flex-1 gap-1">
+                    <span className="text-[11px] font-bold tracking-[0.2em] uppercase">
+                      {s.label}
+                    </span>
+                    <span className="text-[9px] tracking-[0.18em] uppercase opacity-70">
+                      {s.hint}
+                    </span>
+                  </span>
+                  {dirty && (
+                    <span
+                      className="size-1.5 shrink-0 bg-vermilion"
+                      title="unsaved changes"
+                      aria-label="unsaved changes"
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        ))}
       </aside>
 
       <div className="grid gap-4">
+        <SettingsSearch onJump={jumpTo} />
         {err && <ErrorState error={err} onRetry={refresh} />}
         {pendingRestart && (
           <div
@@ -569,6 +763,36 @@ export default function SettingsPanel() {
         )}
         {!data && !err && <SkeletonForm fields={5} />}
 
+        {/* One save bar per section, sticky, and only while something is
+            unsaved. Each section's own SaveBar portals its note + button into
+            the slot below, so the wording, the patch and the error scoping
+            still belong to the section that knows them.
+
+            top-[3.25rem] clears AdminShell's own sticky header (top-0, ~49px
+            tall) rather than tucking under it like the section rail does — this
+            is the one strip that has to stay readable while the operator
+            scrolls a long section looking for what they changed. */}
+        {sectionDirty && (
+          <div className="sticky top-[3.25rem] z-30 grid gap-2.5 border border-vermilion bg-bg p-3 shadow-drawer">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+              <span className="size-2 shrink-0 bg-vermilion" aria-hidden />
+              <span className="text-[11px] font-bold tracking-[0.2em] uppercase">
+                {dirtyLabel}
+              </span>
+              {restartWarn && (
+                <Pill tone="accent" dot>needs a mixer restart</Pill>
+              )}
+              {changedCount > 0 && (
+                <Btn sm className="ml-auto" onClick={discardSection} disabled={busy}>
+                  Discard
+                </Btn>
+              )}
+            </div>
+            <div ref={setSaveSlot} className="grid gap-2.5" />
+          </div>
+        )}
+
+        <SectionChromeProvider value={chrome}>
         {data && form && (() => {
           const updateForm: FormUpdater = (updater) =>
             setForm(prev => (prev ? updater(prev) : prev));
@@ -654,15 +878,6 @@ export default function SettingsPanel() {
                           )
                         }
                       />
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({ archive: { enabled: form.archive.enabled } })
-                        }
-                        disabled={busy}
-                      >
-                        Save
-                      </Btn>
                     </div>
                     <SettingsFieldError path="archive.enabled" errors={fieldErrors} />
                     <div className="field-hint">
@@ -695,17 +910,6 @@ export default function SettingsPanel() {
                           ))}
                         </SelectContent>
                       </Select>
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({
-                            archive: { bitrate: parseInt(form.archive.bitrate, 10) },
-                          })
-                        }
-                        disabled={busy || !form.archive.enabled}
-                      >
-                        Save bitrate
-                      </Btn>
                     </div>
                     <div className="field-hint">
                       Lower bitrate = smaller archives, less encoder CPU
@@ -734,17 +938,6 @@ export default function SettingsPanel() {
                         }
                       />
                       <span className="text-[12px] text-muted">days</span>
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({
-                            archive: { retentionDays: parseInt(form.archive.retentionDays, 10) },
-                          })
-                        }
-                        disabled={busy}
-                      >
-                        Save retention
-                      </Btn>
                     </div>
                     <div className="field-hint">
                       Defaults to 30 days; 0 = keep forever. With a window set, the hourly
@@ -758,6 +951,14 @@ export default function SettingsPanel() {
                 </div>
               </Card>
             )}
+            <SaveBar
+              note="Turning the archive on or off, and changing its bitrate, need a mixer restart. The retention window applies live."
+              busy={busy}
+              onSave={saveArchives}
+              saveLabel="Save archives"
+              errors={fieldErrors}
+              ownedKeys={['archive']}
+            />
           </>
         )}
         {activeSection === 'backup' && <BackupPanel />}
@@ -831,20 +1032,6 @@ export default function SettingsPanel() {
                       }
                     />
                     <span className="text-[12px] text-muted">min</span>
-                    <Btn
-                      sm
-                      onClick={() =>
-                        saveSettings({
-                          stream: {
-                            idleWhenEmpty: form.stream.idleWhenEmpty,
-                            idleAfterMinutes: parseInt(form.stream.idleAfterMinutes, 10),
-                          },
-                        })
-                      }
-                      disabled={busy}
-                    >
-                      Save
-                    </Btn>
                   </div>
                   <div className="field-hint">
                     After this long with zero listeners the programme pauses mid-track and the DJ
@@ -857,6 +1044,7 @@ export default function SettingsPanel() {
               </Card>
             )}
 
+            <Advanced note="crossfade, transitions, loudness and the extra stream mounts">
             {form && (
               <Card title="Crossfade" sub="track transition overlap">
                 <div className="field">
@@ -877,15 +1065,6 @@ export default function SettingsPanel() {
                       }
                     />
                     <span className="text-[12px] text-muted">sec</span>
-                    <Btn
-                      sm
-                      onClick={() =>
-                        saveSettings({ crossfadeDuration: parseFloat(form.crossfadeDuration) })
-                      }
-                      disabled={busy}
-                    >
-                      Save crossfade
-                    </Btn>
                   </div>
                   <SettingsFieldError path="crossfadeDuration" errors={fieldErrors} />
                   <div className="field-hint">
@@ -979,19 +1158,6 @@ export default function SettingsPanel() {
                         ).toLocaleString('en-GB')}{' '}
                         tracks
                       </span>
-                      {/* Its own save button: without one, an edit here misses the
-                          card-level "Save transitions" and silently reverts. */}
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({
-                            audio: { stemCacheGb: Number(form.transitions.stemCacheGb) },
-                          })
-                        }
-                        disabled={busy}
-                      >
-                        Save budget
-                      </Btn>
                     </div>
                     <div className="field-hint">
                       How much disk the stem cache may use before the oldest entries are evicted
@@ -1017,24 +1183,6 @@ export default function SettingsPanel() {
                           )
                         }
                       />
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({
-                            transitions: {
-                              pairDrain: form.transitions.pairDrain,
-                              stemBlends: form.transitions.stemBlends,
-                            },
-                            audio: {
-                              stemCache: form.transitions.stemCache,
-                              stemCacheGb: Number(form.transitions.stemCacheGb),
-                            },
-                          })
-                        }
-                        disabled={busy}
-                      >
-                        Save transitions
-                      </Btn>
                     </div>
                     <div className="field-hint">
                       When two tempo-compatible tracks meet and both have cached stems, the seam
@@ -1068,15 +1216,6 @@ export default function SettingsPanel() {
                     <span className="text-[12px] text-muted">
                       sec · 0 = no limit · min {data?.values?.minTrackSeconds ?? 30}s
                     </span>
-                    <Btn
-                      sm
-                      onClick={() =>
-                        saveSettings({ maxTrackSeconds: parseInt(form.maxTrackSeconds, 10) || 0 })
-                      }
-                      disabled={busy}
-                    >
-                      Save limit
-                    </Btn>
                   </div>
                   <SettingsFieldError path="maxTrackSeconds" errors={fieldErrors} />
                   <div className="field-hint">
@@ -1135,20 +1274,6 @@ export default function SettingsPanel() {
                         }
                       />
                       <span className="text-[12px] text-muted">ms</span>
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({
-                            silenceTrim: {
-                              enabled: form.silenceTrim.enabled,
-                              minGapMs: parseInt(form.silenceTrim.minGapMs, 10) || 1500,
-                            },
-                          })
-                        }
-                        disabled={busy}
-                      >
-                        Save trim
-                      </Btn>
                     </div>
                     <SettingsFieldError path="silenceTrim.minGapMs" errors={fieldErrors} />
                     <div className="field-hint">
@@ -1243,21 +1368,6 @@ export default function SettingsPanel() {
                         }
                       />
                       <span className="text-[12px] text-muted">dB · 0 to 12</span>
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({
-                            loudness: {
-                              targetLufs: parseFloat(form.loudness.targetLufs),
-                              maxBoostDb: parseFloat(form.loudness.maxBoostDb),
-                              source: form.loudness.source,
-                            },
-                          })
-                        }
-                        disabled={busy}
-                      >
-                        Save loudness
-                      </Btn>
                     </div>
                     <div className="field-hint">
                       Cap on how far a quiet track is turned up (0 = level down only). Boost is
@@ -1293,15 +1403,6 @@ export default function SettingsPanel() {
                           )
                         }
                       />
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({ stream: { opusEnabled: form.stream.opusEnabled } })
-                        }
-                        disabled={busy}
-                      >
-                        Save
-                      </Btn>
                     </div>
                     <SettingsFieldError path="stream.opusEnabled" errors={fieldErrors} />
                     <div className="field-hint">
@@ -1336,17 +1437,6 @@ export default function SettingsPanel() {
                           ))}
                         </SelectContent>
                       </Select>
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({
-                            stream: { opusBitrate: parseInt(form.stream.opusBitrate, 10) },
-                          })
-                        }
-                        disabled={busy}
-                      >
-                        Save bitrate
-                      </Btn>
                     </div>
                     <SettingsFieldError path="stream.opusBitrate" errors={fieldErrors} />
                     <div className="field-hint">
@@ -1380,15 +1470,6 @@ export default function SettingsPanel() {
                         )
                       }
                     />
-                    <Btn
-                      sm
-                      onClick={() =>
-                        saveSettings({ stream: { flacEnabled: form.stream.flacEnabled } })
-                      }
-                      disabled={busy}
-                    >
-                      Save
-                    </Btn>
                   </div>
                   <SettingsFieldError path="stream.flacEnabled" errors={fieldErrors} />
                   {form.stream.flacEnabled && (
@@ -1434,15 +1515,6 @@ export default function SettingsPanel() {
                         )
                       }
                     />
-                    <Btn
-                      sm
-                      onClick={() =>
-                        saveSettings({ stream: { oggIcyMetadata: form.stream.oggIcyMetadata } })
-                      }
-                      disabled={busy}
-                    >
-                      Save
-                    </Btn>
                   </div>
                   <SettingsFieldError path="stream.oggIcyMetadata" errors={fieldErrors} />
                   <div className="field-hint">
@@ -1479,15 +1551,6 @@ export default function SettingsPanel() {
                           )
                         }
                       />
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({ stream: { aacEnabled: form.stream.aacEnabled } })
-                        }
-                        disabled={busy}
-                      >
-                        Save
-                      </Btn>
                     </div>
                     <SettingsFieldError path="stream.aacEnabled" errors={fieldErrors} />
                     {form.stream.aacEnabled && (
@@ -1529,17 +1592,6 @@ export default function SettingsPanel() {
                           ))}
                         </SelectContent>
                       </Select>
-                      <Btn
-                        sm
-                        onClick={() =>
-                          saveSettings({
-                            stream: { aacBitrate: parseInt(form.stream.aacBitrate, 10) },
-                          })
-                        }
-                        disabled={busy}
-                      >
-                        Save bitrate
-                      </Btn>
                     </div>
                     <SettingsFieldError path="stream.aacBitrate" errors={fieldErrors} />
                     <div className="field-hint">
@@ -1576,17 +1628,6 @@ export default function SettingsPanel() {
                         ))}
                       </SelectContent>
                     </Select>
-                    <Btn
-                      sm
-                      onClick={() =>
-                        saveSettings({
-                          stream: { bitrate: parseInt(form.stream.bitrate, 10) },
-                        })
-                      }
-                      disabled={busy}
-                    >
-                      Save bitrate
-                    </Btn>
                   </div>
                   <SettingsFieldError path="stream.bitrate" errors={fieldErrors} />
                   <div className="field-hint">
@@ -1623,17 +1664,6 @@ export default function SettingsPanel() {
                       }
                     />
                     <span className="text-[12px] text-muted">seconds</span>
-                    <Btn
-                      sm
-                      onClick={() =>
-                        saveSettings({
-                          stream: { bufferSeconds: Number(form.stream.bufferSeconds) },
-                        })
-                      }
-                      disabled={busy}
-                    >
-                      Save listener buffer
-                    </Btn>
                   </div>
                   <SettingsFieldError path="stream.bufferSeconds" errors={fieldErrors} />
                   <div className="field-hint">
@@ -1646,6 +1676,9 @@ export default function SettingsPanel() {
                 </div>
               </Card>
             )}
+
+
+            </Advanced>
 
             <Card title="Mixer" sub="apply pending Liquidsoap-level settings">
               <div className="grid gap-2">
@@ -1662,8 +1695,18 @@ export default function SettingsPanel() {
                 </div>
               </div>
             </Card>
+
+            <SaveBar
+              note="Crossfade, the encoder settings and the listener buffer only reach the stream after a mixer restart. Idle pause, loudness, dead-air trim and the track-length cap apply live."
+              busy={busy}
+              onSave={saveDanger}
+              saveLabel="Save danger zone"
+              errors={fieldErrors}
+              ownedKeys={['crossfadeDuration', 'maxTrackSeconds', 'silenceTrim', 'transitions', 'audio', 'loudness', 'stream']}
+            />
           </>
         )}
+        </SectionChromeProvider>
       </div>
 
       <V3AlertDialog

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -116,6 +116,25 @@ const OPUS_BITRATES = SETTINGS_OPUS_BITRATES;
 const AAC_BITRATES = SETTINGS_AAC_BITRATES;
 
 /**
+ * Settings keys a save posts under a name the FormState does NOT use.
+ *
+ * `rebaselineSavedPatch` already re-homes the VALUES (audio.stemCache* is edited
+ * as `transitions.*`); anything that scopes by FormState key has to follow the
+ * same map or it misses the alias. Discard is the case that bites: rolling back
+ * `transitions` while leaving the `audio.stemCacheGb` message on screen parks an
+ * error under a value that no longer produced it.
+ */
+const FORM_KEY_ALIASES: Record<string, readonly string[]> = {
+  transitions: ['audio'],
+};
+
+/** Does `path` belong to any of these FormState keys, alias included? */
+function ownsErrorPath(formKeys: readonly string[], path: string): boolean {
+  const under = (key: string) => path === key || path.startsWith(`${key}.`);
+  return formKeys.some(key => under(key) || (FORM_KEY_ALIASES[key] ?? []).some(under));
+}
+
+/**
  * Replace exactly the errors belonging to the keys this patch carried.
  *
  * Scoped by TOP-LEVEL key, because that is the unit a save button posts and the
@@ -138,6 +157,46 @@ function mergePatchErrors(
   }
   for (const [path, message] of Object.entries(next || {})) out[path] = message;
   return out;
+}
+
+/**
+ * How long a search jump waits for its target card to mount, in animation
+ * frames (~1s at 60Hz). Generous on purpose: the cost of waiting is invisible
+ * — the scroll simply happens on the frame the card appears — while the cost of
+ * giving up early is a jump that silently does nothing.
+ */
+const JUMP_MAX_FRAMES = 60;
+
+/**
+ * Collector for the number boxes in a whole-block save.
+ *
+ * Archives and the danger zone post EVERY field on every click, so a box the
+ * operator cleared and has not refilled rides along with whatever they actually
+ * edited — and neither JS coercion fails safely there. `Number('')` is 0, which
+ * is a VALID listener buffer and a valid retention window, so saving an AAC
+ * toggle would quietly set the buffer to 0s and flag a mixer restart.
+ * `parseInt('')` is NaN, which JSON.stringify posts as `null` and fails the
+ * whole block with a message pointing at a field nobody touched.
+ *
+ * So a blank box refuses the save and names itself instead. An explicitly typed
+ * `0` still parses, which is what keeps "0 = no limit" on max track length.
+ */
+function numberFields() {
+  const bad: Record<string, string> = {};
+  const read = (path: string, raw: string, parse: (s: string) => number) => {
+    const text = String(raw).trim();
+    // Blank is checked before the parser, not by it: Number('') is a finite 0.
+    const n = text ? parse(text) : NaN;
+    if (Number.isFinite(n)) return n;
+    bad[path] = 'enter a number';
+    return 0;
+  };
+  return {
+    bad,
+    int: (path: string, raw: string) => read(path, raw, t => parseInt(t, 10)),
+    float: (path: string, raw: string) => read(path, raw, t => parseFloat(t)),
+    num: (path: string, raw: string) => read(path, raw, Number),
+  };
 }
 
 const sameForm = (a: FormState, b: FormState) => JSON.stringify(a) === JSON.stringify(b);
@@ -565,6 +624,22 @@ export default function SettingsPanel() {
   };
 
   /**
+   * Post a whole-block patch — unless a number box in it was left blank, in
+   * which case name the box and save nothing. See `numberFields`.
+   */
+  const saveBlock = (n: ReturnType<typeof numberFields>, patch: Record<string, unknown>) => {
+    const blanks = Object.keys(n.bad);
+    if (blanks.length > 0) {
+      setFieldErrors(prev => mergePatchErrors(prev, patch, n.bad));
+      notify.err(blanks.length === 1
+        ? 'a number field is empty — fill it in before saving'
+        : `${blanks.length} number fields are empty — fill them in before saving`);
+      return;
+    }
+    saveSettings(patch);
+  };
+
+  /**
    * Archives and the danger zone used to carry a Save button per card — one for
    * the bitrate, one for the retention window, one for each stream mount. Each
    * now folds into the section's one save.
@@ -572,27 +647,30 @@ export default function SettingsPanel() {
    * Posting the whole block is safe rather than noisy: `settings.update()`
    * change-gates every field in these two blocks against the CURRENT value
    * before deciding it changed, so an untouched field posted alongside an
-   * edited one neither writes nor flags a restart.
+   * edited one neither writes nor flags a restart. What it is NOT safe against
+   * is a blank number box, which is why both go through `saveBlock`.
    */
   const saveArchives = () => {
     if (!form) return;
-    saveSettings({
+    const n = numberFields();
+    saveBlock(n, {
       archive: {
         enabled: form.archive.enabled,
-        bitrate: parseInt(form.archive.bitrate, 10),
-        retentionDays: parseInt(form.archive.retentionDays, 10),
+        bitrate: n.int('archive.bitrate', form.archive.bitrate),
+        retentionDays: n.int('archive.retentionDays', form.archive.retentionDays),
       },
     });
   };
 
   const saveDanger = () => {
     if (!form) return;
-    saveSettings({
-      crossfadeDuration: parseFloat(form.crossfadeDuration),
-      maxTrackSeconds: parseInt(form.maxTrackSeconds, 10) || 0,
+    const n = numberFields();
+    saveBlock(n, {
+      crossfadeDuration: n.float('crossfadeDuration', form.crossfadeDuration),
+      maxTrackSeconds: n.int('maxTrackSeconds', form.maxTrackSeconds),
       silenceTrim: {
         enabled: form.silenceTrim.enabled,
-        minGapMs: parseInt(form.silenceTrim.minGapMs, 10) || 1500,
+        minGapMs: n.int('silenceTrim.minGapMs', form.silenceTrim.minGapMs),
       },
       transitions: {
         pairDrain: form.transitions.pairDrain,
@@ -600,24 +678,24 @@ export default function SettingsPanel() {
       },
       audio: {
         stemCache: form.transitions.stemCache,
-        stemCacheGb: Number(form.transitions.stemCacheGb),
+        stemCacheGb: n.num('audio.stemCacheGb', form.transitions.stemCacheGb),
       },
       loudness: {
-        targetLufs: parseFloat(form.loudness.targetLufs),
-        maxBoostDb: parseFloat(form.loudness.maxBoostDb),
+        targetLufs: n.float('loudness.targetLufs', form.loudness.targetLufs),
+        maxBoostDb: n.float('loudness.maxBoostDb', form.loudness.maxBoostDb),
         source: form.loudness.source,
       },
       stream: {
         idleWhenEmpty: form.stream.idleWhenEmpty,
-        idleAfterMinutes: parseInt(form.stream.idleAfterMinutes, 10),
+        idleAfterMinutes: n.int('stream.idleAfterMinutes', form.stream.idleAfterMinutes),
         opusEnabled: form.stream.opusEnabled,
-        opusBitrate: parseInt(form.stream.opusBitrate, 10),
+        opusBitrate: n.int('stream.opusBitrate', form.stream.opusBitrate),
         flacEnabled: form.stream.flacEnabled,
         oggIcyMetadata: form.stream.oggIcyMetadata,
         aacEnabled: form.stream.aacEnabled,
-        aacBitrate: parseInt(form.stream.aacBitrate, 10),
-        bitrate: parseInt(form.stream.bitrate, 10),
-        bufferSeconds: Number(form.stream.bufferSeconds),
+        aacBitrate: n.int('stream.aacBitrate', form.stream.aacBitrate),
+        bitrate: n.int('stream.bitrate', form.stream.bitrate),
+        bufferSeconds: n.num('stream.bufferSeconds', form.stream.bufferSeconds),
       },
     });
   };
@@ -659,8 +737,7 @@ export default function SettingsPanel() {
     setFieldErrors(prev => {
       const out: Record<string, string> = {};
       for (const [path, message] of Object.entries(prev)) {
-        const owned = activeSpec.formKeys.some(k => path === k || path.startsWith(`${k}.`));
-        if (!owned) out[path] = message;
+        if (!ownsErrorPath(activeSpec.formKeys, path)) out[path] = message;
       }
       return out;
     });
@@ -671,14 +748,22 @@ export default function SettingsPanel() {
     setActiveSection(section);
     if (advanced) setAdvOpen(prev => ({ ...prev, [section]: true }));
     // The section swap and the disclosure both have to commit before the target
-    // card exists to scroll to, so this waits a beat rather than a frame.
-    window.setTimeout(() => {
+    // card exists to scroll to. A fixed delay is a bet against render time that
+    // a 1200-control section can lose, and a lost jump looks exactly like a
+    // broken search result — no scroll, no flash, no error. So watch for the
+    // card across frames instead, and give up only after JUMP_MAX_FRAMES.
+    let frames = 0;
+    const settle = () => {
       const el = document.querySelector(`[data-card="${anchor}"]`);
-      if (!(el instanceof HTMLElement)) return;
+      if (!(el instanceof HTMLElement)) {
+        if (frames++ < JUMP_MAX_FRAMES) window.requestAnimationFrame(settle);
+        return;
+      }
       el.scrollIntoView({ behavior: 'smooth', block: 'center' });
       el.setAttribute('data-flash', '');
       window.setTimeout(() => el.removeAttribute('data-flash'), 2600);
-    }, 90);
+    };
+    window.requestAnimationFrame(settle);
   }, []);
 
   const chrome = useMemo(() => ({

--- a/web/components/admin/settings/LibrarySection.tsx
+++ b/web/components/admin/settings/LibrarySection.tsx
@@ -11,6 +11,7 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup,
 } from '../../ui/select';
 import { Card, Btn, Seg } from '../ui';
+import { Advanced } from './section-chrome';
 import { EmbeddingProviderSelector } from '../embedding/EmbeddingProviderSelector';
 import { ModelCombobox } from '../llm/ModelCombobox';
 import { LLM_ENV_VARS, llmProviderLabel } from '../llm/providerMeta';
@@ -146,7 +147,6 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
   >(null);
   const [probing, setProbing] = useState(false);
   const [detecting, setDetecting] = useState(false);
-  const [advancedOpen, setAdvancedOpen] = useState(false);
   // Local servers (llama.cpp/locca) need a dedicated embedding endpoint; cloud
   // and Ollama providers serve embeddings on the same endpoint as chat.
   const needsServerUrl = effectiveProvider === 'locca' || effectiveProvider === 'openai-compatible';
@@ -620,15 +620,7 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
       {/* No run button: the bulk tagger is launched from the Library page's
           "Start tagging" flow. */}
 
-      <button
-        type="button"
-        onClick={() => setAdvancedOpen(o => !o)}
-        className="mb-1 w-fit text-[11px] font-bold tracking-[0.14em] text-muted uppercase hover:text-ink"
-      >
-        {advancedOpen ? '▾' : '▸'} Advanced: seed count, propagation, enrichment
-      </button>
-      {advancedOpen && (
-        <>
+      <Advanced note="seed count, propagation thresholds and enrichment">
       <Card title="Seed phase" sub="how many tracks to LLM-tag">
         <div className="grid gap-[18px]">
           <div className="field">
@@ -847,8 +839,7 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
           </div>
         </div>
       </Card>
-        </>
-      )}
+      </Advanced>
 
       <SaveBar
         note={`Saved values apply the next time the bulk tagger runs. Current run (if any) keeps its own snapshot.${

--- a/web/components/admin/settings/LibrarySection.tsx
+++ b/web/components/admin/settings/LibrarySection.tsx
@@ -852,6 +852,10 @@ export function LibrarySection({ data, form, setForm, busy, saveSettings, adminF
         saveLabel="Save library tagger"
         errors={fieldErrors}
         ownedKeys={['embedding', 'audio']}
+        // Both key boxes are component-local — the panel diffs FormState and
+        // cannot see them, so a pasted key alone would leave the section
+        // "clean" and unmount the very button that saves it.
+        dirty={!!(embeddingKeyInput.trim() || compatEmbedKeyInput.trim())}
       />
     </>
   );

--- a/web/components/admin/settings/LikesSection.tsx
+++ b/web/components/admin/settings/LikesSection.tsx
@@ -8,6 +8,7 @@ import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import { Card, Pill, Seg } from '../ui';
 import { SectionHeader, SaveBar, type SectionProps, type LikesForm } from './shared';
+import { Advanced } from './section-chrome';
 
 export function LikesSection({ data, form, setForm, busy, saveSettings, fieldErrors }: SectionProps) {
   const lk = form.likes;
@@ -91,6 +92,7 @@ export function LikesSection({ data, form, setForm, busy, saveSettings, fieldErr
         </div>
       </Card>
 
+      <Advanced note="how listener taste feeds back into track selection">
       <Card title="AI DJ influence" sub="feed listener taste back into track selection">
         <div className="grid gap-[18px]">
           <div className="field">
@@ -139,16 +141,17 @@ export function LikesSection({ data, form, setForm, busy, saveSettings, fieldErr
             </div>
           </div>
         </div>
-
-        <SaveBar
-          note="Applies from the next pick, no restart needed."
-          busy={busy}
-          onSave={save}
-          saveLabel="Save likes"
-          errors={fieldErrors}
-          ownedKeys={['likes']}
-        />
       </Card>
+      </Advanced>
+
+      <SaveBar
+        note="Applies from the next pick, no restart needed."
+        busy={busy}
+        onSave={save}
+        saveLabel="Save likes"
+        errors={fieldErrors}
+        ownedKeys={['likes']}
+      />
     </>
   );
 }

--- a/web/components/admin/settings/LlmSection.tsx
+++ b/web/components/admin/settings/LlmSection.tsx
@@ -15,6 +15,7 @@ import { Card, Btn, Pill, Seg } from '../ui';
 import { ProviderSelector } from '../llm/ProviderSelector';
 import { ModelCombobox } from '../llm/ModelCombobox';
 import { LLM_ENV_VARS, llmProviderLabel } from '../llm/providerMeta';
+import { Advanced } from './section-chrome';
 import {
   SectionHeader, SaveBar, KeyStatus, KeyTestResult, KEY_HINTS,
   type SectionProps,
@@ -600,6 +601,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
         </div>
       </Card>
 
+      <Advanced note="tuning, the fallback chain, the picker and the daily budget">
       <Card title="Fallback" sub="backup when the primary is offline">
         <div className="grid gap-[18px]">
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto] sm:items-center sm:gap-4">
@@ -1219,6 +1221,7 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
           </div>
         )}
       </Card>
+      </Advanced>
 
       <SaveBar
         note={`Active model: ${data.llm?.active}. Applies to the next LLM call, no restart needed.`}

--- a/web/components/admin/settings/LlmSection.tsx
+++ b/web/components/admin/settings/LlmSection.tsx
@@ -1230,6 +1230,14 @@ export function LlmSection({ data, form, setForm, busy, saveSettings, adminFetch
         saveLabel="Save LLM provider"
         errors={fieldErrors}
         ownedKeys={['llm']}
+        // All four key boxes are component-local — the panel diffs FormState
+        // and cannot see them, so a pasted key alone would leave the section
+        // "clean" and unmount the very button that saves it. The managed pair
+        // has a Test-and-save path too; the compat pair only has this button.
+        dirty={!!(
+          primaryKeyInput.trim() || fallbackKeyInput.trim()
+          || compatKeyInput.trim() || compatFallbackKeyInput.trim()
+        )}
       />
 
       {/* The SAFE outcome (keep the embedding pin) is the default; only the explicit

--- a/web/components/admin/settings/NavidromeSection.tsx
+++ b/web/components/admin/settings/NavidromeSection.tsx
@@ -32,6 +32,12 @@ export function NavidromeSection({ data, adminFetch, refresh }: NavidromeSection
   const [testing, setTesting] = useState(false);
   const [result, setResult] = useState<TestResult | null>(null);
 
+  // These creds are section-local (setup-config.json, not settings.json), so
+  // the panel cannot diff them for the sticky save bar — this section says so
+  // itself. A typed password is always a change: the GET only ever returns a
+  // `passSet` flag, never the value, so there is nothing to compare it to.
+  const dirty = url !== (nv?.url ?? '') || user !== (nv?.user ?? '') || pass !== '';
+
   const env = { url: !!nv?.env?.url, user: !!nv?.env?.user, pass: !!nv?.env?.pass };
   const allEnv = env.url && env.user && env.pass;
   const passSet = !!nv?.passSet;
@@ -202,6 +208,7 @@ export function NavidromeSection({ data, adminFetch, refresh }: NavidromeSection
           busy={busy}
           onSave={save}
           saveLabel="Save music source"
+          dirty={dirty}
         />
       )}
     </>

--- a/web/components/admin/settings/ScrobbleSection.tsx
+++ b/web/components/admin/settings/ScrobbleSection.tsx
@@ -282,6 +282,22 @@ export function ScrobbleSection({ data, form, setForm, busy, saveSettings, admin
               Cosmetic, used to label the &quot;scrobbling as&quot; status line above.
             </div>
           </div>
+
+          {/* Test probes the SAVED credentials, so it belongs in the card and
+              not beside the save button: the save bar renders only while the
+              section is dirty, which is the one state in which there is
+              nothing saved worth testing. */}
+          <div className="field">
+            <div className="flex flex-wrap items-center gap-3">
+              <Btn sm onClick={() => sendTest('lastfm')} disabled={busy || !lfReady}>
+                Test
+              </Btn>
+              <span className="text-[12px] leading-[1.5] text-muted">
+                Sends a now-playing update for the on-air track with the saved
+                credentials. Needs something playing.
+              </span>
+            </div>
+          </div>
         </div>
 
         <SaveBar
@@ -289,11 +305,6 @@ export function ScrobbleSection({ data, form, setForm, busy, saveSettings, admin
           busy={busy}
           onSave={saveLastfm}
           saveLabel="Save Last.fm"
-          extra={
-            <Btn sm onClick={() => sendTest('lastfm')} disabled={busy || !lfReady}>
-              Test
-            </Btn>
-          }
         />
       </Card>
 
@@ -392,6 +403,22 @@ export function ScrobbleSection({ data, form, setForm, busy, saveSettings, admin
             />
             <div className="field-hint">Cosmetic only.</div>
           </div>
+
+          {/* Test probes the SAVED credentials, so it belongs in the card and
+              not beside the save button: the save bar renders only while the
+              section is dirty, which is the one state in which there is
+              nothing saved worth testing. */}
+          <div className="field">
+            <div className="flex flex-wrap items-center gap-3">
+              <Btn sm onClick={() => sendTest('listenbrainz')} disabled={busy || !lbReady}>
+                Test
+              </Btn>
+              <span className="text-[12px] leading-[1.5] text-muted">
+                Sends a now-playing update for the on-air track with the saved
+                credentials. Needs something playing.
+              </span>
+            </div>
+          </div>
         </div>
 
         <SaveBar
@@ -399,11 +426,6 @@ export function ScrobbleSection({ data, form, setForm, busy, saveSettings, admin
           busy={busy}
           onSave={saveListenbrainz}
           saveLabel="Save ListenBrainz"
-          extra={
-            <Btn sm onClick={() => sendTest('listenbrainz')} disabled={busy || !lbReady}>
-              Test
-            </Btn>
-          }
         />
       </Card>
     </>

--- a/web/components/admin/settings/SettingsSearch.tsx
+++ b/web/components/admin/settings/SettingsSearch.tsx
@@ -44,13 +44,33 @@ function isTyping(): boolean {
   return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
 }
 
+/**
+ * Is a modal layer already holding the keyboard?
+ *
+ * `isTyping` is not enough: inside a Radix alert dialog ("Restart mixer") focus
+ * sits on a plain <button>, and inside an open Radix select `/` is that widget's
+ * OWN typeahead key. Either way this palette portals outside their focus trap,
+ * so it would paint over a dialog that keeps every keystroke — visible, and
+ * unusable. Matches Radix's own open-state markers — every one of these four
+ * content elements carries `role` and `data-state` on the SAME node — so a new
+ * dialog or menu is covered the day it is added, with nothing to register here.
+ */
+function isOverlayOpen(): boolean {
+  return !!document.querySelector([
+    '[data-state="open"][role="dialog"]',      // Dialog
+    '[data-state="open"][role="alertdialog"]', // AlertDialog
+    '[data-state="open"][role="listbox"]',     // Select
+    '[data-state="open"][role="menu"]',        // DropdownMenu
+  ].join(','));
+}
+
 export function SettingsSearch({ onJump }: SettingsSearchProps) {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
-      if (e.key !== '/' || isTyping()) return;
+      if (e.repeat || e.metaKey || e.ctrlKey || e.altKey || e.defaultPrevented) return;
+      if (e.key !== '/' || isTyping() || isOverlayOpen()) return;
       e.preventDefault();
       setOpen(true);
     };

--- a/web/components/admin/settings/SettingsSearch.tsx
+++ b/web/components/admin/settings/SettingsSearch.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+// Search across every setting, so "crossfade" or "api key" reaches the control
+// without the operator remembering which of twelve sections owns it.
+//
+// Built on the vendored cmdk primitives rather than the design's hand-rolled
+// scorer: the fuzzy ranking, the arrow-key navigation and the focus trap are
+// already there and already match the rest of the admin's palettes.
+//
+// The chord is `/`, NOT ⌘K — AdminShell already owns ⌘K for the admin-wide
+// panel jump list, and shadowing it inside one panel would make the same
+// keystroke mean two things depending on where you were.
+
+import { useEffect, useState } from 'react';
+import { Search } from 'lucide-react';
+import {
+  CommandDialog, CommandEmpty, CommandInput, CommandItem, CommandList,
+} from '../../ui/command';
+import { Kbd } from '../../ui/kbd';
+import { Pill } from '../ui';
+import {
+  SETTINGS_INDEX, sectionById, isAdvancedCard, type SectionId,
+} from './registry';
+import { cardAnchor } from '../ui';
+
+export interface SettingsJump {
+  section: SectionId;
+  /** `data-card` slug to scroll to and flash. */
+  anchor: string;
+  /** Whether the target sits behind the section's Advanced disclosure. */
+  advanced: boolean;
+}
+
+interface SettingsSearchProps {
+  onJump: (jump: SettingsJump) => void;
+}
+
+/** Is the operator typing into something? `/` must not steal that keystroke. */
+function isTyping(): boolean {
+  const el = document.activeElement as HTMLElement | null;
+  if (!el) return false;
+  if (el.isContentEditable) return true;
+  const tag = el.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+export function SettingsSearch({ onJump }: SettingsSearchProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat || e.metaKey || e.ctrlKey || e.altKey) return;
+      if (e.key !== '/' || isTyping()) return;
+      e.preventDefault();
+      setOpen(true);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  const pick = (index: number) => {
+    const entry = SETTINGS_INDEX[index];
+    if (!entry) return;
+    setOpen(false);
+    const anchor = cardAnchor(entry.card);
+    onJump({
+      section: entry.section,
+      anchor,
+      advanced: isAdvancedCard(entry.section, anchor),
+    });
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex w-full cursor-pointer items-stretch border border-ink bg-[var(--field)] text-left font-[inherit] transition-colors hover:bg-[var(--ink-soft)]"
+      >
+        <span className="inline-flex items-center border-r border-[var(--separator-strong)] px-2.5 text-muted">
+          <Search className="size-3.5" strokeWidth={2} aria-hidden />
+        </span>
+        <span className="min-w-0 flex-1 truncate px-2.5 py-2 text-[13px] text-muted">
+          Search settings — crossfade, api key, bitrate, timezone…
+        </span>
+        <span className="inline-flex items-center border-l border-[var(--separator-strong)] px-2.5">
+          <Kbd>/</Kbd>
+        </span>
+      </button>
+
+      <CommandDialog open={open} onOpenChange={setOpen} label="Search settings">
+        <CommandInput placeholder="Search every setting…" />
+        {/* Deliberately FLAT — no CommandGroup per section. cmdk sorts within a
+            group and leaves group order as authored, so grouping buried the
+            best match: typing "bitrate" put Station's "Seconds between
+            requests" above every actual bitrate field, purely because Station
+            is the first section. Flat lets one ranking cover all 100 rows, and
+            each row carries its own section in the trail line anyway. */}
+        <CommandList>
+          <CommandEmpty>No matching settings.</CommandEmpty>
+          {SETTINGS_INDEX.map((entry, index) => {
+            const section = sectionById(entry.section);
+            const anchor = cardAnchor(entry.card);
+            return (
+              <CommandItem
+                key={index}
+                // Labels repeat across cards ("Bitrate" three times in the
+                // danger zone, "Provider" in four sections) and cmdk keys on
+                // `value`, so the index disambiguates. Everything else that
+                // should MATCH rides `keywords`, which cmdk scores below the
+                // value — a hit on the field's own name outranks a hit on its
+                // synonyms, which is the ordering the operator expects.
+                value={`${entry.label} ${entry.card} #${index}`}
+                keywords={[section?.label ?? '', entry.keywords ?? ''].filter(Boolean)}
+                onSelect={() => pick(index)}
+              >
+                <span className="grid min-w-0 gap-0.5">
+                  <span className="truncate text-[13px] font-semibold">{entry.label}</span>
+                  <span className="truncate text-[10px] tracking-[0.14em] uppercase opacity-70">
+                    {section?.label} · {entry.card}
+                  </span>
+                </span>
+                {isAdvancedCard(entry.section, anchor) && (
+                  <Pill className="shrink-0">adv</Pill>
+                )}
+              </CommandItem>
+            );
+          })}
+        </CommandList>
+      </CommandDialog>
+    </>
+  );
+}

--- a/web/components/admin/settings/StationSection.tsx
+++ b/web/components/admin/settings/StationSection.tsx
@@ -9,6 +9,7 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
 } from '../../ui/select';
 import { Card, Btn, Pill, Seg } from '../ui';
+import { Advanced } from './section-chrome';
 import { LocationPicker, type GeocodeResult } from '../../LocationPicker';
 import {
   SectionHeader, SaveBar, SettingsFieldError,
@@ -380,6 +381,7 @@ export function StationSection({ data, form, setForm, busy, saveSettings, fieldE
         </div>
       </Card>
 
+      <Advanced note="request rate limits and the public-API switch">
       <Card title="Listener requests" sub="Rate limits and the pause switch for POST /request">
         <div className="grid gap-3">
           <div className="field">
@@ -537,6 +539,7 @@ export function StationSection({ data, form, setForm, busy, saveSettings, fieldE
           </div>
         </div>
       </Card>
+      </Advanced>
 
       <SaveBar
         note="Station name, location, timezone, locale, the private player, listener-request limits, and the public-API toggle apply live. Turning the stream password on or off needs a mixer restart."

--- a/web/components/admin/settings/TtsSection.tsx
+++ b/web/components/admin/settings/TtsSection.tsx
@@ -1500,6 +1500,10 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
         busy={busy}
         onSave={save}
         saveLabel="Save TTS settings"
+        // Both key boxes are component-local — the panel diffs FormState and
+        // cannot see them, so a pasted key alone would leave the section
+        // "clean" and unmount the very button that saves it.
+        dirty={!!(cloudKeyInput.trim() || compatKeyInput.trim())}
       />
     </>
   );

--- a/web/components/admin/settings/TtsSection.tsx
+++ b/web/components/admin/settings/TtsSection.tsx
@@ -18,6 +18,7 @@ import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup, SelectLabel,
 } from '../../ui/select';
 import { Card, Btn, Pill, Seg } from '../ui';
+import { Advanced } from './section-chrome';
 import { EngineSelector } from '../tts/EngineSelector';
 import { CloudProviderSelector } from '../tts/CloudProviderSelector';
 import { cloudProviderLabel, resolveKeyPresence } from '../tts/cloudProviderMeta';
@@ -1429,6 +1430,7 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
 
       {/* The operator's explicit rescue, ahead of the hardcoded
           default-engine → Piper → Kokoro floor. */}
+      <Advanced note="the rescue voice for a persona whose own engine fails">
       <Card
         title="Fallback voice"
         sub="what speaks when a persona's engine fails"
@@ -1489,6 +1491,7 @@ export function TtsSection({ data, form, setForm, busy, saveSettings, adminFetch
           </div>
         )}
       </Card>
+      </Advanced>
 
       <SaveBar
         note={ttsDirty

--- a/web/components/admin/settings/registry.ts
+++ b/web/components/admin/settings/registry.ts
@@ -1,0 +1,301 @@
+'use client';
+
+// The settings surface described once, so three things can read it instead of
+// re-deriving it: the grouped nav rail, the per-section dirty dot + sticky save
+// bar, and the search box that jumps to a field.
+//
+// Only the SHAPE lives here — labels, which section owns which slice of the
+// form, which paths cost a mixer restart. The controls themselves stay in their
+// section components; this file never renders anything.
+
+import {
+  Radio, Palette, Cpu, Mic, Library, Search,
+  Activity, Archive, Save, AlertTriangle, Heart, Music2,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+/**
+ * The four rail clusters, in rail order.
+ *
+ * Grouping is editorial, not structural: "the station" is what the operator
+ * sets up once, "the dj" is what talks, "listeners" is what the audience
+ * touches, "operations" is what can interrupt the broadcast.
+ */
+export const SECTION_GROUPS = ['the station', 'the dj', 'listeners', 'operations'] as const;
+
+export type SectionGroup = (typeof SECTION_GROUPS)[number];
+
+export interface SectionSpec {
+  id: string;
+  group: SectionGroup;
+  label: string;
+  hint: string;
+  icon: LucideIcon;
+  /**
+   * Top-level FormState keys this section owns. The sticky save bar and the
+   * rail's unsaved dot both diff these against the saved baseline, so a section
+   * whose state does NOT ride FormState (music: Navidrome creds live in
+   * setup-config.json; theme: every control saves on click) lists none and
+   * reports its own dirtiness through SaveBar's `dirty` prop instead.
+   */
+  formKeys: readonly string[];
+}
+
+export const SECTIONS: readonly SectionSpec[] = [
+  {
+    id: 'station', group: 'the station', label: 'Station',
+    hint: 'name · location · privacy', icon: Radio,
+    formKeys: ['station', 'stationDescription', 'timezone', 'locale', 'weather', 'privacy', 'requests'],
+  },
+  {
+    id: 'music', group: 'the station', label: 'Music source',
+    hint: 'navidrome · subsonic', icon: Music2,
+    formKeys: [],
+  },
+  {
+    id: 'theme', group: 'the station', label: 'Skin & Themes',
+    hint: 'player skin · palette', icon: Palette,
+    formKeys: [],
+  },
+  {
+    id: 'llm', group: 'the dj', label: 'LLM provider',
+    hint: 'model routing', icon: Cpu,
+    formKeys: ['llm'],
+  },
+  {
+    id: 'tts', group: 'the dj', label: 'TTS voice',
+    hint: 'default engine', icon: Mic,
+    formKeys: ['tts', 'kokoroLang'],
+  },
+  {
+    id: 'library', group: 'the dj', label: 'Library tagger',
+    hint: 'embedding · propagation', icon: Library,
+    formKeys: ['embedding'],
+  },
+  {
+    id: 'search', group: 'the dj', label: 'Web search',
+    hint: 'live-facts backend', icon: Search,
+    formKeys: ['search'],
+  },
+  {
+    id: 'likes', group: 'listeners', label: 'Likes',
+    hint: 'heart button · stars', icon: Heart,
+    formKeys: ['likes'],
+  },
+  {
+    id: 'scrobble', group: 'listeners', label: 'Scrobbling',
+    hint: 'last.fm · listenbrainz', icon: Activity,
+    formKeys: ['scrobble'],
+  },
+  {
+    id: 'archives', group: 'operations', label: 'Archives',
+    hint: 'hourly recordings', icon: Archive,
+    formKeys: ['archive'],
+  },
+  {
+    id: 'backup', group: 'operations', label: 'Backup',
+    hint: 'export · restore', icon: Save,
+    formKeys: [],
+  },
+  {
+    id: 'danger', group: 'operations', label: 'Danger zone',
+    hint: 'mixer · broadcast', icon: AlertTriangle,
+    formKeys: ['crossfadeDuration', 'maxTrackSeconds', 'silenceTrim', 'transitions', 'stream', 'loudness'],
+  },
+] as const;
+
+export type SectionId = (typeof SECTIONS)[number]['id'];
+
+export const sectionById = (id: string) => SECTIONS.find(s => s.id === id);
+
+/**
+ * Dotted FormState paths whose change costs a mixer restart.
+ *
+ * Mirrors the `restart = true` branches in `controller/src/settings.ts` — the
+ * controller stays the authority (it answers `requiresRestart` on the save and
+ * the existing banner reacts to that). This list only decides whether the save
+ * bar warns BEFORE the operator commits, so a stale entry costs a missing or
+ * spurious warning, never a wrong save.
+ */
+export const RESTART_PATHS: readonly string[] = [
+  'station',
+  'privacy.listenerAuth',
+  'crossfadeDuration',
+  'archive.enabled',
+  'archive.bitrate',
+  'stream.opusEnabled',
+  'stream.opusBitrate',
+  'stream.flacEnabled',
+  'stream.oggIcyMetadata',
+  'stream.aacEnabled',
+  'stream.aacBitrate',
+  'stream.bitrate',
+  'stream.bufferSeconds',
+];
+
+/**
+ * Card titles that sit behind each section's Advanced disclosure.
+ *
+ * Keyed by section id → the anchors (see `cardAnchor`) of the cards to defer.
+ * A section renders its own <Advanced> wrapper; this table exists so the search
+ * index can say "adv" on a result and open the disclosure when it jumps there.
+ */
+export const ADVANCED_CARDS: Record<string, readonly string[]> = {
+  station: ['listener-requests', 'public-api'],
+  llm: ['fallback', 'reasoning', 'next-track-picker', 'idle-behaviour', 'daily-token-budget'],
+  tts: ['fallback-voice'],
+  library: ['seed-phase', 'propagation', 'enrichment'],
+  likes: ['ai-dj-influence'],
+  danger: [
+    'crossfade', 'stem-transitions', 'max-track-length', 'dead-air-trim',
+    'loudness-levelling', 'opus-stream', 'flac-stream', 'ogg-metadata',
+    'aac-stream', 'stream-mp3-bitrate', 'listener-buffer',
+  ],
+};
+
+export const isAdvancedCard = (section: string, anchor: string) =>
+  (ADVANCED_CARDS[section] || []).includes(anchor);
+
+export interface IndexEntry {
+  /** The control's own label, as the operator reads it on screen. */
+  label: string;
+  section: SectionId;
+  /** Card title, shown as the result's trail and used as the scroll anchor. */
+  card: string;
+  /** Extra words that should match but are not in the label. */
+  keywords?: string;
+}
+
+/** Every setting the operator can search for, in rail order. */
+export const SETTINGS_INDEX: readonly IndexEntry[] = [
+  // ── station ────────────────────────────────────────────────────────────────
+  { label: 'Station name', section: 'station', card: 'Station identity', keywords: 'call sign title dj prompt' },
+  { label: 'Share description', section: 'station', card: 'Station identity', keywords: 'blurb og meta social' },
+  { label: 'Location', section: 'station', card: 'Station location', keywords: 'weather forecast open-meteo latitude longitude' },
+  { label: 'On-air location', section: 'station', card: 'Station location', keywords: 'spoken public place' },
+  { label: 'Weather units', section: 'station', card: 'Station location', keywords: 'metric imperial celsius fahrenheit' },
+  { label: 'Station timezone', section: 'station', card: 'Timezone', keywords: 'clock time zone schedule slots' },
+  { label: 'Station locale', section: 'station', card: 'Localization', keywords: 'language 24h am pm date format' },
+  { label: 'Private player', section: 'station', card: 'Privacy', keywords: 'password gate hide lock' },
+  { label: 'Stream password', section: 'station', card: 'Privacy', keywords: 'listener auth icecast lock restart' },
+  { label: 'Station password', section: 'station', card: 'Privacy', keywords: 'secret shared passphrase' },
+  { label: 'Accept requests', section: 'station', card: 'Listener requests', keywords: 'request line open closed' },
+  { label: 'Max queued requests', section: 'station', card: 'Listener requests', keywords: 'pending queue limit' },
+  { label: 'Seconds between requests', section: 'station', card: 'Listener requests', keywords: 'cooldown rate limit' },
+  { label: 'Per-listener hourly cap', section: 'station', card: 'Listener requests', keywords: 'ip rate limit hour' },
+  { label: 'Station hourly cap', section: 'station', card: 'Listener requests', keywords: 'global rate limit hour' },
+  { label: 'Repeat cooldown', section: 'station', card: 'Listener requests', keywords: 'same track again minutes' },
+  { label: 'One request per listener at a time', section: 'station', card: 'Listener requests', keywords: 'ip pending single' },
+  { label: 'Publish persona souls', section: 'station', card: 'Public API', keywords: 'system prompt schedule personas public json' },
+
+  // ── music source ───────────────────────────────────────────────────────────
+  { label: 'Server URL', section: 'music', card: 'Navidrome server', keywords: 'navidrome subsonic host url' },
+  { label: 'Username', section: 'music', card: 'Navidrome server', keywords: 'navidrome subsonic login user' },
+  { label: 'Password', section: 'music', card: 'Navidrome server', keywords: 'navidrome subsonic secret salt token' },
+
+  // ── skin & themes ──────────────────────────────────────────────────────────
+  { label: 'Station skin', section: 'theme', card: 'Player skin', keywords: 'classic unit platter drift subamp tty listen face' },
+  { label: 'Active theme', section: 'theme', card: 'Themes', keywords: 'palette colours colors newsprint nightshift dark light' },
+  { label: 'Show the tune-in overlay', section: 'theme', card: 'Tune-in overlay', keywords: 'gate tap to listen splash' },
+  { label: 'Show the Booth Sprite', section: 'theme', card: 'Booth Buddy', keywords: 'mascot sprite request box' },
+
+  // ── llm provider ───────────────────────────────────────────────────────────
+  { label: 'Provider', section: 'llm', card: 'Provider', keywords: 'ollama anthropic openai google deepseek openrouter requesty gateway compatible' },
+  { label: 'Ollama server URL', section: 'llm', card: 'Provider', keywords: 'host docker internal 11434 local' },
+  { label: 'API key', section: 'llm', card: 'Provider', keywords: 'token secret credential sk-' },
+  { label: 'Model', section: 'llm', card: 'Provider', keywords: 'llama claude gpt gemini model id' },
+  { label: 'Forced tool calls', section: 'llm', card: 'Provider', keywords: 'tool choice required auto' },
+  { label: 'Context window (num_ctx)', section: 'llm', card: 'Provider', keywords: 'tokens history numctx' },
+  { label: 'Repetition penalty (repeat_penalty)', section: 'llm', card: 'Provider', keywords: 'repeat penalty phrasing' },
+  { label: 'Max response size (tokens)', section: 'llm', card: 'Reasoning', keywords: 'max output tokens' },
+  { label: 'Reasoning', section: 'llm', card: 'Reasoning', keywords: 'thinking trace chain of thought' },
+  { label: 'Backup provider', section: 'llm', card: 'Fallback', keywords: 'fallback secondary offline' },
+  { label: 'Backup model', section: 'llm', card: 'Fallback', keywords: 'fallback secondary model id' },
+  { label: 'Agent deadline', section: 'llm', card: 'Next-track picker', keywords: 'timeout seconds give up pool picker' },
+  { label: 'Discovery rounds per pick', section: 'llm', card: 'Next-track picker', keywords: 'steps tool loops' },
+  { label: 'No-repeat window (tracks)', section: 'llm', card: 'Next-track picker', keywords: 'repeat history variety' },
+  { label: 'Artist spacing (slots)', section: 'llm', card: 'Next-track picker', keywords: 'artist variety window' },
+  { label: 'Daily token cap', section: 'llm', card: 'Daily token budget', keywords: 'budget spend limit cost' },
+  { label: 'Soft threshold', section: 'llm', card: 'Daily token budget', keywords: 'warning percent budget dash' },
+  { label: 'Pause the DJ when nobody is listening', section: 'llm', card: 'Idle behaviour', keywords: 'idle empty room quiet' },
+
+  // ── tts voice ──────────────────────────────────────────────────────────────
+  { label: 'DJ speech', section: 'tts', card: 'Station voice', keywords: 'on air music only mute silent' },
+  { label: 'Engine', section: 'tts', card: 'Voice engine', keywords: 'piper kokoro chatterbox pocket-tts cloud remote' },
+  { label: 'Voice', section: 'tts', card: 'Voice engine', keywords: 'speaker accent alba amy' },
+  { label: 'Voice level (dB)', section: 'tts', card: 'Voice engine', keywords: 'gain trim loudness decibel' },
+  { label: 'Speech speed', section: 'tts', card: 'Voice engine', keywords: 'rate tempo faster slower' },
+  { label: 'API key', section: 'tts', card: 'Voice engine', keywords: 'openai elevenlabs fish audio cloud token' },
+  { label: 'Model', section: 'tts', card: 'Voice engine', keywords: 'cloud speech model gpt-4o-mini-tts' },
+  { label: 'Latency mode', section: 'tts', card: 'Voice engine', keywords: 'fish audio low normal balanced' },
+  { label: 'Server URL', section: 'tts', card: 'Voice engine', keywords: 'remote http endpoint' },
+  { label: 'Fallback engine', section: 'tts', card: 'Fallback voice', keywords: 'rescue voice slot backup' },
+
+  // ── library tagger ─────────────────────────────────────────────────────────
+  { label: 'Tagger', section: 'library', card: 'Tagger', keywords: 'enabled tagging runs moods genres' },
+  { label: 'LLM batch size', section: 'library', card: 'Tagger', keywords: 'batch tracks per call seed' },
+  { label: 'Provider', section: 'library', card: 'Embedding server', keywords: 'embedding ollama openai google inherit' },
+  { label: 'Model', section: 'library', card: 'Embedding server', keywords: 'nomic-embed-text embedding model reindex' },
+  { label: 'Embedding server URL', section: 'library', card: 'Embedding server', keywords: 'base url host' },
+  { label: 'Bearer token', section: 'library', card: 'Embedding server', keywords: 'embedding api key auth' },
+  { label: 'Seed count', section: 'library', card: 'Seed phase', keywords: 'seed tracks auto size' },
+  { label: 'KNN neighbours', section: 'library', card: 'Propagation', keywords: 'neighbours vote knn similarity' },
+  { label: 'Mood vote threshold', section: 'library', card: 'Propagation', keywords: 'mood share vote stick' },
+  { label: 'Confidence threshold', section: 'library', card: 'Propagation', keywords: 'confidence active learning' },
+  { label: 'Audio fusion weight', section: 'library', card: 'Propagation', keywords: 'clap audio text fusion analyzer' },
+  { label: 'Active-learning rounds', section: 'library', card: 'Propagation', keywords: 'rounds least confident passes' },
+  { label: 'Last.fm tags', section: 'library', card: 'Enrichment', keywords: 'crowd tags embed text' },
+  { label: 'Lyrics', section: 'library', card: 'Enrichment', keywords: 'lyrics embed text' },
+
+  // ── web search ─────────────────────────────────────────────────────────────
+  { label: 'Provider', section: 'search', card: 'Provider', keywords: 'duckduckgo tavily brave searxng live facts' },
+  { label: 'API key', section: 'search', card: 'Provider', keywords: 'tavily brave token search_api_key' },
+  { label: 'SearXNG URL', section: 'search', card: 'Provider', keywords: 'self hosted meta search json' },
+
+  // ── likes ──────────────────────────────────────────────────────────────────
+  { label: 'Enabled', section: 'likes', card: 'Heart button', keywords: 'heart like listener tap' },
+  { label: 'Star in Navidrome', section: 'likes', card: 'Heart button', keywords: 'subsonic starred favourites' },
+  { label: 'Use likes to influence picks', section: 'likes', card: 'AI DJ influence', keywords: 'taste preference signal picker' },
+  { label: 'Tracks included', section: 'likes', card: 'AI DJ influence', keywords: 'top liked count' },
+  { label: 'Time window (days)', section: 'likes', card: 'AI DJ influence', keywords: 'window days all time' },
+
+  // ── scrobbling ─────────────────────────────────────────────────────────────
+  { label: 'Enabled', section: 'scrobble', card: 'Last.fm', keywords: 'lastfm scrobble spins' },
+  { label: 'API key', section: 'scrobble', card: 'Last.fm', keywords: 'lastfm credential' },
+  { label: 'API secret', section: 'scrobble', card: 'Last.fm', keywords: 'lastfm shared secret handshake' },
+  { label: 'Session key', section: 'scrobble', card: 'Last.fm', keywords: 'authorize session token' },
+  { label: 'Username (display)', section: 'scrobble', card: 'Last.fm', keywords: 'lastfm user dash' },
+  { label: 'Enabled', section: 'scrobble', card: 'ListenBrainz', keywords: 'listenbrainz scrobble spins' },
+  { label: 'User token', section: 'scrobble', card: 'ListenBrainz', keywords: 'listenbrainz profile token' },
+  { label: 'API base URL', section: 'scrobble', card: 'ListenBrainz', keywords: 'self hosted instance endpoint' },
+  { label: 'Username (display)', section: 'scrobble', card: 'ListenBrainz', keywords: 'listenbrainz user dash' },
+
+  // ── archives ───────────────────────────────────────────────────────────────
+  { label: 'Record the broadcast to disk', section: 'archives', card: 'Hourly archive', keywords: 'archive recording mp3 tapes restart' },
+  { label: 'Archive bitrate', section: 'archives', card: 'Hourly archive', keywords: 'kbps encoder cpu restart' },
+  { label: 'Keep recordings for', section: 'archives', card: 'Hourly archive', keywords: 'retention days disk cleanup' },
+
+  // ── danger zone ────────────────────────────────────────────────────────────
+  { label: 'Stop stream', section: 'danger', card: 'Broadcast', keywords: 'off air disconnect icecast mount' },
+  { label: 'Pause when the room is empty', section: 'danger', card: 'Idle pause', keywords: 'idle empty listeners resume' },
+  { label: 'Crossfade duration', section: 'danger', card: 'Crossfade', keywords: 'overlap seams transition restart' },
+  { label: 'Pair-aware transitions', section: 'danger', card: 'Stem transitions', keywords: 'pair drain successor crossfade' },
+  { label: 'Stem cache', section: 'danger', card: 'Stem transitions', keywords: 'demucs drums bass vocals disk' },
+  { label: 'Stem cache budget', section: 'danger', card: 'Stem transitions', keywords: 'gb evict oldest' },
+  { label: 'Stem-blend seams', section: 'danger', card: 'Stem transitions', keywords: 'drums carry under intro blend' },
+  { label: 'Maximum track length', section: 'danger', card: 'Max track length', keywords: 'cap cut long tracks seconds' },
+  { label: 'Trim silent edges', section: 'danger', card: 'Dead-air trim', keywords: 'silence cue in cue out dead air' },
+  { label: 'Shortest gap worth cutting', section: 'danger', card: 'Dead-air trim', keywords: 'min gap ms silence' },
+  { label: 'Loudness source', section: 'danger', card: 'Loudness levelling', keywords: 'replaygain measured lufs' },
+  { label: 'Target loudness', section: 'danger', card: 'Loudness levelling', keywords: 'lufs normalisation level' },
+  { label: 'Max boost', section: 'danger', card: 'Loudness levelling', keywords: 'db cap gain ceiling' },
+  { label: 'Serve the secondary Opus mount', section: 'danger', card: 'Opus stream', keywords: 'opus ogg mount restart' },
+  { label: 'Bitrate', section: 'danger', card: 'Opus stream', keywords: 'opus kbps restart' },
+  { label: 'Serve the lossless FLAC mount', section: 'danger', card: 'FLAC stream', keywords: 'flac lossless ogg mount restart' },
+  { label: 'Push ICY track titles on the Ogg mounts', section: 'danger', card: 'Ogg metadata', keywords: 'icy metadata ogg titles' },
+  { label: 'Serve the AAC mount', section: 'danger', card: 'AAC stream', keywords: 'aac adts mount restart' },
+  { label: 'Bitrate', section: 'danger', card: 'AAC stream', keywords: 'aac kbps restart' },
+  { label: 'Bitrate', section: 'danger', card: 'Stream MP3 bitrate', keywords: 'mp3 kbps stream restart' },
+  { label: 'Listener buffer', section: 'danger', card: 'Listener buffer', keywords: 'burst size seconds behind live edge restart' },
+  { label: 'Restart mixer', section: 'danger', card: 'Mixer', keywords: 'restart liquidsoap apply pending' },
+];

--- a/web/components/admin/settings/registry.ts
+++ b/web/components/admin/settings/registry.ts
@@ -41,7 +41,12 @@ export interface SectionSpec {
   formKeys: readonly string[];
 }
 
-export const SECTIONS: readonly SectionSpec[] = [
+// `satisfies`, never a `readonly SectionSpec[]` annotation: the annotation
+// widens every `id` back to `string` and takes `SectionId` — and with it every
+// typo guard on SETTINGS_INDEX, ADVANCED_CARDS and `activeSection` — down with
+// it. A bad id then compiles clean and dies quietly at runtime (`sectionById`
+// → undefined → no formKeys → no dirty tracking, no save bar).
+export const SECTIONS = [
   {
     id: 'station', group: 'the station', label: 'Station',
     hint: 'name · location · privacy', icon: Radio,
@@ -102,7 +107,7 @@ export const SECTIONS: readonly SectionSpec[] = [
     hint: 'mixer · broadcast', icon: AlertTriangle,
     formKeys: ['crossfadeDuration', 'maxTrackSeconds', 'silenceTrim', 'transitions', 'stream', 'loudness'],
   },
-] as const;
+] as const satisfies readonly SectionSpec[];
 
 export type SectionId = (typeof SECTIONS)[number]['id'];
 
@@ -140,7 +145,7 @@ export const RESTART_PATHS: readonly string[] = [
  * A section renders its own <Advanced> wrapper; this table exists so the search
  * index can say "adv" on a result and open the disclosure when it jumps there.
  */
-export const ADVANCED_CARDS: Record<string, readonly string[]> = {
+export const ADVANCED_CARDS: Partial<Record<SectionId, readonly string[]>> = {
   station: ['listener-requests', 'public-api'],
   llm: ['fallback', 'reasoning', 'next-track-picker', 'idle-behaviour', 'daily-token-budget'],
   tts: ['fallback-voice'],
@@ -153,7 +158,7 @@ export const ADVANCED_CARDS: Record<string, readonly string[]> = {
   ],
 };
 
-export const isAdvancedCard = (section: string, anchor: string) =>
+export const isAdvancedCard = (section: SectionId, anchor: string) =>
   (ADVANCED_CARDS[section] || []).includes(anchor);
 
 export interface IndexEntry {

--- a/web/components/admin/settings/section-chrome.tsx
+++ b/web/components/admin/settings/section-chrome.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+// The chrome SettingsPanel wraps around whichever section is on screen: the one
+// sticky save bar, and the Advanced disclosure.
+//
+// Both need to be owned by the panel (the bar is sticky against the panel's
+// scroll container; the search box has to be able to open a disclosure it is
+// jumping into) while being AUTHORED inside the section, next to the fields
+// they belong to. The bar solves that with a portal — SaveBar still renders in
+// the section's tree, its output lands in the panel's sticky slot — so a
+// section keeps its own save closure, its own note and its own error scoping,
+// and no section had to hand a patch builder upwards.
+
+import {
+  Children,
+  createContext,
+  useContext,
+  useEffect,
+  useId,
+  type ReactNode,
+} from 'react';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '../../../lib/cn';
+import { Pill } from '../ui';
+
+export interface SectionChromeValue {
+  /**
+   * Portal target for the sticky save bar's buttons, or null when the bar is
+   * hidden (nothing unsaved). A SaveBar with nowhere to render renders nothing,
+   * which is what makes "no changes → no save button" fall out for free.
+   */
+  saveSlot: HTMLElement | null;
+  /**
+   * Report dirtiness for a section whose editable state does NOT live in
+   * FormState — the panel cannot diff what it does not hold. See
+   * `SectionSpec.formKeys`.
+   */
+  reportDirty: (id: string, dirty: boolean) => void;
+  /** Whether the active section's Advanced disclosure is open. */
+  advOpen: boolean;
+  setAdvOpen: (open: boolean) => void;
+}
+
+const NOOP_CHROME: SectionChromeValue = {
+  saveSlot: null,
+  reportDirty: () => {},
+  advOpen: true,
+  setAdvOpen: () => {},
+};
+
+const SectionChromeContext = createContext<SectionChromeValue>(NOOP_CHROME);
+
+export const SectionChromeProvider = SectionChromeContext.Provider;
+
+/**
+ * Outside a provider this returns a chrome with no save slot and Advanced
+ * permanently OPEN. That is the safe default in both directions: a section
+ * rendered somewhere else (a dialog, a test) shows all of its fields rather
+ * than hiding half of them behind a disclosure that nothing can open.
+ */
+export const useSectionChrome = () => useContext(SectionChromeContext);
+
+/**
+ * Register a section's dirtiness with the panel for as long as this component
+ * is mounted, and withdraw it on unmount so a section left dirty and navigated
+ * away from does not keep the previous section's bar alive.
+ */
+export function useReportDirty(dirty: boolean | undefined) {
+  const { reportDirty } = useSectionChrome();
+  const id = useId();
+  useEffect(() => {
+    if (dirty === undefined) return;
+    reportDirty(id, dirty);
+    return () => reportDirty(id, false);
+  }, [dirty, id, reportDirty]);
+}
+
+interface AdvancedProps {
+  /**
+   * What the closed row says the disclosure holds. Section-specific, because
+   * "thresholds and fallbacks" is right for the tagger and wrong for the
+   * danger zone.
+   */
+  note?: string;
+  children?: ReactNode;
+}
+
+/**
+ * The per-section Advanced disclosure.
+ *
+ * Open/closed state lives in the panel, not here, so a search result can open
+ * the disclosure it is scrolling into. The count on the right is the number of
+ * cards inside — a straight `Children.count`, which is honest as long as
+ * sections put one card per child (they do).
+ */
+export function Advanced({ note, children }: AdvancedProps) {
+  const { advOpen, setAdvOpen } = useSectionChrome();
+  const count = Children.toArray(children).filter(Boolean).length;
+  if (count === 0) return null;
+  return (
+    <div className="grid gap-4">
+      <button
+        type="button"
+        onClick={() => setAdvOpen(!advOpen)}
+        aria-expanded={advOpen}
+        className="flex w-full cursor-pointer items-center gap-3 border border-ink bg-[var(--ink-softer)] p-3.5 text-left font-[inherit] transition-colors hover:bg-[var(--ink-soft)]"
+      >
+        <ChevronRight
+          className={cn('size-3.5 shrink-0 text-vermilion transition-transform', advOpen && 'rotate-90')}
+          strokeWidth={2.5}
+          aria-hidden
+        />
+        <span className="text-[11px] font-bold tracking-[0.25em] text-ink uppercase">
+          Advanced
+        </span>
+        <span className="hidden min-w-0 text-[12px] text-muted sm:inline">
+          {advOpen ? 'the rest of this section' : note || 'thresholds, fallbacks and the settings you set once'}
+        </span>
+        <Pill className="ml-auto shrink-0">{count}</Pill>
+      </button>
+      {advOpen && (
+        <div className="grid gap-4 border-l border-[var(--separator-strong)] pl-4">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react';
 import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { m } from 'motion/react';
 import { notify, errorMessage } from '../../../lib/notify';
 import { adminResponse } from '../../../lib/admin-query';
@@ -10,6 +11,7 @@ import type { StationLocale } from '../../../lib/format';
 import type { EngineAvailability } from '../tts/engineMeta';
 import { Play } from 'lucide-react';
 import { Btn, Eyebrow, Metric } from '../ui';
+import { useSectionChrome, useReportDirty } from './section-chrome';
 import { Button } from '../../ui/button';
 import { FieldError } from '../../ui/field';
 
@@ -589,6 +591,12 @@ interface SaveBarProps {
   errors?: SettingsFieldErrors;
   /** The top-level settings keys this bar's save owns, e.g. ['search']. */
   ownedKeys?: readonly string[];
+  /**
+   * Whether this save has anything to commit — ONLY for a section whose
+   * editable state does not live in FormState (see `SectionSpec.formKeys`).
+   * Everyone else leaves it undefined and the panel diffs the form itself.
+   */
+  dirty?: boolean;
 }
 
 /**
@@ -612,12 +620,25 @@ export function ownedFieldErrors(
  * lands here, beside the button that caused it. These sections save a whole
  * block at once, so several fields can fail one click — and each message
  * already names its own dotted field, so grouping them loses nothing.
+ *
+ * The bar is authored HERE, at the end of the section it saves, but renders in
+ * SettingsPanel's one sticky bar via a portal. Keeping the component in the
+ * section's tree is what lets each save keep its own closure, note and error
+ * scoping — nothing had to be lifted, and a section with two independent saves
+ * (Scrobbling: Last.fm and ListenBrainz are separate services) simply portals
+ * two rows.
+ *
+ * No portal target means nothing is unsaved, and the bar renders nothing.
  */
-export function SaveBar({ note, busy, onSave, saveLabel, extra, errors, ownedKeys }: SaveBarProps) {
+export function SaveBar({ note, busy, onSave, saveLabel, extra, errors, ownedKeys, dirty }: SaveBarProps) {
+  const { saveSlot } = useSectionChrome();
+  // Only a section whose state does not ride FormState passes `dirty`; for the
+  // rest the panel already diffs the form against its saved baseline.
+  useReportDirty(dirty);
   const owned = ownedFieldErrors(errors, ownedKeys);
-  return (
-    <div className="flex flex-wrap items-center gap-3 border border-ink bg-[var(--ink-softer)] p-3">
-      <span className="size-1.5 shrink-0 rounded-full bg-vermilion" />
+  if (!saveSlot) return null;
+  return createPortal(
+    <div className="flex flex-wrap items-center gap-3 border-t border-[var(--separator-soft)] pt-2.5 first:border-0 first:pt-0">
       {owned.length > 0 && (
         // Full width so it sits on its own row above the note/button cluster,
         // which is where a wrapped flex child lands anyway.
@@ -630,7 +651,7 @@ export function SaveBar({ note, busy, onSave, saveLabel, extra, errors, ownedKey
       {/* min-w-0 + break-words: notes carry unbroken values (an
           `openai-compatible:Qwen3…gguf` model id) that would otherwise set the
           flex item's min-content and push the bar past a phone viewport. */}
-      <span className="min-w-0 text-[12px] leading-[1.5] break-words text-muted">{note}</span>
+      <span className="min-w-0 flex-1 text-[12px] leading-[1.5] break-words text-muted">{note}</span>
       {/* Full-width action row on a phone; `sm:` restores the inline cluster. */}
       <span className="ml-auto flex w-full gap-2 sm:w-auto">
         {extra}
@@ -640,7 +661,8 @@ export function SaveBar({ note, busy, onSave, saveLabel, extra, errors, ownedKey
           <Btn tone="accent" onClick={onSave} disabled={busy} className="w-full sm:w-auto">{saveLabel}</Btn>
         </m.span>
       </span>
-    </div>
+    </div>,
+    saveSlot,
   );
 }
 

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -586,7 +586,6 @@ interface SaveBarProps {
   busy: boolean;
   onSave: () => void;
   saveLabel: ReactNode;
-  extra?: ReactNode;
   /** Server errors from the last save, keyed by dotted path. */
   errors?: SettingsFieldErrors;
   /** The top-level settings keys this bar's save owns, e.g. ['search']. */
@@ -628,9 +627,12 @@ export function ownedFieldErrors(
  * (Scrobbling: Last.fm and ListenBrainz are separate services) simply portals
  * two rows.
  *
- * No portal target means nothing is unsaved, and the bar renders nothing.
+ * No portal target means nothing is unsaved, and the bar renders nothing —
+ * which is also why the bar carries NOTHING but the save. A "Test" button next
+ * to it would disappear the moment the section went clean, i.e. exactly when a
+ * saved connection is worth testing. Non-save actions belong in the card.
  */
-export function SaveBar({ note, busy, onSave, saveLabel, extra, errors, ownedKeys, dirty }: SaveBarProps) {
+export function SaveBar({ note, busy, onSave, saveLabel, errors, ownedKeys, dirty }: SaveBarProps) {
   const { saveSlot } = useSectionChrome();
   // Only a section whose state does not ride FormState passes `dirty`; for the
   // rest the panel already diffs the form against its saved baseline.
@@ -654,7 +656,6 @@ export function SaveBar({ note, busy, onSave, saveLabel, extra, errors, ownedKey
       <span className="min-w-0 flex-1 text-[12px] leading-[1.5] break-words text-muted">{note}</span>
       {/* Full-width action row on a phone; `sm:` restores the inline cluster. */}
       <span className="ml-auto flex w-full gap-2 sm:w-auto">
-        {extra}
         {/* whileTap fires before the network call, so the commit is felt before
             the save toast lands. */}
         <m.span whileTap={{ scale: 0.97 }} className="inline-flex flex-1 sm:flex-none">

--- a/web/components/admin/ui.tsx
+++ b/web/components/admin/ui.tsx
@@ -12,6 +12,19 @@ import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
 import { Switch } from '../ui/switch';
 import { Badge, badgeVariants } from '../ui/badge';
 
+/**
+ * A card title reduced to a stable scroll target: `"Listener requests"` →
+ * `"listener-requests"`. Lives here rather than next to its one caller because
+ * the anchor is a property of the Card, and a jump table elsewhere has to be
+ * able to spell the same slug without importing a panel.
+ */
+export function cardAnchor(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
 export interface EyebrowProps {
   children?: ReactNode;
   className?: string;
@@ -32,11 +45,21 @@ export interface CardProps {
   // Drops the box border/background and side padding, for sections inside
   // EditorDialog (.card.is-flat in globals.css).
   flat?: boolean;
+  /**
+   * Scroll-target slug, exposed as `data-card`. Defaults to the slugged title;
+   * pass one explicitly when the title is not a plain string.
+   */
+  anchor?: string;
 }
 
-export function Card({ title, sub, right, children, className, bodyClass, headClass, flat }: CardProps) {
+export function Card({ title, sub, right, children, className, bodyClass, headClass, flat, anchor }: CardProps) {
+  // Anchor slug derived from the title so /admin/settings' search can scroll to
+  // a card without every section having to hand-label one. Only a plain-string
+  // title is slugged — an interpolated one ("{provider} API key") would give a
+  // slug that moves with the data, which is worse than having none.
+  const slug = anchor ?? (typeof title === 'string' ? cardAnchor(title) : undefined);
   return (
-    <section className={cn('card', flat && 'is-flat', className)}>
+    <section data-card={slug} className={cn('card', flat && 'is-flat', className)}>
       {(title || right) && (
         <div className={cn('card-head', headClass)}>
           {title && <span className="title">{title}</span>}


### PR DESCRIPTION
## What changes

**Grouped rail.** Twelve sections clustered into *the station* / *the dj* / *listeners* / *operations*, each showing a dot while it holds unsaved changes.

**Search over every setting.** `/`, or the bar at the top. ~110 indexed fields; picking one switches section, opens the Advanced disclosure if the target is behind it, scrolls to the card and flashes it. Built on the vendored `cmdk` primitives rather than a hand-rolled scorer.

**Advanced disclosure per section.** Station 2 cards, Likes 1, TTS 1, Library 3, LLM 5, Danger zone 11. Open/closed state lives in the panel so a search result can open the disclosure it is jumping into. `LibrarySection`'s bespoke `▸ Advanced` toggle is replaced by the shared one for that reason.

**One sticky save bar per section**, with a leaf-accurate change count, a pre-save mixer-restart warning, and a Discard scoped to the section's own fields.

## Notes for review

**`SaveBar` kept its call sites.** It now portals into the panel's sticky slot instead of rendering in place, so each section keeps its own save closure, note and `ownedKeys` error scoping — nothing had to be lifted, and Scrobbling still posts Last.fm and ListenBrainz independently. No portal target (nothing unsaved) means the bar renders nothing.

**Sections whose state isn't in `FormState`** report dirtiness themselves via a new `dirty` prop — Music source (Navidrome creds live in `setup-config.json`). Skin & Themes saves on click and so registers no bar; it keeps player skin and themes exactly as they were.

**Archives and the danger zone lost 18 per-card save buttons** for one section save each. Verified equivalent rather than assumed: against a pristine `settings.json`, a single-key `{crossfadeDuration:6}` POST and the full union save produce **byte-identical** files. `settings.update()` re-serialises the whole normalised object either way, and change-gates every field, so an untouched field neither writes nor flags a restart.

**The restart-warning path list** in `registry.ts` mirrors the `restart = true` branches in `controller/src/settings.ts`. The controller stays the authority — its `requiresRestart` still raises the persistent banner. This list only decides whether the bar warns *before* the operator commits, so drift costs a missing or spurious warning, never a wrong save.

## Two deliberate departures from the design

- **The shortcut is `/`, not `⌘K`** — `AdminShell` already owns `⌘K` for the admin-wide panel jump list, and shadowing it inside one panel would make the same keystroke mean two things depending on where you were.
- **Search jumps to the card, not the individual field.** `Card` now derives a `data-card` anchor from its title in one place; field-level anchors would mean touching ~200 call sites across the 13 section files.

## Verification

`npm run lint` (eslint + tsc) clean in `web/`.

Driven manually against a dev stack, on an isolated state dir seeded from a real `settings.json`: grouped rail and dirty dots; search ranking (`bitrate` puts the three real bitrate fields first, disambiguated by their `SECTION · CARD` trail, `ADV` badges on deferred ones); all four Advanced disclosures with their counts; sticky bar appearing and clearing; Discard rolling a toggle back; the restart warning firing on a crossfade edit; and the unified danger-zone save committing 18s → 6s with `requiresRestart` honoured.
