### PR TITLE
docs: concept explainers, update/rollback procedure, split-port recipe

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -199,9 +199,23 @@ If a deploy goes wrong, roll back:
 
 ```bash
 git log --oneline -5
-git checkout <previous-sha>
+git checkout <previous-tag-or-sha>
 docker compose -f docker-compose.yml up -d --build
 ```
+
+On an **image** install (the standalone CLI, or plain compose off GHCR) there is
+nothing to check out — move the pin instead:
+
+```bash
+sed -i 's/^SUBWAVE_VERSION=.*/SUBWAVE_VERSION=1.4.2/' .env
+docker compose pull && docker compose up -d
+```
+
+Take a backup **before** you update, and read the state caveats before rolling
+back more than one release: settings the newer version added are dropped on the
+older version's first save, and the library database migrates forward only.
+Those, plus recovery for a broken login, a silent stream and a restart-looping
+controller, are in [`docs/updating.md`](docs/updating.md).
 
 ## 8. Operations
 
@@ -213,9 +227,6 @@ docker compose -f docker-compose.yml logs -f caddy
 
 # Restart just one service
 docker compose -f docker-compose.yml restart controller
-
-# Manual skip (controller exposes POST /skip, Caddy proxies it under /api)
-curl -X POST http://localhost/api/skip
 
 # What's queued / playing / in the DJ log
 curl -s http://localhost/api/state | jq
@@ -272,14 +283,24 @@ to bootstrap state, jingle rendering, updates, and backup. Skip section 6
 
 ## 10. Backup
 
-The only stateful path is `state/` (under the repo). Two things really matter:
+The only stateful path is `state/` (under the repo). Three things matter, in
+this order:
 
-- `archive/` — your show recordings. Big. Back up or rotate.
+- `settings.json` + `schedule.json` + `library.db` — your configuration, your
+  show grid, and every LLM enrichment pass over your library. The expensive
+  one is `library.db`: rebuilding it costs hours and tokens, not just a rescan.
+  **Admin → Settings → Backup → Export** zips all three (plus jingles, SFX,
+  custom voices, themes, skills and persona avatars) with a WAL-safe copy of
+  the database. API keys are redacted, so re-enter cloud keys after a restore.
+- `archive/` — your show recordings. Big, and deliberately **not** in the
+  export. Back up or rotate separately.
 - `jingles/` + `jingles.m3u` — re-derivable from `scripts/generate-jingles.sh`,
   so backup is optional.
 
 Everything else (`voice/`, `auto.m3u`, `now-playing.json`, the queue files)
 is ephemeral and regenerates within minutes of a fresh boot.
 
-A nightly tar of `state/archive/` to an external box is
-sufficient.
+A nightly tar of `state/` to an external box covers everything, archives
+included. If that's too big, tar `state/archive/` on its own schedule and take
+the admin export before each update — see
+[`docs/updating.md`](docs/updating.md#before-you-update).

--- a/README.md
+++ b/README.md
@@ -318,7 +318,9 @@ bin/subwave        Operator CLI entry: setup, status, doctor, lifecycle
 ## Documentation
 
 - **[`DEPLOY.md`](DEPLOY.md):** production deployment, updates, backup.
-- **[`docs/reverse-proxy.md`](docs/reverse-proxy.md):** complete nginx, Nginx Proxy Manager, Traefik, and Cloudflare Tunnel route recipes.
+- **[`docs/updating.md`](docs/updating.md):** updating on every install shape, and the half people need at 2am — how to roll back to a previous version, and how to recover a broken login, a silent stream or a restart-looping controller.
+- **[`docs/concepts.md`](docs/concepts.md):** the seven things that get asked over and over — the persona tone dials, candidate pool vs the agent picker, playlists vs shows, the stem cache, private player vs stream password, dayparts at high latitude, and what a heart actually does to rotation.
+- **[`docs/reverse-proxy.md`](docs/reverse-proxy.md):** complete nginx, Nginx Proxy Manager, Traefik, and Cloudflare Tunnel route recipes — including [public stream, LAN-only admin](docs/reverse-proxy.md#public-stream-lan-only-admin).
 - **[`docs/unraid.md`](docs/unraid.md):** running on Unraid — one-click from Community Applications, or the Compose Manager Plus stack.
 - **[`docs/tts-heavy.md`](docs/tts-heavy.md):** the opt-in `tts-heavy` voices and the default-on acoustic `analyzer` service — what each does and how to toggle them, including [running analysis on another machine](docs/tts-heavy.md#running-the-analyzer-on-another-machine) (a GPU box elsewhere on the network).
 - **[`docs/custom-tts.md`](docs/custom-tts.md):** bring your own TTS server — point the DJ at any HTTP endpoint you run (your GPU box, a bridge in front of a vendor API), the same way the LLM side takes a custom base URL.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,345 @@
+# Concepts
+
+Seven things that get asked over and over — not because they're broken, but
+because the name doesn't tell you what's underneath. Each section says what the
+thing is, what changes when you move it, and where the control lives.
+
+> Running a station already? The same material, illustrated, lives in the
+> in-app manual at **/manual/concepts**. This page is the repo-side copy for
+> someone reading on GitHub before they have a station to click around in.
+
+- [Local Colour (and the other two dials)](#local-colour-and-the-other-two-dials)
+- [Candidate pool vs the agent picker](#candidate-pool-vs-the-agent-picker)
+- [Playlists vs shows](#playlists-vs-shows)
+- [The stem cache](#the-stem-cache)
+- [Private player vs stream password](#private-player-vs-stream-password)
+- [Dayparts, and why they don't move with the sun](#dayparts-and-why-they-dont-move-with-the-sun)
+- [Hearts: what a like actually does](#hearts-what-a-like-actually-does)
+
+---
+
+## Local Colour (and the other two dials)
+
+**Where:** Admin → Personas → *(a persona)* → Behaviour.
+
+Every persona carries three 0–10 dials: **Humour**, **Local Colour** and
+**Warmth**. They are not sliders on a mixing desk — nothing scales
+proportionally as you drag them. Each dial resolves to one of three bands:
+
+| Value | Band |
+| --- | --- |
+| 0–3 | low |
+| 4–6 | neutral |
+| 7–10 | high |
+
+Only a band **away from neutral** appends a sentence to the persona's prompt.
+So 4, 5 and 6 are the same setting, and so are 7 and 10.
+
+That is deliberate. A model cannot tell `humour=6` from `humour=7` in a raw
+"7/10" instruction, so rather than pretend to a precision that isn't there, the
+dial picks one of two style directives:
+
+| Dial | Low band says | High band says |
+| --- | --- | --- |
+| **Humour** | Play it straight; keep any wit rare and understated. | Lean into dry, playful wit; an aside or a wink is welcome. |
+| **Local Colour** | Keep it universal; skip local references and place-specific colour. | Lean on the local setting (the town, the weather, the hour) as texture. |
+| **Warmth** | Keep a cool, dry distance; let the music carry the warmth. | Be warm and earnest; speak to the listener like a friend. |
+
+**Local Colour specifically** governs how much the DJ reaches for *where and
+when you are* — your town, today's weather, the hour — as material. Turned up,
+links start with the drizzle outside; turned down, the same DJ could be
+broadcasting from anywhere.
+
+Three things it does **not** do:
+
+- It doesn't add facts. The place name, weather and clock come from the station
+  context regardless; the dial only decides whether the DJ leans on them.
+- It doesn't invent a second location. Exactly one place name reaches any
+  prompt (the on-air location you set under Settings → Station). If the DJ names
+  a different city, that's the model improvising, not the dial.
+- A persona left at the defaults renders a **byte-identical** prompt to a
+  station that never had the dials, which is why upgrading changes nothing.
+
+---
+
+## Candidate pool vs the agent picker
+
+**Where:** Admin → Settings → LLM → **Agentic picker** (`Candidate pool` / `Agent`).
+
+Both end at the same place — one track id, handed to the queue — and both run
+inside a session and get logged. They differ in *who does the searching*.
+
+### Candidate pool (off)
+
+The controller builds the shortlist itself, then asks the model once.
+
+It merges up to sixteen sources into one pool — mood matches from the library,
+sonically similar tracks, embedding neighbours, the current show's genres and
+playlists, starred and frequently-played, recently added, listener favourites,
+a wildcard and a little pure random — de-duplicates, applies the recency and
+artist filters, caps it, and sends the survivors to the model as a list. The
+model makes **one call**: pick one of these.
+
+- One LLM round-trip per track.
+- Works on a small local model — there is no tool loop to get lost in.
+- Bounded latency, bounded tokens.
+- The model can only choose from what the pool already found.
+
+### Agent (on, the default)
+
+The model drives. It gets a toolbox of roughly eighteen discovery tools —
+similar songs, tracks like this one, search by sound, search by lyrics, by
+mood, by energy, by genre, deep cuts, recently added, top songs by artist,
+tracks toward a journey — and searches the library itself over the session's
+chat history, then commits its pick with a `done` call.
+
+- Several round-trips per track, so it costs more tokens and more wall-clock.
+- Needs a model that is genuinely good at **multi-step, forced tool calling**
+  with a context window of at least 16384. Most "the agent stopped without
+  calling done" reports are this requirement not being met.
+- Bounded by **Agent deadline** (default 45s). On timeout or failure it falls
+  back to the candidate pool, so a slot is never lost.
+
+### Which to run
+
+Start on **Agent** if you're on a cloud model or a 12B-class local model. Drop
+to **Candidate pool** if picks are slow, if the log shows repeated
+`djAgentRepick` loops, or if you're on a 9B-class model — the station still
+picks, still writes links, still honours requests.
+
+Two related behaviours worth knowing, whichever you pick:
+
+- **Variety is enforced after the choice, not inside the search.** The
+  discovery tools carry no artist filter on purpose — filtering inside them
+  gutted the similarity pool on niche catalogues. Instead, a pick that repeats
+  an artist from the last few slots triggers a re-pick. So an eight-of-eight
+  same-artist candidate set is expected, and the guard is what stops it
+  reaching air.
+- **The daily token cap degrades in tiers.** Past the soft threshold the
+  station drops to the candidate pool and mutes optional segments; at the cap
+  it stops calling the model at all and coasts on the fallback playlist. Music
+  never stops.
+
+---
+
+## Playlists vs shows
+
+They sound like alternatives. They're layers — a show can *use* playlists.
+
+|  | Playlist | Show |
+| --- | --- | --- |
+| **What it is** | A named set of tracks | A block of programming on the schedule |
+| **Lives in** | Navidrome (SUB/WAVE reads it over Subsonic) | `state/schedule.json`, edited in admin |
+| **Has a time** | No | Yes — that's the point |
+| **Has a persona / theme / topic** | No | Yes |
+| **Where** | Admin → Playlists | Admin → Shows, Admin → Shows → Schedule |
+
+A **playlist** is just tracks. You can build one by hand in Navidrome, or let
+the playlist builder assemble one from a description ("late-night driving,
+mostly instrumental, 90 minutes") — it merges candidates from the same vector,
+mood and similarity machinery the picker uses, then makes one model call to
+select and order them into an energy arc.
+
+A **show** is an hour (or several) with an identity: which persona is on air,
+which theme the player wears, what the show is about, and a set of music
+filters — moods, genres, eras, energies, vocals. The DJ still picks each track
+live; the show narrows what it may pick from.
+
+### Where they meet
+
+A show can be **anchored** to one or more playlists. Then:
+
+- **Anchored, not strict** — the playlist union becomes the show's dominant
+  source, but the DJ may still reach outside it for a better fit.
+- **Anchored + strict** — the playlist union is the show's entire universe.
+  Every off-playlist candidate is dropped before ranking.
+
+If a show pins playlists that resolve to nothing (deleted and recreated in
+Navidrome, so the id moved), the anchor is **ignored and logged** — including a
+note that the strict toggle had no effect. The show still airs; it just airs
+unanchored. Re-select the playlists in the show editor to fix it.
+
+### Rules of thumb
+
+- Recurring identity, fixed hour, its own voice → **show**.
+- A set of tracks you want to reach for, from anywhere → **playlist**.
+- "This hour, only these tracks" → **show anchored to a playlist, strict on**.
+
+---
+
+## The stem cache
+
+**Where:** Admin → Settings → Transitions.
+
+Stem-blend transitions mix the outgoing and incoming tracks by *instrument*
+rather than crossfading two finished mixes: the outgoing drums duck out under
+the incoming bass, vocals clear before the new vocal enters. Doing that needs
+the four separated stems (drums, bass, other, vocals) for both sides of the
+seam.
+
+Separating stems takes far longer than the gap between two tracks, so it can't
+happen at the seam. The analyzer separates them **during analysis** and writes
+a head window (first 40s) and a tail window (last 20s) as FLAC under
+`state/stems/<trackId>/`. A transition render is then a fast mix of cached
+files.
+
+### The trade-off
+
+The cost is disk, and it is the only cost — the separation is paid for during
+analysis whether you keep the output or not.
+
+- Budget one is **~13–25 MB per track**. The ceiling is 25 MB; real caches run
+  nearer 13 MB, because stem FLACs are mostly quiet channels and compress hard.
+- The default budget is **15 GB**, so roughly 600–1,200 tracks.
+- Past the budget, an LRU sweep evicts the least recently used directories.
+
+The thing that surprises people: **a blend needs stems on *both* tracks of a
+pair.** With half the library cached, far fewer than half your seams blend —
+most fall back to a plain crossfade, which is not a failure, just the ordinary
+behaviour. That is the honest reason to raise the budget: coverage of pairs,
+not coverage of tracks. `subwave doctor` says this outright, with the track
+count your current budget actually holds.
+
+### Sizing it
+
+- **Small library (a few thousand tracks)** — raise the budget until it covers
+  the lot and let the analysis pass backfill.
+- **Large library (tens of thousands)** — the budget will always bind. Blends
+  will land on the tracks that happen to be cached.
+- **Short on disk** — turn the cache off. Every seam becomes a crossfade and
+  nothing else changes.
+- **Moving it to a bigger disk** — bind-mount your disk at
+  `<state>/stems`. There is no path setting; the mount is the mechanism.
+  Mount it world-writable, or the analyzer (a different uid) can't write to it.
+
+---
+
+## Private player vs stream password
+
+Two independent locks, one shared station password, both under
+**Admin → Settings → Station → Privacy**. They're often confused because
+turning either one on asks for the same password.
+
+| | Private player | Stream password |
+| --- | --- | --- |
+| **Hides** | The web pages (`/`, `/listen`) | The audio itself, on every mount |
+| **Enforced by** | The web UI | Icecast, via a callback to the controller |
+| **Applies** | Live | Enabling/disabling needs a mixer restart; password changes are live |
+| **Stops** `curl /stream.mp3` | **No** | Yes |
+
+The short version: **the private player is a curtain, the stream password is a
+lock.** The private player hides the interface; the now-playing endpoints stay
+public (the player and admin dash need them) and anyone who knows
+`/stream.mp3` can still listen. If you want actual gating, you want the stream
+password — usually both together, so one prompt unlocks the page and the audio.
+
+A third thing is often mistaken for these two: **HTTP Basic Auth in front of
+the whole station**, applied at your own reverse proxy. That is not a SUB/WAVE
+feature and it behaves differently — notably for the mobile apps.
+
+Full detail on all three, including how to tune in from VLC, Sonos, hardware
+radios and the apps once a password is on:
+**[`docs/private-station.md`](private-station.md)**.
+
+---
+
+## Dayparts, and why they don't move with the sun
+
+**Where:** Admin → Moods → Moments.
+
+The station divides the day into eight named periods:
+
+| Period | Hours (station timezone) |
+| --- | --- |
+| early-morning | 05:00–09:00 |
+| morning | 09:00–12:00 |
+| midday | 12:00–14:00 |
+| afternoon | 14:00–17:00 |
+| drive-time | 17:00–19:00 |
+| evening | 19:00–22:00 |
+| late-evening | 22:00–01:00 |
+| after-hours | 01:00–05:00 |
+
+These boundaries are **fixed wall-clock hours in the station's timezone**. They
+are not derived from sunrise or sunset, and they are not configurable.
+
+That reads oddly above roughly 55°N or below 55°S, where "evening" is full
+daylight in June and pitch dark in December. It's a deliberate trade, for two
+reasons. A daypart is a *programming* concept — "drive-time" means the end of
+the working day, which is 17:00 whatever the sky is doing — and it has to be
+predictable: the schedule, the mood plan and the show grid are all built
+against named hours, and boundaries that drifted by three hours across the year
+would quietly move your shows.
+
+### What *is* sun-aware
+
+The DJ's own description of the outside world. The station reads whether the
+sun is up right now from Open-Meteo and puts that on the prompt, which is what
+stops it describing dusk two hours after dark in December — or "the last of the
+light" at 21:00 in June. That runs off real solar position at your coordinates,
+so it is correct at any latitude. If the weather fetch fails, the flag is
+simply absent and the model falls back to inferring from the clock.
+
+### What you can change
+
+Each period's **mood** is yours — Admin → Moods → Moments maps every daypart to
+a mood from your vocabulary. So the lever at high latitude is not to move the
+boundary but to retune what happens inside it: give a Nordic summer "evening" a
+brighter mood than the default wind-down, and let the sun-aware flag keep the
+DJ's language honest.
+
+Two related nudges sit on top of the table and are not editable: the small
+hours pull the speaking pace down regardless of which period the hour formally
+belongs to, and commute windows push it up. A show with a pinned energy
+overrides both — a scheduled slot is an explicit operator decision.
+
+---
+
+## Hearts: what a like actually does
+
+There are two hearts, and they are not the same signal.
+
+- **The listener heart**, on the player. One like per apparent listener per
+  *airing* — the same song aired again later is likeable again. Listeners have
+  no accounts, so "apparent listener" is an HMAC of the IP; the raw address is
+  never stored, and everyone behind one NAT shares a key. It's lightweight
+  dedup, not identity.
+- **The operator heart**, in Admin → Library. Curation, not a taste snapshot.
+
+### What a like does by default
+
+By default, **nothing to rotation.** A like is recorded, it shows up in stats,
+and — if Navidrome starring is on — the track is starred in Navidrome. The DJ
+does not know about it.
+
+Rotation influence is opt-in: **Admin → Settings → Likes → AI DJ influence → Use likes to influence picks**.
+Turned on, the most-liked tracks become one more source feeding the candidate
+pool, capped like every other source. It is a weighted preference, never a
+lock — the crowd can steer the pool without taking it over. By default that's
+the top 10 tracks liked in the last 30 days (both numbers are settings; a
+window of 0 means all time).
+
+### Why the two hearts age differently
+
+An operator heart is **exempt from the window and from the record trim**. A
+listener like ageing out of the 30-day window is a taste snapshot expiring,
+which is correct. An operator like ageing out would be the DJ forgetting
+curation you set by hand, which is not.
+
+### Clearing them
+
+Yes. Per track, from the row actions in **Admin → Library**:
+
+- **Un-heart** as the operator — removes only your heart. If it was the last
+  like standing and Navidrome starring is on, the track is unstarred there too.
+- **Clear likes** — drops the listener likes on that track as well.
+
+Note the asymmetry: un-hearting as the operator leaves listener likes in place;
+**Clear likes** removes both.
+
+To wipe the whole store there is no button — it's `DELETE /likes` on the admin
+API:
+
+```bash
+curl -u "$ADMIN_USER:$ADMIN_PASS" -X DELETE https://radio.example.com/api/likes
+```

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -289,6 +289,140 @@ edge address. Once the direct public route is closed, preserve real listener
 IPs with the trusted-proxy setup in
 [deployment.md](deployment.md#cloudflare-tunnel).
 
+## Public stream, LAN-only admin
+
+A common homelab shape: the player and the stream reachable from the internet,
+the operator console reachable only from home. SUB/WAVE has no setting for
+this — the split is made at your proxy, and this section is the recipe.
+
+### What can and cannot be split
+
+There are two operator surfaces, and only one of them separates cleanly by
+path.
+
+| Surface | Paths | Can you restrict it by path? |
+| --- | --- | --- |
+| Operator **UI** | `/admin*`, `/onboarding` | **Yes.** Distinct prefixes, served by the web container. |
+| Operator **API** | admin routes under `/api/*` | **No.** The controller mounts public and admin routes on one flat namespace — `/api/now-playing` and `/api/settings` are siblings. There is no `/api/admin/` prefix to deny. |
+
+So the practical split is: **deny the console's pages from the internet, and
+let the admin API stay guarded by HTTP Basic auth**, which is what guards it
+today on every default install (`ADMIN_USER` / `ADMIN_PASS`, mandatory in
+production). That gets you the requested outcome — nobody outside your LAN sees
+a login box, let alone a console — without an allowlist that breaks the next
+time a listener-facing endpoint is added.
+
+If you want the admin API off the public interface as well, see
+[Two front doors](#two-front-doors) below.
+
+Leave `SITE_URL` pointing at the **public** origin either way. It's the
+canonical address the tune-in files, share cards and the Connect panel hand
+out; the LAN address is how *you* reach the box, not how listeners reach the
+station.
+
+### One hostname, restricted console
+
+Add this to the recipe you already applied, above the catch-all web rule.
+
+**nginx** — order matters, `location` prefixes are matched before the `/`
+fallback:
+
+```nginx
+# Operator console: LAN only. Everything else on this server block stays public.
+location ~ ^/(admin|onboarding) {
+    allow 192.168.1.0/24;   # your LAN
+    allow 100.64.0.0/10;    # Tailscale, if you use it
+    deny  all;
+
+    proxy_pass http://127.0.0.1:7700;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+**Caddy** — including the bundled `docker/Caddyfile`, where this goes above the
+final `handle`:
+
+```caddyfile
+@console path /admin /admin/* /onboarding /onboarding/*
+handle @console {
+	@notlan not remote_ip 192.168.1.0/24 100.64.0.0/10
+	respond @notlan 404
+	reverse_proxy web:7700
+}
+```
+
+`404` rather than `403` — a 403 confirms there is a console there to find.
+
+**Traefik** — attach an `ipAllowList` middleware to a higher-priority router
+matching the same paths:
+
+```yaml
+labels:
+  - "traefik.http.middlewares.subwave-lan.ipallowlist.sourcerange=192.168.1.0/24,100.64.0.0/10"
+  - "traefik.http.routers.subwave-console.rule=Host(`radio.example.com`) && (PathPrefix(`/admin`) || PathPrefix(`/onboarding`))"
+  - "traefik.http.routers.subwave-console.priority=100"
+  - "traefik.http.routers.subwave-console.middlewares=subwave-lan@docker"
+  - "traefik.http.routers.subwave-console.service=subwave-web"
+```
+
+Behind Cloudflare or a tunnel, the connecting peer is the edge, not the
+listener — your allowlist must read the forwarded address, which means the
+trusted-proxy setup in [deployment.md](deployment.md#real-listener-ips-behind-a-proxy)
+has to be correct first. Test it before you rely on it: a misconfigured
+trusted-proxy list turns an IP allowlist into either a lockout or a no-op.
+
+Do **not** add `/api` to the allowlist. The player calls `/api/now-playing`,
+`/api/state`, `/api/session`, `/api/request`, `/api/like` and `/api/cover/:id`
+from every listener's browser; denying `/api` from the internet takes the
+public player down with it.
+
+### Two front doors
+
+For a genuinely separate admin surface — the console *and* its API off the
+public interface — run two front ends over the same containers. The web bundle
+calls `/api` and `/stream.mp3` **relative to its own origin**, so both work
+with the stock image and no rebuild.
+
+Use [`docker-compose.byo.yml`](../docker-compose.byo.yml) with
+`BIND_ADDRESS=127.0.0.1`, then:
+
+- **Public front end** (`radio.example.com`, port 443 on the WAN) — the route
+  contract above, minus the console: `/admin*` and `/onboarding` return 404.
+- **LAN front end** (`subwave.lan`, or port 8443 bound to your LAN interface) —
+  the full route contract, nothing denied.
+
+Then decide what the public front end does with `/api/*`. Two honest options:
+
+- **Pass it through** (simple, recommended). The admin API stays reachable from
+  the internet and stays protected by Basic auth. This is the same posture as a
+  default install; the win is that the console pages are gone.
+- **Allowlist the listener endpoints** (strict, brittle). Route only
+  `/api/now-playing`, `/api/state`, `/api/session`, `/api/health`,
+  `/api/schedule`, `/api/themes`, `/api/beacon`, `/api/cover/*`, `/api/request`,
+  `/api/request/*`, `/api/like` and `/api/station-auth`, and 404 the rest. It
+  works, and it will silently break a listener feature the first time a release
+  adds an endpoint to that list. Pin `SUBWAVE_VERSION` and re-read this list at
+  each upgrade if you take this path.
+
+`/api/onboarding/status` is deliberately absent from that list. The player
+calls it to redirect a fresh install to the wizard and treats any non-200 as
+"nothing to do", so denying it publicly costs nothing and stops the public
+origin advertising an unconfigured station.
+
+`/api/listener-auth` stays denied on **both** front ends. Icecast calls the
+controller over the private Compose network; it never needs a route.
+
+### On the all-in-one image
+
+The AIO image can't do this internally — it bundles Caddy, the controller, the
+web UI and Icecast behind one host port by design. Put your own proxy in front
+of that single port and apply the console rule there, exactly as above with the
+AIO's port as the upstream. That works on Unraid, where the outer proxy is
+usually SWAG or Nginx Proxy Manager already fronting everything else.
+
 ## Verify the public route table
 
 Run these after applying any recipe:

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -1,0 +1,315 @@
+# Updating, rolling back, and recovering
+
+Updating SUB/WAVE is one command on every install shape. This page is mostly
+about the other half — what to do when an update lands badly, which is the part
+that was missing.
+
+> Just want the command? Jump to [Update](#update). Something already broken?
+> Jump to [Recovery](#recovery-when-an-update-goes-wrong).
+
+---
+
+## Before you update
+
+Two minutes, once, and rollback stops being a research project.
+
+### 1. Take a backup
+
+**Admin → Settings → Backup → Export** downloads a zip containing
+`settings.json`, the
+show schedule, the library tag database (`library.db` — a consistent online
+copy, not a raw file grab), your jingles, SFX, custom voices, themes, skills
+and persona avatars.
+
+Two things it deliberately does **not** contain:
+
+- **Secrets.** API keys and webhook auth are redacted before export, so a
+  backup zip is safe to store but is not a complete restore — you re-enter
+  cloud keys afterwards.
+- **Archives.** `state/archive/` (hourly stream recordings) is excluded because
+  it's enormous. Back that up separately, or accept losing it.
+
+The tag database is the expensive thing in there. It represents every LLM
+enrichment pass over your library; rebuilding it costs hours and tokens, not
+just a rescan.
+
+### 2. Write down the version you're on
+
+```bash
+grep SUBWAVE_VERSION .env        # image installs
+git describe --tags              # clone installs
+```
+
+You cannot roll back to a version you can't name. On image installs, if
+`SUBWAVE_VERSION` is unset or `latest`, note the running image digest instead:
+
+```bash
+docker compose images
+```
+
+### 3. Read the release notes
+
+[`CHANGELOG.md`](../CHANGELOG.md), or the GitHub release for the tag. Anything
+touching settings, schemas or Icecast rendering is worth reading before rather
+than after.
+
+---
+
+## Update
+
+### Standalone CLI install (the default)
+
+```bash
+subwave update        # pull new images, recreate what changed
+subwave self-update   # replace the `subwave` binary itself
+```
+
+`subwave update` moves the `SUBWAVE_VERSION` pin in `.env` forward to match the
+CLI's own release, then pulls and recreates. It only moves a **concrete**
+version pin — an install deliberately following `latest` stays on `latest`.
+
+`subwave update` pins the stack to **the CLI binary's own release**, so if the
+binary is behind, so is the stack. To land on the newest release, run
+`self-update` first and `update` second. If `update` then warns that your
+compose files are behind the CLI, run `subwave sync` — new services and changed
+env wiring don't ride an image bump, and only `sync` re-materialises the compose
+files (it backs up the current ones first).
+
+### Images, no CLI
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Pin `SUBWAVE_VERSION` in `.env` first if you want a repeatable version rather
+than whatever `latest` resolves to today. Same flow with
+`-f docker-compose.byo.yml`.
+
+### Clone install
+
+```bash
+./scripts/update.sh
+```
+
+Which is `git pull --ff-only` → `docker compose pull --ignore-buildable` →
+`docker compose build --pull` → `up -d --remove-orphans` → image prune.
+
+Remember that **prod images `COPY` source at build time**. `docker compose
+restart controller` reruns the same baked-in code; a source change needs
+`up -d --build`.
+
+### AIO / Unraid
+
+- **One-click (Community Applications)** — Unraid's normal **Check for
+  Updates** → **Apply Update**.
+- **Compose stack** — stack menu → **Pull & Up**.
+
+---
+
+## Verify
+
+Do this every time. Ninety seconds now beats a "the station's been off for a
+day" discovery later.
+
+```bash
+./scripts/health-check.sh            # clone installs: containers + /api/health
+                                     # + /api/now-playing + a log scan
+curl -s http://localhost:7700/api/health     # anywhere: {"status":"on-air"}
+```
+
+Then:
+
+1. **Listen.** Open the player and confirm audio, not just a 200.
+2. **Admin → Monitor → DJ Doc** (`/admin/doctor`) — the full diagnostic sweep,
+   in the UI. `subwave doctor` is the same thing on the CLI.
+3. **Watch the logs for a minute**, especially after a broadcast rebuild:
+
+   ```bash
+   docker compose logs -f controller broadcast
+   ```
+
+A silent stream with healthy containers usually means Liquidsoap, not the
+controller — check `state/logs/radio.log`.
+
+---
+
+## Roll back
+
+Rollback is a version change plus a recreate. What that looks like depends on
+how you installed.
+
+### Image installs (CLI or plain compose)
+
+Move the pin backwards and recreate:
+
+```bash
+# .env
+SUBWAVE_VERSION=1.4.2
+```
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Published tags are bare semver (`1.4.2`), plus `latest`. The list is on the
+[GHCR package pages](https://github.com/perminder-klair?tab=packages&repo_name=subwave)
+and matches the repo's `v*` git tags.
+
+Every service references `${SUBWAVE_VERSION:-latest}`, so one line moves the
+whole stack together. Don't pin services individually — a controller and a
+broadcast image from different releases is a configuration nobody tests.
+
+### Clone installs
+
+```bash
+git log --oneline -10
+git checkout <previous-tag-or-sha>
+docker compose up -d --build
+```
+
+### AIO / Unraid
+
+Edit the container's **Repository** field to a specific tag instead of
+`latest`:
+
+```
+ghcr.io/perminder-klair/subwave-aio:1.4.2
+```
+
+Apply, and Unraid pulls that tag. Set it back to `:latest` when you want to
+resume following releases.
+
+### What rolling back does to your state
+
+`state/` is **not** versioned alongside the images, and it does not roll back
+with them. Two consequences worth knowing before you do it:
+
+- **Settings added by the newer version are dropped.** The controller loads
+  `settings.json` into a fully-normalised shape and writes that shape back, so
+  keys the older version doesn't know about disappear on its first save.
+  Rolling forward again leaves those settings at their defaults, not at what
+  you had configured. Usually harmless; occasionally surprising.
+- **The library database migrates forward only.** Schema steps are versioned
+  by `PRAGMA user_version` and applied in order on open; there are no down
+  migrations. An older build opening a newer database mostly just ignores the
+  extra columns, but a few historical steps rebuilt tables outright, and across
+  one of those a downgrade is not a supported path.
+
+So: rolling back **one release** is routine. Rolling back **several**, or
+across a release whose notes mention a schema change, is the case where you
+restore the backup you took first.
+
+Rolling back is a way to get back on air, not a fix. Open an issue with what
+broke — a version people have to pin away from is worth knowing about.
+
+---
+
+## Recovery: when an update goes wrong
+
+### The admin console won't accept your login
+
+Admin credentials come from the root `.env` — `ADMIN_USER` and `ADMIN_PASS` —
+and **only** from there. They are not in `settings.json`, so no backup, restore
+or settings edit can change them, and nothing an upgrade does to `state/` can
+lock you out.
+
+```bash
+grep -E '^(ADMIN_USER|ADMIN_PASS)=' .env
+docker compose logs controller | grep -i 'auth'
+```
+
+Three things to check:
+
+1. **Are they set at all?** In production the controller refuses to start
+   without both and says so:
+
+   ```
+   [auth] FATAL: NODE_ENV=production but ADMIN_USER and ADMIN_PASS are not set.
+   ```
+
+   If you see that, the controller isn't running — you're looking at a stale
+   page or a proxy error, not a login failure.
+
+2. **Did the container pick them up?** Compose reads `.env` at *recreate*, not
+   at restart:
+
+   ```bash
+   docker compose exec controller printenv ADMIN_USER
+   docker compose up -d --force-recreate controller   # if it's stale
+   ```
+
+3. **Are special characters mangling the value?** `.env` is not a shell:
+   quoting and escaping rules differ from what you'd expect, and `$` and `#`
+   are the usual culprits. Compare what the container actually received
+   (`printenv` above) against what you wrote. Set an alphanumeric password to
+   confirm the diagnosis, then pick a permanent one that survives the round
+   trip.
+
+On AIO/Unraid the same two values are container environment variables in the
+template rather than lines in a `.env`.
+
+### The stream is silent but containers are healthy
+
+The controller and Icecast can both be fine while Liquidsoap is not.
+
+```bash
+docker compose logs --tail=100 broadcast
+tail -100 state/logs/radio.log
+```
+
+Then restart the pair — they're supervised together, so restarting `broadcast`
+bounces both:
+
+```bash
+docker compose restart broadcast
+```
+
+Remember that Icecast config is rendered **at broadcast boot** from `.env` and
+the controller-written state files. Settings that say *restart required* in
+admin (Opus/AAC/FLAC mounts, listener buffer, the stream password) genuinely
+need this bounce, not just a settings save.
+
+### The controller restart-loops
+
+```bash
+docker compose logs --tail=200 controller
+```
+
+Most boot failures name their cause in the first twenty lines. The two common
+shapes:
+
+- **A fatal config error** — missing admin credentials in production, an
+  unreadable state path. Fix the input and recreate.
+- **A state file the new version can't read.** Move the offending file aside
+  and let it regenerate:
+
+  ```bash
+  mv state/settings.json state/settings.json.bak
+  docker compose up -d --force-recreate controller
+  ```
+
+  You lose your configuration, not your library — then restore from the backup
+  zip via **Admin → Settings → Backup → Import**.
+
+### Everything else
+
+`state/` is the only thing that matters and it survives `docker compose down`
+(it's a bind mount, not a volume). So the nuclear option is cheap:
+
+```bash
+docker compose down
+docker compose up -d --force-recreate
+```
+
+If that doesn't do it, roll back to the previous version and open an issue.
+
+---
+
+## Related
+
+- [`DEPLOY.md`](../DEPLOY.md) — production deployment, Cloudflare, operations.
+- [`docs/deployment.md`](deployment.md) — the deploy matrix, state layout and
+  configuration precedence.
+- [`docs/unraid.md`](unraid.md) — Unraid specifics.

--- a/web/app/manual/concepts/page.tsx
+++ b/web/app/manual/concepts/page.tsx
@@ -1,0 +1,13 @@
+import Concepts from '../../../components/manual/Concepts';
+import { pageMeta } from '@/lib/seo';
+
+export const metadata = pageMeta({
+  title: 'SUB/WAVE — Manual · Concepts',
+  description:
+    'The SUB/WAVE concepts that get asked about most — the persona tone dials, candidate pool vs the agent picker, playlists vs shows, the stem cache, private player vs stream password, dayparts, and what a heart does.',
+  path: '/manual/concepts',
+});
+
+export default function ConceptsPage() {
+  return <Concepts />;
+}

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -28,6 +28,7 @@ const ROUTES = [
   '/manual/themes',
   '/manual/analysis',
   '/manual/observatory',
+  '/manual/concepts',
   '/manual/faq',
   '/setup',
   '/setup/prerequisites',

--- a/web/components/manual/Concepts.tsx
+++ b/web/components/manual/Concepts.tsx
@@ -1,0 +1,402 @@
+import Link from 'next/link';
+import ManualPage from './ManualPage';
+
+// The seven things that get asked over and over — not because they're broken,
+// but because the name doesn't say what's underneath. The repo-side copy of
+// this material lives in docs/concepts.md; keep the two in step.
+
+const DIALS: { dial: string; low: string; high: string }[] = [
+  {
+    dial: 'Humour',
+    low: 'Plays it straight; wit stays rare and understated.',
+    high: 'Leans into dry, playful wit; an aside or a wink is welcome.',
+  },
+  {
+    dial: 'Local Colour',
+    low: 'Keeps it universal; skips local references and place-specific colour.',
+    high: 'Leans on the local setting — the town, the weather, the hour — as texture.',
+  },
+  {
+    dial: 'Warmth',
+    low: 'Keeps a cool, dry distance; lets the music carry the warmth.',
+    high: 'Warm and earnest; speaks to the listener like a friend.',
+  },
+];
+
+const DAYPARTS: { period: string; hours: string }[] = [
+  { period: 'early-morning', hours: '05:00 – 09:00' },
+  { period: 'morning', hours: '09:00 – 12:00' },
+  { period: 'midday', hours: '12:00 – 14:00' },
+  { period: 'afternoon', hours: '14:00 – 17:00' },
+  { period: 'drive-time', hours: '17:00 – 19:00' },
+  { period: 'evening', hours: '19:00 – 22:00' },
+  { period: 'late-evening', hours: '22:00 – 01:00' },
+  { period: 'after-hours', hours: '01:00 – 05:00' },
+];
+
+export default function Concepts() {
+  return (
+    <ManualPage
+      eyebrow="MANUAL · 15"
+      title="Concepts, explained."
+      intro="Seven things that get asked over and over — not because they're broken, but because the name doesn't tell you what's underneath. What each one is, what changes when you move it, and where the control lives."
+      current="/manual/concepts"
+    >
+      <section className="bs-section">
+        <p className="bs-eyebrow">PERSONA TONE</p>
+        <h2>Local Colour, and the other two dials.</h2>
+        <p>
+          Every persona carries three dials from 0 to 10 &mdash;{' '}
+          <strong>Humour</strong>, <strong>Local Colour</strong> and{' '}
+          <strong>Warmth</strong>. They look like faders, but nothing scales smoothly as
+          you drag them. Each one resolves to a <em>band</em>: 0&ndash;3 is low,
+          4&ndash;6 is neutral, 7&ndash;10 is high. Only a band away from neutral changes
+          anything, so 4, 5 and 6 are the same setting &mdash; and so are 7 and 10.
+        </p>
+        <p>
+          That&rsquo;s on purpose. A model can&rsquo;t hear the difference between a 6 and
+          a 7 in a raw &ldquo;7 out of 10&rdquo; instruction, so rather than fake a
+          precision that isn&rsquo;t there, the dial picks one of two style directions.
+        </p>
+        <table className="bs-doc-table">
+          <thead>
+            <tr>
+              <th>Dial</th>
+              <th>Turned down</th>
+              <th>Turned up</th>
+            </tr>
+          </thead>
+          <tbody>
+            {DIALS.map((d) => (
+              <tr key={d.dial}>
+                <td><strong>{d.dial}</strong></td>
+                <td>{d.low}</td>
+                <td>{d.high}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p>
+          <strong>Local Colour</strong> is the one people ask about. It governs how much
+          the DJ reaches for <em>where and when you are</em> &mdash; your town,
+          today&rsquo;s weather, the hour &mdash; as raw material. Turned up, links open
+          with the drizzle outside. Turned down, the same DJ could be broadcasting from
+          anywhere.
+        </p>
+        <p className="text-muted">
+          It doesn&rsquo;t add facts: the place, the weather and the clock reach the DJ
+          either way, and the dial only decides whether it leans on them. It can&rsquo;t
+          invent a second location either &mdash; exactly one place name reaches any
+          script, the on-air location under Settings &rarr; Station. A persona left at the
+          defaults writes exactly what it wrote before the dials existed. Find them under{' '}
+          <Link href="/admin/personas" className="bs-link">Personas</Link> &rarr;
+          Behaviour.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">CHOOSING THE NEXT TRACK</p>
+        <h2>Candidate pool vs the agent picker.</h2>
+        <p>
+          Both end in the same place &mdash; one track, handed to the queue &mdash; and
+          both run inside a session and get logged. What differs is who does the
+          searching.
+        </p>
+        <p>
+          With the <strong>candidate pool</strong>, the station does. It merges up to
+          sixteen sources into one shortlist &mdash; mood matches, sonically similar
+          tracks, embedding neighbours, the current show&rsquo;s genres and playlists,
+          starred and frequently-played, recently added, listener favourites, a wildcard
+          and a little pure random &mdash; de-duplicates, applies the recency and artist
+          filters, caps it, and asks the model <em>once</em>: pick one of these. One
+          round-trip per track, bounded tokens, and it works happily on a small local
+          model because there&rsquo;s no tool loop to get lost in. The catch is that the
+          model can only choose from what the pool already found.
+        </p>
+        <p>
+          With the <strong>agent</strong> &mdash; the default &mdash; the model drives. It
+          gets about eighteen discovery tools (similar songs, tracks like this one, search
+          by sound, search by lyrics, by mood, by energy, by genre, deep cuts, recently
+          added, tracks toward a journey) and searches the library itself across the
+          session&rsquo;s memory before committing. Richer, more coherent across a run,
+          and more expensive: several round-trips per track, and it needs a model that is
+          genuinely good at multi-step tool calling with a context window of at least
+          16,384. Most &ldquo;the DJ stopped without choosing&rdquo; reports are that
+          requirement not being met.
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">WHICH ONE</div>
+          <p>
+            Start on <strong>Agent</strong>{' '}if you&rsquo;re on a cloud model or a 12B-class
+            local one. Drop to <strong>Candidate pool</strong>{' '}if picks are slow, if the
+            DJ keeps re-picking, or if you&rsquo;re on a 9B-class model. Nothing is lost
+            either way: the station still picks, still writes links, still honours
+            requests. The agent already falls back to the pool on a timeout, so a slot is
+            never dropped.
+          </p>
+        </div>
+        <p className="text-muted">
+          Two behaviours hold whichever you run. <strong>Variety is enforced after the
+          choice, not inside the search</strong> &mdash; the discovery tools carry no
+          artist filter on purpose, because filtering inside them gutted the similarity
+          pool on smaller libraries; instead a pick that repeats a recent artist triggers
+          a re-pick. And <strong>the daily token budget degrades in tiers</strong>: past
+          the soft threshold the station drops to the pool and mutes optional segments; at
+          the cap it stops calling the model at all and coasts on the fallback playlist.
+          The music never stops. The switch is under Settings &rarr; LLM &rarr; Agentic
+          picker; the model side is on{' '}
+          <Link href="/manual/llm" className="bs-link">Models &amp; Tokens</Link>.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">TWO KINDS OF GROUPING</p>
+        <h2>Playlists vs shows.</h2>
+        <p>
+          They sound like alternatives. They&rsquo;re layers &mdash; and a show can{' '}
+          <em>use</em> playlists.
+        </p>
+        <table className="bs-doc-table">
+          <thead>
+            <tr>
+              <th></th>
+              <th>Playlist</th>
+              <th>Show</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>What it is</strong></td>
+              <td>A named set of tracks</td>
+              <td>A block of programming on the schedule</td>
+            </tr>
+            <tr>
+              <td><strong>Lives in</strong></td>
+              <td>Navidrome</td>
+              <td>The station&rsquo;s own schedule</td>
+            </tr>
+            <tr>
+              <td><strong>Has a time</strong></td>
+              <td>No</td>
+              <td>Yes &mdash; that&rsquo;s the point</td>
+            </tr>
+            <tr>
+              <td><strong>Has a persona, theme, topic</strong></td>
+              <td>No</td>
+              <td>Yes</td>
+            </tr>
+          </tbody>
+        </table>
+        <p>
+          A <strong>playlist</strong>{' '}is just tracks. Build one by hand in Navidrome, or
+          describe what you want (&ldquo;late-night driving, mostly instrumental, ninety
+          minutes&rdquo;) and let the playlist builder assemble it from the same mood,
+          vector and similarity machinery the DJ picks with, then order it into an energy
+          arc.
+        </p>
+        <p>
+          A <strong>show</strong>{' '}is an hour or more with an identity: which persona is on
+          the mic, which skin the player wears, what the show is about, and a set of music
+          filters &mdash; moods, genres, eras, energies, vocals. The DJ still picks every
+          track live; the show narrows what it may pick from.
+        </p>
+        <p>
+          Where they meet: a show can be <strong>anchored</strong>{' '}to one or more
+          playlists. Anchored on its own makes the playlists the show&rsquo;s dominant
+          source while leaving the DJ free to reach outside for a better fit. Anchored
+          with <strong>strict</strong>{' '}on makes them the show&rsquo;s entire universe, and
+          everything off-playlist is dropped before the DJ ever sees it.
+        </p>
+        <p className="text-muted">
+          If a show pins playlists that no longer resolve &mdash; deleted and recreated in
+          Navidrome, so the id moved &mdash; the anchor is ignored and the station says so
+          in the log, including that the strict toggle had no effect. The show still airs;
+          it just airs unanchored. Re-select the playlists in the show editor to fix it.
+          Rule of thumb: recurring identity at a fixed hour is a <em>show</em>; a set of
+          tracks you want to reach for is a <em>playlist</em>; &ldquo;this hour, only
+          these tracks&rdquo; is a show anchored to a playlist with strict on.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">DISK FOR SEAMS</p>
+        <h2>The stem cache, and what it buys.</h2>
+        <p>
+          A stem-blend transition mixes two tracks <em>by instrument</em>{' '}rather than
+          fading two finished mixes together: the outgoing drums duck out under the
+          incoming bass, and the vocals clear before the new vocal enters. Doing that
+          needs the four separated stems &mdash; drums, bass, other, vocals &mdash; for
+          both sides of the seam.
+        </p>
+        <p>
+          Separating them takes far longer than the gap between two songs, so it
+          can&rsquo;t happen at the seam. The analyzer does it during{' '}
+          <Link href="/manual/analysis" className="bs-link">acoustic analysis</Link>{' '}
+          instead, keeping the first forty seconds and the last twenty of each track. A
+          transition is then a fast mix of files already on disk.
+        </p>
+        <p>
+          Which makes the trade a simple one: <strong>the cost is disk, and only
+          disk</strong>. The separation is paid for during analysis whether you keep the
+          output or not. Budget 13&ndash;25&nbsp;MB per track; the default 15&nbsp;GB
+          budget holds somewhere between six hundred and twelve hundred of them, and an
+          LRU sweep evicts the least recently used once you&rsquo;re over.
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">THE PART THAT SURPRISES PEOPLE</div>
+          <p>
+            A blend needs stems on <strong>both</strong>{' '}tracks of a pair. With half your
+            library cached, far fewer than half your seams will blend &mdash; most fall
+            back to a plain crossfade, which isn&rsquo;t a failure, just the ordinary
+            behaviour. So the reason to raise the budget is coverage of <em>pairs</em>,
+            not coverage of tracks. DJ Doc says this outright, with the track count your
+            current budget actually holds.
+          </p>
+        </div>
+        <p className="text-muted">
+          Small library? Raise the budget until it covers the lot and let the analysis
+          pass backfill. Tens of thousands of tracks? The budget will always bind, and
+          blends land wherever the cache happens to be warm. Short on disk? Turn the cache
+          off &mdash; every seam becomes a crossfade and nothing else changes. The dial is
+          under Settings &rarr; Transitions.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">TWO LOCKS, ONE PASSWORD</p>
+        <h2>Private player vs stream password.</h2>
+        <p>
+          These get confused because turning either one on asks for the same station
+          password. They are independent, and only one of them actually stops anyone
+          listening.
+        </p>
+        <p>
+          The <strong>private player</strong> swaps the public pages for a password
+          prompt. It hides the <em>interface</em>. The now-playing endpoints stay public
+          &mdash; the player and the admin dash need them &mdash; and anyone who knows the
+          stream address can still tune in. It applies live, with no restart.
+        </p>
+        <p>
+          The <strong>stream password</strong> turns on listener authentication at Icecast
+          itself, on every mount. That is the real boundary: without the password, there
+          is no audio. Turning it on or off needs a mixer restart; changing the password
+          applies live.
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">THE SHORT VERSION</div>
+          <p>
+            The private player is a curtain. The stream password is a lock. Most people
+            who want a private station want both, so that one prompt unlocks the page and
+            the audio together.
+          </p>
+        </div>
+        <p className="text-muted">
+          A third thing is often mistaken for these two: HTTP Basic Auth applied in front
+          of the whole station at your own reverse proxy. That isn&rsquo;t a SUB/WAVE
+          feature and it behaves differently, particularly for the mobile apps. Both locks
+          live under Settings &rarr; Station &rarr; Privacy; tuning in from VLC, Sonos,
+          hardware radios and the apps once a password is on is covered on{' '}
+          <Link href="/manual/clients" className="bs-link">Listen With</Link>.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">THE SHAPE OF THE DAY</p>
+        <h2>Dayparts don&rsquo;t move with the sun.</h2>
+        <p>
+          The station divides the day into eight named periods, on fixed wall-clock hours
+          in your station&rsquo;s timezone.
+        </p>
+        <table className="bs-doc-table">
+          <thead>
+            <tr>
+              <th>Period</th>
+              <th>Hours</th>
+            </tr>
+          </thead>
+          <tbody>
+            {DAYPARTS.map((d) => (
+              <tr key={d.period}>
+                <td><code>{d.period}</code></td>
+                <td>{d.hours}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p>
+          These boundaries are not derived from sunrise or sunset, and they aren&rsquo;t
+          configurable. Which reads oddly above about 55&deg; north or south, where
+          &ldquo;evening&rdquo; is full daylight in June and pitch dark in December.
+        </p>
+        <p>
+          It&rsquo;s a deliberate trade. A daypart is a <em>programming</em>{' '}idea &mdash;
+          drive-time means the end of the working day, which is five o&rsquo;clock
+          whatever the sky is doing &mdash; and it has to be predictable, because the
+          schedule, the mood plan and the show grid are all built against named hours.
+          Boundaries that drifted three hours across the year would quietly move your
+          shows with them.
+        </p>
+        <p>
+          What <em>is</em>{' '}sun-aware is the DJ&rsquo;s description of the world outside.
+          The station reads whether the sun is currently up at your coordinates and puts
+          that on the prompt, which is what stops it describing dusk two hours after dark
+          in December, or &ldquo;the last of the light&rdquo; at nine in the evening in
+          June. That runs off real solar position, so it&rsquo;s right at any latitude.
+        </p>
+        <p className="text-muted">
+          So the lever at high latitude isn&rsquo;t moving the boundary, it&rsquo;s
+          retuning what happens inside it: each period&rsquo;s <strong>mood</strong>{' '}is
+          yours to set, under Moods &rarr; Moments. Give a Nordic summer evening a
+          brighter mood than the default wind-down and let the sun-aware flag keep the
+          DJ&rsquo;s language honest. Two nudges sit on top of the table and aren&rsquo;t
+          editable: the small hours pull the speaking pace down whatever period the hour
+          formally belongs to, and commute windows push it up. A show with a pinned energy
+          overrides both.
+        </p>
+      </section>
+
+      <section className="bs-section">
+        <p className="bs-eyebrow">LISTENER SIGNAL</p>
+        <h2>What a heart actually does.</h2>
+        <p>
+          There are two hearts and they aren&rsquo;t the same signal. The{' '}
+          <strong>listener heart</strong> on the player is one like per apparent listener
+          per <em>airing</em> &mdash; the same song aired again later can be liked again.
+          Listeners have no accounts, so &ldquo;apparent listener&rdquo; is a one-way hash
+          of the address; the raw address is never stored and everyone behind one router
+          shares a key. It&rsquo;s lightweight de-duplication, not identity. The{' '}
+          <strong>operator heart</strong> in the admin library is something else:
+          curation, not a taste snapshot.
+        </p>
+        <p>
+          By default a like changes <strong>nothing</strong>{' '}about rotation. It&rsquo;s
+          recorded, it shows up in stats, and the track gets starred in Navidrome if
+          you&rsquo;ve left that on. The DJ never hears about it.
+        </p>
+        <p>
+          Influence is opt-in, under Settings &rarr; Likes. Turned on, the most-liked
+          tracks become one more source feeding the candidate pool, capped like every
+          other source &mdash; a weighted preference, never a lock, so the crowd can steer
+          the pool without taking it over. Out of the box that means the ten most-liked
+          tracks of the last thirty days; both numbers are yours to change, and a window
+          of zero means all time.
+        </p>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">WHY THE TWO HEARTS AGE DIFFERENTLY</div>
+          <p>
+            An operator heart never expires from that window. A listener like ageing out
+            is a taste snapshot going stale, which is right. An operator like ageing out
+            would be the DJ forgetting curation you set by hand, which isn&rsquo;t.
+          </p>
+        </div>
+        <p className="text-muted">
+          Clearing them: from any row in{' '}
+          <Link href="/admin/library" className="bs-link">the admin library</Link>,{' '}
+          <strong>un-heart</strong> removes your own heart and leaves listener likes
+          alone, while <strong>clear likes</strong> removes both. If yours was the last
+          like standing and Navidrome starring is on, the track is unstarred there too.
+        </p>
+      </section>
+    </ManualPage>
+  );
+}

--- a/web/components/manual/Faq.tsx
+++ b/web/components/manual/Faq.tsx
@@ -4,7 +4,7 @@ import ManualPage from './ManualPage';
 export default function Faq() {
   return (
     <ManualPage
-      eyebrow="MANUAL · 15"
+      eyebrow="MANUAL · 16"
       title="Questions & answers."
       intro="The things people ask most about how SUB/WAVE behaves — how it copes with an empty room, what it needs from a model, and what the moving parts behind the DJ actually do."
       current="/manual/faq"
@@ -75,20 +75,20 @@ export default function Faq() {
         <p className="bs-eyebrow">CHOOSING THE NEXT SONG</p>
         <h2>What are the candidate pool and the agentic picker?</h2>
         <p>
-          They are two ways the DJ chooses what to play next. The{' '}
-          <strong>candidate pool</strong> picker is the straightforward one: it gathers a
-          shortlist of tracks from your library (similar songs, similar artists, mood
-          matches, recently-added and frequently-played albums), caps it to a couple of
-          dozen, and asks the model to pick one from that list.
+          Two ways the DJ chooses what to play next. With the{' '}
+          <strong>candidate pool</strong>, the station gathers a shortlist from your
+          library and asks the model once to pick one from it. With the{' '}
+          <strong>agentic picker</strong> &mdash; the default &mdash; the model searches
+          the library itself with a set of tools, so its choices stay coherent across a
+          run. If the agent ever fails or runs slow the station quietly falls back to the
+          pool, so the music never stops either way.
         </p>
         <p>
-          The <strong>agentic picker</strong> is the richer one. It runs as a small
-          reasoning loop with a memory of the current session and tools to search the
-          library itself, so its choices (and the links between them) stay coherent
-          across a run rather than starting cold each time. It is on by default; if it
-          ever fails or runs slow, the station quietly falls back to the candidate pool,
-          so the music never stops either way. Which one suits you comes down to the
-          model; see <Link href="/manual/llm" className="bs-link">Models &amp; Tokens</Link>.
+          Which one suits you comes down to your model. The full comparison, and how to
+          decide, is on{' '}
+          <Link href="/manual/concepts" className="bs-link">Concepts</Link>; the model
+          side is on{' '}
+          <Link href="/manual/llm" className="bs-link">Models &amp; Tokens</Link>.
         </p>
       </section>
 

--- a/web/components/manual/pages.ts
+++ b/web/components/manual/pages.ts
@@ -22,5 +22,6 @@ export const MANUAL_PAGES: ManualPageEntry[] = [
   { href: '/manual/voices', label: 'Voices & TTS' },
   { href: '/manual/analysis', label: 'Acoustic Analysis' },
   { href: '/manual/mcp', label: 'Agent Access' },
+  { href: '/manual/concepts', label: 'Concepts' },
   { href: '/manual/faq', label: 'FAQ' },
 ];

--- a/web/components/setup/Updates.tsx
+++ b/web/components/setup/Updates.tsx
@@ -86,6 +86,80 @@ docker compose up -d`}</CodeBlock>
       </section>
 
       <section className="bs-section">
+        <p className="bs-eyebrow">WHEN AN UPDATE LANDS BADLY</p>
+        <h2>Rolling back.</h2>
+        <p>
+          Two minutes of preparation makes this a command rather than an
+          investigation. Before you update, take a backup from{' '}
+          <Link href="/admin/settings?section=backup" className="bs-link">
+            Settings &rarr; Backup
+          </Link>{' '}
+          &mdash; it zips your settings, show schedule and the library tag
+          database, which is the expensive thing to rebuild &mdash; and write
+          down the version you are on.
+        </p>
+        <CodeBlock>{`grep SUBWAVE_VERSION .env    # image installs
+git describe --tags          # clone installs`}</CodeBlock>
+
+        <p className="mt-4">
+          Rolling back is then a version change plus a recreate. On an image
+          install, move the pin backwards; every service reads the same
+          variable, so one line moves the whole stack together:
+        </p>
+        <CodeBlock>{`# .env
+SUBWAVE_VERSION=1.4.2`}</CodeBlock>
+        <CodeBlock>{`docker compose pull
+docker compose up -d`}</CodeBlock>
+
+        <p className="mt-4">On a clone, check out the previous tag instead:</p>
+        <CodeBlock>{`git log --oneline -10
+git checkout <previous-tag>
+docker compose up -d --build`}</CodeBlock>
+
+        <div className="bs-callout">
+          <div className="bs-eyebrow">WHAT ROLLING BACK DOES TO YOUR STATE</div>
+          <p>
+            <code className="bs-code-inline">state/</code>{' '}does not roll back
+            with the images. Settings a newer version added are dropped on the
+            older version&apos;s first save, and the library database migrates
+            forward only. So going back <strong>one</strong> release is
+            routine; going back several, or across a release whose notes
+            mention a schema change, is the case where you restore that backup.
+          </p>
+        </div>
+
+        <div className="bs-callout">
+          <div className="bs-eyebrow">LOCKED OUT OF ADMIN?</div>
+          <p>
+            Admin credentials come from{' '}
+            <code className="bs-code-inline">ADMIN_USER</code> and{' '}
+            <code className="bs-code-inline">ADMIN_PASS</code> in the root{' '}
+            <code className="bs-code-inline">.env</code>, and only from there
+            &mdash; nothing an upgrade does to your station data can change
+            them. Compose reads that file when a container is{' '}
+            <em>recreated</em>, not restarted, so a stale container is the
+            usual cause:
+          </p>
+          <CodeBlock>{`docker compose exec controller printenv ADMIN_USER
+docker compose up -d --force-recreate controller`}</CodeBlock>
+        </div>
+
+        <p className="mt-4 text-muted">
+          The full procedure &mdash; every install shape, plus recovery for a
+          silent stream and a restart-looping controller &mdash; is in{' '}
+          <a
+            href="https://github.com/perminder-klair/subwave/blob/main/docs/updating.md"
+            target="_blank"
+            rel="noreferrer"
+            className="bs-link"
+          >
+            docs/updating.md &#8599;
+          </a>
+          .
+        </p>
+      </section>
+
+      <section className="bs-section">
         <p className="bs-eyebrow">WHEN THINGS GO WRONG</p>
         <h2>Logs are the source of truth.</h2>
         <ul className="bs-list">

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Three of the five **Docs and discoverability** items from #1485. The other two (`ICECAST_MAX_CLIENTS` as a first-class setting, Connect panel findability) are code rather than docs and follow in a separate PR.

Every claim here was checked against the code, not described from the outside. Where the answer turned out to be "you can't actually do that cleanly", the doc says so.

## Concept explainers

New `docs/concepts.md` (repo-side) + `/manual/concepts` (in-app), the same split #1305 established for `docs/custom-tts.md` vs `/manual/voices`. Seven topics:

| Concept | The thing people don't know |
| --- | --- |
| **Local Colour** | The dials aren't continuous — 0-3 / 4-6 / 7-10 are three bands, and only a band away from neutral changes the prompt at all. So 4, 5 and 6 are the same setting. |
| **Pool vs agent picker** | What each actually does, and which to run at which model size. Plus the two behaviours that hold either way: variety is enforced *after* the choice (#618), and the token budget degrades in tiers rather than stopping the music. |
| **Playlists vs shows** | Not alternatives — layers. Includes the anchored / anchored+strict distinction and what happens when a pinned playlist id no longer resolves. |
| **Stem cache** | A blend needs stems on **both** tracks of a pair, so at half-library coverage far fewer than half your seams blend. That's the real reason to raise the budget, and it isn't obvious from a GB figure. |
| **Private player vs stream password** | A curtain vs a lock. Short version here, links to `docs/private-station.md` rather than duplicating it. |
| **Dayparts** | Boundaries are fixed clock hours and deliberately so; what *is* sun-aware is the DJ's daylight language, off real solar position. The lever at high latitude is Moods → Moments, not the boundary. |
| **Hearts** | By default a like changes nothing about rotation. Influence is opt-in. Operator hearts are exempt from the window because an operator like ageing out is the DJ forgetting curation set by hand. And yes, they can be cleared. |

The FAQ already carried a short "what are the candidate pool and the agentic picker?" answer. Rather than ship a second copy, that entry keeps the two-sentence version and now links to the full comparison.

## Update procedure and rollback

New `docs/updating.md`. The tracker's framing was exact: the update commands and health checks already existed, the rollback/recovery path did not.

- **Before you update** — take the export, note the version. What the export contains, and the two things it deliberately doesn't (secrets are redacted; archives are excluded).
- **Update** on all four shapes — CLI, plain images, clone, AIO/Unraid.
- **Verify** — health check, then actually listen, then DJ Doc.
- **Roll back** — move the `SUBWAVE_VERSION` pin, check out a tag, or retag the AIO `Repository` field.
- **What rollback does to your state** — the part that makes one release different from several. `settings.json` is loaded into a normalised shape and written back, so keys the older version doesn't know are dropped on its first save; `library.db` migrates forward only and a few historical steps rebuilt tables outright.
- **Recovery** — broken admin login (credentials are `.env`-only, and a stale container is the usual cause), silent stream with healthy containers, restart-looping controller.

`web/components/setup/Updates.tsx` gains the rollback essentials inline and links out for the rest.

## Public stream, LAN-only admin

New section in `docs/reverse-proxy.md`. The honest answer is that only half of it splits cleanly:

- The operator **UI** (`/admin*`, `/onboarding`) has distinct prefixes — an IP allowlist works, with nginx / Caddy / Traefik recipes.
- The operator **API** does not. The controller mounts public and admin routes on one flat namespace, so `/api/now-playing` and `/api/settings` are siblings and there is no `/api/admin/` to deny. Basic auth stays the guard, which is the default posture anyway.

So the recommended recipe is the allowlist, with a two-front-door variant for anyone who wants more — and an explicit warning that its stricter listener-endpoint allowlist will silently break the next time a release adds one. Also notes that the AIO image can't do this internally and needs an outer proxy, and that `SITE_URL` stays the public origin.

## Stale lines fixed on the way through

- `DEPLOY.md` documented `POST /skip`. There is no `/skip` endpoint — track-end is the only natural transition.
- Its rollback covered clone installs only; image installs had nothing to check out.
- Its backup section named archives as what matters and omitted `library.db`, which is the one thing that costs hours and tokens to rebuild.

## Verification

- `web`: `npm run lint` clean (eslint + `tsc --noEmit`); `next build` succeeds and registers `/manual/concepts`.
- Rendered both changed pages against the built server and checked them visually — sidebar entry, tables, callouts and prev/next pagination all match the rest of the manual.
- All relative links and section anchors in the new and edited docs resolve.

Closes part of #1485.