### PR TITLE
tag-library-batch: LLM deadlocks between tool_choice=required and a "Return ONLY JSON" instruction

### DIFF
--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -14,6 +14,8 @@ import { stripThinking, truncationError, extractJson, usageOf, perfOf, warningsO
 import { withDeadline, withTransientRetry, retryAfterMs } from '../src/llm/internal/core/retry.js';
 import { reasoningFor, needsToolCallObject, repeatPenaltyApplies, appliedNumCtx, appliedRepeatPenalty, forcedToolChoice, discoveryStepsFor, gatedMaxStepsFor, runDiscoverySteps, DISCOVERY_STEPS_MIN, DISCOVERY_STEPS_MAX } from '../src/llm/internal/provider/capabilities.js';
 import { agentPlan } from '../src/llm/internal/strategy/plan.js';
+import { objectViaToolCall, emitInstructions, EMIT_ANSWER_INSTRUCTION } from '../src/llm/internal/strategy/object-via-tool.js';
+import { NATIVE_JSON_INSTRUCTION } from '../src/llm/internal/strategy/object.js';
 import { introBudgetPhrase, enforceIntroBudget } from '../src/llm/internal/prompts/intro-budget.js';
 import { embeddingBaseUrl } from '../src/llm/internal/provider/embedding.js';
 import { DEFAULT_LOCCA_EMBED_BASE_URL, openAICompatibleFetch } from '../src/llm/internal/provider/registry.js';
@@ -587,6 +589,75 @@ async function main() {
     for (const cfg of [{ provider: 'anthropic' }, { provider: 'openai' }, { provider: 'ollama' }, { provider: 'anthropic', discoverySteps: 5 }]) {
       assert.equal(runDiscoverySteps(cfg, false), DISCOVERY_STEPS_MIN, JSON.stringify(cfg));
       assert.equal(runDiscoverySteps(cfg, true), discoveryStepsFor(cfg), JSON.stringify(cfg));
+    }
+  });
+
+  // ---- Forced-tool transport instruction (issue #1536) ----
+  // The forced-tool branch states its OWN answer channel, in the system channel,
+  // and no caller states one. Callers cannot: needsToolCallObject picks the
+  // branch per LEG at call time, so a caller's output-channel wording is right
+  // on one branch and wrong on the other two. The tagger's "Return ONLY a JSON
+  // object" met toolChoice:'required' and gemma-4-12b on llama.cpp spent whole
+  // generations deciding which of the two to obey, tagging zero tracks.
+  //
+  // Asserted against a MOCK MODEL rather than a string, because the property
+  // that matters is that the instruction reaches the wire — a constant that
+  // exists but is no longer composed into `instructions` is the regression.
+  // The mock answers with text and never calls `emit`, which is the #1536
+  // failure itself: objectViaToolCall throws, and what we pin is what the model
+  // had been told before it did.
+  console.log('objectViaToolCall (the forced-tool branch carries its own answer channel):');
+  async function forcedToolCall(system?: string) {
+    let seen: any;
+    const model = new MockLanguageModelV3({
+      doGenerate: async (opts: any) => {
+        seen = opts;
+        return {
+          content: [{ type: 'text', text: 'here is the answer instead of calling the tool' }],
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          warnings: [],
+        };
+      },
+    });
+    const err: any = await objectViaToolCall(
+      { model, cfg: { provider: 'ollama', reasoning: false } },
+      { system, prompt: 'tag these', schema: z.object({ a: z.string() }), temperature: 0.2, maxOutputTokens: 256 },
+    ).catch((e: any) => e);
+    return { seen, err };
+  }
+  await test('the emit instruction reaches the model alongside the caller system prompt', async () => {
+    const { seen, err } = await forcedToolCall('CALLER SYSTEM PROMPT');
+    assert.match(String(err?.message), /never called the emit tool/);
+    // Serialised, so the assertion does not depend on how the SDK shapes the
+    // system turn — only on the text having been sent.
+    const wire = JSON.stringify(seen.prompt);
+    assert.ok(wire.includes('CALLER SYSTEM PROMPT'), 'caller system prompt survives');
+    assert.ok(wire.includes(EMIT_ANSWER_INSTRUCTION), 'transport instruction is appended');
+    assert.equal(seen.toolChoice?.type, 'required');
+    assert.deepEqual((seen.tools || []).map((t: any) => t.name), ['emit']);
+  });
+  await test('a caller with no system prompt still gets the instruction', async () => {
+    const { seen } = await forcedToolCall(undefined);
+    assert.ok(JSON.stringify(seen.prompt).includes(EMIT_ANSWER_INSTRUCTION));
+  });
+  await test('the instruction goes LAST, nearest the model turn', () => {
+    assert.ok(emitInstructions('SYSTEM').endsWith(EMIT_ANSWER_INSTRUCTION));
+    assert.equal(emitInstructions(''), EMIT_ANSWER_INSTRUCTION);
+    assert.equal(emitInstructions(undefined), EMIT_ANSWER_INSTRUCTION);
+  });
+  await test("the NATIVE branch's rule stays a FORMAT rule, never a channel rule", () => {
+    // Its job is to carry the shape for `openrouter`/`gateway` legs whose
+    // downstream model ignores response_format. It must NOT tell the model where
+    // to put the answer: @ai-sdk/anthropic implements responseFormat:'json' by
+    // forcing a synthesized `json` tool, so "reply with JSON, don't call a tool"
+    // here would recreate #1536 on Anthropic — the same collision, other branch.
+    assert.match(NATIVE_JSON_INSTRUCTION, /single JSON object/i, 'still carries the shape');
+    for (const channelWord of ['tool', 'reply', 'respond', 'instead']) {
+      assert.ok(
+        !NATIVE_JSON_INSTRUCTION.toLowerCase().includes(channelWord),
+        `native rule must not name an answer channel (found "${channelWord}")`,
+      );
     }
   });
 

--- a/controller/scripts/tagger-prompt.test.ts
+++ b/controller/scripts/tagger-prompt.test.ts
@@ -1,38 +1,87 @@
+// The tagger prompts state the tagging CONTRACT and nothing about transport.
+//
+// Two different rules are pinned here, and they fail for different reasons:
+//
+//   1. Contract — the vocabulary, the three energies, and (batch) one entry per
+//      input track in input order. These are not prose preferences: sanitizeTag
+//      drops any mood outside moodVocab() and nulls any energy outside the three,
+//      and tagBatch THROWS on a length mismatch and maps results positionally.
+//      A prompt that stops stating them degrades silently into empty tags.
+//
+//   2. No transport wording — issue #1536. Which output channel a tag call uses
+//      is chosen per LEG inside djObject: a forced `emit` tool call for
+//      ollama/openai-compatible/locca, the provider's native structured output
+//      for the cloud providers, free text on the recovery attempt. Each branch
+//      states its own rule (EMIT_ANSWER_INSTRUCTION / NATIVE_JSON_INSTRUCTION /
+//      the recovery prompt). A prompt written here cannot know which branch it
+//      will run down, so any channel wording it carries is wrong on two of the
+//      three — "Return ONLY a JSON object" met toolChoice:'required' and
+//      gemma-4-12b on llama.cpp deadlocked choosing between them, tagging zero
+//      tracks. The guard is a word ban rather than a phrase match on purpose:
+//      the earlier regex matched only the two exact sentences that were removed,
+//      so "Output only JSON" or "do not call a tool" would have sailed past it.
+//      Describe the result with the literal example already in the prompt; never
+//      name a serialisation format or an answer channel.
+//
+// The other half of rule 2 — that the forced-tool branch DOES carry its
+// instruction — is pinned in scripts/llm-pure.test.ts against a mock model.
+
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { moodVocab } from '../src/settings.js';
 import { taggerBatchSystem, taggerSystem } from '../src/music/tagger-core.js';
 
-const RAW_JSON_ONLY = /\b(?:return|output)\s+only\s+(?:a\s+)?json object\b/i;
-const UNKNOWN_TRACK_FALLBACK = /\{"moods":\[\],"energy":"medium"\}/;
-const ALLOWED_ENERGIES = /"low"\s*\|\s*"medium"\s*\|\s*"high"/;
+// Words that only ever appear in a prompt to name a wire format or an answer
+// channel. None of them can occur in a mood/energy tagging contract, and none
+// collides with the shipped mood vocabulary.
+const TRANSPORT_WORDS = [
+  'json',
+  'tool',
+  'markdown',
+  'fence',
+  'code block',
+  'plain text',
+  'respond with',
+  'reply with',
+];
 
-function assertSharedTaggingContract(prompt: string): void {
-  assert.doesNotMatch(prompt, RAW_JSON_ONLY, 'prompt must not prescribe a raw JSON-only response');
-  assert.match(prompt, ALLOWED_ENERGIES, 'prompt keeps the allowed energy values');
+function assertSharedTaggingContract(label: string, prompt: string): void {
+  const lower = prompt.toLowerCase();
+  for (const word of TRANSPORT_WORDS) {
+    assert.ok(
+      !lower.includes(word),
+      `${label} must not name an output channel or wire format (found "${word}") — `
+        + 'djObject picks the channel per leg and states the rule itself (#1536)',
+    );
+  }
   assert.ok(
     prompt.includes(moodVocab().join(', ')),
-    'prompt includes the complete live mood vocabulary',
+    `${label} includes the complete live mood vocabulary — sanitizeTag drops anything outside it`,
   );
-  assert.match(prompt, UNKNOWN_TRACK_FALLBACK, 'prompt keeps the unknown-track fallback');
-  assert.match(prompt, /Do not invent\./, 'prompt keeps the anti-invention guidance');
+  assert.match(
+    prompt,
+    /"low" \| "medium" \| "high"/,
+    `${label} keeps the three allowed energies — sanitizeTag nulls anything else`,
+  );
+  assert.match(prompt, /\{"moods":\[\],"energy":"medium"\}/, `${label} keeps the unknown-track fallback`);
 }
 
-test('single-track tagger prompt is transport-neutral and preserves its result contract', () => {
+test('single-track tagger prompt states the contract and no transport', () => {
   const prompt = taggerSystem();
 
-  assertSharedTaggingContract(prompt);
-  assert.match(prompt, /"moods": \[1-3 strings/, 'prompt keeps the one-to-three moods constraint');
-  assert.match(prompt, /"energy":/, 'prompt keeps the energy field');
+  assertSharedTaggingContract('taggerSystem()', prompt);
+  assert.match(prompt, /"moods": \[1-3 strings/, 'keeps the one-to-three moods constraint');
 });
 
-test('batch tagger prompt is transport-neutral and preserves count and order constraints', () => {
+test('batch tagger prompt additionally pins cardinality and order', () => {
   const prompt = taggerBatchSystem();
 
-  assertSharedTaggingContract(prompt);
-  assert.match(prompt, /"results": \[/, 'prompt keeps the results array shape');
-  assert.match(prompt, /moods: 1-3 strings/, 'prompt keeps the per-entry mood constraint');
-  assert.match(prompt, /exactly one entry per input track/i, 'prompt keeps the batch cardinality');
-  assert.match(prompt, /same order as the numbered list/i, 'prompt keeps input order');
-  assert.match(prompt, /for that entry/i, 'prompt scopes the unknown fallback to one batch entry');
+  assertSharedTaggingContract('taggerBatchSystem()', prompt);
+  assert.match(prompt, /"results": \[/, 'keeps the results array shape');
+  assert.match(prompt, /moods: 1-3 strings/, 'keeps the per-entry mood constraint');
+  // tagBatch throws `batch length mismatch` and maps results positionally, so
+  // both halves of this are load-bearing, not phrasing.
+  assert.match(prompt, /exactly one entry per input track/i, 'keeps the batch cardinality');
+  assert.match(prompt, /same order as the numbered list/i, 'keeps input order');
+  assert.match(prompt, /for that entry/i, 'scopes the unknown fallback to one batch entry');
 });

--- a/controller/scripts/tagger-prompt.test.ts
+++ b/controller/scripts/tagger-prompt.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { moodVocab } from '../src/settings.js';
+import { taggerBatchSystem, taggerSystem } from '../src/music/tagger-core.js';
+
+const RAW_JSON_ONLY = /\b(?:return|output)\s+only\s+(?:a\s+)?json object\b/i;
+const UNKNOWN_TRACK_FALLBACK = /\{"moods":\[\],"energy":"medium"\}/;
+const ALLOWED_ENERGIES = /"low"\s*\|\s*"medium"\s*\|\s*"high"/;
+
+function assertSharedTaggingContract(prompt: string): void {
+  assert.doesNotMatch(prompt, RAW_JSON_ONLY, 'prompt must not prescribe a raw JSON-only response');
+  assert.match(prompt, ALLOWED_ENERGIES, 'prompt keeps the allowed energy values');
+  assert.ok(
+    prompt.includes(moodVocab().join(', ')),
+    'prompt includes the complete live mood vocabulary',
+  );
+  assert.match(prompt, UNKNOWN_TRACK_FALLBACK, 'prompt keeps the unknown-track fallback');
+  assert.match(prompt, /Do not invent\./, 'prompt keeps the anti-invention guidance');
+}
+
+test('single-track tagger prompt is transport-neutral and preserves its result contract', () => {
+  const prompt = taggerSystem();
+
+  assertSharedTaggingContract(prompt);
+  assert.match(prompt, /"moods": \[1-3 strings/, 'prompt keeps the one-to-three moods constraint');
+  assert.match(prompt, /"energy":/, 'prompt keeps the energy field');
+});
+
+test('batch tagger prompt is transport-neutral and preserves count and order constraints', () => {
+  const prompt = taggerBatchSystem();
+
+  assertSharedTaggingContract(prompt);
+  assert.match(prompt, /"results": \[/, 'prompt keeps the results array shape');
+  assert.match(prompt, /moods: 1-3 strings/, 'prompt keeps the per-entry mood constraint');
+  assert.match(prompt, /exactly one entry per input track/i, 'prompt keeps the batch cardinality');
+  assert.match(prompt, /same order as the numbered list/i, 'prompt keeps input order');
+  assert.match(prompt, /for that entry/i, 'prompt scopes the unknown fallback to one batch entry');
+});

--- a/controller/src/llm/internal/strategy/object-via-tool.ts
+++ b/controller/src/llm/internal/strategy/object-via-tool.ts
@@ -10,6 +10,36 @@ import { generateText, tool, isStepCount } from 'ai';
 import { usageOf, perfOf, warningsOf } from '../core/pure.js';
 import { reasoningFor, forcedToolChoice } from '../provider/capabilities.js';
 
+// The TRANSPORT rule for this path, stated in the system channel because that
+// is where the model weighs it. It lives HERE, not in any caller's prompt, for
+// the reason every other cross-cutting decision in this codebase lives in one
+// module: the caller cannot know which branch djObject will take
+// (needsToolCallObject resolves that per LEG, at call time), so a caller that
+// writes its own output-channel instruction is guessing — and half the time it
+// guesses against the transport actually chosen.
+//
+// Issue #1536 is that failure with a measurement attached: the tagger's prompt
+// said "Return ONLY a JSON object" while this path sent toolChoice:'required',
+// and gemma-4-12b on llama.cpp spent its whole generation budget arguing with
+// itself over which of the two to obey ("Wait! I just noticed... 'Return ONLY'.
+// ... Tool calls are often used for *actions*. I'll go with direct output.")
+// before being cancelled. The `emit` tool's DESCRIPTION already said calling it
+// is how you answer; a tool description does not carry the weight a system
+// instruction does against a system instruction pulling the other way.
+//
+// Kept to one line, no double quotes: it is prepended to every forced-object
+// call on every leg, including the picker's terminal collapse.
+export const EMIT_ANSWER_INSTRUCTION =
+  'Answer by calling the `emit` tool exactly once with the complete result — the tool call IS your answer. Do not write the result as text, JSON or a code block in your reply.';
+
+// The caller's system prompt with the transport rule appended, or the rule
+// alone when the caller has no system prompt. Last, so it is the nearest thing
+// to the model's turn.
+export function emitInstructions(system?: string): string {
+  const base = typeof system === 'string' ? system.trim() : '';
+  return base ? `${base}\n\n${EMIT_ANSWER_INSTRUCTION}` : EMIT_ANSWER_INSTRUCTION;
+}
+
 export async function objectViaToolCall(
   leg: any,
   { system, prompt, messages, schema, temperature, maxOutputTokens, signal }: any,
@@ -24,7 +54,7 @@ export async function objectViaToolCall(
     // Forced single-tool call — always no-think (the no-think model is identical
     // to leg.model except for OpenRouter, where reasoning is fixed at build time).
     model: leg.noThinkModel ?? leg.model,
-    instructions: system,
+    instructions: emitInstructions(system),
     ...(messages ? { messages } : { prompt }),
     temperature,
     maxOutputTokens,

--- a/controller/src/llm/internal/strategy/object.ts
+++ b/controller/src/llm/internal/strategy/object.ts
@@ -11,6 +11,15 @@
 //                   Zod-validate ourselves. Catches models that wrap the JSON
 //                   in reasoning the native parser chokes on.
 // Throws only if BOTH attempts fail.
+//
+// EACH branch states its own output rule, and no caller states one. A system
+// prompt is written once and then runs down whichever branch the LEG resolves
+// to (needsToolCallObject, per call), so an output-channel instruction written
+// at the call site is right on one branch and wrong on another — issue #1536,
+// where the tagger's "Return ONLY a JSON object" met the forced-tool branch and
+// a 12B local model deadlocked choosing between them. Keep the rules here:
+// EMIT_ANSWER_INSTRUCTION (tool), NATIVE_JSON_INSTRUCTION (native), and the
+// recovery prompt's own line below.
 
 import { generateText, Output } from 'ai';
 import { withFailover } from '../core/failover.js';
@@ -23,6 +32,25 @@ import { resolveMaxOutputTokens } from '../../../settings.js';
 // Operator-overridable via settings.llm.maxOutputTokens (issue #712); 0 keeps
 // this default.
 const MAX_TOKENS_OBJECT = 8000;
+
+// The output rule for the NATIVE branch. Output.object forwards the schema as
+// the provider's own structured-output mode, which is enforced by constrained
+// decoding on the first-party providers — but `openrouter` and `gateway` hand
+// response_format to whatever downstream model the id resolves to, and one that
+// doesn't implement structured output simply ignores it and answers in prose.
+// Until this PR the tagger's own "output ONLY a JSON object" was what carried
+// those legs; removing it from the prompt without restating it here would have
+// pushed every such call into the recovery attempt — a second billable call per
+// batch, against settings.llm.dailyTokenCap, on a bulk job that runs per track.
+//
+// Deliberately a FORMAT rule, not a channel rule: it says what the result must
+// look like and never where to put it. @ai-sdk/anthropic implements
+// responseFormat:'json' by forcing a synthesized `json` tool, so a line here
+// reading "reply with JSON, do not call a tool" would recreate #1536 on
+// Anthropic — the exact conflict this change exists to remove. One line, no
+// double quotes, same as EMIT_ANSWER_INSTRUCTION.
+export const NATIVE_JSON_INSTRUCTION =
+  'The result must be a single JSON object matching the required shape — no prose, no markdown fences.';
 
 export async function djObject({
   system,
@@ -63,7 +91,10 @@ export async function djObject({
             const result = await withTransientRetry(kind, () => generateText({
               model: l.model,
               instructions: system,
-              prompt,
+              // Appended to the PROMPT, not to `system` — same placement as the
+              // recovery branch below, and it leaves the caller's system prompt
+              // byte-identical (the tagger hashes its own into prompt_hash).
+              prompt: `${prompt}\n\n${NATIVE_JSON_INSTRUCTION}`,
               temperature,
               maxOutputTokens,
               output: Output.object({ schema }),

--- a/controller/src/music/tagger-core.ts
+++ b/controller/src/music/tagger-core.ts
@@ -21,6 +21,16 @@ export const BatchTagSchema = z.object({
 // System prompts are FUNCTIONS, not consts: the mood list is operator-editable
 // (settings.moods) and read live, so the prompt — and the promptVocabHash the
 // tagger keys re-tagging on — reflect the current vocabulary each call.
+//
+// Both prompts describe the RESULT and never the output channel. Which channel
+// a tag call actually uses is decided per leg inside djObject (forced `emit`
+// tool for ollama/openai-compatible/locca, native structured output for the
+// cloud providers, free text on the recovery attempt), and each branch states
+// its own rule there. These prompts used to say "Return ONLY a JSON object",
+// which was true on one of those three branches: on the forced-tool branch it
+// contradicted toolChoice:'required' and gemma-4-12b on llama.cpp burned whole
+// generations deciding which to obey, never tagging a single batch (#1536).
+// Keep output-channel wording out of here — it cannot be right from here.
 export function taggerSystem(): string {
   return `You tag music tracks with mood and energy for a personal radio station.
 
@@ -35,7 +45,7 @@ A spiritual Punjabi devotional is "spiritual" and "reflective" — not "cultural
 A high-BPM dance track is "energetic" and "workout" — not "celebratory" unless it sounds festive.
 A slow rainy-day instrumental is "calm" and "rainy" — not "evening" just because it's chill.
 
-If you genuinely cannot tell from the title/artist/album, return {"moods":[],"energy":"medium"}. Do not invent.`;
+If you genuinely cannot tell from the title/artist/album, the result is {"moods":[],"energy":"medium"}. Do not invent.`;
 }
 
 export function taggerBatchSystem(): string {
@@ -60,7 +70,7 @@ A spiritual Punjabi devotional is "spiritual" and "reflective" — not "cultural
 A high-BPM dance track is "energetic" and "workout" — not "celebratory" unless it sounds festive.
 A slow rainy-day instrumental is "calm" and "rainy" — not "evening" just because it's chill.
 
-If you genuinely cannot tell from the title/artist/album for a track, return {"moods":[],"energy":"medium"} for that entry. Do not invent.`;
+If you genuinely cannot tell from the title/artist/album for a track, use {"moods":[],"energy":"medium"} for that entry. Do not invent.`;
 }
 
 export interface TaggableSong {

--- a/controller/src/music/tagger-core.ts
+++ b/controller/src/music/tagger-core.ts
@@ -24,7 +24,7 @@ export const BatchTagSchema = z.object({
 export function taggerSystem(): string {
   return `You tag music tracks with mood and energy for a personal radio station.
 
-For each track, output ONLY a JSON object:
+For each track, the required result has this shape:
 {
   "moods": [1-3 strings, each from this exact list: ${moodVocab().join(', ')}],
   "energy": "low" | "medium" | "high"
@@ -41,7 +41,7 @@ If you genuinely cannot tell from the title/artist/album, return {"moods":[],"en
 export function taggerBatchSystem(): string {
   return `You tag music tracks with mood and energy for a personal radio station.
 
-You will be given a numbered list of tracks. Return ONLY a JSON object of the form:
+You will be given a numbered list of tracks. The required result has this shape:
 {
   "results": [
     { "moods": [...], "energy": "low" | "medium" | "high" },


### PR DESCRIPTION
Closes #1536

## Summary

Approve. The actual diff is narrowly scoped to making both tagger prompt builders transport-neutral, preserves the specified tagging contract and all structured-output plumbing, and adds a meaningful regression test that independently fails against the base branch. Focused tests and lint/typecheck pass; the full-suite failures are unrelated environment/baseline issues.

## Changes

- `controller/src/music/tagger-core.ts`: Reworded both single-track and batch tagger system prompts to describe the required result shape without directing the model to produce a raw JSON-only response. Existing vocabulary interpolation, mood and energy constraints, examples, batch cardinality/order requirements, unknown-track fallback, and anti-invention guidance remain unchanged.
- `controller/scripts/tagger-prompt.test.ts`: Added an auto-discovered node:test regression suite covering both prompt builders. The tests reject raw JSON-only directives and pin the live vocabulary, energy values, mood count, result shape, batch count/order, fallback, and anti-invention contracts.

## Acceptance criteria

- [x] For `tag-library-batch` calls run through a locca/openai-compatible/Ollama forced-object leg with `llm.toolChoice: "required"`, the system prompt no longer instructs the model to return/output a raw JSON-only response while the request continues to require the single `emit` tool call.: `taggerBatchSystem()` now says “The required result has this shape” rather than “Return ONLY a JSON object.” The unchanged `object-via-tool.ts` still exposes only `emit` and passes `toolChoice: forcedToolChoice(leg.cfg)`, whose documented default is required. The focused regression test passes and direct prompt inspection reports no matching raw JSON-only directive.
- [x] `taggerBatchSystem()` still specifies a `results` object/array with exactly one mood/energy entry per input track, in the input order, and preserves live mood vocabulary and allowed energy values.: The batch prompt retains the `results` array shape, exact-one-per-input and same-order language, dynamic `moodVocab()` interpolation, and `low | medium | high` values. `tagger-prompt.test.ts` asserts each of these conditions; its batch test passed.
- [x] `taggerSystem()`—used by the per-track fallback—also contains no raw JSON-only output instruction and continues to specify the same mood/energy semantics and unknown-track fallback.: The single-track prompt receives the same transport-neutral wording change while retaining one-to-three moods from the live vocabulary, allowed energy values, the unknown-track `{moods:[],energy:"medium"}` fallback, and anti-invention guidance. Its focused test passed.
- [x] Non-forced structured-output behavior remains intact: no change to `TagSchema`, `BatchTagSchema`, `djObject` native structured output, recovery JSON parsing, tag sanitization, batch count mismatch handling, temperature, kind labels, or primary/fallback leg forwarding.: The real diff is limited to two prompt lines in `tagger-core.ts` plus the new test file. The schemas, `djObject` calls/options, sanitization, cardinality failure, and LLM strategy files are unchanged.
- [x] A regression test fails if a raw JSON-only directive is restored to either tagger prompt or if the retained schema/order/fallback constraints are removed.: The new auto-discovered `node:test` file asserts absence of the prior raw JSON-only forms for both builders and asserts the retained vocabulary, energy, fallback, anti-invention, batch shape, count, and order contracts. Independently copying the test onto `develop` produced two failures on the original directives, demonstrating that it would have caught this regression.
- [x] Controller lint/typecheck passes, and the focused prompt test passes (with the full controller suite run where the environment permits).: Independent `npm test -- tagger-prompt` passed both tests. `npm run lint` exited 0 (with pre-existing warning-only `any` reports) and `git diff --check` passed. The full `npm test` was run: 954 passed; the only failures were `analyzer-python.test.ts` and seven pending-promise cancellations in `voice-air-events.test.ts`, unrelated to this two-file prompt-only diff and consistent with the reported environment/baseline gap.

## Verification

- `cd /workspace/repo/controller && npm test -- tagger-prompt`: Expected red before the fix: exit 1; 2 tests ran and both failed specifically because the single and batch prompts contained the raw JSON-only directive.
- `cd /workspace/repo/controller && npm test -- tagger-prompt`: Green after the fix: exit 0; 2 tests passed, 0 failed.
- `cd /workspace/repo/controller && npm run lint`: Passed with exit 0. ESLint reported 661 existing warnings and 0 errors; TypeScript completed with no errors.
- `cd /workspace/repo/controller && npm test`: Not fully green: exit 1 after 962 tests; 954 passed, 1 failed, and 7 were cancelled. analyzer-python.test.ts failed because NumPy is unavailable; voice-air-events.test.ts had pending-promise cancellations.
- `cd /workspace/repo/controller && npm test -- analyzer-python`: Reproduced unrelated suite failure: exit 1; vocal_gate_test.py raised ModuleNotFoundError for numpy and analyzer_silence_test.py reported that NumPy is required.
- `cd /workspace/repo/controller && npm test -- voice-air-events`: Reproduced unrelated suite issue: exit 1; 8 tests passed and 7 were cancelled because promise resolution remained pending after the event loop resolved.
- `cd /workspace/repo/controller && npx eslint scripts/tagger-prompt.test.ts src/music/tagger-core.ts && npm run typecheck`: Passed with exit 0. The scripts directory is ignored by the ESLint configuration, producing one ignored-file warning; tagger-core lint and the full TypeScript no-emit check succeeded.
- `cd /workspace/repo && git diff --check`: Passed with no whitespace errors.
- `cd /workspace/repo/controller && npm test -- tagger-prompt`: Post-commit verification passed: exit 0; 2 tests passed, 0 failed.
- `git commit -m "fix(tagger): remove forced-tool JSON prompt conflict"`: Created commit cfbe1b5d3597c5bbfc33e52af5849697db300fc9 with 2 files changed, 40 insertions, and 2 deletions.

## Deviations

- None.

## Known limitations

- The environment-specific locca/llama.cpp/Gemma reproduction was not run because no configured local model endpoint was available. The prompt-builder regression test verifies the conflicting instruction is absent, but does not make a live LLM request.
- The full controller suite is not fully green for unrelated existing/environmental reasons: analyzer-python.test.ts requires NumPy, which is not installed, and voice-air-events.test.ts has seven tests cancelled because promises remain pending after the event loop resolves. Both failures reproduce when run independently.

## Reviewer suggestions

- No live locca/llama.cpp endpoint was configured, so the forced-tool request was validated by tracing the unchanged transport code and prompt-builder tests rather than by an end-to-end model call.