### PR TITLE
docs(contributing): ask bug reports to include the running version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ Open an issue with:
 
 - what you expected vs. what happened,
 - steps to reproduce,
-- relevant logs (`docker compose logs -f controller` / `liquidsoap`).
+- relevant logs (`docker compose logs -f controller` / `liquidsoap`),
+- the version you are running (`git describe --tags` or the release tag).
 
 ## Pull requests
 


### PR DESCRIPTION
Adds the running version to the bug report checklist in CONTRIBUTING.md so triage can tell whether a report is against a current release.