### PR TITLE
feat(dj): announce-only link style — "This is <artist>" / "Next up, <artist>"

### DIFF
--- a/controller/scripts/link-style.test.ts
+++ b/controller/scripts/link-style.test.ts
@@ -1,0 +1,177 @@
+// Per-persona linkStyle:'natural' | 'announce' — the operator control for a
+// matter-of-fact station whose links are exactly "This is <artist>." or
+// "Next up, <artist>." instead of the ordinary "set it up, name the artist"
+// contract. Covers: persona normalisation (absent/valid/garbage), the
+// settings.announceLinks() helper, the two pure prompt builders that carry a
+// fallback announce contract to the model (dj-agent's buildLinkClause and
+// llm/internal/prompts/scripts.ts's linkPrompt), and announce-line.ts — the
+// module that actually COMPOSES the announcement in code, since a model can
+// neither hold a fixed string reliably nor alternate with a line it is never
+// shown.
+//
+// Run: npx tsx scripts/link-style.test.ts (auto-discovered by npm test).
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+process.env.STATE_DIR = mkdtempSync(join(tmpdir(), 'subwave-link-style-'));
+
+const { normalizePersona } = await import('../src/settings/normalize.js');
+const { announceLinks } = await import('../src/settings/persona.js');
+const { buildLinkClause } = await import('../src/broadcast/dj-agent/link-clause.js');
+const { linkPrompt, generateLink } = await import('../src/llm/internal/prompts/scripts.js');
+const { announceLine, resetAnnounceAlternation } = await import('../src/broadcast/announce-line.js');
+
+const basePersona = () => ({
+  name: 'Nova',
+  soul: 'warm and dry',
+  frequency: 'moderate',
+  tts: { engine: 'piper', cloudProvider: 'openai', voice: '' },
+});
+
+// ── persona normalisation ────────────────────────────────────────────────────
+
+test('linkStyle absent normalises to natural', () => {
+  const p = normalizePersona(basePersona());
+  assert.equal(p?.linkStyle, 'natural');
+});
+
+test('linkStyle "announce" survives normalisation', () => {
+  const p = normalizePersona({ ...basePersona(), linkStyle: 'announce' });
+  assert.equal(p?.linkStyle, 'announce');
+});
+
+test('garbage linkStyle falls back to natural and does not throw', () => {
+  assert.doesNotThrow(() => {
+    const p = normalizePersona({ ...basePersona(), linkStyle: 'shout-it-from-the-rooftops' });
+    assert.equal(p?.linkStyle, 'natural');
+  });
+});
+
+// ── announceLinks() helper ───────────────────────────────────────────────────
+
+test('announceLinks is true only when linkStyle is exactly "announce"', () => {
+  assert.equal(announceLinks({ linkStyle: 'announce' }), true);
+  assert.equal(announceLinks({ linkStyle: 'natural' }), false);
+  assert.equal(announceLinks({}), false);
+  assert.equal(announceLinks(null), false);
+  assert.equal(announceLinks(undefined), false);
+});
+
+// ── dj-agent's per-pick event clause (buildLinkClause) ───────────────────────
+
+test('announce link clause carries the fixed two-form contract, not the variety instructions or the alternate instruction', () => {
+  const clause = buildLinkClause({ djMode: true, announce: true, angle: null, recentOpeners: [] });
+  assert.match(clause, /This is/);
+  assert.match(clause, /Next up,/);
+  assert.doesNotMatch(clause, /Approach for this link/);
+  assert.doesNotMatch(clause, /start this one differently/);
+  // The station composes and alternates the final line (announce-line.ts) —
+  // the model is never asked to alternate with a line it can't see.
+  assert.doesNotMatch(clause, /[Aa]lternate/);
+});
+
+test('natural link clause keeps the pre-existing variety contract', () => {
+  const clause = buildLinkClause({
+    djMode: false,
+    announce: false,
+    angle: 'lead with one specific image from the track itself.',
+    recentOpeners: [],
+  });
+  assert.match(clause, /Approach for this link/);
+});
+
+test('natural link clause output is unchanged versus the pre-extraction template', () => {
+  const angle = 'lead with one specific image from the track itself.';
+  const withoutDjMode = buildLinkClause({ djMode: false, announce: false, angle, recentOpeners: [] });
+  assert.equal(
+    withoutDjMode,
+    ` Also write the "say" link — it airs as your pick starts.`
+      + ` Approach for this link: ${angle} Vary your first words — don't default to "here's", "this is", or "coming up".`,
+  );
+
+  const withDjMode = buildLinkClause({ djMode: true, announce: false, angle, recentOpeners: ['Here we go'] });
+  assert.equal(
+    withDjMode,
+    ` Also write the "say" link — it airs as your pick starts. If the track you pick shows an intro_ms, keep the link short enough to finish before then, so you land just as the vocals come in.`
+      + ` Approach for this link: ${angle} Vary your first words — don't default to "here's", "this is", or "coming up".`
+      + ` You opened recent lines with "Here we go…" — start this one differently.`,
+  );
+});
+
+// ── scripts.ts's pure prompt builder (linkPrompt) ────────────────────────────
+
+test('announce link prompt names the artist in the fixed two-form contract', () => {
+  const prompt = linkPrompt({
+    announce: true,
+    current: { artist: 'Marvin Gaye' },
+    teaseClause: ' Name the artist or capture the feel so listeners know what they\'re hearing.',
+    patterClause: '',
+    budget: null,
+    lengthPhraseText: 'one or two sentences',
+    clockClause: ' Never state the clock time.',
+    feelClause: ' A feel note...',
+  });
+  assert.match(prompt, /This is Marvin Gaye\./);
+  assert.match(prompt, /Next up, Marvin Gaye\./);
+  assert.doesNotMatch(prompt, /Vary how you open/);
+  assert.doesNotMatch(prompt, /feel note/);
+  assert.doesNotMatch(prompt, /Never state the clock time/);
+  assert.doesNotMatch(prompt, /[Aa]lternate/);
+});
+
+// ── announce-line.ts — the station composes and alternates, the model never does ──
+
+test('announceLine alternates This is -> Next up -> This is, and trims the artist', () => {
+  resetAnnounceAlternation();
+  assert.equal(announceLine('  Marvin Gaye  '), 'This is Marvin Gaye.');
+  assert.equal(announceLine('Kim Weston'), 'Next up, Kim Weston.');
+  assert.equal(announceLine('Lee Hazlewood'), 'This is Lee Hazlewood.');
+});
+
+test('announceLine returns empty string for an empty/whitespace-only artist', () => {
+  resetAnnounceAlternation();
+  assert.equal(announceLine(''), '');
+  assert.equal(announceLine('   '), '');
+});
+
+// ── generateLink composes in code and never calls the model when it has an artist ──
+
+test('generateLink in announce mode returns the composed line with no LLM call', async () => {
+  resetAnnounceAlternation();
+  const persona = { linkStyle: 'announce', name: 'Nova', soul: 'warm and dry' };
+  const result = await generateLink({
+    previous: null,
+    current: { title: 'Ain\'t No Mountain High Enough', artist: 'Chris Stapleton' },
+    context: {},
+    persona,
+  });
+  // Deterministic: alternation was just reset, so the first call is 'This is'.
+  // If this ever fell through to the model, either the LLM call would throw
+  // (no provider configured in this throwaway STATE_DIR) or return different
+  // text — either way this exact-equality assertion fails.
+  assert.equal(result, 'This is Chris Stapleton.');
+});
+
+test('natural link prompt is unchanged versus the pre-extraction template', () => {
+  const prompt = linkPrompt({
+    announce: false,
+    current: { artist: 'Marvin Gaye' },
+    teaseClause: ' Name the artist or capture the feel so listeners know what they\'re hearing.',
+    patterClause: '',
+    budget: null,
+    lengthPhraseText: 'one or two sentences',
+    clockClause: ' Never state the clock time.',
+    feelClause: '',
+  });
+  assert.equal(
+    prompt,
+    `Write a short DJ link to carry into the track now starting — set it up, capture its feel, weave in the moment.`
+      + ` Name the artist or capture the feel so listeners know what they're hearing. one or two sentences, conversational.`
+      + ` Vary how you open — don't default to "here's", "this is", "coming up", or "that was"; find a different way in each time.`
+      + ` Keep it forward-looking: don't back-announce, recap, or name the track that just played — focus on what's playing now.`
+      + ` Never state the clock time.`,
+  );
+});

--- a/controller/scripts/link-style.test.ts
+++ b/controller/scripts/link-style.test.ts
@@ -7,7 +7,10 @@
 // llm/internal/prompts/scripts.ts's linkPrompt), and announce-line.ts — the
 // module that actually COMPOSES the announcement in code, since a model can
 // neither hold a fixed string reliably nor alternate with a line it is never
-// shown.
+// shown. The compose is PURE: it alternates against the link that last AIRED
+// (handed in by the caller), refuses the artists an English frame cannot carry,
+// and pins the /dj/segment button's link to the only form true of a track
+// already playing.
 //
 // Run: npx tsx scripts/link-style.test.ts (auto-discovered by npm test).
 import assert from 'node:assert/strict';
@@ -22,7 +25,8 @@ const { normalizePersona } = await import('../src/settings/normalize.js');
 const { announceLinks } = await import('../src/settings/persona.js');
 const { buildLinkClause } = await import('../src/broadcast/dj-agent/link-clause.js');
 const { linkPrompt, generateLink } = await import('../src/llm/internal/prompts/scripts.js');
-const { announceLine, resetAnnounceAlternation } = await import('../src/broadcast/announce-line.js');
+const { announceLine, nextAnnounceForm } = await import('../src/broadcast/announce-line.js');
+const { queue } = await import('../src/broadcast/queue.js');
 
 const basePersona = () => ({
   name: 'Nova',
@@ -124,35 +128,150 @@ test('announce link prompt names the artist in the fixed two-form contract', () 
 
 // ── announce-line.ts — the station composes and alternates, the model never does ──
 
-test('announceLine alternates This is -> Next up -> This is, and trims the artist', () => {
-  resetAnnounceAlternation();
-  assert.equal(announceLine('  Marvin Gaye  '), 'This is Marvin Gaye.');
-  assert.equal(announceLine('Kim Weston'), 'Next up, Kim Weston.');
-  assert.equal(announceLine('Lee Hazlewood'), 'This is Lee Hazlewood.');
+test('announceLine alternates against the line that last aired, and trims the artist', () => {
+  assert.equal(announceLine('  Marvin Gaye  ', null, { lastLine: null }), 'This is Marvin Gaye.');
+  assert.equal(
+    announceLine('Kim Weston', null, { lastLine: 'This is Marvin Gaye.' }),
+    'Next up, Kim Weston.',
+  );
+  assert.equal(
+    announceLine('Lee Hazlewood', null, { lastLine: 'Next up, Kim Weston.' }),
+    'This is Lee Hazlewood.',
+  );
+});
+
+// The whole point of anchoring on the AIRED line rather than a counter: a
+// composed line that never airs (silence ordered, intro budget, refused pick)
+// must not flip the form, or the next line the listener hears repeats the last
+// one they heard.
+test('a composed link that never airs does not disturb the alternation', () => {
+  const aired = announceLine('A', null, { lastLine: null });
+  assert.equal(aired, 'This is A.');
+  // Composed for a pick that was then deduped/dropped — never logged, so the
+  // next compose still sees the same last-aired line.
+  assert.equal(announceLine('B', null, { lastLine: aired }), 'Next up, B.');
+  assert.equal(announceLine('C', null, { lastLine: aired }), 'Next up, C.');
+});
+
+test('nextAnnounceForm restarts the sequence after a non-announce line', () => {
+  assert.equal(nextAnnounceForm(null), 'this-is');
+  assert.equal(nextAnnounceForm('Dust motes are dancing in the sun.'), 'this-is');
+  assert.equal(nextAnnounceForm('"Next up, Kim Weston."'), 'this-is');
+  assert.equal(nextAnnounceForm('this is marvin gaye.'), 'next-up');
+});
+
+// A link fired from /dj/segment airs OVER the track already playing, so
+// "Next up, <artist>." would be a false claim about what the listener is
+// hearing. Only "This is" is true there, whatever the alternation says.
+test('a link for the track already on air is pinned to the This is form', () => {
+  assert.equal(
+    announceLine('Marvin Gaye', null, { lastLine: 'Next up, Kim Weston.', currentIsOnAir: true }),
+    'This is Marvin Gaye.',
+  );
+  assert.equal(
+    announceLine('Marvin Gaye', null, { lastLine: 'This is Kim Weston.', currentIsOnAir: true }),
+    'This is Marvin Gaye.',
+  );
 });
 
 test('announceLine returns empty string for an empty/whitespace-only artist', () => {
-  resetAnnounceAlternation();
-  assert.equal(announceLine(''), '');
-  assert.equal(announceLine('   '), '');
+  assert.equal(announceLine('', null), '');
+  assert.equal(announceLine('   ', null), '');
+  assert.equal(announceLine(null, null), '');
+  assert.equal(announceLine(undefined, null), '');
+});
+
+// languageDirective binds a persona to speak exclusively in its own language;
+// a hardcoded English frame would put an English line on a Turkish station.
+test('announceLine refuses to compose for a persona that does not speak English', () => {
+  assert.equal(announceLine('Barış Manço', { language: 'Turkish' }), '');
+  assert.equal(announceLine('Marvin Gaye', { language: 'Punjabi' }), '');
+  // Unset and an explicit English both mean English.
+  assert.equal(announceLine('Marvin Gaye', { language: '' }), 'This is Marvin Gaye.');
+  assert.equal(announceLine('Marvin Gaye', { language: 'english' }), 'This is Marvin Gaye.');
+});
+
+// spokenProperNounDirective requires ZERO CJK characters in a spoken field and
+// tells the MODEL to romanize. Composed code can't romanize, so it stands down
+// rather than handing an English voice characters it cannot read.
+test('announceLine refuses to compose a non-Latin artist name', () => {
+  assert.equal(announceLine('ウルフルズ', null), '');
+  assert.equal(announceLine('周杰倫', null), '');
+  assert.equal(announceLine('방탄소년단', null), '');
+  // A Latin name with accents is fine — the directive is about CJK scripts.
+  assert.equal(announceLine('Café Tacvba', null), 'This is Café Tacvba.');
 });
 
 // ── generateLink composes in code and never calls the model when it has an artist ──
 
+// Every generateLink assertion below is also a no-LLM-call assertion: nothing
+// is configured to serve a model in this throwaway STATE_DIR, so a fall-through
+// would either throw or return something else — the exact equality catches both.
+const announcePersona = { linkStyle: 'announce', name: 'Nova', soul: 'warm and dry' };
+
 test('generateLink in announce mode returns the composed line with no LLM call', async () => {
-  resetAnnounceAlternation();
-  const persona = { linkStyle: 'announce', name: 'Nova', soul: 'warm and dry' };
   const result = await generateLink({
     previous: null,
     current: { title: 'Ain\'t No Mountain High Enough', artist: 'Chris Stapleton' },
     context: {},
-    persona,
+    persona: announcePersona,
   });
-  // Deterministic: alternation was just reset, so the first call is 'This is'.
-  // If this ever fell through to the model, either the LLM call would throw
-  // (no provider configured in this throwaway STATE_DIR) or return different
-  // text — either way this exact-equality assertion fails.
   assert.equal(result, 'This is Chris Stapleton.');
+});
+
+test('generateLink alternates announce mode against the link that last aired', async () => {
+  assert.equal(
+    await generateLink({
+      previous: null, current: { artist: 'Chris Stapleton' }, context: {},
+      persona: announcePersona, lastLink: 'This is Kim Weston.',
+    }),
+    'Next up, Chris Stapleton.',
+  );
+  assert.equal(
+    await generateLink({
+      previous: null, current: { artist: 'Chris Stapleton' }, context: {},
+      persona: announcePersona, lastLink: 'Next up, Kim Weston.',
+    }),
+    'This is Chris Stapleton.',
+  );
+});
+
+// scheduler.runLink (the /dj/segment button) airs over the track already
+// playing and passes currentIsOnAir — "Next up" about it would be false.
+test('generateLink announces the on-air track with This is, whatever the alternation', async () => {
+  assert.equal(
+    await generateLink({
+      previous: null, current: { artist: 'Chris Stapleton' }, context: {},
+      persona: announcePersona, lastLink: 'This is Kim Weston.', currentIsOnAir: true,
+    }),
+    'This is Chris Stapleton.',
+  );
+});
+
+// The bug this replaces: with no artist, the announce prompt asked the model
+// for a line whose only permitted forms were "This is <artist>." / "Next up,
+// <artist>." — and a model at temperature 0.3 reads the placeholder out.
+// There is nothing to announce, so there is no link.
+test('generateLink in announce mode drops the link when the track has no artist', async () => {
+  for (const current of [{ title: 'Untitled' }, { title: 'Untitled', artist: '' }, { title: 'Untitled', artist: '   ' }]) {
+    assert.equal(
+      await generateLink({ previous: null, current, context: {}, persona: announcePersona }),
+      '',
+    );
+  }
+});
+
+test('the announce prompt never carries a placeholder in place of an artist name', () => {
+  const prompt = linkPrompt({
+    announce: true,
+    current: { artist: '' },
+    teaseClause: '', patterClause: '', budget: null,
+    lengthPhraseText: 'one or two sentences', clockClause: '', feelClause: '',
+  });
+  assert.doesNotMatch(prompt, /<artist>/);
+  // With no name to announce it falls back to the well-formed natural ask
+  // rather than a two-form contract it cannot fill.
+  assert.match(prompt, /Write a short DJ link/);
 });
 
 test('natural link prompt is unchanged versus the pre-extraction template', () => {
@@ -174,4 +293,48 @@ test('natural link prompt is unchanged versus the pre-extraction template', () =
       + ` Keep it forward-looking: don't back-announce, recap, or name the track that just played — focus on what's playing now.`
       + ` Never state the clock time.`,
   );
+});
+
+// ── the air-truth anchor the alternation reads ───────────────────────────────
+
+// djLog entries for voice kinds are written by onSpoken, i.e. after the clip
+// reached the stream — which is the whole reason announce mode alternates
+// against this rather than a counter it advances while composing.
+test('getLastLinkText returns the most recently aired link and ignores other kinds', () => {
+  (queue as any).djLog = [];
+  assert.equal(queue.getLastLinkText(), null);
+
+  queue.log('link', 'This is Marvin Gaye.');
+  queue.log('station-id', 'You are listening to SUB/WAVE.');
+  queue.log('ai-pick', 'Helpless — Neil Young');
+  assert.equal(queue.getLastLinkText(), 'This is Marvin Gaye.');
+  assert.equal(nextAnnounceForm(queue.getLastLinkText()), 'next-up');
+
+  queue.log('link', 'Next up, Kim Weston.');
+  assert.equal(queue.getLastLinkText(), 'Next up, Kim Weston.');
+  assert.equal(nextAnnounceForm(queue.getLastLinkText()), 'this-is');
+  (queue as any).djLog = [];
+});
+
+// ── the announce contract follows the persona who SPEAKS the line ────────────
+
+// The link is pinned to session.onAirPersona() at enqueue, and inside the
+// handoff look-ahead that disagrees with the wall-clock getEffectivePersona()
+// — which is what a bare announceLinks() resolves to. Written the incoming
+// DJ's line under the outgoing DJ's link contract. Source-level because the
+// two personas only diverge inside a live look-ahead window.
+test('every announce-mode call site names the persona it resolves against', async () => {
+  const { readFileSync } = await import('node:fs');
+  for (const file of [
+    '../src/broadcast/dj-agent.ts',
+    '../src/broadcast/dj-agent/schemas.ts',
+  ]) {
+    const src = readFileSync(new URL(file, import.meta.url), 'utf8');
+    assert.doesNotMatch(
+      src,
+      /announceLinks\(\s*\)/,
+      `${file} calls announceLinks() with no persona — it must pass session.onAirPersona()`,
+    );
+    assert.match(src, /announceLinks\(\s*(?:link)?[Ss]peaker|announceLinks\(session\.onAirPersona\(\)\)/);
+  }
 });

--- a/controller/scripts/persona-schema.test.ts
+++ b/controller/scripts/persona-schema.test.ts
@@ -568,6 +568,7 @@ test('anything the strict path accepts, the lenient path returns unchanged', () 
     frequency: 'chatty',
     scriptLength: 'extended',
     djMode: true,
+    linkStyle: 'natural',
     humour: 8,
     localColour: 2,
     warmth: 7,

--- a/controller/src/broadcast/announce-line.ts
+++ b/controller/src/broadcast/announce-line.ts
@@ -1,0 +1,30 @@
+// Composes the fixed announce-mode link line in CODE rather than asking the
+// model to produce it: a model cannot reliably hold to an exact fixed
+// string, and it cannot alternate with a line it is never shown — the agent
+// path writes the link before the pick after it airs, and the scripted path
+// never carries the previous link forward at all. Per the station's own
+// posture (fix shape in code, don't just instruct the model harder), both
+// call sites compose the line here and only ask the model whether to speak.
+//
+// One shared alternation for the whole air chain: the agent picker and the
+// stateless pool picker are two different code paths for the same on-air
+// slot, and a listener hears one continuous sequence of links regardless of
+// which path produced each one.
+let lastForm: 'this-is' | 'next-up' | null = null;
+
+/**
+ * `This is <artist>.` or `Next up, <artist>.`, alternating every call.
+ * Empty/whitespace-only artist returns '' — the caller's signal for "no link".
+ */
+export function announceLine(artist: string): string {
+  const trimmed = String(artist ?? '').trim();
+  if (!trimmed) return '';
+  const form = lastForm === 'this-is' ? 'next-up' : 'this-is';
+  lastForm = form;
+  return form === 'this-is' ? `This is ${trimmed}.` : `Next up, ${trimmed}.`;
+}
+
+/** Test-only: reset the alternation so a test can assert on a known next form. */
+export function resetAnnounceAlternation(): void {
+  lastForm = null;
+}

--- a/controller/src/broadcast/announce-line.ts
+++ b/controller/src/broadcast/announce-line.ts
@@ -1,30 +1,88 @@
 // Composes the fixed announce-mode link line in CODE rather than asking the
-// model to produce it: a model cannot reliably hold to an exact fixed
-// string, and it cannot alternate with a line it is never shown — the agent
-// path writes the link before the pick after it airs, and the scripted path
-// never carries the previous link forward at all. Per the station's own
-// posture (fix shape in code, don't just instruct the model harder), both
-// call sites compose the line here and only ask the model whether to speak.
+// model to produce it: a model cannot reliably hold to an exact fixed string,
+// and it cannot alternate with a line it is never shown — the agent path
+// writes the link before the pick after it airs, and the scripted path never
+// carries the previous link forward at all. Per the station's own posture (fix
+// shape in code, don't just instruct the model harder), both call sites
+// compose the line here and only ask the model whether to speak.
 //
-// One shared alternation for the whole air chain: the agent picker and the
-// stateless pool picker are two different code paths for the same on-air
-// slot, and a listener hears one continuous sequence of links regardless of
-// which path produced each one.
-let lastForm: 'this-is' | 'next-up' | null = null;
+// PURE — the alternation is derived from the line that last AIRED, handed in
+// by the caller (queue.getLastLinkText(), written by onSpoken once the clip
+// reached the stream). It used to be a module-level counter advanced at
+// composition time, which is not the same thing: three routine paths consume a
+// composed link without airing it — a model writing a `say` when the event
+// ordered silence, trimLinkToIntro dropping the line on a track whose vocals
+// enter under 2.5s, and enqueuePick refusing the pick (dedup / never-play) —
+// and each one left the NEXT aired line repeating the form the listener had
+// just heard ("This is A." … "This is C."). Anchoring on air truth cannot
+// drift, and one shared sequence covers the whole air chain: the agent picker
+// and the stateless pool picker are two code paths for the same on-air slot,
+// and a listener hears one continuous sequence of links regardless of which
+// produced each one.
+
+// The composed frame is English, and only the model can write it in anything
+// else — languageDirective (settings/persona.ts) binds the persona to speak
+// exclusively in its own language, and code has no translation of "This is".
+// Same field read as languageDirective's: unset means English.
+const ENGLISH_LANGUAGE = /^english$/i;
+
+// spokenProperNounDirective (settings/persona.ts) requires ZERO CJK characters
+// in any spoken field and tells the model to romanize (ウルフルズ → Ulfuls,
+// 周杰倫 → Jay Chou). A composed line interpolates the artist tag verbatim, so
+// a name in one of these scripts has to go through the model or an English
+// voice reads nothing at all. Hangul rides along for the same reason.
+const NON_LATIN_NAME = new RegExp(
+  '[\\u3000-\\u303f'   // CJK punctuation
+  + '\\u3040-\\u30ff'  // hiragana + katakana
+  + '\\u31f0-\\u31ff'  // katakana phonetic extensions
+  + '\\u3400-\\u4dbf'  // CJK unified ideographs extension A
+  + '\\u4e00-\\u9fff'  // CJK unified ideographs
+  + '\\uac00-\\ud7af'  // hangul syllables
+  + '\\uf900-\\ufaff'  // CJK compatibility ideographs
+  + '\\uff65-\\uff9f]' // halfwidth katakana
+);
+
+export type AnnounceForm = 'this-is' | 'next-up';
 
 /**
- * `This is <artist>.` or `Next up, <artist>.`, alternating every call.
- * Empty/whitespace-only artist returns '' — the caller's signal for "no link".
+ * The form that follows `lastLine` — the previous link exactly as it AIRED.
+ * Anything that isn't one of the two forms (a natural link from before the
+ * operator flipped the style, or nothing aired yet) starts the sequence.
  */
-export function announceLine(artist: string): string {
-  const trimmed = String(artist ?? '').trim();
-  if (!trimmed) return '';
-  const form = lastForm === 'this-is' ? 'next-up' : 'this-is';
-  lastForm = form;
-  return form === 'this-is' ? `This is ${trimmed}.` : `Next up, ${trimmed}.`;
+export function nextAnnounceForm(lastLine?: string | null): AnnounceForm {
+  const prev = String(lastLine ?? '').replace(/^["'\s]+/, '').toLowerCase();
+  if (prev.startsWith('next up')) return 'this-is';
+  if (prev.startsWith('this is')) return 'next-up';
+  return 'this-is';
 }
 
-/** Test-only: reset the alternation so a test can assert on a known next form. */
-export function resetAnnounceAlternation(): void {
-  lastForm = null;
+export interface AnnounceLineOptions {
+  /** The between-track link that last aired, for the alternation. */
+  lastLine?: string | null;
+  /** True when `artist` is the track ALREADY playing (the /dj/segment link
+   *  button airs over it) rather than the pick about to start — "Next up" is a
+   *  false claim there, so the form is pinned to "This is". */
+  currentIsOnAir?: boolean;
+}
+
+/**
+ * `This is <artist>.` or `Next up, <artist>.` — or `''` when the station
+ * cannot compose the line itself and the model has to write it: no artist to
+ * name, a persona that speaks something other than English, or an artist tag
+ * in a script an English frame can't carry. `''` is the caller's signal to
+ * fall back, never a line to air.
+ */
+export function announceLine(
+  artist: unknown,
+  persona: unknown,
+  { lastLine = null, currentIsOnAir = false }: AnnounceLineOptions = {},
+): string {
+  const trimmed = String(artist ?? '').trim();
+  if (!trimmed || NON_LATIN_NAME.test(trimmed)) return '';
+  const language = String(
+    (persona as { language?: unknown } | null | undefined)?.language ?? '',
+  ).trim();
+  if (language && !ENGLISH_LANGUAGE.test(language)) return '';
+  const form = currentIsOnAir ? 'this-is' : nextAnnounceForm(lastLine);
+  return form === 'this-is' ? `This is ${trimmed}.` : `Next up, ${trimmed}.`;
 }

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -410,7 +410,19 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
   // by announce-line.ts, because a model cannot reliably hold to a fixed
   // string and cannot alternate with a line it is never shown. Silence stays
   // the model's call; wording never is.
-  if (rawSay && settings.announceLinks()) rawSay = announceLine(song.artist);
+  //
+  // Resolved off the ON-AIR persona, not the wall-clock effective one: this
+  // line is spoken by whoever enqueuePick pins it to (session.onAirPersona()),
+  // and inside the handoff look-ahead those two disagree — the incoming DJ's
+  // line would otherwise be written under the outgoing DJ's link contract.
+  // An empty compose means no English/Latin frame fits this persona or artist
+  // (announce-line.ts): the model's own line stands, written under the same
+  // fixed-form schema description and its language directives.
+  const linkSpeaker = session.onAirPersona();
+  if (rawSay && settings.announceLinks(linkSpeaker)) {
+    const composed = announceLine(song.artist, linkSpeaker, { lastLine: queue.getLastLinkText() });
+    if (composed) rawSay = composed;
+  }
   // Talk-within-the-intro (feature 3a): enqueuePick re-applies this trim at
   // the chokepoint (near-idempotent — see the note there); it runs here too so
   // the session turn below records the line as it will actually air — trimmed,
@@ -521,6 +533,9 @@ async function pickViaPool(queue, ctx, { wantLink, current, showAt = null }: { w
         recap: queue.getDjRecap(),
         recentTracks: queue.getRecentTracks(),
         recentOpeners: queue.getRecentOpeners(),
+        // Announce mode alternates against the link that last AIRED; every
+        // queue read stays at the call site, the prompt layer is handed values.
+        lastLink: queue.getLastLinkText(),
       });
     } catch (err) {
       queue.log('error', `DJ link failed: ${err.message}`);
@@ -621,7 +636,9 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     const current = predecessor ?? queue.current?.track ?? null;
     const previous = predecessor ? (prior ?? null) : (queue.history[0]?.track ?? null);
     const djMode = !!settings.getEffectivePersona()?.djMode;
-    const announce = settings.announceLinks();
+    // On-air persona, not the wall-clock effective one — same reason as the
+    // announce compose in pickViaAgent: the link belongs to whoever speaks it.
+    const announce = settings.announceLinks(session.onAirPersona());
 
     // Feature 4 + Phase 2 — advance/maybe-start a mini-run; get the tempo/key
     // re-rank target and (when the audio index supports it) a sonic-journey

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -52,6 +52,8 @@ import {
 import { dropEchoedLink, enqueuePick, trackFields, trimLinkToIntro } from './dj-agent/enqueue.js';
 import { advanceRun, runActive } from './dj-agent/runs.js';
 import { pickSchemaBase, pickSystem, requestSystem } from './dj-agent/schemas.js';
+import { buildLinkClause } from './dj-agent/link-clause.js';
+import { announceLine } from './announce-line.js';
 import { guardIntro, screenAck, isNamedRequester } from '../util/request-guard.js';
 import * as likes from './likes.js';
 import { classifyPickFailure, type PickFailure } from '../util/pick-seed.js';
@@ -402,7 +404,13 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
     song = guarded.song;
   }
 
-  const rawSay = typeof object.say === 'string' ? object.say.trim() : '';
+  let rawSay = typeof object.say === 'string' ? object.say.trim() : '';
+  // Announce mode: the model's `say` only signals "speak" — the exact line
+  // (and its alternation with whatever aired before it) is composed in code
+  // by announce-line.ts, because a model cannot reliably hold to a fixed
+  // string and cannot alternate with a line it is never shown. Silence stays
+  // the model's call; wording never is.
+  if (rawSay && settings.announceLinks()) rawSay = announceLine(song.artist);
   // Talk-within-the-intro (feature 3a): enqueuePick re-applies this trim at
   // the chokepoint (near-idempotent — see the note there); it runs here too so
   // the session turn below records the line as it will actually air — trimmed,
@@ -613,6 +621,7 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     const current = predecessor ?? queue.current?.track ?? null;
     const previous = predecessor ? (prior ?? null) : (queue.history[0]?.track ?? null);
     const djMode = !!settings.getEffectivePersona()?.djMode;
+    const announce = settings.announceLinks();
 
     // Feature 4 + Phase 2 — advance/maybe-start a mini-run; get the tempo/key
     // re-rank target and (when the audio index supports it) a sonic-journey
@@ -648,8 +657,13 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     // up…"). Feed it the same two signals through the event message: one random
     // forward-looking angle to vary the approach, and the recent openers to
     // steer clear of. Only when a link is actually being written.
-    const linkAngle = wantLink ? dj.pickAngle('link') : null;
-    const recentOpeners = wantLink ? queue.getRecentOpeners() : [];
+    //
+    // Announce mode skips both: alternating between exactly two fixed forms
+    // ("This is <artist>." / "Next up, <artist>.") IS the variety, and an
+    // opener blocklist built from those same two forms would eventually
+    // forbid both allowed ones (the bug this feature exists to fix).
+    const linkAngle = wantLink && !announce ? dj.pickAngle('link') : null;
+    const recentOpeners = wantLink && !announce ? queue.getRecentOpeners() : [];
     // Clock discipline for the link (#864). The agent path carries no clock of
     // its own, so the model extrapolates one from stale stamped lines in its
     // session window — and the link then airs a full track later, putting spoken
@@ -681,21 +695,14 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
             ? ` The link airs at about ${airClock.display || airClock.hhmm} — if you mention the clock, that is the time to use, never an earlier one.`
             : ` Never state the clock time in the link — you can't know exactly when it airs.`)
       : '';
-    const varietyClause = wantLink
-      ? ` Approach for this link: ${linkAngle} Vary your first words — don't default to "here's", "this is", or "coming up".`
-        + (recentOpeners.length
-            ? ` You opened recent lines with ${recentOpeners.slice(0, 6).map(o => `"${o}…"`).join(', ')} — start this one differently.`
-            : '')
-      : '';
     // The full link contract (introduce the pick, no back-announce, vary the
-    // opener) lives in the "say" schema description (pickSchemaBase), which
-    // travels on every call — this clause only TRIGGERS the link and carries
-    // the per-pick extras the schema can't know (the intro_ms budget, the
-    // opener blocklist). Restating the contract here doubled it per pick.
+    // opener — or, in announce mode, the fixed two-form contract) lives in the
+    // "say" schema description (pickSchemaBase), which travels on every call —
+    // this clause only TRIGGERS the link and carries the per-pick extras the
+    // schema can't know (the intro_ms budget, the opener blocklist). Restating
+    // the contract here doubled it per pick. See dj-agent/link-clause.ts.
     const linkClause = wantLink
-      ? (djMode
-          ? ` Also write the "say" link — it airs as your pick starts. If the track you pick shows an intro_ms, keep the link short enough to finish before then, so you land just as the vocals come in.${varietyClause}`
-          : ` Also write the "say" link — it airs as your pick starts.${varietyClause}`)
+      ? buildLinkClause({ djMode, announce, angle: linkAngle, recentOpeners })
       : ' Stay silent — no link this time.';
     // Surface the current track's real Subsonic id so similarSongs /
     // tracksLikeThis ("pass the currently-playing song id") actually have one

--- a/controller/src/broadcast/dj-agent/link-clause.ts
+++ b/controller/src/broadcast/dj-agent/link-clause.ts
@@ -1,0 +1,48 @@
+// The event-turn clause that tells the agent to write (or skip) a spoken
+// link. Extracted from dj-agent.ts's runTrackEvent so the two link postures —
+// the ordinary "introduce the pick, vary your opener" contract and the
+// linkStyle:'announce' matter-of-fact contract — are each one pure, testable
+// function of their inputs.
+//
+// The full link contract (introduce the pick, no back-announce) lives in the
+// "say" schema description (dj-agent/schemas.ts's pickSchemaBase), which
+// travels on every call — this clause only TRIGGERS the link and carries the
+// per-pick extras the schema can't know (the intro_ms budget, the opener
+// blocklist, or — for announce — nothing extra at all).
+
+export interface BuildLinkClauseInput {
+  /** wantLink must already be true for this to be called; kept out of the
+   *  signature — the caller decides the silent branch. */
+  djMode: boolean;
+  announce: boolean;
+  /** A rotating forward-looking angle (dj.pickAngle('link')), or null when
+   *  none was drawn / announce mode never draws one. */
+  angle: string | null;
+  /** The station's recent link openers, oldest-first-trimmed by the caller. */
+  recentOpeners: string[];
+}
+
+/**
+ * The clause appended after "Also write the 'say' link — it airs as your pick
+ * starts." Natural output is byte-identical to the pre-extraction template.
+ */
+export function buildLinkClause({ djMode, announce, angle, recentOpeners }: BuildLinkClauseInput): string {
+  if (announce) {
+    // No intro_ms sentence — an announcement is always short enough to land
+    // clear of any vocal entry. No angle, no opener blocklist: alternating
+    // between exactly two fixed forms IS the variety. This is a sane fallback
+    // description only — the model's `say` here only signals "speak this
+    // pick"; the runTrackEvent chokepoint in dj-agent.ts overwrites the text
+    // with announce-line.ts's own composed, alternating line before it airs.
+    return ' Also write the "say" link — it airs as your pick starts.'
+      + ' The "say" line must be exactly one of: "This is <artist>." or "Next up, <artist>." — nothing before or after it: no title, album, year, feel, or clock.'
+      + ' Use the artist name exactly as shown on the chosen track.';
+  }
+  const varietyClause = ` Approach for this link: ${angle} Vary your first words — don't default to "here's", "this is", or "coming up".`
+    + (recentOpeners.length
+        ? ` You opened recent lines with ${recentOpeners.slice(0, 6).map(o => `"${o}…"`).join(', ')} — start this one differently.`
+        : '');
+  return djMode
+    ? ` Also write the "say" link — it airs as your pick starts. If the track you pick shows an intro_ms, keep the link short enough to finish before then, so you land just as the vocals come in.${varietyClause}`
+    : ` Also write the "say" link — it airs as your pick starts.${varietyClause}`;
+}

--- a/controller/src/broadcast/dj-agent/schemas.ts
+++ b/controller/src/broadcast/dj-agent/schemas.ts
@@ -71,8 +71,18 @@ export function pickSchemaBase() {
   const clockRule = speakClockAllowed()
     ? 'Never state a clock time unless the event message tells you when the link airs — then use exactly that time.'
     : 'Never state a clock time, the hour, or the time of day.';
+  // Announce mode (persona linkStyle:'announce') replaces the ordinary
+  // introduce-the-pick contract with a fixed, matter-of-fact one. This
+  // description is a sane fallback only: runTrackEvent (dj-agent.ts)
+  // overwrites whatever text the model returns with announce-line.ts's own
+  // composed, alternating line — a model cannot reliably hold to a fixed
+  // string or alternate with a line it is never shown, so `say` here only
+  // has to signal "speak" (non-empty) versus "stay silent" (null).
+  const sayDescription = settings.announceLinks()
+    ? `when the latest event message says to write a spoken link, set this to EXACTLY one of: "This is <artist>." or "Next up, <artist>." — nothing before or after it: no title, album, year, feel, or clock. Use the artist name exactly as shown on the chosen track. When the event says stay silent, set this to null`
+    : `when the latest event message says to write a spoken link, set this to ${dj.lengthPhrase('link')} of natural speech in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). ${clockRule} When the event says stay silent, set this to null`;
   return base.extend({
-    say: z.string().nullable().describe(`when the latest event message says to write a spoken link, set this to ${dj.lengthPhrase('link')} of natural speech in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). ${clockRule} When the event says stay silent, set this to null`),
+    say: z.string().nullable().describe(sayDescription),
   });
 }
 

--- a/controller/src/broadcast/dj-agent/schemas.ts
+++ b/controller/src/broadcast/dj-agent/schemas.ts
@@ -78,7 +78,10 @@ export function pickSchemaBase() {
   // composed, alternating line — a model cannot reliably hold to a fixed
   // string or alternate with a line it is never shown, so `say` here only
   // has to signal "speak" (non-empty) versus "stay silent" (null).
-  const sayDescription = settings.announceLinks()
+  // Off the ON-AIR persona (as pickSystem/requestSystem below resolve theirs),
+  // never the wall-clock effective one: inside the handoff look-ahead they
+  // disagree, and the contract must match the persona whose line this is.
+  const sayDescription = settings.announceLinks(session.onAirPersona())
     ? `when the latest event message says to write a spoken link, set this to EXACTLY one of: "This is <artist>." or "Next up, <artist>." — nothing before or after it: no title, album, year, feel, or clock. Use the artist name exactly as shown on the chosen track. When the event says stay silent, set this to null`
     : `when the latest event message says to write a spoken link, set this to ${dj.lengthPhrase('link')} of natural speech in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). ${clockRule} When the event says stay silent, set this to null`;
   return base.extend({

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -401,6 +401,21 @@ class Queue {
     return out;
   }
 
+  // The text of the most recent between-track link that actually AIRED, or
+  // null. djLog entries for voice kinds are written by onSpoken — after the
+  // clip reached the stream — which is what makes this the right anchor for
+  // announce-mode's alternation (broadcast/announce-line.ts): a link that was
+  // composed and then dropped (silence ordered, intro budget, refused pick)
+  // never lands here, so the next one can't repeat the form the listener just
+  // heard. 'link' is the kind both link paths log under — enqueuePick's
+  // introKind and announce()'s own kind.
+  getLastLinkText(): string | null {
+    for (const entry of this.djLog) {
+      if (entry.kind === 'link') return entry.message || null;
+    }
+    return null;
+  }
+
   // Timestamp (ms) of the most recent on-air spoken segment, or 0. Defaults to
   // every voice kind; pass `kinds` to narrow it (the segment director's
   // frequency floor asks only about the scheduler's wall-clock talkers —

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -623,11 +623,21 @@ export async function runLink() {
       // Unlike a pick-attached link, this one airs right now (announce below),
       // so the live clock in ctx is the air time — the model may speak it.
       clockIsAirTime: true,
+      // …and `current` is the track ALREADY PLAYING, not a pick about to
+      // start. Announce mode has to know: "Next up, <artist>." over a track
+      // three minutes in is a false claim, so this link is pinned to the
+      // "This is" form (announce-line.ts). Every queue read stays here.
+      currentIsOnAir: true,
+      lastLink: queue.getLastLinkText(),
       recap: queue.getDjRecap(),
       recentTracks: queue.getRecentTracks(),
       recentOpeners: queue.getRecentOpeners(),
       persona: speaker,
     });
+    // Announce mode drops the link when the on-air track carries no artist
+    // name — there is nothing for it to announce. Say so rather than answering
+    // the button press with a silent success.
+    if (!script) throw new Error('no link to air — this track has no artist name to announce');
     await queue.announce(script, 'link', {
       persona: speaker, meta: { personaId: speaker?.id, personaName: speaker?.name },
     });

--- a/controller/src/community/registry.ts
+++ b/controller/src/community/registry.ts
@@ -23,6 +23,7 @@ import { fetchWithTimeout } from '../util/fetch-timeout.js';
 import { queue } from '../broadcast/queue.js';
 import {
   FREQUENCIES,
+  LINK_STYLES,
   SCRIPT_LENGTHS,
   SHOW_MOODS,
   SHOW_ENERGY,
@@ -71,6 +72,7 @@ export interface CommunityPersona {
   frequency: 'silent' | 'quiet' | 'moderate' | 'chatty' | 'aggressive';
   scriptLength: 'one-liner' | 'concise' | 'extended' | 'storyteller';
   djMode: boolean;
+  linkStyle?: 'natural' | 'announce';
   humour?: number;
   localColour?: number;
   warmth?: number;
@@ -205,6 +207,7 @@ function normalizePersona(raw: any): CommunityPersona | null {
     frequency: (FREQUENCIES as string[]).includes(raw?.frequency) ? raw.frequency : 'moderate',
     scriptLength: (SCRIPT_LENGTHS as string[]).includes(raw?.scriptLength) ? raw.scriptLength : 'concise',
     djMode: raw?.djMode === true,
+    linkStyle: (LINK_STYLES as string[]).includes(raw?.linkStyle) ? raw.linkStyle : 'natural',
     humour: dial(raw?.humour),
     localColour: dial(raw?.localColour),
     warmth: dial(raw?.warmth),

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -12,6 +12,7 @@ import { isNamedRequester } from '../../../util/request-guard.js';
 import { introBudgetPhrase, introMsFor, firstVocalMsFor, bpmKeyFor } from './intro-budget.js';
 import { trackEraYear } from '../../../music/show-filter.js';
 import { trackFeelSuffix } from './track-feel.js';
+import { announceLine } from '../../../broadcast/announce-line.js';
 
 // The feel note appended to a track line (track-feel.ts) is a STEER, not copy.
 // Without this the model reads the label out — "high-energy" spoken flat is
@@ -228,8 +229,38 @@ export async function generateAdLib({ instruction, context = null, recap = null,
   });
 }
 
+// Pure prompt-assembly for generateLink, split out for testability. `announce`
+// (persona linkStyle:'announce', settings.announceLinks()) replaces the whole
+// natural instruction — set it up, tease the feel, vary the opener — with a
+// fixed, matter-of-fact one: the whole line is "This is <artist>." or "Next
+// up, <artist>.", alternating with the previous link. Everything else (tease,
+// patter, the intro budget, "vary how you open", the feel clause) is a
+// natural-only concern and plays no part in announce mode.
+export function linkPrompt({
+  announce, current, teaseClause, patterClause, budget, lengthPhraseText, clockClause, feelClause,
+}: {
+  announce: boolean;
+  current: { artist?: string | null } | null | undefined;
+  teaseClause: string;
+  patterClause: string;
+  budget: string | null;
+  lengthPhraseText: string;
+  clockClause: string;
+  feelClause: string;
+}): string {
+  if (announce) {
+    // Fallback prompt only — generateLink composes the line itself in code
+    // (announce-line.ts) whenever it has an artist to work with, and calls
+    // the model only when it doesn't (see below).
+    const artist = current?.artist || '<artist>';
+    return `Write the DJ link for the track now starting. It must be EXACTLY one of: "This is ${artist}." or "Next up, ${artist}." — nothing before or after it: no title, album, year, feel, or clock.`;
+  }
+  return `Write a short DJ link to carry into the track now starting — set it up, capture its feel, weave in the moment.${teaseClause}${patterClause}${budget ? ' ' + budget : ''} ${lengthPhraseText}, conversational. Vary how you open — don't default to "here's", "this is", "coming up", or "that was"; find a different way in each time. Keep it forward-looking: don't back-announce, recap, or name the track that just played — focus on what's playing now.${clockClause}${feelClause}`;
+}
+
 export async function generateLink({ previous, current, context, clockIsAirTime = false, recap = null, recentTracks = null, recentOpeners = null, persona = null }: any) {
   const speaker = persona || settings.getEffectivePersona();
+  const announce = settings.announceLinks(speaker);
   // A pick-attached link is written when the pick is made but airs a full
   // track later, so a clock reference baked in at generation time is stale by
   // the length of whatever is playing now — "18:10" spoken at 18:20 (issue
@@ -283,14 +314,39 @@ export async function generateLink({ previous, current, context, clockIsAirTime 
   // deterministic backstop would drop the line anyway; better not to write it.
   const budget = introBudgetPhrase(introMsFor(current), firstVocalMsFor(current));
   const feelClause = feelSuffix ? FEEL_CLAUSE : '';
-  const prompt = `Write a short DJ link to carry into the track now starting — set it up, capture its feel, weave in the moment.${teaseClause}${patterClause}${budget ? ' ' + budget : ''} ${lengthPhrase('link', speaker)}, conversational. Vary how you open — don't default to "here's", "this is", "coming up", or "that was"; find a different way in each time. Keep it forward-looking: don't back-announce, recap, or name the track that just played — focus on what's playing now.${clockClause}${feelClause}\n\n${ctxLines.join('\n')}`;
+  // Announce mode: compose the line in code (announce-line.ts) whenever we
+  // have an artist to work with — no LLM call at all, and no risk of a model
+  // drifting off the fixed form or failing to alternate. Fall through to the
+  // announce prompt below only when there is no artist to announce (current
+  // is null/unknown), which the model-composed fallback still covers.
+  if (announce) {
+    const composed = announceLine(current?.artist || '');
+    if (composed) return composed;
+  }
 
-  return djText({
-    system: djSystem(speaker),
-    prompt: decoratePrompt(prompt, { kind: 'link', recap, recentOpeners }),
-    temperature: 0.95, topP: 0.92, repeatPenalty: 1.2, seed: randomSeed(),
-    kind: 'generateLink',
+  const instruction = linkPrompt({
+    announce, current, teaseClause, patterClause, budget,
+    lengthPhraseText: lengthPhrase('link', speaker), clockClause, feelClause,
   });
+  const prompt = `${instruction}\n\n${ctxLines.join('\n')}`;
+
+  // Announce mode: no tone angle (there is nothing to vary), no recap, no
+  // opener blocklist — a fixed kind absent from ANGLES draws no angle line,
+  // and recap/recentOpeners are withheld outright. Lower temperature too:
+  // with only two allowed outputs there is nothing left to vary creatively.
+  return announce
+    ? djText({
+        system: djSystem(speaker),
+        prompt: decoratePrompt(prompt, { kind: 'announce-link', recap: null, recentOpeners: null }),
+        temperature: 0.3, topP: 0.92, repeatPenalty: 1.2, seed: randomSeed(),
+        kind: 'generateLink',
+      })
+    : djText({
+        system: djSystem(speaker),
+        prompt: decoratePrompt(prompt, { kind: 'link', recap, recentOpeners }),
+        temperature: 0.95, topP: 0.92, repeatPenalty: 1.2, seed: randomSeed(),
+        kind: 'generateLink',
+      });
 }
 
 export async function generateHourlyTime({ recap = null, context = null, recentOpeners = null, persona = null }: any = {}) {

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -233,9 +233,17 @@ export async function generateAdLib({ instruction, context = null, recap = null,
 // (persona linkStyle:'announce', settings.announceLinks()) replaces the whole
 // natural instruction — set it up, tease the feel, vary the opener — with a
 // fixed, matter-of-fact one: the whole line is "This is <artist>." or "Next
-// up, <artist>.", alternating with the previous link. Everything else (tease,
-// patter, the intro budget, "vary how you open", the feel clause) is a
-// natural-only concern and plays no part in announce mode.
+// up, <artist>.". Everything else (tease, patter, the intro budget, "vary how
+// you open", the feel clause) is a natural-only concern and plays no part in
+// announce mode.
+//
+// The announce branch is reached only for the artists the station cannot frame
+// itself — a non-English persona, or a name in a script the composed English
+// line can't carry (announce-line.ts) — so it always has a REAL artist name to
+// name. It must never fall back to a placeholder: the only two lines this
+// prompt permits are the two it writes out, so a `<artist>` stand-in is a line
+// the model reads onto the air verbatim. With no artist at all there is
+// nothing to announce, and generateLink drops the link before it gets here.
 export function linkPrompt({
   announce, current, teaseClause, patterClause, budget, lengthPhraseText, clockClause, feelClause,
 }: {
@@ -248,17 +256,14 @@ export function linkPrompt({
   clockClause: string;
   feelClause: string;
 }): string {
-  if (announce) {
-    // Fallback prompt only — generateLink composes the line itself in code
-    // (announce-line.ts) whenever it has an artist to work with, and calls
-    // the model only when it doesn't (see below).
-    const artist = current?.artist || '<artist>';
+  const artist = String(current?.artist ?? '').trim();
+  if (announce && artist) {
     return `Write the DJ link for the track now starting. It must be EXACTLY one of: "This is ${artist}." or "Next up, ${artist}." — nothing before or after it: no title, album, year, feel, or clock.`;
   }
   return `Write a short DJ link to carry into the track now starting — set it up, capture its feel, weave in the moment.${teaseClause}${patterClause}${budget ? ' ' + budget : ''} ${lengthPhraseText}, conversational. Vary how you open — don't default to "here's", "this is", "coming up", or "that was"; find a different way in each time. Keep it forward-looking: don't back-announce, recap, or name the track that just played — focus on what's playing now.${clockClause}${feelClause}`;
 }
 
-export async function generateLink({ previous, current, context, clockIsAirTime = false, recap = null, recentTracks = null, recentOpeners = null, persona = null }: any) {
+export async function generateLink({ previous, current, context, clockIsAirTime = false, recap = null, recentTracks = null, recentOpeners = null, persona = null, lastLink = null, currentIsOnAir = false }: any) {
   const speaker = persona || settings.getEffectivePersona();
   const announce = settings.announceLinks(speaker);
   // A pick-attached link is written when the pick is made but airs a full
@@ -314,14 +319,25 @@ export async function generateLink({ previous, current, context, clockIsAirTime 
   // deterministic backstop would drop the line anyway; better not to write it.
   const budget = introBudgetPhrase(introMsFor(current), firstVocalMsFor(current));
   const feelClause = feelSuffix ? FEEL_CLAUSE : '';
-  // Announce mode: compose the line in code (announce-line.ts) whenever we
-  // have an artist to work with — no LLM call at all, and no risk of a model
-  // drifting off the fixed form or failing to alternate. Fall through to the
-  // announce prompt below only when there is no artist to announce (current
-  // is null/unknown), which the model-composed fallback still covers.
+  // Announce mode: compose the line in code (announce-line.ts) whenever the
+  // station can frame it itself — no LLM call at all, and no risk of a model
+  // drifting off the fixed form. `lastLink` is the link that last AIRED, which
+  // is what the two forms alternate against; `currentIsOnAir` says `current`
+  // is the track already playing (the /dj/segment button), where "Next up"
+  // would be a false claim.
   if (announce) {
-    const composed = announceLine(current?.artist || '');
+    const composed = announceLine(current?.artist, speaker, { lastLine: lastLink, currentIsOnAir });
     if (composed) return composed;
+    // Nothing to announce. An announce-mode station has no other line to fall
+    // back on — its whole contract is naming the artist — and an unannounced
+    // track is a non-event on air, so drop the link rather than ask the model
+    // for a line whose only permitted forms need a name we don't have.
+    // '' is every caller's no-link signal (queue.announce ignores it,
+    // trimLinkToIntro nulls it).
+    if (!String(current?.artist ?? '').trim()) return '';
+    // Otherwise the artist exists but the composed English frame can't carry
+    // it (non-English persona, or a name in a non-Latin script): the model
+    // writes the line under djSystem's language + proper-noun directives.
   }
 
   const instruction = linkPrompt({

--- a/controller/src/routes/personas.ts
+++ b/controller/src/routes/personas.ts
@@ -204,6 +204,7 @@ router.post('/personas/community/:slug/install', requireAdmin, async (req, res) 
     frequency: cp.frequency,
     scriptLength: cp.scriptLength,
     djMode: cp.djMode,
+    linkStyle: cp.linkStyle ?? 'natural',
     humour: cp.humour ?? 5,
     localColour: cp.localColour ?? 5,
     warmth: cp.warmth ?? 5,

--- a/controller/src/routes/public.ts
+++ b/controller/src/routes/public.ts
@@ -433,6 +433,7 @@ router.get('/dj', async (req, res) => {
       soul: persona?.soul || '',
       frequency: persona?.frequency || 'moderate',
       djMode: persona?.djMode === true,
+      linkStyle: persona?.linkStyle === 'announce' ? 'announce' : 'natural',
       avatar: avatarUrlFor(persona?.id),
       station: s.station,
       // Station-level share-card blurb. Persona-independent by design, so a

--- a/controller/src/schemas/persona.ts
+++ b/controller/src/schemas/persona.ts
@@ -81,6 +81,16 @@ export const PERSONA_SCRIPT_LENGTHS = [
   'storyteller',
 ] as const;
 
+// 'natural' (default) writes the ordinary between-track link — set the track
+// up, name the artist or capture its feel, vary the opener. 'announce' is a
+// matter-of-fact station: the link is exactly "This is <artist>." or "Next
+// up, <artist>." — nothing else. Absent/invalid → 'natural', same posture as
+// djMode's absent → false, so an upgraded station keeps its old links.
+export const PERSONA_LINK_STYLES = [
+  'natural',
+  'announce',
+] as const;
+
 // Per-persona tone dials — 0-10 with 5 the neutral default.
 export const PERSONA_DIAL_MIN = 0;
 export const PERSONA_DIAL_MAX = 10;
@@ -389,6 +399,7 @@ export interface PersonaParsed {
   frequency: string;
   scriptLength: string;
   djMode: boolean;
+  linkStyle: string;
   humour: number;
   localColour: number;
   warmth: number;
@@ -490,6 +501,15 @@ export const personaSchema = z
       personaNullToUndefined,
       z.boolean({ error: 'djMode must be a boolean' }).default(false),
     ),
+    // Absent → 'natural' (the historical link behaviour). See PERSONA_LINK_STYLES.
+    linkStyle: z.preprocess(
+      personaNullToUndefined,
+      z
+        .enum(PERSONA_LINK_STYLES, {
+          error: `linkStyle must be one of: ${PERSONA_LINK_STYLES.join(', ')}`,
+        })
+        .default('natural'),
+    ),
     // An absent dial reads as neutral, which is what clampPersonaDial returns
     // for undefined — see the note on personaCoercedText for the .optional().
     humour: z.unknown().optional().transform(clampPersonaDial),
@@ -563,6 +583,7 @@ export const personaSchema = z
       frequency: p.frequency,
       scriptLength: p.scriptLength,
       djMode: p.djMode,
+      linkStyle: p.linkStyle,
       humour: p.humour,
       localColour: p.localColour,
       warmth: p.warmth,
@@ -622,6 +643,9 @@ export function repairPersonaForLoad(
       ? raw.scriptLength
       : undefined,
     djMode: raw.djMode === true ? true : undefined,
+    linkStyle: (PERSONA_LINK_STYLES as readonly string[]).includes(raw.linkStyle as string)
+      ? raw.linkStyle
+      : undefined,
     avatar:
       typeof raw.avatar === 'string' && PERSONA_AVATAR_FILENAME_RE.test(raw.avatar.trim())
         ? raw.avatar.trim()

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -136,6 +136,7 @@ export {
   KOKORO_LANGS,
   KOKORO_VOICES,
   KOKORO_VOICE_LANGUAGES,
+  LINK_STYLES,
   LLM_PROVIDERS,
   LOUDNESS_SOURCES,
   MAX_OUTPUT_TOKENS_MAX,
@@ -209,6 +210,7 @@ export {
 export {
   agentLanguageReminder,
   agentPersonaPreamble,
+  announceLinks,
   castHouseRulesBlock,
   effectiveFrequency,
   effectiveMaxTrackSec,

--- a/controller/src/settings/persona.ts
+++ b/controller/src/settings/persona.ts
@@ -47,6 +47,16 @@ export function effectsActive(persona: unknown = getEffectivePersona()): boolean
   return !!(persona as { djMode?: unknown } | null | undefined)?.djMode;
 }
 
+// True only when the effective persona's linkStyle is explicitly 'announce'.
+// Absent/invalid (normalisation already repairs those to 'natural') reads as
+// false, so a station that never touched the field keeps its old links.
+// Every announce-aware call site (dj-agent.ts, dj-agent/schemas.ts,
+// llm/internal/prompts/scripts.ts) reads it from here rather than inlining
+// the string compare, same precedent as effectsActive() above.
+export function announceLinks(persona: unknown = getEffectivePersona()): boolean {
+  return (persona as { linkStyle?: unknown } | null | undefined)?.linkStyle === 'announce';
+}
+
 // Effective track-length cap in SECONDS for the moment a pick is made, or null
 // for "no cap". A scheduled show's maxTrackSeconds (when set) overrides the
 // station default; 0 at the winning level means unlimited. This is the single

--- a/controller/src/settings/vocab.ts
+++ b/controller/src/settings/vocab.ts
@@ -36,6 +36,7 @@ import {
   PERSONA_DIAL_NEUTRAL,
   PERSONA_FREQUENCIES,
   PERSONA_LIMIT as PERSONA_LIMIT_VALUE,
+  PERSONA_LINK_STYLES,
   PERSONA_SCRIPT_LENGTHS,
   PERSONA_SKILLS_LIMIT,
   PERSONA_SOUL_MAX,
@@ -97,6 +98,9 @@ export const FREQUENCIES: readonly string[] = PERSONA_FREQUENCIES;
 // doubles, 'storyteller' roughly triples for long-form monologues.
 // See llm/internal/prompts/system.ts LENGTH_PHRASES for the actual directives.
 export const SCRIPT_LENGTHS: readonly string[] = PERSONA_SCRIPT_LENGTHS;
+
+// 'natural' (default) or 'announce' — see PERSONA_LINK_STYLES / announceLinks().
+export const LINK_STYLES: readonly string[] = PERSONA_LINK_STYLES;
 
 // Per-persona tone dials. Each is 0-10 with 5 (DIAL_NEUTRAL) the default. A
 // model can't distinguish humour=6 from 7, so rather than inject a raw "7/10"

--- a/docs/community.md
+++ b/docs/community.md
@@ -147,6 +147,7 @@ tagline: Liner notes and why this take.   # ≤80 chars (optional)
 frequency: quiet                 # silent | quiet | moderate | chatty | aggressive
 scriptLength: extended           # one-liner | concise | extended | storyteller
 djMode: false                    # true = chattier + transition FX
+linkStyle: natural                # natural | announce (announce = "This is <artist>." / "Next up, <artist>.")
 humour: 3                        # tone dials 0–10 (5 = neutral); also localColour, warmth
 language: English                # free-text on-air language, ≤60 chars (optional)
 ---

--- a/web/components/admin/PersonasPanel.tsx
+++ b/web/components/admin/PersonasPanel.tsx
@@ -216,7 +216,7 @@ export default function PersonasPanel() {
     const newId = clientMintId();
     appendPersonaField({
       id: newId, name: 'New persona', tagline: '',
-      frequency: 'moderate', scriptLength: 'concise', djMode: false,
+      frequency: 'moderate', scriptLength: 'concise', djMode: false, linkStyle: 'natural',
       humour: DIAL_NEUTRAL, localColour: DIAL_NEUTRAL, warmth: DIAL_NEUTRAL, soul: '',
       language: '',
       avatar: '',
@@ -405,6 +405,7 @@ export default function PersonasPanel() {
             frequency: p.frequency,
             scriptLength: p.scriptLength,
             djMode: p.djMode,
+            linkStyle: p.linkStyle,
             humour: p.humour,
             localColour: p.localColour,
             warmth: p.warmth,

--- a/web/components/admin/personas/PersonaBehaviorCard.tsx
+++ b/web/components/admin/personas/PersonaBehaviorCard.tsx
@@ -11,7 +11,7 @@
 // so no adapter is needed at any of the four sites below.
 import { useController, type Control } from 'react-hook-form';
 import type { PersonasFormValues } from './types';
-import { FREQUENCIES, SCRIPT_LENGTHS, TONE_DIALS, toneBandIndex } from './constants';
+import { FREQUENCIES, LINK_STYLES, SCRIPT_LENGTHS, TONE_DIALS, toneBandIndex } from './constants';
 import { Card, Toggle } from '../ui';
 import { SteppedFader } from './SteppedFader';
 import { ToneKnob } from './ToneKnob';
@@ -25,6 +25,7 @@ export function PersonaBehaviorCard({ index, control }: PersonaBehaviorCardProps
   const frequency = useController({ control, name: `personas.${index}.frequency` });
   const scriptLength = useController({ control, name: `personas.${index}.scriptLength` });
   const djMode = useController({ control, name: `personas.${index}.djMode` });
+  const linkStyle = useController({ control, name: `personas.${index}.linkStyle` });
   const humour = useController({ control, name: `personas.${index}.humour` });
   const localColour = useController({ control, name: `personas.${index}.localColour` });
   const warmth = useController({ control, name: `personas.${index}.warmth` });
@@ -66,6 +67,14 @@ export function PersonaBehaviorCard({ index, control }: PersonaBehaviorCardProps
               ariaLabel="Work the desk like a real DJ"
             />
           </div>
+
+          <div className="rule-label">link style</div>
+          <SteppedFader
+            ariaLabel="Link style"
+            stops={LINK_STYLES}
+            value={linkStyle.field.value || 'natural'}
+            onChange={linkStyle.field.onChange}
+          />
         </div>
 
         <div className="mt-4 lg:mt-0">

--- a/web/components/admin/personas/PersonaEditor.tsx
+++ b/web/components/admin/personas/PersonaEditor.tsx
@@ -80,6 +80,7 @@ export function PersonaEditor({
       frequency: persona.frequency,
       'script-length': persona.scriptLength,
       'dj-mode': persona.djMode ? 'on' : '',
+      'link-style': persona.linkStyle,
       humour: persona.humour !== DIAL_NEUTRAL ? String(persona.humour) : '',
       'local-colour': persona.localColour !== DIAL_NEUTRAL ? String(persona.localColour) : '',
       warmth: persona.warmth !== DIAL_NEUTRAL ? String(persona.warmth) : '',

--- a/web/components/admin/personas/PersonaRoster.test.tsx
+++ b/web/components/admin/personas/PersonaRoster.test.tsx
@@ -12,6 +12,7 @@ const persona: Persona = {
   frequency: 'moderate',
   scriptLength: 'concise',
   djMode: false,
+  linkStyle: 'natural',
   humour: 5,
   localColour: 5,
   warmth: 5,

--- a/web/components/admin/personas/constants.ts
+++ b/web/components/admin/personas/constants.ts
@@ -16,6 +16,11 @@ export const SCRIPT_LENGTHS = [
   { id: 'extended',    label: 'Extended',    desc: 'Longer, storytelling segments. Roughly double the length across intros, links, weather and idents.' },
   { id: 'storyteller', label: 'Storyteller', desc: 'Long-form — proper scene-setting monologues, roughly triple the default length.' },
 ];
+// Ids must match the controller's PERSONA_LINK_STYLES (schemas/persona.ts).
+export const LINK_STYLES = [
+  { id: 'natural',  label: 'Natural',  desc: 'The ordinary between-track link — sets the track up, names the artist or captures its feel, varies the opener.' },
+  { id: 'announce', label: 'Announce only', desc: 'Matter-of-fact: the link is exactly "This is <artist>." or "Next up, <artist>." — nothing else.' },
+];
 // 0–10, default 5, mapping to three prompt bands server-side
 // (settings.personaToneDirectives): 0–3 low, 7–10 high, 4–6 neutral (nothing
 // injected). Surfacing the band stops operators expecting 6 vs 7 to differ.

--- a/web/components/admin/personas/helpers.ts
+++ b/web/components/admin/personas/helpers.ts
@@ -25,6 +25,7 @@ export function personaFromSettings(p: Partial<Persona> | undefined, allSkills: 
     frequency: p?.frequency ?? 'moderate',
     scriptLength: p?.scriptLength ?? 'concise',
     djMode: p?.djMode === true,
+    linkStyle: p?.linkStyle === 'announce' ? 'announce' : 'natural',
     humour: typeof p?.humour === 'number' ? p.humour : DIAL_NEUTRAL,
     localColour: typeof p?.localColour === 'number' ? p.localColour : DIAL_NEUTRAL,
     warmth: typeof p?.warmth === 'number' ? p.warmth : DIAL_NEUTRAL,

--- a/web/components/admin/personas/types.ts
+++ b/web/components/admin/personas/types.ts
@@ -23,6 +23,10 @@ export interface Persona {
   // Back-announces AND teases what's next, and runs callbacks across the session.
   // Off = the tasteful-narrator behaviour.
   djMode: boolean;
+  // 'natural' (default) writes the ordinary between-track link. 'announce' is
+  // a matter-of-fact station: the link is exactly "This is <artist>." or
+  // "Next up, <artist>." — nothing else.
+  linkStyle: 'natural' | 'announce';
   // Tone dials, 0–10, default 5 (neutral). Map to prompt bands server-side.
   humour: number;
   localColour: number;
@@ -138,6 +142,7 @@ export interface CommunityPersona {
   frequency: 'silent' | 'quiet' | 'moderate' | 'chatty' | 'aggressive';
   scriptLength: 'one-liner' | 'concise' | 'extended' | 'storyteller';
   djMode: boolean;
+  linkStyle?: 'natural' | 'announce';
   humour?: number;
   localColour?: number;
   warmth?: number;

--- a/web/components/personas/CommunityPersonaCard.tsx
+++ b/web/components/personas/CommunityPersonaCard.tsx
@@ -12,6 +12,7 @@ export default function CommunityPersonaCard({ persona }: { persona: CommunityPe
   if (persona.frequency !== 'moderate') tags.push(persona.frequency);
   if (persona.scriptLength !== 'concise') tags.push(persona.scriptLength);
   if (persona.djMode) tags.push('dj mode');
+  if (persona.linkStyle === 'announce') tags.push('announce only');
   if (persona.language) tags.push(persona.language);
 
   return (

--- a/web/lib/communityPersonas.ts
+++ b/web/lib/communityPersonas.ts
@@ -17,6 +17,7 @@ export interface CommunityPersona {
   frequency: 'silent' | 'quiet' | 'moderate' | 'chatty' | 'aggressive';
   scriptLength: 'one-liner' | 'concise' | 'extended' | 'storyteller';
   djMode: boolean;
+  linkStyle?: 'natural' | 'announce';
   humour?: number; // tone dials 0-10; absent = neutral
   localColour?: number;
   warmth?: number;

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -684,6 +684,16 @@ export const PERSONA_SCRIPT_LENGTHS = [
   'storyteller',
 ] as const;
 
+// 'natural' (default) writes the ordinary between-track link — set the track
+// up, name the artist or capture its feel, vary the opener. 'announce' is a
+// matter-of-fact station: the link is exactly "This is <artist>." or "Next
+// up, <artist>." — nothing else. Absent/invalid → 'natural', same posture as
+// djMode's absent → false, so an upgraded station keeps its old links.
+export const PERSONA_LINK_STYLES = [
+  'natural',
+  'announce',
+] as const;
+
 // Per-persona tone dials — 0-10 with 5 the neutral default.
 export const PERSONA_DIAL_MIN = 0;
 export const PERSONA_DIAL_MAX = 10;
@@ -992,6 +1002,7 @@ export interface PersonaParsed {
   frequency: string;
   scriptLength: string;
   djMode: boolean;
+  linkStyle: string;
   humour: number;
   localColour: number;
   warmth: number;
@@ -1093,6 +1104,15 @@ export const personaSchema = z
       personaNullToUndefined,
       z.boolean({ error: 'djMode must be a boolean' }).default(false),
     ),
+    // Absent → 'natural' (the historical link behaviour). See PERSONA_LINK_STYLES.
+    linkStyle: z.preprocess(
+      personaNullToUndefined,
+      z
+        .enum(PERSONA_LINK_STYLES, {
+          error: `linkStyle must be one of: ${PERSONA_LINK_STYLES.join(', ')}`,
+        })
+        .default('natural'),
+    ),
     // An absent dial reads as neutral, which is what clampPersonaDial returns
     // for undefined — see the note on personaCoercedText for the .optional().
     humour: z.unknown().optional().transform(clampPersonaDial),
@@ -1166,6 +1186,7 @@ export const personaSchema = z
       frequency: p.frequency,
       scriptLength: p.scriptLength,
       djMode: p.djMode,
+      linkStyle: p.linkStyle,
       humour: p.humour,
       localColour: p.localColour,
       warmth: p.warmth,
@@ -1225,6 +1246,9 @@ export function repairPersonaForLoad(
       ? raw.scriptLength
       : undefined,
     djMode: raw.djMode === true ? true : undefined,
+    linkStyle: (PERSONA_LINK_STYLES as readonly string[]).includes(raw.linkStyle as string)
+      ? raw.linkStyle
+      : undefined,
     avatar:
       typeof raw.avatar === 'string' && PERSONA_AVATAR_FILENAME_RE.test(raw.avatar.trim())
         ? raw.avatar.trim()


### PR DESCRIPTION
## What
A per-persona `linkStyle: 'natural' | 'announce'`. With `announce`, every between-track link is exactly `This is <artist>.` or `Next up, <artist>.`, alternating — composed by the station in code, not by the model. Absent → `natural`, byte-identical to today.

## Why
An operator who wants a matter-of-fact station cannot get there with house rules. Three per-link instructions argue against them: the random link angle ("lead with one specific image"), "vary your first words — don't default to 'this is'", and the opener blocklist built from recent lines, which after two announcements forbids both allowed forms. The model resolves the conflict by prepending a sentence — observed on air with gemma4:26b: *"Dust motes are dancing in the afternoon sun. Next up, Marvin Gaye & Kim Weston."* and *"A little slower now. Next up, Lee Hazlewood."* (the second is the DJ-mode tempo patter).

Announce mode skips the angle, the blocklist and the tease/patter/feel clauses on both paths, and — because a model cannot hold a fixed string reliably or alternate with a line it is never shown — `broadcast/announce-line.ts` composes the line. The pick agent's `say` only signals speak-or-silent (silence stays the model's call; wording never is); the scripted `generateLink` returns the composed line with no model call when the artist is known.

Natural mode is untouched: the extracted `buildLinkClause` / `linkPrompt` are asserted byte-identical to the previous inline templates.

Scope: links only. Station idents, hourly time, segments, banter and request intros (`generateIntro`) are unchanged — request intros are the natural follow-up if wanted.

## How tested
- `controller`: `npm test` — 865 pass; the 3 failures (`aio-log-link`, `analyzer-python`, `state-bootstrap`) fail identically on `develop` in this sandbox. New `scripts/link-style.test.ts`: 12/12.
- `npm run lint` clean in `controller`, `web`, `mcp-subwave`; `npm run gen:schemas` re-run and idempotent.
- Web: "link style" fader on the persona behaviour card; found and fixed the save-patch mapper omitting the field (it would have dropped `linkStyle` on every save).

## Notes for reviewers
- `linkStyle` follows `djMode`'s disclosure footprint exactly: on `GET /dj`, absent from the roster-wide public listing, carried through the community persona catalog/install route.
- The web control is a 2-stop `SteppedFader` (named enum, like frequency/scriptLength) rather than a toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8s9fGBF4ahSBKhcWKxSvC