### PR TITLE
feat(prompt): isolate DJ links with verified facts

### DIFF
--- a/controller/scripts/agent-say-boundary.test.ts
+++ b/controller/scripts/agent-say-boundary.test.ts
@@ -1,0 +1,20 @@
+// Pins the one-call agent's listener-facing `say` boundary.
+// Run: npm test -- agent-say-boundary
+
+import assert from 'node:assert/strict';
+import { PICK_SCHEMA, PICK_SAY_BOUNDARY } from '../src/broadcast/dj-agent/schemas.js';
+
+const description = PICK_SCHEMA.shape.say.description || '';
+
+assert.match(PICK_SAY_BOUNDARY, /listener-facing speech only/);
+assert.match(PICK_SAY_BOUNDARY, /never mention tools/);
+assert.match(PICK_SAY_BOUNDARY, /internal reasoning/);
+assert.match(PICK_SAY_BOUNDARY, /selected track title or artist/);
+assert.match(PICK_SAY_BOUNDARY, /do not add or infer music-history claims/);
+
+assert.ok(description.includes(PICK_SAY_BOUNDARY),
+  'the schema field sent to the model must carry the listener-only boundary');
+assert.match(description, /When the event says stay silent, set this to null/,
+  'the existing silent-output contract remains intact');
+
+console.log('agent say boundary: all tests passed');

--- a/controller/scripts/agent-say-boundary.test.ts
+++ b/controller/scripts/agent-say-boundary.test.ts
@@ -1,20 +1,24 @@
-// Pins the one-call agent's listener-facing `say` boundary.
+// Pins the split between session-DJ selection and listener-facing speech.
 // Run: npm test -- agent-say-boundary
 
 import assert from 'node:assert/strict';
-import { PICK_SCHEMA, PICK_SAY_BOUNDARY } from '../src/broadcast/dj-agent/schemas.js';
+import { PICK_SCHEMA } from '../src/broadcast/dj-agent/schemas.js';
 
-const description = PICK_SCHEMA.shape.say.description || '';
+assert.equal('say' in PICK_SCHEMA.shape, false,
+  'the selection response must not offer a listener-facing speech field');
 
-assert.match(PICK_SAY_BOUNDARY, /listener-facing speech only/);
-assert.match(PICK_SAY_BOUNDARY, /never mention tools/);
-assert.match(PICK_SAY_BOUNDARY, /internal reasoning/);
-assert.match(PICK_SAY_BOUNDARY, /selected track title or artist/);
-assert.match(PICK_SAY_BOUNDARY, /do not add or infer music-history claims/);
+const picked = PICK_SCHEMA.parse({
+  id: 'selected-track',
+  reason: 'fresh artist',
+  transition: null,
+  say: 'this must be ignored as an unknown field',
+});
+assert.equal('say' in picked, false,
+  'a model cannot smuggle speech through the selection response');
 
-assert.ok(description.includes(PICK_SAY_BOUNDARY),
-  'the schema field sent to the model must carry the listener-only boundary');
-assert.match(description, /When the event says stay silent, set this to null/,
-  'the existing silent-output contract remains intact');
+assert.ok('reason' in PICK_SCHEMA.shape,
+  'selection keeps its internal rationale field');
+assert.ok('transition' in PICK_SCHEMA.shape,
+  'selection keeps its transition decision field');
 
 console.log('agent say boundary: all tests passed');

--- a/controller/scripts/clock-policy.test.ts
+++ b/controller/scripts/clock-policy.test.ts
@@ -35,6 +35,7 @@ const { clockEnabled, speakClockAllowed, autoTimeCheckAllowed, clockStatus } =
 const { shouldFire } = await import('../src/broadcast/dj-gate.js');
 const { buildContextLines } = await import('../src/llm/internal/prompts/context.js');
 const { pickSchemaBase } = await import('../src/broadcast/dj-agent/schemas.js');
+const { linkPrompt } = await import('../src/llm/internal/prompts/scripts.js');
 
 // A moment carrying every tag at once, so one assertion covers all three.
 const CTX = {
@@ -52,12 +53,14 @@ function periodLine(): string | undefined {
     .find((l: string) => l.startsWith('Period:'));
 }
 
-// pickSchemaBase() returns a plain ZodObject; keep the lookup tolerant of a
-// future wrap, the same way voice-policy.test.ts does for requestSchema().
-function sayDescription(): string {
-  const schema: any = pickSchemaBase();
-  const shape = schema?.def?.out?.shape ?? schema.shape;
-  return String(shape.say.description ?? '');
+// Picker output is now selection-only. Clock wording belongs exclusively to
+// the isolated post-selection link prompt.
+function linkDescription(): string {
+  return linkPrompt({
+    current: { title: 'Clock Test', artist: 'Subwave' },
+    context: CTX,
+    clockIsAirTime: speakClockAllowed(),
+  });
 }
 
 const KINDS_UNAFFECTED = ['stationId', 'banter'];
@@ -91,8 +94,10 @@ try {
   assert.ok(liveUnaffected.length > 0,
     'baseline: idents/banter fire somewhere, else the "unaffected" check is vacuous');
   assert.ok(shouldFire('hourly', atMinute(0)), 'baseline: the hourly check fires');
-  assert.match(sayDescription(), /unless the event message tells you/,
-    'clock on: the say schema keeps its conditional clock rule');
+  assert.equal('say' in (pickSchemaBase() as any).shape, false,
+    'the picker schema is selection-only');
+  assert.match(linkDescription(), /If you mention the time, use only the approximate phrase supplied in Current Context/,
+    'clock on: the isolated link writer receives the conditional clock rule');
 
   // ── OFF ────────────────────────────────────────────────────────────────────
   await settings.update({ djSpeakClock: false });
@@ -121,12 +126,10 @@ try {
   assert.deepEqual(stillLive, liveUnaffected,
     'clock off must NOT gag idents or banter — they just stop mentioning the time');
 
-  // The agent path carries its own clock rule and has to follow too.
-  const offSay = sayDescription();
-  assert.ok(!/unless the event message tells you/.test(offSay),
-    'clock off: the say schema drops the escape hatch that can never be met');
-  assert.match(offSay, /Never state a clock time/,
-    'clock off: the say schema states a flat ban');
+  // The isolated link writer carries the clock policy after selection.
+  const offLink = linkDescription();
+  assert.match(offLink, /Do not state a clock time; no verified air time was supplied/,
+    'clock off: the link writer states a flat ban');
 
   // ── Back ON: everything resumes exactly ────────────────────────────────────
   await settings.update({ djSpeakClock: true });

--- a/controller/scripts/link-style.test.ts
+++ b/controller/scripts/link-style.test.ts
@@ -105,25 +105,15 @@ test('natural link clause output is unchanged versus the pre-extraction template
   );
 });
 
-// ── scripts.ts's pure prompt builder (linkPrompt) ────────────────────────────
+// ── scripts.ts's isolated writer prompt ─────────────────────────────────────
 
-test('announce link prompt names the artist in the fixed two-form contract', () => {
+test('the isolated writer prompt never carries the announce-model contract', () => {
   const prompt = linkPrompt({
-    announce: true,
-    current: { artist: 'Marvin Gaye' },
-    teaseClause: ' Name the artist or capture the feel so listeners know what they\'re hearing.',
-    patterClause: '',
-    budget: null,
-    lengthPhraseText: 'one or two sentences',
-    clockClause: ' Never state the clock time.',
-    feelClause: ' A feel note...',
+    current: { title: 'Unknown', artist: 'Marvin Gaye' },
+    context: null,
   });
-  assert.match(prompt, /This is Marvin Gaye\./);
-  assert.match(prompt, /Next up, Marvin Gaye\./);
-  assert.doesNotMatch(prompt, /Vary how you open/);
-  assert.doesNotMatch(prompt, /feel note/);
-  assert.doesNotMatch(prompt, /Never state the clock time/);
-  assert.doesNotMatch(prompt, /[Aa]lternate/);
+  assert.match(prompt, /Verified Facts:/);
+  assert.doesNotMatch(prompt, /This is Marvin Gaye\.|Next up, Marvin Gaye\./);
 });
 
 // ── announce-line.ts — the station composes and alternates, the model never does ──
@@ -261,38 +251,22 @@ test('generateLink in announce mode drops the link when the track has no artist'
   }
 });
 
-test('the announce prompt never carries a placeholder in place of an artist name', () => {
+test('the isolated writer prompt never carries an announce placeholder', () => {
   const prompt = linkPrompt({
-    announce: true,
-    current: { artist: '' },
-    teaseClause: '', patterClause: '', budget: null,
-    lengthPhraseText: 'one or two sentences', clockClause: '', feelClause: '',
+    current: { title: 'Untitled', artist: '' },
+    context: null,
   });
   assert.doesNotMatch(prompt, /<artist>/);
-  // With no name to announce it falls back to the well-formed natural ask
-  // rather than a two-form contract it cannot fill.
-  assert.match(prompt, /Write a short DJ link/);
+  assert.match(prompt, /Task: Give a brief spoken introduction/);
 });
 
-test('natural link prompt is unchanged versus the pre-extraction template', () => {
+test('natural link prompt exposes only the bounded verified-facts packet', () => {
   const prompt = linkPrompt({
-    announce: false,
-    current: { artist: 'Marvin Gaye' },
-    teaseClause: ' Name the artist or capture the feel so listeners know what they\'re hearing.',
-    patterClause: '',
-    budget: null,
-    lengthPhraseText: 'one or two sentences',
-    clockClause: ' Never state the clock time.',
-    feelClause: '',
+    current: { title: 'Unknown', artist: 'Marvin Gaye' },
+    context: { time: { vibe: 'private selection steer' } },
   });
-  assert.equal(
-    prompt,
-    `Write a short DJ link to carry into the track now starting — set it up, capture its feel, weave in the moment.`
-      + ` Name the artist or capture the feel so listeners know what they're hearing. one or two sentences, conversational.`
-      + ` Vary how you open — don't default to "here's", "this is", "coming up", or "that was"; find a different way in each time.`
-      + ` Keep it forward-looking: don't back-announce, recap, or name the track that just played — focus on what's playing now.`
-      + ` Never state the clock time.`,
-  );
+  assert.match(prompt, /Track on air:\n- Unknown by Marvin Gaye/);
+  assert.doesNotMatch(prompt, /private selection steer/);
 });
 
 // ── the air-truth anchor the alternation reads ───────────────────────────────
@@ -323,11 +297,10 @@ test('getLastLinkText returns the most recently aired link and ignores other kin
 // — which is what a bare announceLinks() resolves to. Written the incoming
 // DJ's line under the outgoing DJ's link contract. Source-level because the
 // two personas only diverge inside a live look-ahead window.
-test('every announce-mode call site names the persona it resolves against', async () => {
+test('the deterministic announce writer resolves against its explicit persona', async () => {
   const { readFileSync } = await import('node:fs');
   for (const file of [
-    '../src/broadcast/dj-agent.ts',
-    '../src/broadcast/dj-agent/schemas.ts',
+    '../src/llm/internal/prompts/scripts.ts',
   ]) {
     const src = readFileSync(new URL(file, import.meta.url), 'utf8');
     assert.doesNotMatch(
@@ -335,6 +308,6 @@ test('every announce-mode call site names the persona it resolves against', asyn
       /announceLinks\(\s*\)/,
       `${file} calls announceLinks() with no persona — it must pass session.onAirPersona()`,
     );
-    assert.match(src, /announceLinks\(\s*(?:link)?[Ss]peaker|announceLinks\(session\.onAirPersona\(\)\)/);
+    assert.match(src, /announceLinks\(speaker\)/);
   }
 });

--- a/controller/scripts/show-handover-facts.test.ts
+++ b/controller/scripts/show-handover-facts.test.ts
@@ -1,0 +1,37 @@
+// Deterministic schedule facts for final-quarter-hour links and station IDs.
+// Run: npm test -- show-handover-facts
+
+import assert from 'node:assert/strict';
+import { showHandoverContext } from '../src/context.js';
+import { linkPrompt, stationIdPrompt } from '../src/llm/internal/prompts/scripts.js';
+
+const now = new Date('2026-09-05T10:45:00.000Z');
+const boundary = new Date('2026-09-05T11:00:00.000Z');
+const resolveShow = (at: Date) => at.getTime() < boundary.getTime()
+  ? { id: 'current', name: 'The Scenic Route', persona: { name: 'Chris' } }
+  : { id: 'next', name: 'Lunchtime Rocks', persona: { name: 'Carrie' } };
+
+const handover = showHandoverContext(now, resolveShow);
+assert.deepEqual(handover, {
+  phase: 'final-quarter-hour',
+  nextShow: { name: 'Lunchtime Rocks', presenter: 'Carrie', startsAt: 'eleven in the morning' },
+});
+assert.equal(showHandoverContext(new Date('2026-09-05T10:44:59.000Z'), resolveShow), null);
+
+const context = {
+  activeShow: { name: 'The Scenic Route' },
+  showHandover: handover,
+};
+const link = linkPrompt({ current: { title: 'Headlong', artist: 'Queen' }, context });
+assert.match(link, /Show progress: final 15 minutes/);
+assert.match(link, /Following show: "Lunchtime Rocks" with Carrie/);
+
+const stationId = stationIdPrompt({ context, persona: { name: 'Chris', scriptLength: 'concise' } });
+assert.match(stationId, /The next scheduled show is "Lunchtime Rocks" with Carrie/);
+assert.match(stationId, /one brief nod/);
+assert.doesNotMatch(
+  stationIdPrompt({ context: { activeShow: { name: 'The Scenic Route' } }, persona: { name: 'Chris' } }),
+  /The next scheduled show is/,
+);
+
+console.log('show handover facts: all tests passed');

--- a/controller/scripts/verified-facts.test.ts
+++ b/controller/scripts/verified-facts.test.ts
@@ -1,78 +1,36 @@
-// Unit tests for the deterministic facts handed to the main DJ link prompt.
+// Contract tests for the post-selection PersonaLink fact packet.
 // Run: npm test -- verified-facts
 
 import assert from 'node:assert/strict';
-import {
-  selectSleeveNotes,
-  sleeveNotesFor,
-  verifiedFactsForLink,
-  verifiedFactsSection,
-} from '../src/llm/internal/prompts/sleeve-notes.js';
-
-let failures = 0;
-function test(name: string, fn: () => void) {
-  try {
-    fn();
-    console.log(`  ✓ ${name}`);
-  } catch (err: any) {
-    failures++;
-    console.error(`  ✗ ${name}\n      ${err?.message || err}`);
-  }
-}
+import { sleeveNotesFor, contextSleeveNotesFor } from '../src/llm/internal/prompts/sleeve-notes.js';
+import { linkPrompt } from '../src/llm/internal/prompts/scripts.js';
 
 const track = (over: Record<string, unknown> = {}) => ({
-  title: 'After Laughter (Comes Tears)',
-  artist: 'Wendy Rene',
-  album: 'After Laughter Comes Tears',
-  year: 2012,
-  originalYear: 1964,
-  yearUntrusted: false,
-  ...over,
+  title: 'After Laughter (Comes Tears)', artist: 'Wendy Rene',
+  album: 'After Laughter Comes Tears', year: 2012, originalYear: 1964,
+  yearUntrusted: false, ...over,
 });
 
-test('uses the resolved original year, not a reissue year', () => {
-  assert.deepEqual(sleeveNotesFor(track(), 3), [
-    'Album: After Laughter Comes Tears.',
-    'Release year: 1964.',
-    'Station plays before today: 3.',
-  ]);
-});
+assert.deepEqual(sleeveNotesFor(track(), 3), [
+  'Album: After Laughter Comes Tears.', 'Release year: 1964.', 'Station plays before today: 3.',
+]);
+assert.deepEqual(contextSleeveNotesFor(track(), {
+  date: { season: 'summer' }, weather: { condition: 'cloudy', location: 'The Ribble Valley' },
+}), ['Album: After Laughter Comes Tears.', 'Release year: 1964.', 'Season: summer.', 'Weather in The Ribble Valley: cloudy.']);
 
-test('does not assert an unresolved compilation year', () => {
-  assert.deepEqual(sleeveNotesFor(track({ originalYear: null, yearUntrusted: true }), null), [
-    'Album: After Laughter Comes Tears.',
-  ]);
+const prompt = linkPrompt({
+  current: track(), clockIsAirTime: true,
+  context: {
+    date: { dayLabel: 'Friday', season: 'summer' },
+    clock: { display: '8:30 pm', hhmm: '20:30' },
+    time: { vibe: 'sustained energy' },
+    activeShow: { name: 'Night Drive', moods: ['euphoric'] },
+  },
 });
-
-test('does not repeat a self-titled album or invent a missing play count', () => {
-  assert.deepEqual(sleeveNotesFor(track({ album: 'After Laughter (Comes Tears)' }), null), [
-    'Release year: 1964.',
-  ]);
-});
-
-test('selects one supplemental fact with an injectable random seam', () => {
-  const notes = ['Album: A.', 'Release year: 1999.', 'Station plays before today: 4.'];
-  assert.deepEqual(selectSleeveNotes(notes, () => 0), ['Album: A.']);
-  assert.deepEqual(selectSleeveNotes(notes, () => 0.99), ['Station plays before today: 4.']);
-});
-
-test('builds a bounded verified packet and formats a distinct facts section', () => {
-  const facts = verifiedFactsForLink(track(), 3, () => 0);
-  assert.deepEqual(facts, [
-    'Track: "After Laughter (Comes Tears)" by Wendy Rene.',
-    'Album: After Laughter Comes Tears.',
-  ]);
-  assert.equal(verifiedFactsSection(facts),
-    'Verified facts:\n- Track: "After Laughter (Comes Tears)" by Wendy Rene.\n- Album: After Laughter Comes Tears.');
-});
-
-test('malformed track data produces no factual packet', () => {
-  assert.deepEqual(verifiedFactsForLink({ album: 'Unknown' }), []);
-  assert.equal(verifiedFactsSection([]), '');
-});
-
-if (failures) {
-  console.error(`\n${failures} test(s) failed`);
-  process.exit(1);
-}
-console.log('\nverified facts: all tests passed');
+assert.match(prompt, /Task: Give a brief spoken introduction to the track now playing/);
+assert.match(prompt, /Music facts are limited to the exact entries in Verified facts/);
+assert.match(prompt, /Approximate air time: around half past 8pm/);
+assert.match(prompt, /Current show: "Night Drive"/);
+assert.match(prompt, /Track on air:\n- After Laughter \(Comes Tears\) by Wendy Rene/);
+assert.doesNotMatch(prompt, /sustained energy|euphoric/);
+console.log('verified facts: all tests passed');

--- a/controller/scripts/verified-facts.test.ts
+++ b/controller/scripts/verified-facts.test.ts
@@ -2,7 +2,7 @@
 // Run: npm test -- verified-facts
 
 import assert from 'node:assert/strict';
-import { sleeveNotesFor, contextSleeveNotesFor } from '../src/llm/internal/prompts/sleeve-notes.js';
+import { sleeveNotesFor, contextSleeveNotesFor, stationHistoryNoteFor } from '../src/llm/internal/prompts/sleeve-notes.js';
 import { linkPrompt } from '../src/llm/internal/prompts/scripts.js';
 
 const track = (over: Record<string, unknown> = {}) => ({
@@ -17,6 +17,24 @@ assert.deepEqual(sleeveNotesFor(track(), 3), [
 assert.deepEqual(contextSleeveNotesFor(track(), {
   date: { season: 'summer' }, weather: { condition: 'cloudy', location: 'The Ribble Valley' },
 }), ['Album: After Laughter Comes Tears.', 'Release year: 1964.', 'Season: summer.', 'Weather in The Ribble Valley: cloudy.']);
+
+const airingIndex = {
+  byId: new Map([
+    ['other-track', Date.now()],
+    ['rare-track', Date.now() - 91 * 86_400_000],
+    ['recent-track', Date.now() - 29 * 86_400_000],
+  ]),
+  byKey: new Map(),
+};
+assert.equal(stationHistoryNoteFor({ id: 'first-track' }, null, airingIndex), 'First station play.');
+assert.equal(
+  stationHistoryNoteFor({ id: 'rare-track' }, { count: 1, lastPlayedAtMs: Date.now() - 91 * 86_400_000 }, airingIndex),
+  'Played here only once before; last heard 91 days ago.',
+);
+assert.equal(
+  stationHistoryNoteFor({ id: 'recent-track' }, { count: 1, lastPlayedAtMs: Date.now() - 29 * 86_400_000 }, airingIndex),
+  null,
+);
 
 const prompt = linkPrompt({
   current: track(), clockIsAirTime: true,

--- a/controller/scripts/verified-facts.test.ts
+++ b/controller/scripts/verified-facts.test.ts
@@ -1,0 +1,78 @@
+// Unit tests for the deterministic facts handed to the main DJ link prompt.
+// Run: npm test -- verified-facts
+
+import assert from 'node:assert/strict';
+import {
+  selectSleeveNotes,
+  sleeveNotesFor,
+  verifiedFactsForLink,
+  verifiedFactsSection,
+} from '../src/llm/internal/prompts/sleeve-notes.js';
+
+let failures = 0;
+function test(name: string, fn: () => void) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err: any) {
+    failures++;
+    console.error(`  ✗ ${name}\n      ${err?.message || err}`);
+  }
+}
+
+const track = (over: Record<string, unknown> = {}) => ({
+  title: 'After Laughter (Comes Tears)',
+  artist: 'Wendy Rene',
+  album: 'After Laughter Comes Tears',
+  year: 2012,
+  originalYear: 1964,
+  yearUntrusted: false,
+  ...over,
+});
+
+test('uses the resolved original year, not a reissue year', () => {
+  assert.deepEqual(sleeveNotesFor(track(), 3), [
+    'Album: After Laughter Comes Tears.',
+    'Release year: 1964.',
+    'Station plays before today: 3.',
+  ]);
+});
+
+test('does not assert an unresolved compilation year', () => {
+  assert.deepEqual(sleeveNotesFor(track({ originalYear: null, yearUntrusted: true }), null), [
+    'Album: After Laughter Comes Tears.',
+  ]);
+});
+
+test('does not repeat a self-titled album or invent a missing play count', () => {
+  assert.deepEqual(sleeveNotesFor(track({ album: 'After Laughter (Comes Tears)' }), null), [
+    'Release year: 1964.',
+  ]);
+});
+
+test('selects one supplemental fact with an injectable random seam', () => {
+  const notes = ['Album: A.', 'Release year: 1999.', 'Station plays before today: 4.'];
+  assert.deepEqual(selectSleeveNotes(notes, () => 0), ['Album: A.']);
+  assert.deepEqual(selectSleeveNotes(notes, () => 0.99), ['Station plays before today: 4.']);
+});
+
+test('builds a bounded verified packet and formats a distinct facts section', () => {
+  const facts = verifiedFactsForLink(track(), 3, () => 0);
+  assert.deepEqual(facts, [
+    'Track: "After Laughter (Comes Tears)" by Wendy Rene.',
+    'Album: After Laughter Comes Tears.',
+  ]);
+  assert.equal(verifiedFactsSection(facts),
+    'Verified facts:\n- Track: "After Laughter (Comes Tears)" by Wendy Rene.\n- Album: After Laughter Comes Tears.');
+});
+
+test('malformed track data produces no factual packet', () => {
+  assert.deepEqual(verifiedFactsForLink({ album: 'Unknown' }), []);
+  assert.equal(verifiedFactsSection([]), '');
+});
+
+if (failures) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log('\nverified facts: all tests passed');

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -53,8 +53,6 @@ import {
 import { dropEchoedLink, enqueuePick, trackFields, trimLinkToIntro } from './dj-agent/enqueue.js';
 import { advanceRun, runActive } from './dj-agent/runs.js';
 import { pickSchemaBase, pickSystem, requestSystem } from './dj-agent/schemas.js';
-import { buildLinkClause } from './dj-agent/link-clause.js';
-import { announceLine } from './announce-line.js';
 import { guardIntro, screenAck, isNamedRequester } from '../util/request-guard.js';
 import * as likes from './likes.js';
 import { classifyPickFailure, type PickFailure } from '../util/pick-seed.js';
@@ -77,13 +75,13 @@ export { pickerAgent, requestAgent } from './dj-agent/agents.js';
 // candidates (`seen`), with the id constrained to that exact set — z.enum
 // becomes a decode-time grammar on local models and a Zod reject elsewhere,
 // the same closing move pickNextTrack already uses. Returns a full pick object
-// (id/reason/say/transition) or null; never throws, so a salvage failure falls
+// (id/reason/transition) or null; never throws, so a salvage failure falls
 // through to the caller's pick.rejected path unchanged.
 // `reason`, when given, replaces the default "you returned a bad id" framing —
 // the back-to-back artist guard (#1124) reuses this same constrained re-pick
 // but for a valid pick it wants to swap off the on-air artist, so the bad-id
 // wording would be false and confuse the model.
-async function repickFromSeen({ seen, badId, wantLink, showAt = null, playlistResolved = true, reason = null }: { seen: Map<string, any>; badId: string | null; wantLink: boolean; showAt?: Date | null; playlistResolved?: boolean; reason?: string | null }) {
+async function repickFromSeen({ seen, badId, showAt = null, playlistResolved = true, reason = null }: { seen: Map<string, any>; badId: string | null; showAt?: Date | null; playlistResolved?: boolean; reason?: string | null }) {
   const ids = [...seen.keys()];
   if (ids.length === 0) return null;
   const schema = modelTolerant(pickSchemaBase().extend({
@@ -106,10 +104,7 @@ async function repickFromSeen({ seen, badId, wantLink, showAt = null, playlistRe
       // favourites-aware run this salvages.
       system: pickSystem(showAt, playlistResolved),
       prompt: JSON.stringify({ candidates: [...seen.values()] }, null, 2)
-        + `\n\n${why}`
-        + (wantLink
-            ? ' Write the "say" link for the track you choose, following the same rules.'
-            : ' Set "say" to null.'),
+        + `\n\n${why}`,
       schema,
       temperature: 0.5,
       kind: 'djAgentRepick',
@@ -318,7 +313,7 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
     }
   }
   if (!song && extras.seen.size) {
-    const repicked = await repickFromSeen({ seen: extras.seen, badId: object?.id ?? null, wantLink, showAt, playlistResolved: !!playlistTracks?.length });
+    const repicked = await repickFromSeen({ seen: extras.seen, badId: object?.id ?? null, showAt, playlistResolved: !!playlistTracks?.length });
     if (repicked) {
       logEvent('pick.repicked', { agent: 'pick', from: object?.id ?? null, to: repicked.id, candidates: extras.seen.size });
       queue.log('picker', `agent returned unknown id "${object?.id}" — re-picked "${repicked.id}" from its own candidates`);
@@ -396,7 +391,7 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
     recentRoots: queue.neighbourArtistRoots(varietyWindow),
     window: varietyWindow,
     repick: (alt, reason) => repickFromSeen({
-      seen: alt, badId: null, wantLink, showAt,
+      seen: alt, badId: null, showAt,
       playlistResolved: !!playlistTracks?.length,
       reason,
     }),
@@ -415,36 +410,24 @@ async function pickViaAgent(queue, ctx, { wantLink, audioWaypoint = null, curren
     song = guarded.song;
   }
 
-  let rawSay = typeof object.say === 'string' ? object.say.trim() : '';
-  // Announce mode: the model's `say` only signals "speak" — the exact line
-  // (and its alternation with whatever aired before it) is composed in code
-  // by announce-line.ts, because a model cannot reliably hold to a fixed
-  // string and cannot alternate with a line it is never shown. Silence stays
-  // the model's call; wording never is.
-  //
-  // Resolved off the ON-AIR persona, not the wall-clock effective one: this
-  // line is spoken by whoever enqueuePick pins it to (session.onAirPersona()),
-  // and inside the handoff look-ahead those two disagree — the incoming DJ's
-  // line would otherwise be written under the outgoing DJ's link contract.
-  // An empty compose means no English/Latin frame fits this persona or artist
-  // (announce-line.ts): the model's own line stands, written under the same
-  // fixed-form schema description and its language directives.
-  const linkSpeaker = session.onAirPersona();
-  if (rawSay && settings.announceLinks(linkSpeaker)) {
-    const composed = announceLine(song.artist, linkSpeaker, { lastLine: queue.getLastLinkText() });
-    if (composed) rawSay = composed;
+  // The picker has seen private selection context. Only after its final choice
+  // do we invoke the isolated listener-facing writer with safe prompt data.
+  let rawLink = '';
+  if (wantLink && current) {
+    try {
+      rawLink = await dj.generateLink({
+        previous: current, current: song, context: linkAirContext(ctx, linkAirAt),
+        clockIsAirTime: !!linkAirAt, persona: session.onAirPersona(),
+        recap: queue.getDjRecap(), recentTracks: queue.getRecentTracks(),
+        recentOpeners: queue.getRecentOpeners(),
+        lastLink: queue.getLastLinkText(),
+      });
+    } catch (err: any) {
+      queue.log('error', `DJ link failed: ${err.message}`);
+    }
   }
-  // Talk-within-the-intro (feature 3a): enqueuePick re-applies this trim at
-  // the chokepoint (near-idempotent — see the note there); it runs here too so
-  // the session turn below records the line as it will actually air — trimmed,
-  // and dropped links as null, never a line the listeners didn't hear.
-  // dropEchoedLink rides along for the same invariant: the echo guard also runs
-  // at the chokepoint, but a link nulled only in there would leave `meta.say`
-  // below quoting text no listener ever heard.
-  const say = dropEchoedLink(trimLinkToIntro(rawSay, song), queue) || '';
-  // Transition effects on this pick (persona djMode via settings.effectsActive),
-  // independent of whether a link airs.
-  const link = (wantLink && say) ? say : null;
+  const say = dropEchoedLink(trimLinkToIntro(rawLink, song), queue) || '';
+  const link = say || null;
   const fxActive = settings.effectsActive();
   // The no-FX schema tells the model to leave transition null, but a model can
   // ignore a field description — say so in the log instead of discarding
@@ -544,8 +527,6 @@ async function pickViaPool(queue, ctx, { wantLink, current, showAt = null }: { w
         recap: queue.getDjRecap(),
         recentTracks: queue.getRecentTracks(),
         recentOpeners: queue.getRecentOpeners(),
-        // Announce mode alternates against the link that last AIRED; every
-        // queue read stays at the call site, the prompt layer is handed values.
         lastLink: queue.getLastLinkText(),
       });
     } catch (err) {
@@ -647,9 +628,6 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     const current = predecessor ?? queue.current?.track ?? null;
     const previous = predecessor ? (prior ?? null) : (queue.history[0]?.track ?? null);
     const djMode = !!settings.getEffectivePersona()?.djMode;
-    // On-air persona, not the wall-clock effective one — same reason as the
-    // announce compose in pickViaAgent: the link belongs to whoever speaks it.
-    const announce = settings.announceLinks(session.onAirPersona());
 
     // Feature 4 + Phase 2 — advance/maybe-start a mini-run; get the tempo/key
     // re-rank target and (when the audio index supports it) a sonic-journey
@@ -657,21 +635,10 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     const { rankTarget, audioWaypoint } = advanceRun(djMode, current);
     const inRun = runActive();
 
-    // In DJ mode the link TEASES the next track — artist or feel — rather than
-    // just announcing it. The agent already knows its own pick when it writes
-    // `say`, so this costs nothing extra.
-    //
-    // FORWARD-LOOKING only, never a back-announce: the link airs when the pick
-    // starts, but a listener request can slip ahead in the meantime, so naming
-    // what "just played" goes stale. Introducing the pick is correct whatever
-    // aired before it.
-    //
-    // The "nod to it in the link" half is gated on wantLink, so a silent mid-run
-    // pick isn't told it may phrase something in a link that won't exist. The
-    // energy-direction guidance is pick selection, so it stays unconditional.
+    // Selection steering stays in this prompt, but it no longer shares a
+    // response schema with listener speech.
     const runClause = inRun
       ? ` You're mid-run — keep the energy moving in the same direction (a touch ${energyForDaypart().speed >= 1 ? 'brisker' : 'mellower'}).`
-        + (wantLink ? ' You may nod to it in the link, but never say tempo numbers.' : '')
       : '';
     // Gated on the waypoint itself, not inRun: on a run's final pick the run
     // state is already cleared (advanceRun) but the last waypoint — the
@@ -679,59 +646,9 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     const journeyClause = audioWaypoint && audioWaypoint.length
       ? ' A sonic journey is active: call tracksTowardJourney and lean toward one of its tracks — each carries the sound a step toward where this arc is heading. If it comes back thin, pick via the library mood/genre/audio tools and keep the energy heading the same way. Never mention the journey on air.'
       : '';
-    // Opener variety for the link. The free-text pool path gets a rotating angle
-    // + an anti-repeat opener list via decoratePrompt; the agent `say` path
-    // didn't, so its links settled into the same shape ("here's…", "coming
-    // up…"). Feed it the same two signals through the event message: one random
-    // forward-looking angle to vary the approach, and the recent openers to
-    // steer clear of. Only when a link is actually being written.
-    //
-    // Announce mode skips both: alternating between exactly two fixed forms
-    // ("This is <artist>." / "Next up, <artist>.") IS the variety, and an
-    // opener blocklist built from those same two forms would eventually
-    // forbid both allowed ones (the bug this feature exists to fix).
-    const linkAngle = wantLink && !announce ? dj.pickAngle('link') : null;
-    const recentOpeners = wantLink && !announce ? queue.getRecentOpeners() : [];
-    // Clock discipline for the link (#864). The agent path carries no clock of
-    // its own, so the model extrapolates one from stale stamped lines in its
-    // session window — and the link then airs a full track later, putting spoken
-    // times 10-20 minutes behind.
-    //
-    // With the look-ahead resolved (showAt) the air moment is knowable, but
-    // showAt's clock carries the show-attribution padding and ran two minutes
-    // FAST (#1282), so step it back to air time via linkAirDate before handing
-    // it over as the only time the link may speak. Without the look-ahead, ban
-    // the clock outright. linkClockAt bans it once more (#1314): with too little
-    // of the on-air track left for this round to land before the seam, the
-    // forecast is a coin flip and would name the wrong time for a whole filler
-    // track.
-    //
-    // The station may also be set to keep the clock out entirely
-    // (broadcast/clock-policy.ts). That is a different question from the
-    // accuracy cases above: off wins over accurate, and it gets its own clause,
-    // because "you can't know when it airs" explains a reason that no longer
-    // applies. This clause and the `say` schema description are the ONLY clock
-    // the agent path ever sees — it never builds context lines — so the ban has
-    // to be stated here or it does not reach the model at all.
-    const clockOff = !speakClockAllowed();
-    const airAt = clockOff ? null : linkClockAt(showAt, Date.now());
-    const airClock = airAt && ctx?.clock?.hhmm ? getClockContext(airAt) : null;
-    const clockClause = wantLink
-      ? (clockOff
-          ? ` Never state the clock time, the hour, or the time of day in the link.`
-          : airClock
-            ? ` The link airs at about ${airClock.display || airClock.hhmm} — if you mention the clock, that is the time to use, never an earlier one.`
-            : ` Never state the clock time in the link — you can't know exactly when it airs.`)
-      : '';
-    // The full link contract (introduce the pick, no back-announce, vary the
-    // opener — or, in announce mode, the fixed two-form contract) lives in the
-    // "say" schema description (pickSchemaBase), which travels on every call —
-    // this clause only TRIGGERS the link and carries the per-pick extras the
-    // schema can't know (the intro_ms budget, the opener blocklist). Restating
-    // the contract here doubled it per pick. See dj-agent/link-clause.ts.
-    const linkClause = wantLink
-      ? buildLinkClause({ djMode, announce, angle: linkAngle, recentOpeners })
-      : ' Stay silent — no link this time.';
+    // Resolve the expected air moment after selection uses part of the runway.
+    // It travels only to the isolated writer after a track is final.
+    const linkAirAt = speakClockAllowed() ? linkClockAt(showAt, Date.now()) : null;
     // Surface the current track's real Subsonic id so similarSongs /
     // tracksLikeThis ("pass the currently-playing song id") actually have one
     // to pass. Without it the agent fabricates a slug from the title/artist
@@ -781,9 +698,8 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     const eventText = `Now playing "${current?.title}" by ${current?.artist}`
       + (current?.id ? ` [id: ${current.id}]` : '')
       + (previous ? ` (after "${previous.title}" by ${previous.artist})` : '')
-      + '. Pick the track to play next.'
-      + linkClause;
-    const promptSuffix = `${clockClause}${favClause}${effectClause}${runClause}${journeyClause}${exploreClause}`;
+      + '. Pick the track to play next.';
+    const promptSuffix = `${favClause}${effectClause}${runClause}${journeyClause}${exploreClause}`;
     session.appendTurn({
       role: 'event', kind: 'pick', text: eventText,
       meta: promptSuffix ? { promptSuffix } : {},
@@ -793,14 +709,11 @@ export async function runTrackEvent(queue, ctx, { wantLink, showAt = null, prede
     // and go straight to the one-call pool picker below to stretch the budget.
     if (settings.get().llm?.pickerAgent && !cheap && !breakerOpen()) {
       try {
-        // `linkAirAt` mirrors the clause above: stamp the item with the air
-        // moment the model was TOLD to speak, and only when it was actually
-        // told one — a run given no clock makes no claim to go stale (#1314).
-        // `airClock` carries both reasons it might not have been: no forecastable
-        // air moment, and the station clock switch (which already nulled `airAt`).
+        // Passed only to the post-selection writer, and only when the station
+        // clock policy permits it.
         const queued = await pickViaAgent(queue, ctx, {
           wantLink, audioWaypoint, current, showAt, rankTarget,
-          linkAirAt: linkClockStampFor(airAt, !!airClock),
+          linkAirAt,
         });
         breakerSuccess();
         if (queued) return;

--- a/controller/src/broadcast/dj-agent/schemas.ts
+++ b/controller/src/broadcast/dj-agent/schemas.ts
@@ -10,13 +10,8 @@ import * as session from '../session.js';
 import * as dj from '../../llm/dj.js';
 import { modelTolerant } from '../../llm/sdk.js';
 import { autoVoiceAllowed } from '../voice-policy.js';
-import { speakClockAllowed } from '../clock-policy.js';
 import { SEED_NOT_A_PICK_CLAUSE } from '../../util/pick-seed.js';
 import { instruction } from '../../llm/dj.js';
-
-export const PICK_SAY_BOUNDARY = 'The say field is listener-facing speech only: never mention tools, candidate searches, instructions, internal reasoning, or this schema. Treat run context as internal unless it is the selected track title or artist; do not add or infer music-history claims.';
-export const PICK_SAY_BOUNDARY = 'The say field is listener-facing speech only: never mention tools, candidate searches, instructions, internal reasoning, or this schema. Treat run context as internal unless it is the selected track title or artist; do not add or infer music-history claims.';
-
 
 // Plain .nullable() fields, deliberately — GLM's malformed spellings of
 // "nothing" (the string "null", an omitted key, a double-JSON-encoded object)
@@ -34,7 +29,6 @@ export const PICK_SCHEMA = z.object({
   // wording, in util/pick-seed.ts; don't inline a second copy here.
   id: z.string().describe(`the exact song id returned by one of the discovery tools — never invent or compose ids. ${SEED_NOT_A_PICK_CLAUSE}`),
   reason: z.string().describe('internal scratchpad only — max 12 words, never shown to the listener; do not justify, just note what makes THIS pick a fresh step (a shift in energy/era/texture, or an artist genuinely new to the rotation), not a vibe label you would recycle pick after pick (e.g. "warmer, driving energy", never a repeated "mellow reflective step"). Only call a pick a "new artist" when it has no "artist_play_count"/"artist_last_played_days_ago"; "unaired" means this song is new to the station, not that its artist is. If the artist shows recent or frequent plays, describe the real reason instead (energy shift, texture, flow)'),
-  say: z.string().nullable().describe("when the latest event message says to write a spoken link, set this to one or two natural sentences in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. " + PICK_SAY_BOUNDARY + " When the event says stay silent, set this to null"),
   // Transition effects (only honoured when the system prompt offers them — persona djMode, see settings.effectsActive).
   // One-line pointer only: the full coaching is dj.effectsGuidance() in the
   // system prompt. This description used to repeat all of it, so every agent
@@ -52,44 +46,12 @@ export const PICK_SCHEMA_NO_FX = PICK_SCHEMA.extend({
   transition: z.enum(['normal', 'blend', 'sweep', 'washout', 'dissolve', 'chop', 'loop']).nullable().describe('always set to null — transition effects are not available for this persona'),
 });
 
-// The live pick schema, resolved per run: the transition coaching follows the
-// on-air persona's djMode (settings.effectsActive), and the `say` length
-// follows its scriptLength — without this overlay an 'extended' storytelling
-// persona stretched to 4-6 sentence links on the pool path (generateLink gets
-// lengthPhrase in its prompt) but snapped back to the consts' hard-coded "one
-// or two sentences" whenever the default-on agent picker was doing the talking.
-// The plain (un-wrapped) object — for callers that still need to .extend()
-// (repickFromSeen pins `id` to the run's own candidate set). Extend THIS,
-// then re-wrap with modelTolerant; a ZodPreprocess pipe has no .extend.
+// The picker response deliberately contains no listener-facing speech. The
+// selected song crosses into generateLink only after the tool run is complete,
+// so selection context cannot become DJ copy. Keep this wrapper because
+// constrained re-picks extend the plain schema before tolerance is applied.
 export function pickSchemaBase() {
-  const base = settings.effectsActive() ? PICK_SCHEMA : PICK_SCHEMA_NO_FX;
-  // Clock rule, resolved per run like effectsActive() above. With the station's
-  // clock switch off (broadcast/clock-policy.ts) the "unless the event message
-  // tells you" escape hatch is dropped rather than left dangling: the event
-  // message never offers a time in that mode, and a flat ban is a clearer
-  // instruction than a condition that can never be met. The static description
-  // on PICK_SCHEMA is deliberately NOT gated — it is module-level, so it would
-  // freeze at boot instead of applying live, and this override always replaces
-  // it on the air path.
-  const clockRule = speakClockAllowed()
-    ? 'Never state a clock time unless the event message tells you when the link airs — then use exactly that time.'
-    : 'Never state a clock time, the hour, or the time of day.';
-  // Announce mode (persona linkStyle:'announce') replaces the ordinary
-  // introduce-the-pick contract with a fixed, matter-of-fact one. This
-  // description is a sane fallback only: runTrackEvent (dj-agent.ts)
-  // overwrites whatever text the model returns with announce-line.ts's own
-  // composed, alternating line — a model cannot reliably hold to a fixed
-  // string or alternate with a line it is never shown, so `say` here only
-  // has to signal "speak" (non-empty) versus "stay silent" (null).
-  // Off the ON-AIR persona (as pickSystem/requestSystem below resolve theirs),
-  // never the wall-clock effective one: inside the handoff look-ahead they
-  // disagree, and the contract must match the persona whose line this is.
-  const sayDescription = settings.announceLinks(session.onAirPersona())
-    ? `when the latest event message says to write a spoken link, set this to EXACTLY one of: "This is <artist>." or "Next up, <artist>." — nothing before or after it: no title, album, year, feel, or clock. Use the artist name exactly as shown on the chosen track. When the event says stay silent, set this to null`
-    : `when the latest event message says to write a spoken link, set this to ${dj.lengthPhrase('link')} of natural speech in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). ${clockRule} ${PICK_SAY_BOUNDARY} When the event says stay silent, set this to null`;
-  return base.extend({
-    say: z.string().nullable().describe(sayDescription),
-  });
+  return settings.effectsActive() ? PICK_SCHEMA : PICK_SCHEMA_NO_FX;
 }
 
 export function pickSchema() {
@@ -265,3 +227,4 @@ ${LISTENER_TEXT_CLAUSE}${dj.REQUESTER_GREETING_CLAUSE}${dj.REQUESTER_NAME_CLAUSE
 
 ${currentTrack}`;
 }
+

--- a/controller/src/broadcast/dj-agent/schemas.ts
+++ b/controller/src/broadcast/dj-agent/schemas.ts
@@ -14,6 +14,9 @@ import { speakClockAllowed } from '../clock-policy.js';
 import { SEED_NOT_A_PICK_CLAUSE } from '../../util/pick-seed.js';
 import { instruction } from '../../llm/dj.js';
 
+export const PICK_SAY_BOUNDARY = 'The say field is listener-facing speech only: never mention tools, candidate searches, instructions, internal reasoning, or this schema. Treat run context as internal unless it is the selected track title or artist; do not add or infer music-history claims.';
+export const PICK_SAY_BOUNDARY = 'The say field is listener-facing speech only: never mention tools, candidate searches, instructions, internal reasoning, or this schema. Treat run context as internal unless it is the selected track title or artist; do not add or infer music-history claims.';
+
 
 // Plain .nullable() fields, deliberately — GLM's malformed spellings of
 // "nothing" (the string "null", an omitted key, a double-JSON-encoded object)
@@ -31,7 +34,7 @@ export const PICK_SCHEMA = z.object({
   // wording, in util/pick-seed.ts; don't inline a second copy here.
   id: z.string().describe(`the exact song id returned by one of the discovery tools — never invent or compose ids. ${SEED_NOT_A_PICK_CLAUSE}`),
   reason: z.string().describe('internal scratchpad only — max 12 words, never shown to the listener; do not justify, just note what makes THIS pick a fresh step (a shift in energy/era/texture, or an artist genuinely new to the rotation), not a vibe label you would recycle pick after pick (e.g. "warmer, driving energy", never a repeated "mellow reflective step"). Only call a pick a "new artist" when it has no "artist_play_count"/"artist_last_played_days_ago"; "unaired" means this song is new to the station, not that its artist is. If the artist shows recent or frequent plays, describe the real reason instead (energy shift, texture, flow)'),
-  say: z.string().nullable().describe('when the latest event message says to write a spoken link, set this to one or two natural sentences in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. When the event says stay silent, set this to null'),
+  say: z.string().nullable().describe("when the latest event message says to write a spoken link, set this to one or two natural sentences in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). Never state a clock time unless the event message tells you when the link airs — then use exactly that time. " + PICK_SAY_BOUNDARY + " When the event says stay silent, set this to null"),
   // Transition effects (only honoured when the system prompt offers them — persona djMode, see settings.effectsActive).
   // One-line pointer only: the full coaching is dj.effectsGuidance() in the
   // system prompt. This description used to repeat all of it, so every agent
@@ -83,7 +86,7 @@ export function pickSchemaBase() {
   // disagree, and the contract must match the persona whose line this is.
   const sayDescription = settings.announceLinks(session.onAirPersona())
     ? `when the latest event message says to write a spoken link, set this to EXACTLY one of: "This is <artist>." or "Next up, <artist>." — nothing before or after it: no title, album, year, feel, or clock. Use the artist name exactly as shown on the chosen track. When the event says stay silent, set this to null`
-    : `when the latest event message says to write a spoken link, set this to ${dj.lengthPhrase('link')} of natural speech in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). ${clockRule} When the event says stay silent, set this to null`;
+    : `when the latest event message says to write a spoken link, set this to ${dj.lengthPhrase('link')} of natural speech in the DJ voice that INTRODUCE the track you are about to play — set it up, name the artist or capture its feel, vary your opener. Do NOT back-announce, recap, or name the track that just played (a listener request may slip in ahead of your pick, so what aired right before it is not certain). ${clockRule} ${PICK_SAY_BOUNDARY} When the event says stay silent, set this to null`;
   return base.extend({
     say: z.string().nullable().describe(sayDescription),
   });
@@ -262,4 +265,3 @@ ${LISTENER_TEXT_CLAUSE}${dj.REQUESTER_GREETING_CLAUSE}${dj.REQUESTER_NAME_CLAUSE
 
 ${currentTrack}`;
 }
-

--- a/controller/src/context.ts
+++ b/controller/src/context.ts
@@ -335,6 +335,34 @@ export function energyForDaypart(date = new Date()) {
   return base;
 }
 
+// The next distinct scheduled show is an optional on-air fact only in the
+// final 15 minutes of the current show. It is derived from the timetable, not
+// an LLM or routing decision, so prompt writers can safely offer a brief nod
+// without exposing any selection or control-plane context.
+export function showHandoverContext(now = new Date(), resolveShow: (at: Date) => any = resolveActiveShow) {
+  const current: any = resolveShow(now);
+  if (!current?.id) return null;
+  const { minute } = zonedParts(now);
+  const msToNextHour = (60 - minute) * 60_000 - now.getSeconds() * 1_000 - now.getMilliseconds();
+  let boundary = new Date(now.getTime() + msToNextHour);
+  for (let hoursAhead = 1; hoursAhead <= 168; hoursAhead += 1) {
+    const next: any = resolveShow(boundary);
+    if (!next || next.id !== current.id) {
+      if (!next?.persona?.name || boundary.getTime() - now.getTime() > 15 * 60_000) return null;
+      return {
+        phase: 'final-quarter-hour',
+        nextShow: {
+          name: String(next.name || '').trim(),
+          presenter: String(next.persona.name).trim(),
+          startsAt: spokenHourPhrase(zonedParts(boundary).hour),
+        },
+      };
+    }
+    boundary = new Date(boundary.getTime() + 60 * 60_000);
+  }
+  return null;
+}
+
 // Combined snapshot — what's the vibe right now? Pass `at` to resolve the
 // clock-derived parts (time, festival, date, clock, active show, and therefore
 // dominantMood) for a future moment instead — the queue watcher uses this to
@@ -389,5 +417,8 @@ export async function getFullContext(at?: Date) {
   // roll, stamps the OUTGOING persona onto the INCOMING show's session and
   // makes stampRolledFrom see no persona change at all (mic-pass suppressed).
   // Note this is distinct from `date` (getDateContext's calendar strings).
-  return { at: now.toISOString(), time, weather, festival, dominantMood, date, clock, activeShow, listeners };
+  return {
+    at: now.toISOString(), time, weather, festival, dominantMood, date, clock,
+    activeShow, showHandover: showHandoverContext(now), listeners,
+  };
 }

--- a/controller/src/llm/internal/prompts/recent-speech.ts
+++ b/controller/src/llm/internal/prompts/recent-speech.ts
@@ -1,0 +1,17 @@
+// Recent speech is negative memory only. Bracketed delivery directions in an
+// old line are especially easy for a model to copy, so they must not cross the
+// prompt boundary. Recap metadata (for example, `[link]`) is kept by only
+// applying this to the spoken part of a formatted recap line.
+const SPOKEN_TAG = /\[[^\]\r\n]{1,80}\]\s*/g;
+
+export function stripSpokenTags(value: unknown): string {
+  return String(value ?? '').replace(SPOKEN_TAG, '');
+}
+
+export function stripRecapSpokenTags(value: unknown): string {
+  return String(value ?? '').split('\n').map((line) => {
+    const spokenStart = line.indexOf(': "');
+    if (spokenStart < 0) return stripSpokenTags(line);
+    return line.slice(0, spokenStart + 3) + stripSpokenTags(line.slice(spokenStart + 3));
+  }).join('\n');
+}

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -9,10 +9,13 @@ import { djSystem, lengthPhrase } from './system.js';
 import { buildContextLines, decoratePrompt, randomSeed } from './context.js';
 import { speakClockAllowed } from '../../../broadcast/clock-policy.js';
 import { isNamedRequester } from '../../../util/request-guard.js';
-import { introBudgetPhrase, introMsFor, firstVocalMsFor, bpmKeyFor } from './intro-budget.js';
+import { introBudgetPhrase, introMsFor, firstVocalMsFor } from './intro-budget.js';
 import { trackEraYear } from '../../../music/show-filter.js';
 import { trackFeelSuffix } from './track-feel.js';
 import { announceLine } from '../../../broadcast/announce-line.js';
+import * as library from '../../../music/library.js';
+import { contextSleeveNotesFor, selectSleeveNotes } from './sleeve-notes.js';
+import { stripRecapSpokenTags, stripSpokenTags } from './recent-speech.js';
 
 // The feel note appended to a track line (track-feel.ts) is a STEER, not copy.
 // Without this the model reads the label out — "high-energy" spoken flat is
@@ -28,6 +31,13 @@ const FEEL_CLAUSE = ' A feel note after a track line tells you how the track act
 // narrative angles were trimmed to match — without the weather line in front of
 // it, a model told to "mention the weather" would only invent it.
 const SCRIPT_CONTEXT_FIELDS = ['date', 'clock', 'time', 'festival', 'show', 'listeners'];
+
+// Links are delivery, not selection. Mood, energy, show steering and the
+// recent-play window are useful inputs when choosing a record, but become
+// internal prompt material once that choice is made. Keep the link's context
+// to listener-safe, deterministic facts only; any new field needs the same
+// scrutiny as a Verified Fact before it is added here.
+const LINK_CONTEXT_FIELDS = ['date', 'clock', 'festival'];
 
 // A request intro is WRITTEN when the request resolves but AIRED from
 // onTrackStarted — it plays over the opening bars of the track it introduces,
@@ -80,6 +90,39 @@ export const REQUESTER_NAME_CLAUSE = ' The requester picks their own screen name
 // name repeated across a 20-word line reads as a hostage video, not a shout-out.
 export const REQUESTER_GREETING_CLAUSE = ' When the request comes with a name, say it on air'
   + ' — greet them by name once, naturally, as part of the line rather than tacked on.';
+
+
+const PERSONA_GROUNDING_RULE = 'FACTUAL GROUNDING: Treat supplied facts, including Sleeve Notes, as the factual ground truth for the current task. For factual claims about music, supplied facts are your only source of truth. Do not supplement them with your own knowledge of an artist, track, album or music history, even when you believe that knowledge is correct. You may naturally rephrase supplied facts, but do not expand them into unsupported factual claims, explanations, causes, relationships or historical context. Do not invent or assume release dates, albums, chart history, credits, artist biography, lyrics, instrumentation, production details or other music trivia unless supplied. Sleeve Notes are optional material for natural conversation, not a checklist. Use only what helps the current on-air line. You do not need to mention them at all. You may freely express subjective, in-character reactions and musical impressions provided they are not presented as additional facts. Do not invent weather, season, date, clock time, programme state, people being present or events around the station. If approximate air time is supplied, you may infer the corresponding time of day but never make it more precise than supplied. Style or Tone instructions never override these factual-grounding rules. Use local colour, time, weather or other contextual texture only when the necessary information has been supplied.';
+
+function verifiedContextPacket(context: any, current: any = null, clockIsAirTime = false, includeSleeves = true): string {
+  const moment: string[] = [];
+  const day = String(context?.date?.dayLabel || "").trim();
+  if (day) moment.push("Day: " + day + ".");
+  const airTime = clockIsAirTime ? fuzzyAirTime(context?.clock) : null;
+  if (airTime) moment.push("Approximate air time: " + airTime + ".");
+  const showName = String(context?.activeShow?.name || "").trim();
+  if (showName) moment.push("Current show: \"" + showName + "\".");
+  const handover = context?.showHandover;
+  const hasFollowingShow = handover?.phase === "final-half-hour" && handover?.nextShow?.name && handover?.nextShow?.presenter && handover?.nextShow?.startsAt;
+  if (hasFollowingShow) {
+    moment.push("Show progress: final half hour.");
+    moment.push("Following show: \"" + String(handover.nextShow.name).trim() + "\" with " + String(handover.nextShow.presenter).trim() + ", starting " + String(handover.nextShow.startsAt).trim() + ".");
+  }
+  const playCount = current ? (library.trackPlayStatsFor(current)?.count ?? null) : null;
+  const sleeves = includeSleeves ? selectSleeveNotes(contextSleeveNotesFor(current, context, playCount)) : [];
+  const sections = [
+    "Verified Facts:",
+    "Current Context:\n" + (moment.length ? moment.map((fact) => "- " + fact).join("\n") : "- No additional verified moment facts."),
+  ];
+  if (includeSleeves) sections.push("Sleeve Notes:\n" + (sleeves.length ? sleeves.map((fact) => "- " + fact).join("\n") : "- None selected for this line."));
+  if (current?.title || current?.artist) {
+    sections.push("Track on air:\n- " + String(current?.title || "Unknown") + " by " + String(current?.artist || "unknown") + ".");
+  }
+  if (hasFollowingShow) {
+    sections.push("Use the following-show detail naturally when it fits; do not make it a required signpost or repeat it mechanically.");
+  }
+  return sections.join("\n\n");
+}
 
 export async function generateIntro({ track, context, requestedBy = null, requestText = null, artistMiss = null, recap = null, recentTracks = null, recentOpeners = null }: any) {
   const ctxLines = buildContextLines(context, { recentTracks, contextFields: SCRIPT_CONTEXT_FIELDS });
@@ -235,140 +278,198 @@ export async function generateAdLib({ instruction, context = null, recap = null,
   });
 }
 
-// Pure prompt-assembly for generateLink, split out for testability. `announce`
-// (persona linkStyle:'announce', settings.announceLinks()) replaces the whole
-// natural instruction — set it up, tease the feel, vary the opener — with a
-// fixed, matter-of-fact one: the whole line is "This is <artist>." or "Next
-// up, <artist>.". Everything else (tease, patter, the intro budget, "vary how
-// you open", the feel clause) is a natural-only concern and plays no part in
-// announce mode.
-//
-// The announce branch is reached only for the artists the station cannot frame
-// itself — a non-English persona, or a name in a script the composed English
-// line can't carry (announce-line.ts) — so it always has a REAL artist name to
-// name. It must never fall back to a placeholder: the only two lines this
-// prompt permits are the two it writes out, so a `<artist>` stand-in is a line
-// the model reads onto the air verbatim. With no artist at all there is
-// nothing to announce, and generateLink drops the link before it gets here.
-export function linkPrompt({
-  announce, current, teaseClause, patterClause, budget, lengthPhraseText, clockClause, feelClause,
-}: {
-  announce: boolean;
-  current: { artist?: string | null } | null | undefined;
-  teaseClause: string;
-  patterClause: string;
-  budget: string | null;
-  lengthPhraseText: string;
-  clockClause: string;
-  feelClause: string;
-}): string {
-  const artist = String(current?.artist ?? '').trim();
-  if (announce && artist) {
-    return `Write the DJ link for the track now starting. It must be EXACTLY one of: "This is ${artist}." or "Next up, ${artist}." — nothing before or after it: no title, album, year, feel, or clock.`;
-  }
-  return `Write a short DJ link to carry into the track now starting — set it up, capture its feel, weave in the moment.${teaseClause}${patterClause}${budget ? ' ' + budget : ''} ${lengthPhraseText}, conversational. Vary how you open — don't default to "here's", "this is", "coming up", or "that was"; find a different way in each time. Keep it forward-looking: don't back-announce, recap, or name the track that just played — focus on what's playing now.${clockClause}${feelClause}`;
+export function fuzzyAirTime(clock: any): string | null {
+  const raw = clock?.hhmm || clock?.display;
+  const match = typeof raw === 'string' ? raw.match(/\b(\d{1,2}):(\d{2})\b/) : null;
+  if (!match) return null;
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+
+  const hourLabel = (value: number, landmark = true) => {
+    const normalized = ((value % 24) + 24) % 24;
+    if (landmark && normalized === 0) return 'midnight';
+    if (landmark && normalized === 12) return 'noon';
+    const h12 = normalized % 12 || 12;
+    return `${h12}${normalized < 12 ? 'am' : 'pm'}`;
+  };
+
+  if (minute <= 20) return `just after ${hourLabel(hour)}`;
+  if (minute < 40) return `around half past ${hourLabel(hour, false)}`;
+  return `approaching ${hourLabel(hour + 1)}`;
 }
 
-export async function generateLink({ previous, current, context, clockIsAirTime = false, recap = null, recentTracks = null, recentOpeners = null, persona = null, lastLink = null, currentIsOnAir = false }: any) {
+// Stage C Persona packet for a Producer-selected track. This is intentionally
+// not built through generateLink/buildContextLines/decoratePrompt: those legacy
+// helpers add operational mood, station-wide history, rotating creative angles
+// and other context that this clean boundary is designed to exclude.
+export function linkPrompt({
+  current,
+  context = null,
+  clockIsAirTime = false,
+  recap = null,
+  recentOpeners = null,
+  persona = null,
+  includeIntroBudget = true,
+  guestContribution = null,
+}: any): string {
   const speaker = persona || settings.getEffectivePersona();
-  const announce = settings.announceLinks(speaker);
-  // A pick-attached link is written when the pick is made but airs a full
-  // track later, so a clock reference baked in at generation time is stale by
-  // the length of whatever is playing now — "18:10" spoken at 18:20 (issue
-  // #864). `clockIsAirTime` says the caller resolved `context` at the link's
-  // expected AIR time (the queue watcher's look-ahead, or the manual runLink
-  // that airs immediately): only then may the model speak the clock; otherwise
-  // the Local time line is withheld entirely so it can't leak on air.
-  // Two independent reasons to withhold the clock, and they answer different
-  // questions: `clockIsAirTime` is about ACCURACY (is ctx's clock the moment
-  // this line airs), the policy is about whether the station speaks the clock
-  // at all. Off wins over accurate — a clock that is never spoken can never be
-  // wrong — and it gets its own clause, because the staleness wording explains
-  // a reason that no longer applies.
-  const clockOff = !speakClockAllowed();
-  const contextFields = clockIsAirTime && !clockOff
-    ? SCRIPT_CONTEXT_FIELDS
-    : SCRIPT_CONTEXT_FIELDS.filter((f) => f !== 'clock');
-  const clockClause = clockOff
-    ? ` Never state the clock time, the hour, or the time of day.`
-    : clockIsAirTime
-      ? ` If you mention the clock, "Local time" below is the moment this link airs — use that, never an earlier time.`
-      : ` Never state the clock time — this line airs when the next track starts, and you can't know exactly when that is.`;
-  const ctxLines = buildContextLines(context, { recentTracks, contextFields });
-  // Forward-looking only: the link is written when the pick is made but doesn't
-  // air until that pick actually starts — and a listener request can slip ahead
-  // of it in the meantime, so we can't know what really played just before it.
-  // Naming the previous track is therefore unsafe (it goes stale → the DJ names
-  // a track one older than reality). We intro the track NOW STARTING instead, so
-  // the line is always correct whatever played before it. (`previous` is still
-  // accepted for the tempo/key mix nod below — a vague feel, never a name.)
-  const feelSuffix = trackFeelSuffix(current);
-  if (current?.title) ctxLines.push(`Now playing: "${current.title}" by ${current.artist || 'unknown'}${feelSuffix}`);
+  const rules = [
+    'Output only the words to be spoken on air.',
+    'The named track is already playing. Focus on it and do not refer to the previous track.',
+    'Treat supplied sleeve notes as verified facts, but do not add or infer further music-history claims.',
+    'Do not state a day of week unless it appears in the verified facts.',
+    'Music facts are limited to the exact entries in Verified facts: do not use remembered or learned album, release, chart, reputation, influence, relationship or history information.',
+    'Do not describe instrumentation, production, lyrics or other audio properties unless they are explicitly supplied. Subjective reaction is welcome, but do not present it as observation.',
+    'Intro-runway guidance is production-only: never mention seconds, a countdown, vocals entering or when the track will arrive.',
+    PERSONA_GROUNDING_RULE,
+    lengthPhrase('link', speaker) + '.',
+  ];
+  // Automatic links are attached to the track start, where measured intro and
+  // first-vocal timing is meaningful. An on-demand link can be fired anywhere
+  // in the song, so its original opening runway must not be presented as time
+  // still available to speak.
+  const budget = includeIntroBudget
+    ? introBudgetPhrase(introMsFor(current), firstVocalMsFor(current))
+    : '';
+  if (budget) rules.push(budget);
 
-  // DJ-mode personas lean harder into teasing the track's feel / artist.
-  const djMode = !!speaker?.djMode;
-  const teaseClause = djMode
-    ? ` Name the artist or capture the feel so listeners know what they're hearing.`
-    : '';
-  // DJ-mode mix patter: only when BOTH tracks carry measured tempo/key, and
-  // only as a natural option — never forced, never robotic numbers on air. This
-  // is a feel ("easing into something a touch faster"), not a track name, so it
-  // stays safe even if a request slipped in ahead of this pick.
-  const prevAK = bpmKeyFor(previous);
-  const curAK = bpmKeyFor(current);
-  const patterClause = (djMode && (prevAK.bpm || prevAK.key) && (curAK.bpm || curAK.key))
-    ? ` You may nod to the mix if it feels natural — e.g. easing into something a touch faster or slower, or how it sits in key — but never say raw numbers.`
-    : '';
-  // Talk-within-the-intro budget for the track now starting (current = the pick).
-  // The measured first-vocal entry (when the track has one) upgrades the
-  // phrase to "skip the spoken intro" on vocals-immediate tracks — the
-  // deterministic backstop would drop the line anyway; better not to write it.
-  const budget = introBudgetPhrase(introMsFor(current), firstVocalMsFor(current));
-  const feelClause = feelSuffix ? FEEL_CLAUSE : '';
-  // Announce mode: compose the line in code (announce-line.ts) whenever the
-  // station can frame it itself — no LLM call at all, and no risk of a model
-  // drifting off the fixed form. `lastLink` is the link that last AIRED, which
-  // is what the two forms alternate against; `currentIsOnAir` says `current`
-  // is the track already playing (the /dj/segment button), where "Next up"
-  // would be a false claim.
-  if (announce) {
-    const composed = announceLine(current?.artist, speaker, { lastLine: lastLink, currentIsOnAir });
-    if (composed) return composed;
-    // Nothing to announce. An announce-mode station has no other line to fall
-    // back on — its whole contract is naming the artist — and an unannounced
-    // track is a non-event on air, so drop the link rather than ask the model
-    // for a line whose only permitted forms need a name we don't have.
-    // '' is every caller's no-link signal (queue.announce ignores it,
-    // trimLinkToIntro nulls it).
-    if (!String(current?.artist ?? '').trim()) return '';
-    // Otherwise the artist exists but the composed English frame can't carry
-    // it (non-English persona, or a name in a non-Latin script): the model
-    // writes the line under djSystem's language + proper-noun directives.
+  const facts = verifiedContextPacket(context, current, clockIsAirTime);
+  if (clockIsAirTime && fuzzyAirTime(context?.clock)) {
+    rules.push("If you mention the time, use only the approximate phrase supplied in Current Context; do not turn it into an exact minute.");
+  } else {
+    rules.push("Do not state a clock time; no verified air time was supplied.");
   }
 
-  const instruction = linkPrompt({
-    announce, current, teaseClause, patterClause, budget,
-    lengthPhraseText: lengthPhrase('link', speaker), clockClause, feelClause,
-  });
-  const prompt = `${instruction}\n\n${ctxLines.join('\n')}`;
+  const sections = [
+    'Task: Give a brief spoken introduction to the track now playing.',
+    `Rules:\n${rules.map((rule) => `- ${rule}`).join('\n')}`,
+    facts,
+  ];
+  if (guestContribution?.name) {
+    sections.push("Editorial Context:\n- " + String(guestContribution.name).trim() + " had a verified editorial hand in choosing this track. If natural, the host may briefly credit them; do not call it a favourite or explain selection mechanics.");
+  }
+  if (recap) {
+    sections.push('Recent speech by this presenter, supplied only to prevent repetition. Do not reuse its wording, topics, anecdotes, metaphors or sentence structures:\n' + stripRecapSpokenTags(recap));
+  }
+  if (recentOpeners?.length) {
+    sections.push('Recent opening words used by this presenter. Start differently:\n'
+      + recentOpeners.slice(0, 6).map((opener: string) => `- ${stripSpokenTags(opener)}`).join('\n'));
+  }
+  return sections.join('\n\n');
+}
 
-  // Announce mode: no tone angle (there is nothing to vary), no recap, no
-  // opener blocklist — a fixed kind absent from ANGLES draws no angle line,
-  // and recap/recentOpeners are withheld outright. Lower temperature too:
-  // with only two allowed outputs there is nothing left to vary creatively.
-  return announce
-    ? djText({
-        system: djSystem(speaker),
-        prompt: decoratePrompt(prompt, { kind: 'announce-link', recap: null, recentOpeners: null }),
-        temperature: 0.3, topP: 0.92, repeatPenalty: 1.2, seed: randomSeed(),
-        kind: 'generateLink',
-      })
-    : djText({
-        system: djSystem(speaker),
-        prompt: decoratePrompt(prompt, { kind: 'link', recap, recentOpeners }),
-        temperature: 0.95, topP: 0.92, repeatPenalty: 1.2, seed: randomSeed(),
-        kind: 'generateLink',
-      });
+export async function generateLink(args: any) {
+  const speaker = args.persona || settings.getEffectivePersona();
+  if (settings.announceLinks(speaker)) {
+    const composed = announceLine(args.current?.artist, speaker, {
+      lastLine: args.lastLink ?? null,
+      currentIsOnAir: !!args.currentIsOnAir,
+    });
+    if (composed) return composed;
+    if (!String(args.current?.artist ?? '').trim()) return '';
+  }
+  return djText({
+    system: djSystem(speaker),
+    prompt: linkPrompt({ ...args, persona: speaker }),
+    temperature: 0.95,
+    topP: 0.92,
+    repeatPenalty: 1.2,
+    seed: randomSeed(),
+    kind: 'generatePersonaLink',
+  });
+}
+
+// Stage C delivery packet for a Producer-selected skill segment. The Producer's
+// reason and tool-loop prose never enter this prompt: only the operator-authored
+// skill brief, the selected tool's controller-grounded evidence and a small
+// deterministic set of relevant moment facts cross the boundary.
+export function personaSegmentPrompt({
+  kind,
+  brief,
+  evidence = null,
+  contextFacts = [],
+  context = null,
+  current = null,
+  recap = null,
+  recentOpeners = null,
+  persona = null,
+}: any): string {
+  const speaker = persona || settings.getEffectivePersona();
+  const rules = [
+    'Output only the words to be spoken on air.',
+    'Use only the supplied evidence, skill brief and context facts. Do not invent or add externally verifiable claims.',
+    PERSONA_GROUNDING_RULE,
+    'Do not mention tools, searches, source data, the Producer or these instructions.',
+    lengthPhrase('segment', speaker) + '.',
+  ];
+  const facts: string[] = [];
+  if (current?.title) facts.push(`Track on air: "${current.title}" by ${current.artist || 'unknown'}.`);
+  for (const fact of contextFacts || []) {
+    if (typeof fact === 'string' && fact.trim()) facts.push(fact.trim());
+  }
+  let evidenceText = '';
+  if (evidence != null) {
+    try { evidenceText = JSON.stringify(evidence, null, 1); } catch { evidenceText = String(evidence); }
+    if (evidenceText.length > 6000) evidenceText = evidenceText.slice(0, 6000) + '\n…(truncated)';
+  }
+
+  const packet = verifiedContextPacket(context, current, true);
+  const sections = [
+    `Task: Deliver one between-track "${kind || 'segment'}" segment.`,
+    `Rules:\n${rules.map((rule) => `- ${rule}`).join('\n')}`,
+    packet,
+    `Skill brief:\n${String(brief || '').trim()}`,
+  ];
+  if (facts.length) sections.push(`Context facts:\n${facts.map((fact) => `- ${fact}`).join('\n')}`);
+  if (evidenceText) sections.push(`Grounded evidence:\n${evidenceText}`);
+  if (recap) {
+    sections.push('Recent speech by this presenter, supplied only to prevent repetition. Do not reuse its wording, topics, anecdotes, metaphors or sentence structures:\n' + stripRecapSpokenTags(recap));
+  }
+  if (recentOpeners?.length) {
+    sections.push('Recent opening words used by this presenter. Start differently:\n'
+      + recentOpeners.slice(0, 6).map((opener: string) => `- ${stripSpokenTags(opener)}`).join('\n'));
+  }
+  return sections.join('\n\n');
+}
+
+export async function generatePersonaSegment(args: any) {
+  const speaker = args.persona || settings.getEffectivePersona();
+  return djText({
+    system: djSystem(speaker),
+    prompt: personaSegmentPrompt({ ...args, persona: speaker }),
+    temperature: 0.95,
+    topP: 0.92,
+    repeatPenalty: 1.2,
+    seed: randomSeed(),
+    kind: 'generatePersonaSegment',
+  });
+}
+
+export function personaHourlyTimePrompt({ recap = null, context = null, recentOpeners = null, persona = null }: any = {}) {
+  const speaker = persona || settings.getEffectivePersona();
+  // The time is converted to words in code (context.clock.spokenTime) rather
+  // than asking the model to read the clock line itself — small models get
+  // the 24-hour conversion wrong at the edges ("00:03" announced as "one in
+  // the morning"). The minute-aware phrase replaces the old hour-only one,
+  // which hardcoded "just gone X" whatever the minute — right on the :00 cron
+  // this normally rides, but a manual trigger at 18:31 still said "just gone
+  // six in the evening" (#1282). The fallbacks keep the old behaviour for
+  // contexts that predate spokenTime, then make the absence of a live time a
+  // hard stand-down rather than an invitation to guess.
+  const spokenTime = context?.clock?.spokenTime;
+  const spoken = context?.clock?.spokenHour;
+  const timeClause = spokenTime
+    ? `Live spoken time: "${spokenTime}". Say exactly that time in natural spoken words — never digits or 24-hour form, never a different time.`
+    : spoken
+      ? `Live spoken hour: "${spoken}". Say exactly that hour in natural spoken words ("just gone ${spoken}", or similar) — never digits or 24-hour form, never a different hour.`
+      : `No live spoken time was supplied. Do not state or infer a clock time.`;
+  const lines = [
+    verifiedContextPacket(context, null, true, false),
+    PERSONA_GROUNDING_RULE,
+    `Task: a brief top-of-the-hour time check, in character. ${lengthPhrase('hourly', speaker)}. ${timeClause} Do not infer weather, programme progress, listener activity, studio events or local colour.`,
+  ];
+  return decoratePrompt(lines.join('\n'), { kind: 'persona_hourly', recap, recentOpeners });
 }
 
 export async function generateHourlyTime({ recap = null, context = null, recentOpeners = null, persona = null }: any = {}) {

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -103,9 +103,9 @@ function verifiedContextPacket(context: any, current: any = null, clockIsAirTime
   const showName = String(context?.activeShow?.name || "").trim();
   if (showName) moment.push("Current show: \"" + showName + "\".");
   const handover = context?.showHandover;
-  const hasFollowingShow = handover?.phase === "final-half-hour" && handover?.nextShow?.name && handover?.nextShow?.presenter && handover?.nextShow?.startsAt;
+  const hasFollowingShow = handover?.phase === "final-quarter-hour" && handover?.nextShow?.name && handover?.nextShow?.presenter && handover?.nextShow?.startsAt;
   if (hasFollowingShow) {
-    moment.push("Show progress: final half hour.");
+    moment.push("Show progress: final 15 minutes.");
     moment.push("Following show: \"" + String(handover.nextShow.name).trim() + "\" with " + String(handover.nextShow.presenter).trim() + ", starting " + String(handover.nextShow.startsAt).trim() + ".");
   }
   const playCount = current ? (library.trackPlayStatsFor(current)?.count ?? null) : null;
@@ -184,7 +184,7 @@ export async function generateIntro({ track, context, requestedBy = null, reques
   });
 }
 
-export async function generateStationId({ recap = null, context = null, recentOpeners = null, persona = null }: any = {}) {
+export function stationIdPrompt({ context = null, persona = null }: any = {}) {
   const speaker = persona || settings.getEffectivePersona();
   const djName = speaker?.name || 'your host';
   const stationName = settings.get().station;
@@ -207,10 +207,21 @@ export async function generateStationId({ recap = null, context = null, recentOp
         ? ` If you nod to the clock, say only "${daypart}" — never the hour and never the minutes (this airs a few minutes after you write it, and the hour may have changed by then).`
         : ` If you nod to the clock, name only the part of the day (morning, afternoon, evening, night) — never the hour and never the minutes (this airs a few minutes after you write it, and the hour may have changed by then).`)
     : '';
-  ctxLines.push(`Task: ${lengthPhrase('stationId', speaker)} for ${stationName} with ${djName}. A little understated.${clockNudge}`);
+  const handover = context?.showHandover;
+  const nextShow = handover?.phase === 'final-quarter-hour'
+    && handover?.nextShow?.name && handover?.nextShow?.presenter;
+  const handoverNudge = nextShow
+    ? ` The next scheduled show is "${String(handover.nextShow.name).trim()}" with ${String(handover.nextShow.presenter).trim()}. If natural, give it one brief nod; do not make it a required signpost or explain the schedule.`
+    : '';
+  ctxLines.push(`Task: ${lengthPhrase('stationId', speaker)} for ${stationName} with ${djName}. A little understated.${clockNudge}${handoverNudge}`);
+  return ctxLines.join('\n');
+}
+
+export async function generateStationId({ recap = null, context = null, recentOpeners = null, persona = null }: any = {}) {
+  const speaker = persona || settings.getEffectivePersona();
   return djText({
     system: djSystem(speaker),
-    prompt: decoratePrompt(ctxLines.join('\n'), { kind: 'station_id', recap, recentOpeners }),
+    prompt: decoratePrompt(stationIdPrompt({ context, persona: speaker }), { kind: 'station_id', recap, recentOpeners }),
     temperature: 1.0, topP: 0.9, repeatPenalty: 1.25, seed: randomSeed(),
     kind: 'generateStationId',
   });

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -14,7 +14,7 @@ import { trackEraYear } from '../../../music/show-filter.js';
 import { trackFeelSuffix } from './track-feel.js';
 import { announceLine } from '../../../broadcast/announce-line.js';
 import * as library from '../../../music/library.js';
-import { contextSleeveNotesFor, selectSleeveNotes } from './sleeve-notes.js';
+import { contextSleeveNotesFor, selectSleeveNotes, stationHistoryNoteFor } from './sleeve-notes.js';
 import { stripRecapSpokenTags, stripSpokenTags } from './recent-speech.js';
 
 // The feel note appended to a track line (track-feel.ts) is a STEER, not copy.
@@ -108,8 +108,14 @@ function verifiedContextPacket(context: any, current: any = null, clockIsAirTime
     moment.push("Show progress: final 15 minutes.");
     moment.push("Following show: \"" + String(handover.nextShow.name).trim() + "\" with " + String(handover.nextShow.presenter).trim() + ", starting " + String(handover.nextShow.startsAt).trim() + ".");
   }
-  const playCount = current ? (library.trackPlayStatsFor(current)?.count ?? null) : null;
-  const sleeves = includeSleeves ? selectSleeveNotes(contextSleeveNotesFor(current, context, playCount)) : [];
+  const playStats = current ? library.trackPlayStatsFor(current) : null;
+  const playCount = playStats?.count ?? null;
+  const stationHistoryNote = current
+    ? stationHistoryNoteFor(current, playStats, library.lastAiredInfo())
+    : null;
+  const sleeves = includeSleeves
+    ? selectSleeveNotes(contextSleeveNotesFor(current, context, playCount, stationHistoryNote))
+    : [];
   const sections = [
     "Verified Facts:",
     "Current Context:\n" + (moment.length ? moment.map((fact) => "- " + fact).join("\n") : "- No additional verified moment facts."),

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -32,13 +32,6 @@ const FEEL_CLAUSE = ' A feel note after a track line tells you how the track act
 // it, a model told to "mention the weather" would only invent it.
 const SCRIPT_CONTEXT_FIELDS = ['date', 'clock', 'time', 'festival', 'show', 'listeners'];
 
-// Links are delivery, not selection. Mood, energy, show steering and the
-// recent-play window are useful inputs when choosing a record, but become
-// internal prompt material once that choice is made. Keep the link's context
-// to listener-safe, deterministic facts only; any new field needs the same
-// scrutiny as a Verified Fact before it is added here.
-const LINK_CONTEXT_FIELDS = ['date', 'clock', 'festival'];
-
 // A request intro is WRITTEN when the request resolves but AIRED from
 // onTrackStarted — it plays over the opening bars of the track it introduces,
 // heavy-ducked, not in the gap before it (queue.airIntro, deferred by #189).

--- a/controller/src/llm/internal/prompts/sleeve-notes.ts
+++ b/controller/src/llm/internal/prompts/sleeve-notes.ts
@@ -3,6 +3,7 @@
 // the model prompt: it is a small trusted packet for the main DJ link path.
 
 import { trackEraYear } from '../../../music/show-filter.js';
+import { unairedFlag, type AiredIndex } from '../../../music/airing.js';
 
 function text(value: unknown, max = 180): string {
   return String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
@@ -26,10 +27,34 @@ export function sleeveNotesFor(track: any, playCount: number | null = null): str
   return notes;
 }
 
+// A small amount of station memory makes a link feel like it belongs to this
+// broadcast, but an empty/unavailable play index must never be presented as a
+// first play. `unairedFlag` makes exactly that distinction for the picker.
+// A rare return needs both a low lifetime count and a meaningful gap; without
+// the gap, a new station would call every second spin "rare".
+export function stationHistoryNoteFor(
+  track: any,
+  stats: { count: number; lastPlayedAtMs: number } | null,
+  index: AiredIndex,
+  nowMs = Date.now(),
+): string | null {
+  if (unairedFlag(track, index)) return 'First station play.';
+  if (!stats || stats.count < 1 || stats.count > 2) return null;
+  const days = Math.floor((nowMs - stats.lastPlayedAtMs) / 86_400_000);
+  if (!Number.isFinite(days) || days < 30) return null;
+  const times = stats.count === 1 ? 'once' : 'twice';
+  return `Played here only ${times} before; last heard ${days} days ago.`;
+}
 
 // Extra facts are derived from controller context, never model knowledge.
-export function contextSleeveNotesFor(track: any, context: any, playCount: number | null = null): string[] {
+export function contextSleeveNotesFor(
+  track: any,
+  context: any,
+  playCount: number | null = null,
+  stationHistoryNote: string | null = null,
+): string[] {
   const notes = sleeveNotesFor(track, playCount);
+  if (stationHistoryNote) notes.push(stationHistoryNote);
   const season = text(context?.date?.season);
   if (season) notes.push(`Season: ${season}.`);
   const condition = text(context?.weather?.condition);

--- a/controller/src/llm/internal/prompts/sleeve-notes.ts
+++ b/controller/src/llm/internal/prompts/sleeve-notes.ts
@@ -26,6 +26,25 @@ export function sleeveNotesFor(track: any, playCount: number | null = null): str
   return notes;
 }
 
+
+// Extra facts are derived from controller context, never model knowledge.
+export function contextSleeveNotesFor(track: any, context: any, playCount: number | null = null): string[] {
+  const notes = sleeveNotesFor(track, playCount);
+  const season = text(context?.date?.season);
+  if (season) notes.push(`Season: ${season}.`);
+  const condition = text(context?.weather?.condition);
+  if (condition && condition !== 'unknown') {
+    const place = text(context?.weather?.location);
+    notes.push(`Weather${place ? ` in ${place}` : ''}: ${condition}.`);
+  }
+  const show = context?.activeShow;
+  if (text(show?.topic)) notes.push(`Show theme: ${text(show.topic)}.`);
+  if (text(show?.episodeAngle)) notes.push(`Episode angle: ${text(show.episodeAngle)}.`);
+  const festival = text(context?.festival?.name);
+  if (festival) notes.push(`Festival: ${festival}.`);
+  return notes;
+}
+
 /**
  * A link needs a little colour, not a metadata checklist. Keep a single
  * supplemental fact varied per link while retaining a deterministic seam for

--- a/controller/src/llm/internal/prompts/sleeve-notes.ts
+++ b/controller/src/llm/internal/prompts/sleeve-notes.ts
@@ -1,0 +1,62 @@
+// Deterministic, listener-safe facts assembled after a track is selected.
+// This deliberately knows nothing about picker reasoning, tool transcripts, or
+// the model prompt: it is a small trusted packet for the main DJ link path.
+
+import { trackEraYear } from '../../../music/show-filter.js';
+
+function text(value: unknown, max = 180): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
+}
+
+/** Facts derived from controller/library state, safe to hand to the DJ as facts. */
+export function sleeveNotesFor(track: any, playCount: number | null = null): string[] {
+  const notes: string[] = [];
+  const album = text(track?.album);
+  const title = text(track?.title);
+  if (album && album.toLocaleLowerCase() !== title.toLocaleLowerCase()) {
+    notes.push(`Album: ${album}.`);
+  }
+  const year = trackEraYear(track);
+  if (year != null && Number.isInteger(year) && year >= 1880 && year <= new Date().getFullYear()) {
+    notes.push(`Release year: ${year}.`);
+  }
+  if (Number.isInteger(playCount) && playCount! > 0) {
+    notes.push(`Station plays before today: ${playCount}.`);
+  }
+  return notes;
+}
+
+/**
+ * A link needs a little colour, not a metadata checklist. Keep a single
+ * supplemental fact varied per link while retaining a deterministic seam for
+ * tests. The identity fact is added separately and is never random.
+ */
+export function selectSleeveNotes(notes: readonly string[], random: () => number = Math.random): string[] {
+  if (notes.length < 2) return [...notes];
+  const index = Math.min(notes.length - 1, Math.floor(random() * notes.length));
+  return [notes[index]!];
+}
+
+/**
+ * The complete prompt packet. The track identity is always present when it is
+ * known; at most one supplemental sleeve note follows it. A malformed/raw
+ * track degrades to no packet rather than creating an assertion from guesswork.
+ */
+export function verifiedFactsForLink(
+  track: any,
+  playCount: number | null = null,
+  random: () => number = Math.random,
+): string[] {
+  const title = text(track?.title);
+  if (!title) return [];
+  const artist = text(track?.artist) || 'unknown artist';
+  return [
+    `Track: "${title}" by ${artist}.`,
+    ...selectSleeveNotes(sleeveNotesFor(track, playCount), random),
+  ];
+}
+
+export function verifiedFactsSection(facts: readonly string[]): string {
+  if (!facts.length) return '';
+  return `Verified facts:\n${facts.map((fact) => `- ${fact}`).join('\n')}`;
+}

--- a/docs/internals/enriched-sleeve-notes.md
+++ b/docs/internals/enriched-sleeve-notes.md
@@ -1,0 +1,143 @@
+# Enriched Sleeve Notes — future development note
+
+## Status and scope
+
+This is a future, opt-in enrichment feature. It is not part of the current
+Verified Facts deployment and must not delay music selection, link generation,
+TTS, queue draining, or show handoffs.
+
+It is independent of the retired Producer Routing architecture. It uses native
+controller jobs and a local knowledge cache; no Producer or local-LLM
+fact-checking stage is proposed.
+
+## Purpose
+
+`Sleeve Notes` currently supplies a small deterministic set of trustworthy
+library, station-history, and schedule facts to a DJ link. Enriched Sleeve
+Notes would add optional, source-backed editorial context for music that the
+station actually encounters. It is an enhancement, not a requirement for every
+track or every station.
+
+The intended station behaviour is:
+
+```text
+Track queued
+    |
+    +-- local knowledge exists --> optional eligible Sleeve Note
+    |
+    +-- knowledge absent ------> add low-priority enrichment candidate
+                                      |
+                                      +-- runs only when playback-critical work is idle
+                                      +-- later tracks may use the result
+```
+
+A cache miss always falls back to the present link path. No network call is
+allowed from `generateLink` or any other on-air critical path.
+
+## Editorial classification
+
+Keep the categories distinct in storage and prompt construction:
+
+- **Verified Facts** are deterministic controller/library/station facts.
+- **Sourced Sleeve Notes** are optional editorial material retrieved from a
+  configured source. They are useful on-air context, not a guarantee that a
+  source claim is indisputable.
+- **Creative material** is persona and writing direction. It is never a source
+  of factual assertions.
+
+The DJ receives one compact, approved note, not a raw provider response. Prompt
+rules must prevent it from strengthening or extending a source claim using
+model memory.
+
+## Opt-in station setting
+
+Add a per-station master setting, provisionally named **Enriched Sleeve
+Notes**, disabled by default.
+
+When disabled, it must make no provider calls, schedule no enrichment jobs, and
+leave current Verified Facts and Sleeve Notes behaviour unchanged. This keeps
+fictional, fantasy, and deliberately non-real-world stations fully supported.
+
+When enabled, the UI should distinguish:
+
+1. disabled;
+2. enabled but no source configured; and
+3. enabled and gathering knowledge.
+
+Provider credentials are supplied by the station operator, not bundled with
+Subwave. Provider configuration sits below the master setting.
+
+## Gained-knowledge backlog
+
+Do not scan the whole library. Enrichment is gained knowledge: candidates enter
+a small, persistent backlog only when their tracks are queued. Prefer common
+station artists/releases, for example by admitting an entity after a second
+queued appearance or by weighting it with recent play count.
+
+Jobs are deduplicated by entity and run with strict low priority, bounded
+concurrency, rate limiting, retry backoff, and negative-cache results for
+unmatched entities. Playback, picking, link writing, TTS and handoffs always
+win. The controller need not be literally idle; it must merely have no
+higher-priority work waiting.
+
+Suggested job lifecycle:
+
+```text
+unknown -> queued -> fetching -> ready
+                    |             |
+                    +-> no-match  +-> stale / refreshable
+                    +-> retry-at
+```
+
+Start with artist and release context. Track-specific context should remain
+sparse and be attempted only where the broader entities do not already offer a
+suitable note.
+
+## Local data contract
+
+Use a sidecar database keyed through Subwave's existing library/Subsonic track
+identity, rather than modifying Navidrome's own database. Represent artist,
+release and track entities separately so many tracks can share one artist or
+release lookup.
+
+Each claim should retain at least:
+
+- entity and constrained claim type;
+- short approved on-air wording;
+- provider, provider entity ID and canonical URL;
+- supporting source excerpt;
+- retrieval time and freshness state;
+- source/editorial classification; and
+- eligibility or operator-review state.
+
+The runtime selection step reads only approved local claims and lets them
+compete with existing Sleeve Notes, preserving sparse and varied speech.
+
+## Provider model
+
+Make sources pluggable behind a small native provider interface. Each provider
+owns authentication, rate limiting, matching, retrieval, and its source policy;
+the cache exposes one common claim format to the rest of Subwave.
+
+Possible avenues, subject to API terms and an implementation spike:
+
+- MusicBrainz for structured release identity, dates, credits and relationships;
+- Discogs for edition, label and personnel context;
+- Genius for song-specific, crowdsourced editorial hooks;
+- Last.fm for broad artist biography and community tags; and
+- Wikidata/Wikipedia for wider artist history and cultural context.
+
+Prefer official APIs or explicitly permitted feeds. Do not make scraping a
+foundational dependency.
+
+## First implementation slice
+
+1. Add the disabled-by-default station setting and provider configuration
+   contract.
+2. Add the persistent, deduplicated gained-knowledge backlog, with no runtime
+   consumer initially.
+3. Implement one source adapter and its provenance-preserving local records.
+4. Add deterministic claim selection to Sleeve Notes, guarded by the master
+   setting and the existing prompt-safety boundary.
+5. Observe cache hit rate, work backlog, fetch failures, link latency, and
+   on-air repetition before adding further providers or track-level material.

--- a/docs/prompt-safety-extraction-map.md
+++ b/docs/prompt-safety-extraction-map.md
@@ -53,3 +53,14 @@ The reference range is the work after merge-base `65c840ee` on `codex/producer-r
 - Whether handovers and skill segments should adopt the same boundary later.
 - Additional facts such as artist history, selection intent, audio observations, weather or programme context; each needs an explicit source and assertion policy.
 - How the prompt-only PR will be extracted from any already-completed source changes; this branch favours a clean vanilla implementation.
+
+## One-call agent boundary
+
+The session DJ agent selects a track and writes its listener-facing `say` field
+in the same response. The controller cannot build the resolved Verified Facts
+packet until that response returns, so this path remains one call for now and
+its schema explicitly limits `say` to listener-facing speech.
+
+If prompt leakage is observed on this path, evaluate a post-selection main-DJ
+link generation call. That would let the controller provide the same Verified
+Facts packet, at the cost of an additional LLM call and its latency.

--- a/docs/prompt-safety-extraction-map.md
+++ b/docs/prompt-safety-extraction-map.md
@@ -7,11 +7,11 @@ This branch starts from upstream `develop` and deliberately does not carry the P
 The main DJ LLM remains responsible for listener-facing track links. This work improves prompt inputs and protects the handoff to TTS. It does not add a Producer model, FunctionGemma, segment/skill routing, or native shortlisting.
 
 ```text
-Internal instructions + verified context + selected track
+Selection and operational context
                     ↓
-              main DJ LLM
+  deterministic approved on-air fact plan
                     ↓
-        structured listener-facing speech
+  DJ writer: persona + house rules + approved plan only
                     ↓
              validation / TTS only
 ```
@@ -54,13 +54,32 @@ The reference range is the work after merge-base `65c840ee` on `codex/producer-r
 - Additional facts such as artist history, selection intent, audio observations, weather or programme context; each needs an explicit source and assertion policy.
 - How the prompt-only PR will be extracted from any already-completed source changes; this branch favours a clean vanilla implementation.
 
-## One-call agent boundary
+## Implemented split: selection from listener speech
 
-The session DJ agent selects a track and writes its listener-facing `say` field
-in the same response. The controller cannot build the resolved Verified Facts
-packet until that response returns, so this path remains one call for now and
-its schema explicitly limits `say` to listener-facing speech.
+The existing link-generation function combines internal selection/operational
+context with persona instructions and asks one model call to produce the final
+spoken line. That is no longer an acceptable safety boundary: different models
+can treat even a lightly worded mood, energy, scheduling or tool hint as
+creative material and repeat or imply it on air.
 
-If prompt leakage is observed on this path, evaluate a post-selection main-DJ
-link generation call. That would let the controller provide the same Verified
-Facts packet, at the cost of an additional LLM call and its latency.
+Split it into two explicit stages:
+
+1. **Approved on-air fact plan.** After a track is selected, controller code
+   builds the bounded Verified Facts packet and selects the
+   allowed on-air facts from it. This stage may use selection context, but produces no
+   speech.
+2. **DJ writer.** The existing main DJ writing call receives only the approved
+   fact plan, the required length, safe anti-repeat material, and its persona
+   / house rules. It must never receive selection mood, energy, tempo, key,
+   journey, ranking, candidate lists, show steering, or operational context.
+
+This prevents *prompt-context leakage*: a model cannot turn private selection
+cues into a listener-facing claim if those cues are absent from its prompt. It
+does not make a language model factually infallible, so validation remains
+between the writer and TTS.
+
+The session DJ agent now returns only its selected track, internal reason and
+transition decision. The controller then calls the normal main-DJ link writer
+with the selected track and its bounded Verified Facts packet. This adds one
+writer call to an agent-picked link, so its latency and allowance use must be
+measured separately.

--- a/docs/prompt-safety-extraction-map.md
+++ b/docs/prompt-safety-extraction-map.md
@@ -1,0 +1,55 @@
+# Prompt safety and Verified Facts: extraction map
+
+This branch starts from upstream `develop` and deliberately does not carry the Producer Routing or FunctionGemma architecture forward. This map identifies reusable evidence and the boundaries for a prompt-safety PR.
+
+## Scope
+
+The main DJ LLM remains responsible for listener-facing track links. This work improves prompt inputs and protects the handoff to TTS. It does not add a Producer model, FunctionGemma, segment/skill routing, or native shortlisting.
+
+```text
+Internal instructions + verified context + selected track
+                    ↓
+              main DJ LLM
+                    ↓
+        structured listener-facing speech
+                    ↓
+             validation / TTS only
+```
+
+## Source inventory
+
+The reference range is the work after merge-base `65c840ee` on `codex/producer-routing`. It is evidence, not a cherry-pick queue.
+
+| Source | Classification | Reuse decision |
+| --- | --- | --- |
+| `308a1823` / `443aeae7` — `docs/internals/verifiedContext.md` | Design evidence | Reuse the distinction between verified facts, editorial hooks and audio observations. Turn it into a concise runtime contract; do not depend on a Producer handoff. |
+| `a5397626` — `controller/src/llm/internal/prompts/sleeve-notes.ts` | Prompt grounding | Reimplement/adapt. Its track album, resolved era year and station-play count are deterministic sources available after selection. |
+| `7d62be95` — label sleeve notes as verified facts | Prompt grounding | Reuse the clear “Verified facts” label and explicit assertion boundary. |
+| `22b41387` — vary verified sleeve notes | Prompt grounding | Consider after the basic contract works. A sparse selected fact set is preferable to a metadata dump; selection must remain deterministic/testable. |
+| `a5397626` — `personaLinkPrompt` / `generatePersonaLink` | Mixed | Do not transplant. It is attached to the Producer/Persona Stage C path, new LLM kinds and Producer wiring. Rebuild the useful boundary in vanilla’s main-DJ link path. |
+| `5ad7ba71` — persona handover prompts | Mixed | Do not include in the first PR. It improves prompt isolation but changes programme/handoff behaviour and can be assessed later as a separate slice. |
+| `8cff67d4`, `3c3284ec`, `3cb8fe12` — evidence-backed segments | Segment/skill routing | On hold. These changes live in the skill-agent/Producer path and are outside this PR. |
+| `a5397626`, `bd10ed15`, `55c22368` — Musical Leanings schema/UI | Track selection | Exclude. It is an editorial selection input, not prompt safety or Verified Facts. |
+| Producer settings, agent factory, provider legs, contracts, benchmarks and routing tests | Producer Routing / FunctionGemma | Exclude. |
+
+## First implementation slice
+
+1. Identify vanilla’s single listener-facing link generation and its TTS enqueue point.
+2. Add a small deterministic verified-facts builder beside the existing prompt code. Start with title/artist, album, resolved era year and station-play count only when available and trustworthy.
+3. Feed a bounded selection to the main DJ prompt under `Verified facts`. State that no further externally verifiable claims may be inferred.
+4. Keep prompt instructions and facts separate from the model’s speech field. Only validated listener-facing text may be queued to TTS.
+5. Add focused tests for fact construction, absent/untrusted data, prompt shape, and the invariant that control-plane material is not passed as speech.
+
+## Acceptance criteria
+
+- The normal main-DJ link path receives a small verified-fact packet without a Producer or FunctionGemma call.
+- Facts derive from existing controller/library state and include no model reasoning or tool transcript.
+- TTS receives only the dedicated listener-facing output after validation.
+- Existing behaviour remains when no verified facts are available.
+
+## Deferred decisions
+
+- Exact structured response schema and the output validator’s rejection or repair posture.
+- Whether handovers and skill segments should adopt the same boundary later.
+- Additional facts such as artist history, selection intent, audio observations, weather or programme context; each needs an explicit source and assertion policy.
+- How the prompt-only PR will be extracted from any already-completed source changes; this branch favours a clean vanilla implementation.

--- a/docs/prompt-safety-extraction-map.md
+++ b/docs/prompt-safety-extraction-map.md
@@ -83,3 +83,37 @@ transition decision. The controller then calls the normal main-DJ link writer
 with the selected track and its bounded Verified Facts packet. This adds one
 writer call to an agent-picked link, so its latency and allowance use must be
 measured separately.
+
+## Handoff status — 2026-09-05
+
+This branch is ready for continued observation and refinement.
+
+- The prompt-safety / Verified Facts PR is
+  [perminder-klair/subwave#1542](https://github.com/perminder-klair/subwave/pull/1542),
+  from `feat/prompt-safety-verified-facts`.
+- The deployed live-station checkout is `/home/jaz666/Docker/subwave`, on
+  `test-station/vanilla-debug-handoffs-prompt-safety-live`. It contains the
+  existing station-test work plus these prompt-safety commits:
+  `6de45bb2` (final-quarter following-show context), `a91fcbaa` (station
+  history sleeve notes), and `2a1533cd` (stale link-context cleanup).
+- The controller was rebuilt and restarted after those commits, and its Docker
+  health check passed. Focused verified-facts and show-handover tests plus
+  TypeScript type-checking passed before deployment.
+- Do not reset, clean, or overwrite the live checkout: it deliberately retains
+  an unrelated modified `.dockerignore` and untracked
+  `controller/scripts/functiongemma/` work from other live-station testing.
+
+### What to observe next
+
+1. In the final 15 minutes, confirm that a following-show cue is occasional
+   rather than absent or repeated. The cue is optional model material, while
+   the timing/context constraint is deterministic.
+2. Confirm station-history notes are sparse: a first-ever station play may be
+   mentioned only when the library index is readable, and a return is eligible
+   only for one or two prior plays at least 30 days ago. They deliberately
+   compete with other sleeve-note facts, so no mention on a given link is
+   expected.
+3. Keep the current scope separate from the parallel architecture work:
+   native track shortlisting, handoff timing, and future native segment/skill
+   routing. The former Producer Routing design remains reference material only;
+   it is not part of the live station architecture or a porting target.


### PR DESCRIPTION
## Summary
- split session-DJ track selection from listener-facing link writing
- ground the isolated writer in a small verified-facts packet
- add deterministic final-quarter next-show facts and conservative station-history notes
- retain deterministic announce-link composition

## Safety boundary
The selector retains internal ranking, mood, journey, and tool context. Only the selected track plus approved listener-safe facts reach the link writer; only its validated text reaches TTS.

## Verification
- `npm test -- verified-facts`
- `npm test -- agent-say-boundary`
- `npm test -- clock-policy`
- `npm test -- show-handover-facts`
- `npm test -- link-style`
- `npm run typecheck`