### PR TITLE
docs: document squash merge message cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,17 @@ footer, for anything that breaks compatibility.
 PR titles follow the same convention — squash-merging keeps history clean, and
 the commit carries through `develop` → `main`, where release-please reads it.
 
+For ordinary PRs squash-merged into `develop`, maintainers must inspect GitHub's
+prefilled squash message before confirming the merge. The prefill can include
+branch commit messages and the PR body, so edit or replace it: keep the
+conventional PR title as the subject and only maintainer-approved body and
+footer content. Remove inherited third-party attribution and tool/session
+metadata such as `Co-Authored-By:`, `Claude-Session:`, or session-link footers.
+A `Co-Authored-By:` line may remain when a maintainer intentionally approves
+credit for a genuine human co-author, and a required `BREAKING CHANGE:` footer
+remains valid. This does not apply to the `develop` → `main` release PR, which
+uses a merge commit rather than squash.
+
 ## Releases
 
 You don't cut releases by hand. Maintainers merge `develop` into `main` to ship;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,16 +70,22 @@ footer, for anything that breaks compatibility.
 PR titles follow the same convention — squash-merging keeps history clean, and
 the commit carries through `develop` → `main`, where release-please reads it.
 
-For ordinary PRs squash-merged into `develop`, maintainers must inspect GitHub's
-prefilled squash message before confirming the merge. The prefill can include
-branch commit messages and the PR body, so edit or replace it: keep the
-conventional PR title as the subject and only maintainer-approved body and
-footer content. Remove inherited third-party attribution and tool/session
-metadata such as `Co-Authored-By:`, `Claude-Session:`, or session-link footers.
-A `Co-Authored-By:` line may remain when a maintainer intentionally approves
-credit for a genuine human co-author, and a required `BREAKING CHANGE:` footer
-remains valid. This does not apply to the `develop` → `main` release PR, which
-uses a merge commit rather than squash.
+Commits on `develop` are authored by the repo owner and carry no third-party
+trailers. That holds when a commit is written, but not in GitHub's squash box,
+which prefills the message from every commit on the branch plus the PR body — so
+for ordinary PRs squash-merged into `develop`, read that message before
+confirming. **The default is to delete the inherited tail**: keep the
+conventional PR title as the subject, keep the body you would have written for
+the commit yourself, and drop the concatenated branch commit messages under it.
+Remove anything that rode in that way — attribution trailers
+(`Co-Authored-By:`) and tool or session metadata (`Claude-Session:`,
+generated-by footers, session links).
+
+Two things survive the cut: a `Co-Authored-By:` line you are deliberately
+keeping to credit a genuine human co-author, and a `BREAKING CHANGE:` footer the
+change actually needs. The release PR is merged rather than squashed, for
+reasons of its own — see
+[`.claude/skills/subwave-release-pr/SKILL.md`](.claude/skills/subwave-release-pr/SKILL.md).
 
 ## Releases
 


### PR DESCRIPTION
## Problem

GitHub can prefill an ordinary squash-merge message with branch commit messages and PR-body text. That has allowed inherited contributor and tool trailers into `develop` history. Existing shared-history commits remain unchanged.

## Approach

Add maintainer guidance to `CONTRIBUTING.md` at the existing Conventional Commit and squash-merge guidance. It tells maintainers to review and edit or replace the generated message before confirming an ordinary squash merge into `develop`.

The guidance keeps the Conventional Commit PR-title subject, removes inherited third-party and tool metadata such as `Co-Authored-By:` and `Claude-Session:`, permits deliberately approved credit for genuine human co-authors, and preserves valid `BREAKING CHANGE:` footers. It also keeps the existing `develop` to `main` merge-commit rule intact.

Automated branch-message enforcement is out of scope because it cannot inspect the final GitHub-edited squash message, and its trailer and exception policy still needs a maintainer decision.

## Acceptance criteria

- [x] Guidance covers ordinary PRs squash-merged into `develop` and tells maintainers to inspect and edit or replace the prefilled message.
- [x] Guidance identifies branch commit messages and PR-body material as sources, and names `Co-Authored-By:` and `Claude-Session:` as metadata to remove when inherited.
- [x] The Conventional Commit subject and valid `BREAKING CHANGE:` footer convention remain intact.
- [x] Deliberately approved genuine human co-author credit remains allowed.
- [x] The `develop` to `main` release-PR merge-commit rule remains intact.
- [x] No historical commits or CI workflows changed.

## Verification

- `git diff --check` passed with no whitespace errors.
- Textual checks for all policy boundaries passed.
- Independent review approved the one-file, 11-line documentation diff.
- No Markdown formatter or Markdown-specific test is configured in the repository, and Prettier was not installed.

## Deviations

None.

Closes #1540