### PR TITLE
fix(shows): let strict playlists cycle

### DIFF
--- a/controller/scripts/show-playlist.test.ts
+++ b/controller/scripts/show-playlist.test.ts
@@ -41,4 +41,17 @@ assert.deepEqual(
   'intra-list duplicates collapse',
 );
 
+// Duplicate rips have different Subsonic ids but are the same audible song.
+// Keep the first copy so a strict show cannot offer both to the picker or play
+// them consecutively after the scoped hard window relaxes.
+assert.deepEqual(
+  mergePlaylistTracks([[
+    { id: 'rip-a', title: ' Jolene ', artist: 'Dolly Parton' },
+    { id: 'rip-b', title: 'jolene', artist: ' dolly parton ' },
+    { id: 'other', title: '9 to 5', artist: 'Dolly Parton' },
+  ]]).map(t => t.id),
+  ['rip-a', 'other'],
+  'duplicate title/artist rips collapse onto the first playlist entry',
+);
+
 console.log('show-playlist merge checks passed');

--- a/controller/scripts/show-recency.test.ts
+++ b/controller/scripts/show-recency.test.ts
@@ -50,6 +50,19 @@ assert.equal(
 );
 assert.equal(
   effectiveShowNoRepeatWindow(100, 27_986, {
+    show: { playlistStrict: true, filtersStrict: true, genres: ['Pop Punk'] },
+    playlistTracks: tracks.map((track, i) => ({
+      ...track,
+      genres: [i < 20 ? 'Pop' : 'Rock'],
+    })),
+    excludedIds: null,
+    resolvedGenres: ['Pop'],
+  }),
+  0,
+  'capacity must use the same resolved genre alias as candidate filtering',
+);
+assert.equal(
+  effectiveShowNoRepeatWindow(100, 27_986, {
     show: { playlistStrict: true, filtersStrict: false },
     playlistTracks: tracks,
     excludedIds: new Set(tracks.slice(20).map(track => track.id)),
@@ -80,11 +93,10 @@ assert.equal(
 // library-wide clamp in one path while leaving the helper tests green.
 for (const file of ['../src/music/picker.ts', '../src/broadcast/dj-agent.ts']) {
   const source = readFileSync(new URL(file, import.meta.url), 'utf8');
-  assert.match(
-    source,
-    /effectiveShowNoRepeatWindow\([\s\S]*?\{ show: activeShow, playlistTracks(?:\: playlistPool\?\.tracks \?\? null)?, excludedIds \}/,
-    `${file} must scope its hard no-repeat window through the shared show policy`,
-  );
+  assert.match(source, /effectiveShowNoRepeatWindow\(/,
+    `${file} must scope its hard no-repeat window through the shared show policy`);
+  assert.match(source, /resolvedGenres:/,
+    `${file} must use its resolved genre lock for show capacity`);
 }
 
 console.log('show recency checks passed');

--- a/controller/scripts/show-recency.test.ts
+++ b/controller/scripts/show-recency.test.ts
@@ -2,12 +2,14 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { effectiveShowNoRepeatWindow } from '../src/music/show-recency.js';
 
-const tracks = Array.from({ length: 40 }, (_, i) => ({
+const makeTracks = (n: number) => Array.from({ length: n }, (_, i) => ({
   id: `track-${i + 1}`,
   title: `Track ${i + 1}`,
   artist: `Artist ${i + 1}`,
   genres: [i < 20 ? 'Jazz' : 'Rock'],
 }));
+
+const tracks = makeTracks(40);
 
 // A strict playlist is its own catalogue for the hard no-repeat clamp. With
 // only 21 distinct tracks the configured 100-track guard must self-disable so
@@ -21,6 +23,29 @@ assert.equal(
   }),
   0,
   'a 21-track strict playlist must clamp against 21, not the full library',
+);
+
+// The clamp is arithmetic, not a switch: pin both sides of it, or a regression
+// that simply returned 0 for every strict playlist would satisfy the whole
+// suite. Below the library ceiling the playlist's own 37.5% governs; above it
+// the operator's configured window is already the smaller number and stands.
+assert.equal(
+  effectiveShowNoRepeatWindow(100, 27_986, {
+    show: { playlistStrict: true, filtersStrict: false },
+    playlistTracks: makeTracks(200),
+    excludedIds: null,
+  }),
+  75,
+  'a 200-track strict playlist clamps to floor(200 * 0.375), not the configured 100',
+);
+assert.equal(
+  effectiveShowNoRepeatWindow(100, 27_986, {
+    show: { playlistStrict: true, filtersStrict: false },
+    playlistTracks: makeTracks(400),
+    excludedIds: null,
+  }),
+  100,
+  'a playlist wide enough to carry the configured window keeps it intact',
 );
 
 // Soft anchors and unresolved anchors still pick from the wider catalogue, so

--- a/controller/scripts/show-recency.test.ts
+++ b/controller/scripts/show-recency.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { effectiveShowNoRepeatWindow } from '../src/music/show-recency.js';
+
+const tracks = Array.from({ length: 40 }, (_, i) => ({
+  id: `track-${i + 1}`,
+  title: `Track ${i + 1}`,
+  artist: `Artist ${i + 1}`,
+  genres: [i < 20 ? 'Jazz' : 'Rock'],
+}));
+
+// A strict playlist is its own catalogue for the hard no-repeat clamp. With
+// only 21 distinct tracks the configured 100-track guard must self-disable so
+// the relaxable recency cascade can cycle the show instead of falling out to
+// unrelated library material.
+assert.equal(
+  effectiveShowNoRepeatWindow(100, 27_986, {
+    show: { playlistStrict: true, filtersStrict: false },
+    playlistTracks: tracks.slice(0, 21),
+    excludedIds: null,
+  }),
+  0,
+  'a 21-track strict playlist must clamp against 21, not the full library',
+);
+
+// Soft anchors and unresolved anchors still pick from the wider catalogue, so
+// weakening their station-wide no-repeat window would be a regression.
+for (const scope of [
+  { show: { playlistStrict: false }, playlistTracks: tracks },
+  { show: { playlistStrict: true }, playlistTracks: null },
+]) {
+  assert.equal(
+    effectiveShowNoRepeatWindow(100, 27_986, { ...scope, excludedIds: null }),
+    100,
+    'non-strict or unresolved playlist anchors must remain library-scoped',
+  );
+}
+
+// Strict music filters and excluded playlists narrow the real universe too.
+// Twenty Jazz tracks remain in each case, which is below the minimum useful
+// hard window and must therefore cycle under the relaxable guard.
+assert.equal(
+  effectiveShowNoRepeatWindow(100, 27_986, {
+    show: { playlistStrict: true, filtersStrict: true, genres: ['Jazz'] },
+    playlistTracks: tracks,
+    excludedIds: null,
+  }),
+  0,
+  'strict music filters must narrow the no-repeat clamp universe',
+);
+assert.equal(
+  effectiveShowNoRepeatWindow(100, 27_986, {
+    show: { playlistStrict: true, filtersStrict: false },
+    playlistTracks: tracks,
+    excludedIds: new Set(tracks.slice(20).map(track => track.id)),
+  }),
+  0,
+  'excluded playlist tracks must not inflate the no-repeat clamp universe',
+);
+
+// Different Subsonic ids for the same title/artist are one audible track. If
+// counted separately these 40 rows would enable a 15-track hard window; as 20
+// real songs the guard must switch off instead.
+const duplicateRips = tracks.slice(0, 20).flatMap(track => [
+  track,
+  { ...track, id: `${track.id}-duplicate` },
+]);
+assert.equal(
+  effectiveShowNoRepeatWindow(100, 27_986, {
+    show: { playlistStrict: true, filtersStrict: false },
+    playlistTracks: duplicateRips,
+    excludedIds: null,
+  }),
+  0,
+  'duplicate title/artist rips must count as one track for clamp capacity',
+);
+
+// The shared policy only fixes the live station if both selection paths call
+// it. Pin that wiring so a later picker refactor cannot silently restore the
+// library-wide clamp in one path while leaving the helper tests green.
+for (const file of ['../src/music/picker.ts', '../src/broadcast/dj-agent.ts']) {
+  const source = readFileSync(new URL(file, import.meta.url), 'utf8');
+  assert.match(
+    source,
+    /effectiveShowNoRepeatWindow\([\s\S]*?\{ show: activeShow, playlistTracks(?:\: playlistPool\?\.tracks \?\? null)?, excludedIds \}/,
+    `${file} must scope its hard no-repeat window through the shared show policy`,
+  );
+}
+
+console.log('show recency checks passed');

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -34,7 +34,8 @@ import { linkClockAt, linkClockStampFor } from './queue/pure.js';
 import { djObject, nearestId, modelTolerant } from '../llm/sdk.js';
 import * as budget from './dj-budget.js';
 import { withTrace, logEvent } from '../observability/events.js';
-import { recencyWindowsForLibrary, effectiveNoRepeatWindow } from '../music/recency.js';
+import { recencyWindowsForLibrary } from '../music/recency.js';
+import { effectiveShowNoRepeatWindow } from '../music/show-recency.js';
 import { EXPLORE_SEED_PROBABILITY } from '../music/airing.js';
 import { ARTIST_VARIETY_WINDOW, runArtistGuard } from './dj-agent/artist-guard.js';
 import { hasEraBound, genreResolutionWarningOnce, type VocalMode } from '../music/show-filter.js';
@@ -178,13 +179,6 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
   // "recently played", just in-flight, and shouldn't tighten the hard guard.
   for (const id of queue.queuedIds()) recentIds.add(id);
 
-  // Count-based HARD no-repeat guard: the last N distinct plays can't re-air,
-  // and (unlike recentIds/recentKeys above) this survives the tool-level
-  // starvation cascade. Clamped to library size so a small catalogue never
-  // fully blocks; 0 = off, leaving the relaxable window in sole charge.
-  const effN = effectiveNoRepeatWindow(settings.get().llm?.noRepeatWindow ?? 0, librarySize);
-  const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
-
   // Show playlist anchor: resolve the union here (async Navidrome fetch) and
   // thread it into the agent's tools. Strict → a hard lock set so every tool's
   // results are intersected with the playlist (the agent can only pick in-set);
@@ -198,6 +192,17 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
   const playlistLock = playlistPool && activeShow?.playlistStrict ? playlistPool.ids : null;
   const playlistTracks = playlistPool?.tracks ?? null;
   const excludedIds = activeShow ? await resolveExcludedPlaylistIds(activeShow) : null;
+
+  // Count-based HARD no-repeat guard: the last N distinct plays can't re-air,
+  // and (unlike recentIds/recentKeys above) this survives the tool-level
+  // starvation cascade. A resolved strict playlist is its own catalogue, so
+  // clamp to its real identity count; 0 leaves the relaxable window in charge.
+  const effN = effectiveShowNoRepeatWindow(
+    settings.get().llm?.noRepeatWindow ?? 0,
+    librarySize,
+    { show: activeShow, playlistTracks, excludedIds },
+  );
+  const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
 
   // Strict music locks for the discovery tools (filtersStrict). Resolved HERE,
   // once, off the same show snapshot as the playlist pool — the async work the

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -193,17 +193,6 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
   const playlistTracks = playlistPool?.tracks ?? null;
   const excludedIds = activeShow ? await resolveExcludedPlaylistIds(activeShow) : null;
 
-  // Count-based HARD no-repeat guard: the last N distinct plays can't re-air,
-  // and (unlike recentIds/recentKeys above) this survives the tool-level
-  // starvation cascade. A resolved strict playlist is its own catalogue, so
-  // clamp to its real identity count; 0 leaves the relaxable window in charge.
-  const effN = effectiveShowNoRepeatWindow(
-    settings.get().llm?.noRepeatWindow ?? 0,
-    librarySize,
-    { show: activeShow, playlistTracks, excludedIds },
-  );
-  const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
-
   // Strict music locks for the discovery tools (filtersStrict). Resolved HERE,
   // once, off the same show snapshot as the playlist pool — the async work the
   // sync buildTools can't do — then threaded through run() alongside the
@@ -247,6 +236,23 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
   const vocalLock = strict && activeShow?.vocals && library.vocalAnalyzedCount() > 0
     ? (activeShow.vocals as VocalMode)
     : null;
+
+  // Count-based HARD no-repeat guard: the last N distinct plays can't re-air,
+  // and (unlike recentIds/recentKeys above) this survives the tool-level
+  // starvation cascade. A resolved strict playlist is its own catalogue, so
+  // clamp to its real identity count using the same resolved genre lock as the
+  // tools; 0 leaves the relaxable window in charge.
+  const effN = effectiveShowNoRepeatWindow(
+    settings.get().llm?.noRepeatWindow ?? 0,
+    librarySize,
+    {
+      show: activeShow,
+      playlistTracks,
+      excludedIds,
+      resolvedGenres: genreLock ?? [],
+    },
+  );
+  const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
   // A pinned anchor that resolves to nothing (deleted/recreated playlist →
   // stale id, or a Navidrome error — resolveShowPlaylistPool swallows both)
   // silently un-anchors the show: no lock, no showPlaylistTracks tool. Say so,

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -219,6 +219,22 @@ function softRankByCompat(pool: Candidate[], current: { bpm: number | null; key:
 // Multi-value lists (#929): OR within an attribute, AND across attributes.
 // Empty list = no constraint on that attribute.
 type ShowFilter = { moods: string[]; genres: string[]; eras: YearRange[]; energies: string[]; vocals: VocalMode; strict?: boolean } | null;
+type StrictGenreResolution = { genres: string[]; warnings: string[] };
+
+async function resolveStrictGenres(showFilter: ShowFilter): Promise<StrictGenreResolution> {
+  const genres: string[] = [];
+  const warnings: string[] = [];
+  if (!showFilter?.strict || !showFilter.genres.length) return { genres, warnings };
+  for (const g of showFilter.genres) {
+    try {
+      const resolved = await subsonic.resolveGenreName(g);
+      const warning = genreResolutionWarningOnce(g, resolved);
+      if (warning) warnings.push(warning);
+      if (resolved) genres.push(resolved);
+    } catch {}
+  }
+  return { genres, warnings };
+}
 
 function hasMusicFilter(f: ShowFilter): boolean {
   return !!f && (f.genres.length > 0 || hasEraBound(f.eras));
@@ -282,7 +298,7 @@ async function tracksFromAlbums(albums: { id: string }[], perAlbum: number, max:
   return out;
 }
 
-async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentKeys: Set<string>, recentArtists: Set<string>, currentTrack: Candidate | null, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null, hardRecentIds: Set<string> = new Set(), hardRecentKeys: Set<string> = new Set(), playlistPool: PlaylistPool | null = null, playlistStrict = false, blockedArtists: Set<string> = new Set()) {
+async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentKeys: Set<string>, recentArtists: Set<string>, currentTrack: Candidate | null, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null, hardRecentIds: Set<string> = new Set(), hardRecentKeys: Set<string> = new Set(), playlistPool: PlaylistPool | null = null, playlistStrict = false, blockedArtists: Set<string> = new Set(), strictGenreResolution: StrictGenreResolution = { genres: [], warnings: [] }) {
   await library.load();
   // Airing memory (music/airing.ts) — orders the similarity sources so the
   // unexplored shelf survives their small caps; and the id-level recency union
@@ -320,20 +336,10 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
   // Resolve the show's free-text genres to the library's exact tags ONCE, up
   // front. A resolution failure drops that entry (never-starve: none resolving
   // means no genre filter at all, so misspelled genres never strand the show).
-  const strictGenres: string[] = [];
+  const strictGenres = strictGenreResolution.genres;
   // Resolutions that silently broadened / dropped what the operator configured.
   // Surfaced through strictInfo so the caller (which owns `queue`) can log them.
-  const genreWarnings: string[] = [];
-  if (strict && showFilter?.genres.length) {
-    for (const g of showFilter.genres) {
-      try {
-        const resolved = await subsonic.resolveGenreName(g);
-        const warning = genreResolutionWarningOnce(g, resolved);
-        if (warning) genreWarnings.push(warning);
-        if (resolved) strictGenres.push(resolved);
-      } catch {}
-    }
-  }
+  const genreWarnings = strictGenreResolution.warnings;
   // Hard-prefer every set filter on a discovery source in strict mode; a no-op
   // otherwise. Each prefer* falls back to the full set when nothing in the
   // source matches, so leaning a source can only tighten, never starve it.
@@ -835,6 +841,9 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   const playlistPool = activeShow ? await resolveShowPlaylistPool(activeShow) : null;
   const playlistStrict = !!activeShow?.playlistStrict;
   const excludedIds = activeShow ? await resolveExcludedPlaylistIds(activeShow) : null;
+  // Resolve once, before both capacity and candidate filtering. A fuzzy genre
+  // alias must narrow the hard-window universe exactly as it narrows the pool.
+  const strictGenreResolution = await resolveStrictGenres(showFilter);
   // Count-based HARD no-repeat guard (last N distinct plays) — non-relaxable,
   // survives buildCandidates' starvation cascade. A resolved strict playlist
   // is its own catalogue, so clamp to its post-filter/post-exclusion identity
@@ -842,7 +851,12 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   const effN = effectiveShowNoRepeatWindow(
     settings.get().llm?.noRepeatWindow ?? 0,
     librarySize,
-    { show: activeShow, playlistTracks: playlistPool?.tracks ?? null, excludedIds },
+    {
+      show: activeShow,
+      playlistTracks: playlistPool?.tracks ?? null,
+      excludedIds,
+      resolvedGenres: strictGenreResolution.genres,
+    },
   );
   const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
   // Pinned anchor resolved to nothing → the show is silently un-anchored.
@@ -857,7 +871,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
     const key = artistRootKey({ artist: opts.avoidArtist });
     if (key) blockedArtists.add(key);
   }
-  const { candidates: rawCandidates, sources, strictInfo, playlistInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentKeys, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, hardRecentIds, hardRecentKeys, playlistPool, playlistStrict, blockedArtists);
+  const { candidates: rawCandidates, sources, strictInfo, playlistInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentKeys, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, hardRecentIds, hardRecentKeys, playlistPool, playlistStrict, blockedArtists, strictGenreResolution);
 
   // Excluded playlists (blocklist): drop any track whose id appears in the
   // show's excluded playlist union. Applied after buildCandidates so the full

--- a/controller/src/music/picker.ts
+++ b/controller/src/music/picker.ts
@@ -15,10 +15,11 @@ import * as settings from '../settings.js';
 import { bpmCompat, keyCompat } from './mix.js';
 import { shuffle } from '../util/shuffle.js';
 import { mapPool } from '../util/async-pool.js';
-import { artistRootKey, filterPickerCandidates, recencyWindowsForLibrary, effectiveNoRepeatWindow } from './recency.js';
+import { artistRootKey, filterPickerCandidates, recencyWindowsForLibrary } from './recency.js';
 import { AIRING_RANK_WEIGHT, freshness, freshnessBiasedOrder, lastAiredMsOf, unairedFlag, type AiredIndex } from './airing.js';
 import { normGenre, genreMatches, genreResolutionWarningOnce, preferGenre, preferEra, inYearRange, preferEnergy, preferEnergyStrict, preferMood, preferVocals, applyStrictLocks, hasEraBound, eraSpan, type YearRange, type VocalMode } from './show-filter.js';
 import { resolveShowPlaylistPool, resolveExcludedPlaylistIds, type PlaylistPool } from './show-playlist.js';
+import { effectiveShowNoRepeatWindow } from './show-recency.js';
 import * as likes from '../broadcast/likes.js';
 
 // A track flowing through the pool builder — a raw Subsonic child, a slimTrack
@@ -281,7 +282,7 @@ async function tracksFromAlbums(albums: { id: string }[], perAlbum: number, max:
   return out;
 }
 
-async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentArtists: Set<string>, currentTrack: Candidate | null, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null, hardRecentIds: Set<string> = new Set(), hardRecentKeys: Set<string> = new Set(), playlistPool: PlaylistPool | null = null, playlistStrict = false, blockedArtists: Set<string> = new Set()) {
+async function buildCandidates(mood: string | null | undefined, recentIds: Set<string>, recentKeys: Set<string>, recentArtists: Set<string>, currentTrack: Candidate | null, rankTarget: { bpm: number | null; key: string | null } | null = null, audioWaypoint: number[] | null = null, showFilter: ShowFilter = null, hardRecentIds: Set<string> = new Set(), hardRecentKeys: Set<string> = new Set(), playlistPool: PlaylistPool | null = null, playlistStrict = false, blockedArtists: Set<string> = new Set()) {
   await library.load();
   // Airing memory (music/airing.ts) — orders the similarity sources so the
   // unexplored shelf survives their small caps; and the id-level recency union
@@ -713,6 +714,7 @@ async function buildCandidates(mood: string | null | undefined, recentIds: Set<s
     || (currentTrack?.id ? analysisFor(currentTrack) : { bpm: null, key: null });
   const final = filterPickerCandidates(softRankByCompat(selectionPool, curAnalysis, library.lastAiredInfo()), {
     recentIds,
+    recentKeys,
     recentArtists,
     hardRecentIds,
     hardRecentKeys,
@@ -807,13 +809,8 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   // small one and never reached the wide windows this scaling exists to give it.
   const librarySize = stats.mirrorTotal || stats.total;
   const windows = recencyWindowsForLibrary(stats.distinctArtists, librarySize);
-  const recentIds = queue.recentlyPlayedIds(windows.trackHours);
+  const { ids: recentIds, keys: recentKeys } = queue.recentlyPlayed(windows.trackHours);
   const recentArtists = queue.recentArtistsSince(windows.artistHours);
-  // Count-based HARD no-repeat guard (last N distinct plays) — non-relaxable,
-  // survives buildCandidates' starvation cascade. Clamped to library size so a
-  // small catalogue never fully blocks; 0 = off. Mirrors the agent path.
-  const effN = effectiveNoRepeatWindow(settings.get().llm?.noRepeatWindow ?? 0, librarySize);
-  const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
   const currentTrack = queue.current?.track || null;
   // Resolve the active show once: its music-steering filters shape the pool
   // (below) and its brief steers the LLM pick (further down). Prefer the show
@@ -838,6 +835,16 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
   const playlistPool = activeShow ? await resolveShowPlaylistPool(activeShow) : null;
   const playlistStrict = !!activeShow?.playlistStrict;
   const excludedIds = activeShow ? await resolveExcludedPlaylistIds(activeShow) : null;
+  // Count-based HARD no-repeat guard (last N distinct plays) — non-relaxable,
+  // survives buildCandidates' starvation cascade. A resolved strict playlist
+  // is its own catalogue, so clamp to its post-filter/post-exclusion identity
+  // count; soft/unresolved anchors remain library-scoped. Mirrors the agent.
+  const effN = effectiveShowNoRepeatWindow(
+    settings.get().llm?.noRepeatWindow ?? 0,
+    librarySize,
+    { show: activeShow, playlistTracks: playlistPool?.tracks ?? null, excludedIds },
+  );
+  const { ids: hardRecentIds, keys: hardRecentKeys } = queue.recentlyPlayedByCount(effN);
   // Pinned anchor resolved to nothing → the show is silently un-anchored.
   // Surface it (same warning as the agent path in dj-agent.ts).
   if (activeShow?.playlistIds?.length && !playlistPool) {
@@ -850,7 +857,7 @@ export async function pickViaPool(queue, ctx, rankTarget: { bpm: number | null; 
     const key = artistRootKey({ artist: opts.avoidArtist });
     if (key) blockedArtists.add(key);
   }
-  const { candidates: rawCandidates, sources, strictInfo, playlistInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, hardRecentIds, hardRecentKeys, playlistPool, playlistStrict, blockedArtists);
+  const { candidates: rawCandidates, sources, strictInfo, playlistInfo } = await buildCandidates(ctx.dominantMood, recentIds, recentKeys, recentArtists, currentTrack, rankTarget, audioWaypoint, showFilter, hardRecentIds, hardRecentKeys, playlistPool, playlistStrict, blockedArtists);
 
   // Excluded playlists (blocklist): drop any track whose id appears in the
   // show's excluded playlist union. Applied after buildCandidates so the full

--- a/controller/src/music/show-playlist.ts
+++ b/controller/src/music/show-playlist.ts
@@ -14,7 +14,10 @@ import * as subsonic from './subsonic.js';
 import { trackKey } from './recency.js';
 
 export type PlaylistPool = {
-  ids: Set<string>; // every track id in the union — the strict lock set
+  ids: Set<string>; // every SURVIVING track id — the strict lock set. Not every
+                    // id in the union: an alternate rip collapsed by the
+                    // identity dedupe below is absent, so a strict show cannot
+                    // pick it. resolveShowPlaylistPool warns when that happens.
   tracks: any[];     // deduped Subsonic song objects
   names: string[];   // resolved playlist names, for logging / debug
 };
@@ -91,6 +94,21 @@ export async function resolveShowPlaylistPool(show: any): Promise<PlaylistPool |
 
   const tracks = mergePlaylistTracks(lists);
   if (!tracks.length) return null;
+  // The identity dedupe drops playlist entries the operator can still SEE in
+  // Navidrome, and it shrinks the strict lock set with them. Say so: a strict
+  // show quietly short of the songs its own playlist lists is undiagnosable
+  // from the operator's side — the same reason the pick paths shout when a
+  // pinned anchor resolves to nothing. Only the identity collapses are counted;
+  // a plain id repeated across two pinned playlists is an ordinary union.
+  const distinctIds = new Set<string>();
+  for (const list of lists) {
+    for (const t of list || []) if (t?.id) distinctIds.add(t.id);
+  }
+  const collapsed = distinctIds.size - tracks.length;
+  if (collapsed > 0) {
+    const where = names.length ? names.join(', ') : `${ids.length} playlist(s)`;
+    console.warn(`[show-playlist] ${collapsed} duplicate rip(s) in ${where} collapsed by title/artist — one id per song reaches the pick paths, so the show has ${tracks.length} playable entries, not ${distinctIds.size}.`);
+  }
   return { ids: new Set<string>(tracks.map((t: any) => t.id)), tracks, names };
 }
 

--- a/controller/src/music/show-playlist.ts
+++ b/controller/src/music/show-playlist.ts
@@ -2,14 +2,16 @@
 //
 // A show can pin one or more Navidrome playlists (settings show.playlistIds);
 // the union of their tracks becomes the show's candidate pool. This module
-// turns that id list into a deduped track pool, shared by all three consumers:
+// turns that id list into an identity-deduped track pool, shared by all three consumers:
 // the pool picker (music/picker.ts), the session DJ agent's tools
 // (broadcast/dj-agent.ts), and the LLM-free fallback (broadcast/scheduler.ts).
 //
 // subsonic.getPlaylist already rejects station-archive entries, so there's no
-// extra archive filtering here — the merge is purely union + dedupe by id.
+// extra archive filtering here — the merge is purely union + dedupe by id and
+// normalised title|artist identity.
 
 import * as subsonic from './subsonic.js';
+import { trackKey } from './recency.js';
 
 export type PlaylistPool = {
   ids: Set<string>; // every track id in the union — the strict lock set
@@ -18,16 +20,21 @@ export type PlaylistPool = {
 };
 
 // Pure: flatten a list of playlist track-lists into one deduped array, keeping
-// the first occurrence of each id and dropping entries without an id. The
-// unit-test seam (scripts/show-playlist.test.ts) — no Subsonic, no I/O.
+// the first occurrence of each id or normalised title|artist identity and
+// dropping entries without an id. The unit-test seam
+// (scripts/show-playlist.test.ts) — no Subsonic, no I/O.
 export function mergePlaylistTracks(lists: any[][]): any[] {
-  const seen = new Set<string>();
+  const seenIds = new Set<string>();
+  const seenKeys = new Set<string>();
   const out: any[] = [];
   for (const list of lists) {
     for (const t of list || []) {
       const id = t?.id;
-      if (!id || seen.has(id)) continue;
-      seen.add(id);
+      if (!id || seenIds.has(id)) continue;
+      const key = t?.title ? trackKey(t) : '';
+      if (key && seenKeys.has(key)) continue;
+      seenIds.add(id);
+      if (key) seenKeys.add(key);
       out.push(t);
     }
   }

--- a/controller/src/music/show-recency.ts
+++ b/controller/src/music/show-recency.ts
@@ -31,10 +31,14 @@ export function effectiveShowNoRepeatWindow(
     show,
     playlistTracks,
     excludedIds,
+    resolvedGenres,
   }: {
     show: RecencyShow;
     playlistTracks: ShowTrack[] | null;
     excludedIds: Set<string> | null;
+    // The picker resolves free-text show genres onto exact library tags before
+    // filtering. Use that same lock here so capacity and eligibility agree.
+    resolvedGenres?: string[];
   },
 ): number {
   // A soft anchor can leave the playlist, and an unresolved strict anchor has
@@ -45,7 +49,7 @@ export function effectiveShowNoRepeatWindow(
 
   const filtered = show.filtersStrict
     ? applyStrictLocks(playlistTracks, {
-        genres: show.genres ?? [],
+        genres: resolvedGenres ?? show.genres ?? [],
         eras: show.eras ?? [],
         moods: show.moods ?? [],
         energies: show.energies ?? [],

--- a/controller/src/music/show-recency.ts
+++ b/controller/src/music/show-recency.ts
@@ -1,0 +1,67 @@
+// No-repeat capacity for scheduled shows.
+//
+// The station-wide hard window is safe only when it is clamped to the actual
+// universe a pick may draw from. Most picks use the full library; a resolved
+// playlistStrict show instead uses its post-filter, post-exclusion playlist.
+// Keeping the decision here makes the agent and pool paths share one policy.
+
+import { effectiveNoRepeatWindow, trackKey } from './recency.js';
+import { applyStrictLocks, type FilterTrack, type VocalMode, type YearRange } from './show-filter.js';
+
+type ShowTrack = FilterTrack & {
+  id?: string;
+  title?: string | null;
+  artist?: string | null;
+};
+
+type RecencyShow = {
+  playlistStrict?: boolean;
+  filtersStrict?: boolean;
+  genres?: string[];
+  eras?: YearRange[];
+  moods?: string[];
+  energies?: string[];
+  vocals?: string;
+} | null;
+
+export function effectiveShowNoRepeatWindow(
+  configuredN: number | null | undefined,
+  libraryTotal: number | null | undefined,
+  {
+    show,
+    playlistTracks,
+    excludedIds,
+  }: {
+    show: RecencyShow;
+    playlistTracks: ShowTrack[] | null;
+    excludedIds: Set<string> | null;
+  },
+): number {
+  // A soft anchor can leave the playlist, and an unresolved strict anchor has
+  // no playlist lock at runtime. Both still need the library-wide window.
+  if (!show?.playlistStrict || playlistTracks == null) {
+    return effectiveNoRepeatWindow(configuredN, libraryTotal);
+  }
+
+  const filtered = show.filtersStrict
+    ? applyStrictLocks(playlistTracks, {
+        genres: show.genres ?? [],
+        eras: show.eras ?? [],
+        moods: show.moods ?? [],
+        energies: show.energies ?? [],
+        vocals: (show.vocals === 'instrumental' || show.vocals === 'vocal'
+          ? show.vocals
+          : '') as VocalMode,
+      }, { starve: false })
+    : playlistTracks;
+
+  // Count audible identities, not Subsonic rows: duplicate rips with different
+  // ids consume one slot in the real rotation and must not inflate its capacity.
+  const identities = new Set<string>();
+  for (const track of filtered) {
+    if (!track?.id || excludedIds?.has(track.id)) continue;
+    identities.add(track.title ? `key:${trackKey(track)}` : `id:${track.id}`);
+  }
+
+  return effectiveNoRepeatWindow(configuredN, identities.size);
+}


### PR DESCRIPTION
## Summary

- scope the non-relaxable no-repeat window to the resolved strict playlist universe after strict filters, exclusions, genre resolution, and title/artist identity deduplication
- share that capacity policy across the pool and agent picker paths while leaving soft and unresolved playlist anchors library-scoped
- deduplicate alternate playlist rips by normalized title/artist

## Also in here: the pool path now passes `recentKeys`

Wider blast radius than the rest of the PR, so calling it out separately: `pickViaPool` now reads `queue.recentlyPlayed()` as `{ ids, keys }` and threads `recentKeys` into `filterPickerCandidates`, where before it passed `recentIds` alone.

This is an alignment, not a new rule. `broadcast/scheduler.ts` and `broadcast/dj-agent.ts` already pass `recentKeys`; the pool picker was the one path that did not, so the same duplicate rip could be blocked on the agent path and admitted on the pool path for the same station. `filterPickerCandidates` has always accepted and enforced the field (pinned by `picker-recency-regression.test.ts`), so nothing about the filter itself changes.

Scope of the effect: this touches **every pick on every station**, not just playlist-anchored shows. Two rips of one song with different Subsonic ids now count as one track against the relaxable title/artist recency window in the pool path. It sits inside the relaxation cascade (`mode.recentTracks`), so a starved pool still drops it and never returns empty. It is separate from the no-repeat clamp fix below and could be reverted on its own.

## Verification

- focused show/picker regression suite: passed
- `npm run lint`: passed with 0 errors (653 existing warnings)
- full controller suite: 850 passed, 0 failed, 7 cancelled in the unrelated baseline `voice-air-events.test.ts` unref-timer cases

Review follow-up (4de6cb19):

- the strict-playlist assertions in `show-recency.test.ts` all expected `0`, so a regression returning `0` for every playlist-anchored show passed the whole suite. Both sides of the clamp are now pinned (200 identities -> 75, 400 -> 100), and the gap is confirmed closed by mutation: replacing the return with `return 0` fails the 200-track case, where previously it passed everything.
- `resolveShowPlaylistPool` now warns when the identity dedupe collapses rips. The dedupe removes entries the operator can still see in Navidrome and shrinks the strict lock set with them, and it was silent. Counted in the resolver rather than in `mergePlaylistTracks`, which stays the pure unit-test seam.

Fixes #1480
