### PR TITLE
fix(dj): station ident names the daypart, never the hour

### DIFF
--- a/controller/scripts/clock-phrase.test.ts
+++ b/controller/scripts/clock-phrase.test.ts
@@ -4,7 +4,7 @@
 // Run: `npm test -- clock-phrase` (tsx scripts/clock-phrase.test.ts).
 
 import assert from 'node:assert/strict';
-import { clockDisplay, spokenHourPhrase, spokenTimePhrase } from '../src/time.js';
+import { clockDisplay, spokenHourPhrase, spokenTimePhrase, spokenDaypartPhrase } from '../src/time.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -98,6 +98,24 @@ async function main() {
     assert.equal(spokenTimePhrase(23, 50), 'coming up on midnight');
     assert.equal(spokenTimePhrase(11, 45), 'quarter to noon');
     assert.equal(spokenTimePhrase(0, 20), 'quarter past midnight');
+  });
+
+  await test('daypart phrase — the only clock reading a station ident may speak', () => {
+    assert.equal(spokenDaypartPhrase(0), 'in the morning', 'small hours follow "one in the morning"');
+    assert.equal(spokenDaypartPhrase(5), 'in the morning');
+    assert.equal(spokenDaypartPhrase(11), 'in the morning');
+    assert.equal(spokenDaypartPhrase(12), 'in the afternoon');
+    assert.equal(spokenDaypartPhrase(15), 'in the afternoon');
+    assert.equal(spokenDaypartPhrase(18), 'in the evening');
+    assert.equal(spokenDaypartPhrase(21), 'in the evening');
+    assert.equal(spokenDaypartPhrase(22), 'at night');
+    assert.equal(spokenDaypartPhrase(27), 'in the morning', 'normalises past the day edge like spokenHourPhrase');
+  });
+  await test('daypart phrase agrees with the suffix spokenHourPhrase speaks', () => {
+    for (let h = 0; h < 24; h++) {
+      if (h === 0 || h === 12) continue; // midnight / noon carry no daypart
+      assert.ok(spokenHourPhrase(h).endsWith(spokenDaypartPhrase(h)), `hour ${h}`);
+    }
   });
 
   if (failures) {

--- a/controller/scripts/station-id-daypart.test.ts
+++ b/controller/scripts/station-id-daypart.test.ts
@@ -1,0 +1,34 @@
+// Regression test for boundary-deferred station-ident dayparts.
+// Run: `npm test -- station-id-daypart`.
+//
+// A scheduled ident is written at :15/:30/:45, rendered, then held for a
+// track boundary. The queue may carry it across several voiced boundaries, so
+// the daypart offered to the model must be stamped and compared with the live
+// station daypart before the rendered clip airs. No stamp means the model was
+// not offered a clock reading (for example, djSpeakClock is off), so there is
+// no clock claim to invalidate.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  stationIdDaypartDrifted,
+  stationIdDaypartStamp,
+} from '../src/broadcast/clock-policy.js';
+
+test('stamps only the daypart actually offered to the station-ident model', () => {
+  assert.equal(stationIdDaypartStamp('in the afternoon', true), 'in the afternoon');
+  assert.equal(stationIdDaypartStamp('in the afternoon', false), null);
+  assert.equal(stationIdDaypartStamp('', true), null);
+  assert.equal(stationIdDaypartStamp(null, true), null);
+});
+
+test('drops a deferred ident when its stamped daypart changed before air', () => {
+  assert.equal(stationIdDaypartDrifted('in the afternoon', 'in the afternoon'), false);
+  assert.equal(stationIdDaypartDrifted('in the afternoon', 'in the evening'), true);
+  assert.equal(stationIdDaypartDrifted('at night', 'in the morning'), true);
+});
+
+test('a clockless ident has no daypart claim to invalidate', () => {
+  assert.equal(stationIdDaypartDrifted(null, 'in the evening'), false);
+  assert.equal(stationIdDaypartDrifted('', 'in the evening'), false);
+});

--- a/controller/src/broadcast/clock-policy.ts
+++ b/controller/src/broadcast/clock-policy.ts
@@ -57,6 +57,26 @@ export function speakClockAllowed(): boolean {
   return clockEnabled();
 }
 
+// A boundary-deferred station ident may mention only the computed daypart, but
+// even that can go stale while its rendered WAV waits for a clean track seam.
+// Stamp only a daypart the model was actually allowed to use: an ident written
+// with the station clock off made no clock claim and must not be dropped later
+// merely because the wall clock moved on.
+export function stationIdDaypartStamp(daypart: unknown, clockAllowed: boolean): string | null {
+  if (!clockAllowed || typeof daypart !== 'string') return null;
+  return daypart.trim() || null;
+}
+
+// Air-time backstop for the stamp above. Rendered audio cannot be rewritten,
+// so silence on this one boundary is cheaper than airing the previous daypart.
+// Missing/malformed stamps fail open because they mean no validated daypart
+// claim reached this channel (including controllers predating the stamp).
+export function stationIdDaypartDrifted(stamped: unknown, live: unknown): boolean {
+  if (typeof stamped !== 'string' || !stamped.trim()) return false;
+  if (typeof live !== 'string' || !live.trim()) return false;
+  return stamped.trim() !== live.trim();
+}
+
 // May the AUTOMATIC top-of-the-hour time check fire? Same predicate, named for
 // the call site in broadcast/dj-gate.ts. Manual runners must NOT call this —
 // they bypass the gate entirely, which is what preserves the operator's pad.

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -33,11 +33,12 @@ import * as beds from './beds.js';
 import * as bedPolicy from './bed-policy.js';
 import * as session from './session.js';
 import type { TurnMeta } from './session.js';
-import { getFullContext, energyForDaypart } from '../context.js';
+import { getFullContext, getClockContext, energyForDaypart } from '../context.js';
 import * as settings from '../settings.js';
 import { logEvent } from '../observability/events.js';
 import { djCallsAllowed, presentListeners } from './listeners.js';
 import { autoVoiceAllowed } from './voice-policy.js';
+import { stationIdDaypartDrifted } from './clock-policy.js';
 import * as webhooks from './webhooks.js';
 import * as scrobble from './scrobble.js';
 import * as liquidsoapControl from './liquidsoap-control.js';
@@ -165,7 +166,7 @@ class Queue {
   _emptyDjQueueStreak = 0;      // consecutive reconcile checks seeing an empty dj_queue while sent items remain — see reconcileWithDjQueue
   _resolveFailStreak = 0;       // consecutive pushes Liquidsoap never resolved — re-pick budget, see onPushResolveFailed
   _deadlinePickAt = 0;          // last deadline-pick ATTEMPT (ms epoch) — failure-retry cooldown, see maybeDeadlinePick
-  _pendingVoice: { text: string; kind: string; wavPath: string; persona: Persona | null; meta: TurnMeta; t: number } | null = null; // one boundary-deferred segment awaiting the next track start — see announceAtNextTrack
+  _pendingVoice: { text: string; kind: string; wavPath: string; persona: Persona | null; meta: TurnMeta; daypart: string | null; t: number } | null = null; // one boundary-deferred segment awaiting the next track start — see announceAtNextTrack
   _introRenders = new IntroRenderTracker<QueueItem>(); // timed-out pre-renders stay reusable by airIntro
   _pendingJingles = new Map<string, number>(); // manual jingle presses handed over but not yet heard — see playJingle
 
@@ -1578,11 +1579,11 @@ class Queue {
   // (djLog → recap/opener anti-repeat, session turn, webhook) happens at AIR
   // time, so the DJ's memory reflects what reached the stream, not what was
   // merely scheduled.
-  async announceAtNextTrack(text, kind = 'announcement', { persona = null, meta = {} }: { persona?: Persona | null; meta?: TurnMeta } = {}) {
+  async announceAtNextTrack(text, kind = 'announcement', { persona = null, meta = {}, daypart = null }: { persona?: Persona | null; meta?: TurnMeta; daypart?: string | null } = {}) {
     if (!text || !text.trim()) return;
     try {
       const wavPath = await speak(text, { kind, persona });
-      this._pendingVoice = { text, kind, wavPath, persona, meta, t: Date.now() };
+      this._pendingVoice = { text, kind, wavPath, persona, meta, daypart, t: Date.now() };
       this.log('scheduler', `Holding ${kind} for the next track boundary`);
     } catch (err) {
       this.log('error', `Deferred announce failed: ${(err as Error).message}`);
@@ -1642,6 +1643,16 @@ class Queue {
     // held again below, so a busy stretch can't keep re-deferring a dead ident.
     if (Date.now() - p.t > PENDING_VOICE_MAX_AGE_MS) {
       this.dropPendingVoice('waited too long for a track boundary');
+      return;
+    }
+    // A daypart offered at generation can cross its boundary while the WAV
+    // waits here (for example, an ident written at 17:45 airing after 18:00).
+    // The rendered words cannot be corrected, so apply the same fail-silent
+    // trade as the pick-link clock drift guard. No stamp means the ident was
+    // written with no permitted clock claim and remains eligible.
+    const liveDaypart = getClockContext().spokenDaypart;
+    if (stationIdDaypartDrifted(p.daypart, liveDaypart)) {
+      this.dropPendingVoice(`daypart changed from "${p.daypart}" to "${liveDaypart}" before air`);
       return;
     }
     // This boundary already speaks. The track's own line is tied to THIS song

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -27,6 +27,7 @@ import * as djAgent from './dj-agent.js';
 import * as programme from './programme.js';
 import { cleanupOldVoices } from '../audio/tts.js';
 import { shouldFire } from './dj-gate.js';
+import { speakClockAllowed, stationIdDaypartStamp } from './clock-policy.js';
 import { banterTickPlan, banterCronExpression } from './banter-policy.js';
 import { djCallsAllowed } from './listeners.js';
 import { autoVoiceAllowed } from './voice-policy.js';
@@ -816,13 +817,20 @@ export async function runStationId({ atNextTrack = false } = {}) {
   return withTrace({ kind: 'station-id' }, async () => {
     const ctx = await getFullContext();
     const speaker = settings.pickOnAirSpeaker();
+    // Scheduled idents can wait across several track boundaries. Stamp the
+    // daypart being offered to the model so the queue can refuse a rendered
+    // clip if that fact changed before air. Immediate operator idents do not
+    // enter the deferred path, so the stamp is unnecessary there.
+    const daypart = atNextTrack
+      ? stationIdDaypartStamp(ctx.clock?.spokenDaypart, speakClockAllowed())
+      : null;
     const script = await dj.generateStationId({
       recap: queue.getDjRecap(),
       context: ctx,
       recentOpeners: queue.getRecentOpeners(),
       persona: speaker,
     });
-    const opts = { persona: speaker, meta: { personaId: speaker?.id, personaName: speaker?.name } };
+    const opts = { persona: speaker, daypart, meta: { personaId: speaker?.id, personaName: speaker?.name } };
     if (atNextTrack) await queue.announceAtNextTrack(script, 'station-id', opts);
     else await queue.announce(script, 'station-id', opts);
     return script;

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -6,7 +6,7 @@ import { fetchWithTimeout } from './util/fetch-timeout.js';
 import { resolveActiveShow, resolveOnAirLocation, get as getSettings, moodScheduleFor, weatherMoodFor } from './settings.js';
 import * as session from './broadcast/session.js';
 import { getListenerCount } from './broadcast/listeners.js';
-import { zonedParts, zonedISODate, clockDisplay, spokenHourPhrase, spokenTimePhrase } from './time.js';
+import { zonedParts, zonedISODate, clockDisplay, spokenHourPhrase, spokenTimePhrase, spokenDaypartPhrase } from './time.js';
 
 // The day-period → {vibe, show} table stays in code (these feed spoken-segment
 // prompts and show resolution). Each period's MOOD is operator-editable
@@ -273,6 +273,10 @@ export function getClockContext(date = new Date()) {
     // near :00, "half past six" mid-hour (#1282: a manual trigger at 18:31
     // still announced "just gone six in the evening").
     spokenTime: spokenTimePhrase(h, m),
+    // Daypart only, for the station ident — the one segment that must not
+    // name the hour, because it airs minutes after it is written and the
+    // hour can change in between ("three in the afternoon" on air at 3:50).
+    spokenDaypart: spokenDaypartPhrase(h),
     isWeekend: dow === 0 || dow === 6,
     isLateNight: h < 5,
     isCommute: (minutesOfDay >= 450 && minutesOfDay < 570) ||  // 07:30-09:30

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -145,15 +145,23 @@ export async function generateStationId({ recap = null, context = null, recentOp
   const djName = speaker?.name || 'your host';
   const stationName = settings.get().station;
   const ctxLines = buildContextLines(context, { contextFields: SCRIPT_CONTEXT_FIELDS });
-  // Loose clock only: an ident is generated at the cron tick but airs after
+  // Daypart only: an ident is generated at the cron tick but airs after
   // LLM + TTS + voice-queue latency — an exact "18:15" routinely lands on air
-  // minutes late (issue #864). Time-of-day colour is fine; minutes are not.
+  // minutes late (issue #864). "Keep it loose, never the exact minutes" was
+  // not enough: shown "Local time: 3:49 pm", the model kept the hour and
+  // dropped the minutes, and "three in the afternoon" aired at 3:50 — the
+  // one number that is about to turn over. So the allowed reading is
+  // computed in code (context.clock.spokenDaypart, "in the afternoon") and
+  // the hour is banned outright, not just the minutes.
   //
   // The nudge has to move with the field, not just alongside it: withholding
   // the Local time line while still telling the model to nod at the clock is
   // how you get an invented one (broadcast/clock-policy.ts).
+  const daypart = context?.clock?.spokenDaypart;
   const clockNudge = speakClockAllowed()
-    ? ` If you nod to the clock, keep it loose — the time of day, never the exact minutes (this airs a few minutes after you write it).`
+    ? (daypart
+        ? ` If you nod to the clock, say only "${daypart}" — never the hour and never the minutes (this airs a few minutes after you write it, and the hour may have changed by then).`
+        : ` If you nod to the clock, name only the part of the day (morning, afternoon, evening, night) — never the hour and never the minutes (this airs a few minutes after you write it, and the hour may have changed by then).`)
     : '';
   ctxLines.push(`Task: ${lengthPhrase('stationId', speaker)} for ${stationName} with ${djName}. A little understated.${clockNudge}`);
   return djText({

--- a/controller/src/time.ts
+++ b/controller/src/time.ts
@@ -139,11 +139,24 @@ export function spokenHourPhrase(hour: number) {
   const h = ((hour % 24) + 24) % 24;
   if (h === 0) return 'midnight';
   if (h === 12) return 'noon';
-  const word = HOUR_WORDS[h % 12];
-  if (h < 12) return `${word} in the morning`;
-  if (h < 18) return `${word} in the afternoon`;
-  if (h < 22) return `${word} in the evening`;
-  return `${word} at night`;
+  return `${HOUR_WORDS[h % 12]} ${spokenDaypartPhrase(h)}`;
+}
+
+// The part of the day alone, in the shape spokenHourPhrase appends to the
+// hour: "in the morning", "in the afternoon", "in the evening", "at night".
+// This is what a station ident gets to say about the clock. An ident is
+// written at the cron tick and airs after LLM + TTS + queue latency, so an
+// hour is already too precise: told "the time of day, never the minutes" at
+// 15:49, the model announced "three in the afternoon" — an hour that was
+// eleven minutes from being wrong. The daypart is the only reading that
+// survives that latency, so it is computed here and handed to the prompt
+// rather than left for the model to truncate the clock into.
+export function spokenDaypartPhrase(hour: number) {
+  const h = ((hour % 24) + 24) % 24;
+  if (h < 12) return 'in the morning';
+  if (h < 18) return 'in the afternoon';
+  if (h < 22) return 'in the evening';
+  return 'at night';
 }
 
 // The time as a radio DJ would round it — minute-aware, deliberately coarse


### PR DESCRIPTION
## What happened

At 15:49 station time the controller logged:

```
19:49:32Z [station-id] It is three in the afternoon on Space and Time with Michael.
```

It aired at 15:50. The station's timezone was correct (`America/New_York`); the model had the right hour and dropped the minutes.

## Why

`generateStationId` shows the model `Local time: 3:49 pm` and, since #864, says: *"If you nod to the clock, keep it loose — the time of day, never the exact minutes."* That bans the minutes but not the hour. gemma4:26b read "loose" as "truncate to the hour", which at :49 is the one number about to become wrong. The hourly time check does not have this problem because `spokenTimePhrase` rounds in code ("coming up on four in the afternoon") and the model must repeat it.

## Fix

- `time.ts`: new pure `spokenDaypartPhrase(hour)` → `in the morning` / `in the afternoon` / `in the evening` / `at night`, with the same thresholds `spokenHourPhrase` already uses. `spokenHourPhrase` now builds on it so the two cannot drift.
- `context.ts`: `getClockContext()` exposes it as `clock.spokenDaypart`.
- `prompts/scripts.ts`: the station-ident nudge becomes *say only "in the afternoon" — never the hour and never the minutes*, with a daypart-only fallback wording when the context carries no clock object. The `speakClockAllowed()` gate is unchanged.
- `scripts/clock-phrase.test.ts`: pins the daypart boundaries (incl. normalisation past the day edge) and asserts every non-midnight/noon `spokenHourPhrase` ends with its `spokenDaypartPhrase`.

Daypart rather than the rounded `spokenTime` phrase because an ident can air several minutes late, and "coming up on four" ages almost as badly as "three".

## Checks

- `tsx scripts/clock-phrase.test.ts` — all pins pass
- `tsc --noEmit` — clean; eslint — 0 errors on touched files
- `npm test` — same three environment failures as on `main` here (`analyzer-python` needs numpy; `aio-log-link` and `state-bootstrap` are macOS temp-path checks); everything else passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8s9fGBF4ahSBKhcWKxSvC
