### PR TITLE
docs(skills): add a Todoist to-do nudge example skill

### DIFF
--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -37,8 +37,8 @@ state/skills/
     tool.mjs      # OPTIONAL: a data fetcher, wrapped as a tool the DJ can call
 ```
 
-Two copy-ready examples live in [`docs/examples/skills`](./examples/skills) — copy
-a folder into `state/skills/` and hit **Rescan** in the admin Skills page:
+Three copy-ready examples live in [`docs/examples/skills`](./examples/skills) —
+copy a folder into `state/skills/` and hit **Rescan** in the admin Skills page:
 
 - [`moon-phase`](./examples/skills/moon-phase) — the small end. No settings, no
   network, no memory: it works out the lunar phase from the date and returns it.
@@ -46,6 +46,13 @@ a folder into `state/skills/` and hit **Rescan** in the admin Skills page:
   (`configFields`), a call out to a public API, and `state` so it marks the
   sunset once a day rather than every time it fires. Fill in its coordinates in
   the edit sheet before it will say anything.
+- [`todoist`](./examples/skills/todoist) — the same shape against an
+  **authenticated** API: the DJ picks one outstanding task off your Todoist list
+  and dares the room to go and do it before the next record ends. Put
+  `TODOIST_API_TOKEN` in the root `.env` — the whole file is passed into the
+  controller, so any key you add there reaches `process.env` — then set the
+  filter in the edit sheet. Each task is burned on read for the rest of the day,
+  so it nudges rather than nags.
 
 ## SKILL.md
 
@@ -182,12 +189,16 @@ morning bulletin, a sign-off, a running joke tied to a particular hour. It still
 suits a skill that speaks *only when something is notable* less well: it fires
 on the clock rather than on the news, so it will keep asking at 8am whether
 there is anything to say. It just no longer makes something up when the answer
-is no. Both example skills in
-[`docs/examples/skills`](examples/skills) are in that second group and
-deliberately carry no `cron:` — `moon-phase` is meant to skip an unremarkable
-gibbous, and `sunset` tracks a time that moves through the year, so pinning it to
-a fixed clock reading would be wrong in a different way. Leave those on
-`cooldown:` and let the director decide.
+is no. The example skills in
+[`docs/examples/skills`](examples/skills) ship without a `cron:` for that reason
+— `moon-phase` is meant to skip an unremarkable gibbous, and `sunset` tracks a
+time that moves through the year, so pinning it to a fixed clock reading would be
+wrong in a different way. Leave those on `cooldown:` and let the director decide.
+
+`todoist` is the one that goes either way, which is why its frontmatter carries
+the line commented out: on `cooldown:` it is a nudge that turns up when it turns
+up, and with `cron: 0 8 * * *` + `cronOnly: true` it becomes a fixed morning
+alarm that never fires at random. Pick the one you actually want to hear.
 
 **Daylight saving.** A normal daily cron survives a clock change: `cron: 0 8 * * *`
 fires once at 08:00 local on the spring-forward day, the autumn day, and every

--- a/docs/examples/skills/todoist/SKILL.md
+++ b/docs/examples/skills/todoist/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: todoist
+label: To-do nudge
+cooldown: 90m
+context: date, clock, time, listeners
+# token / filter / maxTasks / owner are this skill's own knobs — set them in the
+# edit sheet (/admin/skills → To-do nudge → Edit), not by hand. tool.mjs
+# declares them, so they appear as form fields and the form writes them back
+# here:
+#   filter: today | overdue
+#   maxTasks: 4
+#   owner: Perminder
+#
+# The API token is better kept OUT of this file: put TODOIST_API_TOKEN in the
+# root .env (the whole file is passed into the controller via env_file) and
+# leave the token field blank. The field is only there for stations that would
+# rather not restart the container to set a key.
+#
+# Want it as a fixed morning alarm rather than a random between-track pick? Add:
+#   cron: 0 8 * * *
+#   cronOnly: true
+---
+Pick ONE thing off the to-do list and dare somebody to go and do it — a quick,
+grinning nudge between records, not a reading of the list. Name the task, keep
+it to a sentence or two, and aim it at whoever is listening as much as at the
+person who wrote it: the bit that lands is "go on then, one song's worth, see
+if it's done before the next track ends". Lean on the record playing if it
+helps ("this one runs four minutes, that's the whole washing-up").
+
+An overdue task is worth a bit of theatre — mock outrage, a raised eyebrow,
+never actual guilt-tripping, and never a lecture about productivity. Say how
+many are left only if it's funny; otherwise let the number go. Never read out
+more than one task, never spell out a due date as a date ("by Thursday" is
+fine, "due 2026-08-27" is not), and never invent a task or a detail the data
+didn't give you. If nothing came back, say nothing at all — a station that
+nags about an empty list is worse than one that stays quiet.

--- a/docs/examples/skills/todoist/tool.mjs
+++ b/docs/examples/skills/todoist/tool.mjs
@@ -1,0 +1,182 @@
+// Example custom-skill data tool for SUB/WAVE — a to-do nudge off a Todoist
+// list. Full signature:
+//   (ctx, state, services, config) => data
+//   ctx      — the moment (time, weather, festival, dominantMood, clock, date)
+//   state    — cross-tick memory, persists between firings
+//   services — the station facade (searchWeb, library, nowPlaying, log, …)
+//   config   — this skill's own SKILL.md frontmatter, i.e. the values behind
+//              the `configFields` declared below
+// Return any JSON-serialisable object; `{ available: false }` tells the agent
+// there is nothing worth airing right now, and the station stands down rather
+// than inventing a task (skills/abstain-policy.ts).
+//
+// The DJ gets exactly ONE task per firing, and each task is burned on read for
+// the rest of the day. That is the difference between a nudge and a nag: the
+// list is a source of one line, not a queue to be read out.
+
+export const description =
+  'Get one outstanding task from the station owner\'s Todoist list to nudge the listeners about. Returns { available, task, overdue, remaining, owner }, picking the most urgent task not already mentioned on air today. Returns { available: false } when the list is clear or Todoist is unreachable.';
+
+// The knobs this skill exposes in /admin/skills. Declared HERE, in the code,
+// so a COPY of this skill keeps its form — duplicate the folder, point the copy
+// at a different filter (a second list, a work project) and you have two.
+export const configFields = {
+  filter: {
+    type: 'text',
+    label: 'Todoist filter',
+    placeholder: 'today | overdue',
+    hint: 'Todoist filter syntax — e.g. "today | overdue", "#Home & p1", "@errand". Blank means today + overdue.',
+  },
+  maxTasks: {
+    type: 'number',
+    label: 'Tasks to fetch',
+    min: 1,
+    max: 20,
+    integer: true,
+    placeholder: '10',
+    hint: 'How many to pull. Only ever ONE goes on air; the rest are the pool to pick from.',
+  },
+  owner: {
+    type: 'text',
+    label: 'Whose list',
+    placeholder: 'Perminder',
+    hint: 'Optional — what the DJ should call the list owner on air. Blank and it stays vague.',
+  },
+  token: {
+    type: 'text',
+    label: 'API token (fallback)',
+    placeholder: 'leave blank if TODOIST_API_TOKEN is set',
+    hint: 'Prefer TODOIST_API_TOKEN in the root .env. A token typed here is stored in plain text in this skill\'s SKILL.md.',
+  },
+};
+
+// Todoist's current API. The unified v1 endpoint takes the filter as `query`
+// and answers `{ results, next_cursor }`; the older REST v2 endpoint takes it
+// as `filter` and answers a bare array. Both are tried, newest first, because
+// which one a token works against depends on when the account was set up — and
+// a skill that goes quiet on an API generation change is indistinguishable from
+// a skill with an empty list, which is the worst way to lose this.
+const ENDPOINTS = [
+  { url: 'https://api.todoist.com/api/v1/tasks/filter', queryParam: 'query', limitParam: 'limit' },
+  { url: 'https://api.todoist.com/rest/v2/tasks', queryParam: 'filter', limitParam: null },
+];
+
+const DEFAULT_FILTER = 'today | overdue';
+const DEFAULT_MAX = 10;
+
+// Todoist priority is inverted on the wire: 4 is the p1 flag in the UI. 1 is
+// the DEFAULT every task carries, so it is deliberately absent from this map —
+// labelling it "p4" would make "has a priority flag" true of every task and
+// silently flatten the ranking below.
+const PRIORITY_LABEL = { 4: 'p1', 3: 'p2', 2: 'p3' };
+
+// A due date as Todoist returns it: "2026-08-27" or "2026-08-27T09:00:00".
+// Compared as strings against the station-zone ISO date, never parsed into a
+// Date — `new Date('2026-08-27')` is UTC midnight, which reads as yesterday for
+// every station west of Greenwich.
+function dueDateOf(task) {
+  const raw = task?.due?.date;
+  return typeof raw === 'string' && raw.length >= 10 ? raw.slice(0, 10) : null;
+}
+
+async function fetchTasks(token, filter, limit, services) {
+  let lastError = null;
+  for (const ep of ENDPOINTS) {
+    const url = new URL(ep.url);
+    url.searchParams.set(ep.queryParam, filter);
+    if (ep.limitParam) url.searchParams.set(ep.limitParam, String(limit));
+    try {
+      // Always bound your own network call. The station guards the whole tool
+      // at 8s, but a hung socket inside it burns the segment's budget anyway.
+      const res = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5000),
+      });
+      if (res.status === 401 || res.status === 403) {
+        // A rejected token is the operator's to fix and will reject on the
+        // other endpoint too — stop here rather than burning a second call.
+        services.log('todoist: token rejected — check TODOIST_API_TOKEN');
+        return null;
+      }
+      if (!res.ok) {
+        lastError = `HTTP ${res.status}`;
+        continue; // wrong API generation for this token — try the next shape
+      }
+      const json = await res.json();
+      const items = Array.isArray(json) ? json : json?.results;
+      if (Array.isArray(items)) return items;
+      lastError = 'unrecognised response shape';
+    } catch (err) {
+      lastError = err.message;
+    }
+  }
+  services.log(`todoist: lookup failed — ${lastError || 'no endpoint answered'}`);
+  return null;
+}
+
+export default async function todoNudge(ctx, state, services, config) {
+  // Env first: the root .env is passed wholesale into the controller, so a
+  // token there never lands in a file the admin UI renders. The config field
+  // is the fallback for stations that would rather not restart the container.
+  const token = (process.env.TODOIST_API_TOKEN || config?.token || '').trim();
+  if (!token) {
+    // A knob the operator hasn't filled in is handled HERE, not in a `ready`
+    // export — `ready(services)` doesn't get `config`, so it cannot see whether
+    // this skill is configured. Say so in the booth log, so a silent skill is
+    // explicable rather than mysterious.
+    services.log('todoist: no API token — set TODOIST_API_TOKEN in .env, or fill the token field in /admin/skills');
+    return { available: false };
+  }
+
+  const filter = String(config?.filter || DEFAULT_FILTER).trim() || DEFAULT_FILTER;
+  const max = Number(config?.maxTasks) > 0 ? Math.min(Number(config.maxTasks), 20) : DEFAULT_MAX;
+
+  const tasks = await fetchTasks(token, filter, max, services);
+  if (!tasks) return { available: false };          // already logged
+  if (!tasks.length) return { available: false };   // list is clear — say nothing
+
+  // Burn-on-read, reset daily. Without this the same top task is the answer
+  // every 90 minutes and the station turns into a person's calendar reading
+  // itself aloud. `ctx.date.iso` is the STATION-zone date, so the reset lands
+  // at local midnight rather than UTC's.
+  const today = ctx?.date?.iso || '';
+  if (state.airedOn !== today) {
+    state.airedOn = today;
+    state.airedIds = [];
+  }
+  const aired = new Set(state.airedIds || []);
+
+  const ranked = tasks
+    .map(t => ({
+      id: String(t.id),
+      content: String(t.content || '').trim(),
+      // Todoist's own wording for the due date ("tomorrow", "every Monday") —
+      // far better on air than a date, and it's what the brief asks for.
+      due: t.due?.string ? String(t.due.string) : null,
+      recurring: !!t.due?.is_recurring,
+      priority: PRIORITY_LABEL[t.priority] || null,
+      overdue: !!(today && dueDateOf(t) && dueDateOf(t) < today),
+    }))
+    .filter(t => t.content && !aired.has(t.id))
+    // Overdue first, then flagged priority, then the order Todoist gave.
+    .sort((a, b) => (Number(b.overdue) - Number(a.overdue)) || (Number(!!b.priority) - Number(!!a.priority)));
+
+  // Everything left has already been aired today. Repeating one would be the
+  // nagging this skill exists to avoid.
+  if (!ranked.length) return { available: false };
+
+  const pick = ranked[0];
+  state.airedIds = [...aired, pick.id].slice(-60);
+
+  return {
+    available: true,
+    owner: config?.owner || null,   // null → the DJ just won't name anyone
+    task: pick.content,
+    due: pick.due,
+    recurring: pick.recurring,
+    priority: pick.priority,
+    overdue: pick.overdue,
+    // How many are outstanding in total, for the DJ to lean on if it's funny.
+    remaining: tasks.length,
+  };
+}


### PR DESCRIPTION
## What

A third copy-ready example under `docs/examples/skills` — `todoist`. Between records the DJ pulls one outstanding task off the operator's Todoist list and dares the room to go and do it before the next track ends. `SKILL.md` + `tool.mjs`, plus the two spots in `docs/custom-skills.md` that enumerate the examples.

## Why

The two existing examples cover the small end (`moon-phase`: no settings, no network) and a public keyless API (`sunset`). Nothing showed the shape most operators actually want to write next: an **authenticated** third-party API, where the token has to live somewhere sane and an empty or unreachable list has to stand the skill down rather than let the model invent something.

It also answers a request in its own right — a between-track reminder segment that pushes tasks at the listeners instead of reading a list at them.

## How tested

Docs/example only — no controller, web, or mcp-subwave source touched, so the lint gates are unaffected.

- Ran `tool.mjs` against the loader's tool contract with a stubbed `fetch`, 8 cases: no token, v1 `{ results }` shape and ranking, burn-on-read across three firings, the daily reset, the REST v2 fallback, a 401 short-circuit, an empty list, and env-token-beats-config plus a network throw. All pass.
- Verified the `SKILL.md` frontmatter parses as real YAML (the loader's parser) and that `configFields` survives `parseConfigFields` — 4 fields, no reserved keys, hints inside the length cap.
- Not exercised against a live Todoist account — I have no token, and `developer.todoist.com` is egress-blocked from this environment. See the note below.

## Notes for reviewers

- **Token placement.** `state/secrets.env` only loads an allowlisted key set (`SECRET_ENV_KEYS`), so an arbitrary `TODOIST_API_TOKEN` there would be silently dropped. The documented path is the root `.env`, which compose passes into the controller wholesale. There is a config-field fallback for stations that would rather not restart the container, with a hint saying plainly that it lands in plain text in the skill's own `SKILL.md`.
- **Two API generations are tried**, v1 `/api/v1/tasks/filter?query=` first, then REST v2 `/rest/v2/tasks?filter=`, accepting both `{ results }` and a bare array. I could not reach Todoist's docs to confirm which endpoint a given token answers on, so this is doing real work rather than being defensive padding — and the failure it prevents is the bad kind, where an endpoint change is indistinguishable from an empty list and the skill just goes quiet. A 401/403 stops after one call instead of burning a second.
- **Nudge, not nag.** One task per firing, burned on read until the date rolls. The reset keys off `ctx.date.iso` (station zone) rather than a `Date` — `new Date('2026-08-27')` is UTC midnight, which reads as yesterday for every station west of Greenwich. Same reason due dates are compared as strings.
- Todoist's `priority: 1` is the default every task carries, so it is deliberately absent from the label map. Labelling it `p4` made "has a priority flag" true of every task and silently flattened the ranking — caught by the burn-on-read test case.
- **Deliberately not an 8th built-in.** It needs a personal API key, so seeding it into every station would put an inert entry in everyone's skill list, and promoting it means touching the "seven built-ins" copy in six places plus the admin icon map. Happy to do that instead if you'd rather it shipped pre-installed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScFS5QiR261uKa4unda4s8)_