### PR TITLE
update zod package to latest version

### DIFF
--- a/controller/package-lock.json
+++ b/controller/package-lock.json
@@ -30,7 +30,7 @@
         "tsx": "^4.19.2",
         "umap-js": "^1.4.0",
         "yaml": "^2.9.0",
-        "zod": "^4.4.3"
+        "zod": "^4.5.1"
       },
       "devDependencies": {
         "@types/express": "^5.0.0",
@@ -4633,9 +4633,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.1.tgz",
+      "integrity": "sha512-P3GqeAEOEDqKvafVGLezbg+39YW/ze4xrD4qdS0adOY8eoI3zfjv1PQM4UwQzgT8mZKXEbqtVt8K+ZKGqkMFKg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/controller/package.json
+++ b/controller/package.json
@@ -43,7 +43,7 @@
     "tsx": "^4.19.2",
     "umap-js": "^1.4.0",
     "yaml": "^2.9.0",
-    "zod": "^4.4.3"
+    "zod": "^4.5.1"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -1397,9 +1397,21 @@ async function main() {
   await test('every field stays in `required` under io:\'input\' — identical to the plain object schema', () => {
     const rendered: any = z.toJSONSchema(pickLike(), { target: 'draft-7', io: 'input' });
     assert.deepEqual(rendered.required.sort(), ['id', 'reason', 'say', 'transition']);
-    // Nullable-ness and enum values survive too — the model still sees the contract.
-    assert.deepEqual(rendered.properties.say.anyOf.map((b: any) => b.type).sort(), ['null', 'string']);
-    assert.deepEqual(rendered.properties.transition.anyOf[0].enum, ['normal', 'blend']);
+    // Nullable-ness and enum values survive too — the model still sees the
+    // contract. Draft 7 supports both `type: ["string", "null"]` (Zod 4.5's
+    // string output) and the older semantically-equivalent `anyOf` form, so pin
+    // the accepted values rather than one serializer's incidental layout.
+    const typesOf = (node: any): string[] => {
+      const direct = Array.isArray(node.type) ? node.type : node.type ? [node.type] : [];
+      const alternatives = Array.isArray(node.anyOf) ? node.anyOf.flatMap(typesOf) : [];
+      return [...new Set([...direct, ...alternatives])].sort();
+    };
+    assert.deepEqual(typesOf(rendered.properties.say), ['null', 'string']);
+    assert.deepEqual(typesOf(rendered.properties.transition), ['null', 'string']);
+    const transitionEnum = rendered.properties.transition.anyOf
+      ?.find((branch: any) => Array.isArray(branch.enum))?.enum
+      ?? rendered.properties.transition.enum;
+    assert.deepEqual(transitionEnum, ['normal', 'blend']);
     // Field descriptions still travel (they are the model's primary coaching channel).
     assert.equal(rendered.properties.id.description, 'the exact id');
   });

--- a/controller/scripts/validate-middleware.test.ts
+++ b/controller/scripts/validate-middleware.test.ts
@@ -128,21 +128,34 @@ test('flattenIssues surfaces an error on a field named like an Object.prototype 
   assert.equal(out['constructor'], 'constructor must be a string');
 });
 
-test('flattenIssues surfaces an error on a field literally named __proto__', () => {
-  // An object LITERAL can't carry a real own '__proto__' key (the literal form
-  // sets the prototype instead), so both the schema shape and the input are
-  // built the same null-prototype way the accumulator itself is.
-  const shape: Record<string, z.ZodTypeAny> = Object.create(null);
-  shape['__proto__'] = z.string({ error: 'proto must be a string' });
-  const input: Record<string, unknown> = Object.create(null);
-  input['__proto__'] = 1;
-  const r = z.object(shape).safeParse(input);
-  assert.equal(r.success, false);
-  const out = flattenIssues(r.error);
+test('flattenIssues surfaces an issue whose path is literally __proto__', () => {
+  // Zod 4.5 reserves and drops an own `__proto__` object key before evaluating
+  // an object shape, so using z.object({ __proto__: ... }) no longer exercises
+  // the formatter. Issue paths can still come from refinements and other Zod
+  // schemas, and flattenIssues must represent every path without prototype
+  // mutation. Construct the error directly to pin that actual contract.
+  const error = new z.ZodError([
+    { code: 'custom', path: ['__proto__'], message: 'proto must be a string' },
+  ]);
+  const out = flattenIssues(error);
   assert.equal(out['__proto__'], 'proto must be a string');
   // And the accumulator itself must not have been mutated into a prototype set.
   assert.equal(Object.getPrototypeOf(out), null);
   assert.deepEqual(Object.keys(out), ['__proto__']);
+});
+
+test('zod strips an own __proto__ payload key instead of copying it to parsed data', () => {
+  // This is the safe Zod 4.5 boundary behaviour for the reserved key: normal
+  // fields survive, `__proto__` cannot become either an own output property or
+  // a prototype mutation, and nothing reaches Object.prototype.
+  const input: Record<string, unknown> = Object.create(null);
+  input['name'] = 'safe';
+  input['__proto__'] = { polluted: true };
+  const parsed = z.object({ name: z.string() }).parse(input);
+  assert.deepEqual(parsed, { name: 'safe' });
+  assert.equal(Object.hasOwn(parsed, '__proto__'), false);
+  assert.equal((parsed as Record<string, unknown>)['polluted'], undefined);
+  assert.equal(({} as Record<string, unknown>)['polluted'], undefined);
 });
 
 test('a null-prototype accumulator still serialises and enumerates normally', () => {

--- a/controller/scripts/validate-wire-shape.test.ts
+++ b/controller/scripts/validate-wire-shape.test.ts
@@ -99,6 +99,23 @@ test('a valid body is REPLACED with the parsed value before the handler', async 
   });
 });
 
+test('a reserved __proto__ payload key is stripped before the handler', async () => {
+  // Zod 4.5 deliberately reserves this key. The middleware must hand the route
+  // only parsed data: no own `__proto__`, no prototype mutation, and no global
+  // pollution, while valid fields continue through normally.
+  const body: Record<string, unknown> = Object.create(null);
+  body['label'] = 'Safe';
+  body['field'] = 'genre';
+  body['values'] = ['ambient'];
+  body['__proto__'] = { polluted: true };
+  const r = await run(validateBody(blockRuleSchema), body);
+  assert.equal(r.nexted, true);
+  assert.equal(Object.hasOwn(r.reqBody as object, '__proto__'), false);
+  assert.equal((r.reqBody as Record<string, unknown>)['polluted'], undefined);
+  assert.equal(({} as Record<string, unknown>)['polluted'], undefined);
+  assert.equal((r.reqBody as Record<string, unknown>)['label'], 'Safe');
+});
+
 test("the 'verbatim' posture changes only the flat string, never fieldErrors", async () => {
   const body = { label: '', field: 'genre', values: ['x'] };
   const prefixed = await run(validateBody(blockRuleSchema), body);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -64,7 +64,7 @@
         "tw-animate-css": "^1.4.0",
         "use-stick-to-bottom": "^1.1.6",
         "usehooks-ts": "^3.1.1",
-        "zod": "^4.4.3"
+        "zod": "^4.5.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.3.0",
@@ -12808,9 +12808,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.1.tgz",
+      "integrity": "sha512-P3GqeAEOEDqKvafVGLezbg+39YW/ze4xrD4qdS0adOY8eoI3zfjv1PQM4UwQzgT8mZKXEbqtVt8K+ZKGqkMFKg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web/package.json
+++ b/web/package.json
@@ -67,7 +67,7 @@
     "tw-animate-css": "^1.4.0",
     "use-stick-to-bottom": "^1.1.6",
     "usehooks-ts": "^3.1.1",
-    "zod": "^4.4.3"
+    "zod": "^4.5.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.3.0",


### PR DESCRIPTION
Closes #1529

## Summary

Independent review approved the recovered Zod 4.5.1 update across controller and web.

## Changes

- `controller/package.json`: Updates the controller Zod dependency to 4.5.1.
- `controller/package-lock.json`: Locks the controller dependency graph to Zod 4.5.1.
- `web/package.json`: Updates the web Zod dependency to 4.5.1, preserving controller and web parity.
- `web/package-lock.json`: Locks the web dependency graph to Zod 4.5.1.
- `controller/scripts/llm-pure.test.ts`: Recovers the Zod 4.5 compatibility coverage for LLM-pure schemas.
- `controller/scripts/validate-middleware.test.ts`: Recovers middleware validation compatibility coverage for Zod 4.5.
- `controller/scripts/validate-wire-shape.test.ts`: Adds the recovered wire-shape compatibility coverage.

## Acceptance criteria

- [x] Controller and web use Zod 4.5.1 and remain version-aligned.: Both manifests and lockfiles resolve Zod 4.5.1, and the parity check passed.
- [x] The compatibility coverage from the earlier update is recovered.: The LLM-pure, middleware validation, and wire-shape checks are present and passed.
- [x] The update is independently reviewed without a branch-specific regression.: Independent review approved the branch; remaining full-suite failures reproduce on unchanged develop.

## Verification

- `focused Zod compatibility tests`: passed
- `generated-file drift checks`: passed
- `controller and web dependency parity check`: passed
- `controller and MCP lint checks`: passed
- `web production build`: passed
- `full controller suite on branch and develop`: the same missing-numpy and pending-promise failures reproduce on unchanged develop

## Deviations

- None.

## Known limitations

- The full controller suite still reports a missing Python numpy dependency and existing voice-air-events pending-promise cancellations; both reproduce on unchanged develop.

## Reviewer suggestions

- None.