### PR TITLE
fix(analyzer): remove the staging file when a capped download fails

### DIFF
--- a/controller/scripts/analyzer-download-cleanup.test.ts
+++ b/controller/scripts/analyzer-download-cleanup.test.ts
@@ -1,0 +1,149 @@
+// downloadCapped must not leave its staging file behind when it throws.
+//
+// `createWriteStream` truncates `<analyze-tmp>/<id>.audio` into existence the
+// moment the pipeline starts, and three of downloadCapped's throws land AFTER
+// that line: a pipeline rejection (the request timeout aborting mid-body), the
+// `read === 0` guard, and the small-file non-audio backstop. Only the SUCCESS
+// path returns a path, and the caller only ever removes paths it was handed —
+// runAnalysisPass's one-ahead prefetch reduces a rejection to `{err}` and drops
+// the filename — so an orphan is unreachable until the pass's end-of-run
+// `rm -rf analyze-tmp`, which a crash or a mid-pass rebuild skips entirely.
+//
+// Every failing case here SEEDS the destination first, so the assertion is
+// "the cleanup ran", not the weaker "no file happened to be created" — that
+// distinction is what makes the content-type case (which throws before any
+// write) worth pinning alongside the three that do write.
+//
+// Loopback HTTP only, no external network: the same shape as
+// analyzer-path-fallback.test.ts — stand a server up, point NAVIDROME_URL at
+// it, then dynamically import analyzer.js so its module-level ANALYZE_TMP_DIR
+// resolves against the temp STATE_DIR.
+
+import assert from 'node:assert/strict';
+import { createServer, type ServerResponse } from 'node:http';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test, { after, before } from 'node:test';
+
+// One behaviour per song id, so each test names the failure it is pinning.
+type Mode = 'truncated' | 'empty' | 'tiny-envelope' | 'json-header' | 'ok';
+
+const AUDIO = 'audio/mpeg';
+
+function respond(mode: Mode, res: ServerResponse): void {
+  switch (mode) {
+    // Promises more body than it sends, then kills the socket — the shape a
+    // request-timeout abort or a dropped connection takes mid-download.
+    case 'truncated':
+      res.writeHead(200, { 'Content-Type': AUDIO, 'Content-Length': '4096' });
+      res.write(Buffer.alloc(64, 0x41));
+      setTimeout(() => res.destroy(), 10);
+      return;
+    // 200, audio content type, no bytes — trips the `read === 0` guard after
+    // the write stream has already created the file.
+    case 'empty':
+      res.writeHead(200, { 'Content-Type': AUDIO, 'Content-Length': '0' });
+      res.end();
+      return;
+    // A Subsonic error envelope wearing an audio content type: slips the header
+    // guard, gets written to disk, and is caught by the <1024-byte backstop.
+    case 'tiny-envelope': {
+      const body = JSON.stringify({
+        'subsonic-response': { status: 'failed', error: { code: 70, message: 'Song not found' } },
+      });
+      res.writeHead(200, { 'Content-Type': AUDIO, 'Content-Length': String(Buffer.byteLength(body)) });
+      res.end(body);
+      return;
+    }
+    // Honest error envelope — rejected by the content-type guard, before any
+    // file is created. Seeded anyway, so this pins that the cleanup is blanket.
+    case 'json-header': {
+      const body = JSON.stringify({
+        'subsonic-response': { status: 'failed', error: { code: 70, message: 'Song not found' } },
+      });
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': String(Buffer.byteLength(body)) });
+      res.end(body);
+      return;
+    }
+    // Real (if short) audio — the success path, which must KEEP its file.
+    case 'ok': {
+      const body = Buffer.alloc(2048, 0x5a);
+      body.writeUInt8(0xff, 0); // not '{' or '<', so the small-file backstop stays clear
+      res.writeHead(200, { 'Content-Type': AUDIO, 'Content-Length': String(body.length) });
+      res.end(body);
+      return;
+    }
+  }
+}
+
+const server = createServer((req, res) => {
+  const id = new URL(req.url || '/', 'http://localhost').searchParams.get('id') || '';
+  respond(id as Mode, res);
+});
+
+let analyzer: typeof import('../src/music/analyzer.js');
+let tmpDir: string;
+
+// The path downloadCapped stages to, recomputed the way the module does.
+function stagedPath(id: string): string {
+  return join(tmpDir, 'analyze-tmp', `${encodeURIComponent(id)}.audio`);
+}
+
+// Put a file where the download will stage, so "gone afterwards" means the
+// cleanup ran rather than nothing having been written in the first place.
+function seed(id: string): string {
+  const dest = stagedPath(id);
+  mkdirSync(join(tmpDir, 'analyze-tmp'), { recursive: true });
+  writeFileSync(dest, 'stale');
+  return dest;
+}
+
+before(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'subwave-analyzer-cleanup-'));
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  process.env.STATE_DIR = tmpDir;
+  process.env.NAVIDROME_URL = `http://127.0.0.1:${address.port}`;
+  process.env.NAVIDROME_USER = 'test';
+  process.env.NAVIDROME_PASS = 'test';
+  analyzer = await import('../src/music/analyzer.js');
+});
+
+after(async () => {
+  analyzer?.shutdown();
+  await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+});
+
+test('a download cut off mid-body leaves no partial file behind', async () => {
+  const dest = seed('truncated');
+  await assert.rejects(analyzer.downloadCapped('truncated'));
+  assert.equal(existsSync(dest), false, 'the partial .audio must be removed when the pipeline rejects');
+});
+
+test('a 200 with no audio bytes leaves no zero-length file behind', async () => {
+  const dest = seed('empty');
+  await assert.rejects(analyzer.downloadCapped('empty'), /empty audio/);
+  assert.equal(existsSync(dest), false, 'the zero-length .audio must be removed');
+});
+
+test('an error envelope wearing an audio content type leaves no file behind', async () => {
+  const dest = seed('tiny-envelope');
+  await assert.rejects(analyzer.downloadCapped('tiny-envelope'), analyzer.NonAudioResponseError);
+  assert.equal(existsSync(dest), false, 'the .audio holding a Subsonic error envelope must be removed');
+});
+
+test('an error envelope caught on the content type also clears a stale staging file', async () => {
+  const dest = seed('json-header');
+  await assert.rejects(analyzer.downloadCapped('json-header'), analyzer.NonAudioResponseError);
+  assert.equal(existsSync(dest), false, 'cleanup is blanket — it does not depend on this throw having written a file');
+});
+
+test('a successful download keeps its file for the caller to hand on', async () => {
+  const { path, complete } = await analyzer.downloadCapped('ok');
+  assert.equal(path, stagedPath('ok'));
+  assert.equal(existsSync(path), true, 'the success path must keep the staged file — the caller owns it from here');
+  assert.equal(statSync(path).size, 2048);
+  assert.equal(complete, true, 'a body under the byte cap is a complete file');
+});

--- a/controller/scripts/analyzer-download-cleanup.test.ts
+++ b/controller/scripts/analyzer-download-cleanup.test.ts
@@ -1,35 +1,40 @@
-// downloadCapped must not leave its staging file behind when it throws.
-//
-// `createWriteStream` truncates `<analyze-tmp>/<id>.audio` into existence the
-// moment the pipeline starts, and three of downloadCapped's throws land AFTER
-// that line: a pipeline rejection (the request timeout aborting mid-body), the
-// `read === 0` guard, and the small-file non-audio backstop. Only the SUCCESS
-// path returns a path, and the caller only ever removes paths it was handed —
-// runAnalysisPass's one-ahead prefetch reduces a rejection to `{err}` and drops
-// the filename — so an orphan is unreachable until the pass's end-of-run
-// `rm -rf analyze-tmp`, which a crash or a mid-pass rebuild skips entirely.
+// downloadCapped must not leave its staging file behind when it throws — and
+// must KEEP it on every path that returns one, including the deliberate
+// cap-hit truncation the outro analysis depends on.
 //
 // Every failing case here SEEDS the destination first, so the assertion is
 // "the cleanup ran", not the weaker "no file happened to be created" — that
-// distinction is what makes the content-type case (which throws before any
-// write) worth pinning alongside the three that do write.
+// distinction is what makes the two guards ABOVE the pipeline (a non-200, an
+// honest error envelope caught on the content type) worth pinning alongside
+// the three throws that do write a file.
 //
 // Loopback HTTP only, no external network: the same shape as
 // analyzer-path-fallback.test.ts — stand a server up, point NAVIDROME_URL at
 // it, then dynamically import analyzer.js so its module-level ANALYZE_TMP_DIR
-// resolves against the temp STATE_DIR.
+// and ANALYZE_MAX_BYTES resolve against the temp STATE_DIR and the small cap
+// set below.
 
 import assert from 'node:assert/strict';
 import { createServer, type ServerResponse } from 'node:http';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test, { after, before } from 'node:test';
 
 // One behaviour per song id, so each test names the failure it is pinning.
-type Mode = 'truncated' | 'empty' | 'tiny-envelope' | 'json-header' | 'ok';
+type Mode = 'truncated' | 'empty' | 'tiny-envelope' | 'json-header' | 'server-error' | 'over-cap' | 'tiny-audio' | 'ok';
 
 const AUDIO = 'audio/mpeg';
+
+// The byte cap the module reads at import time. Small enough that a test can
+// serve past it in one response — the real default is 12 MB.
+const MAX_BYTES = 4096;
+
+// One envelope shared by the two cases that serve one, so they can only ever
+// differ in the header under test.
+const ERROR_BODY = JSON.stringify({
+  'subsonic-response': { status: 'failed', error: { code: 70, message: 'Song not found' } },
+});
 
 function respond(mode: Mode, res: ServerResponse): void {
   switch (mode) {
@@ -48,25 +53,43 @@ function respond(mode: Mode, res: ServerResponse): void {
       return;
     // A Subsonic error envelope wearing an audio content type: slips the header
     // guard, gets written to disk, and is caught by the <1024-byte backstop.
-    case 'tiny-envelope': {
-      const body = JSON.stringify({
-        'subsonic-response': { status: 'failed', error: { code: 70, message: 'Song not found' } },
-      });
-      res.writeHead(200, { 'Content-Type': AUDIO, 'Content-Length': String(Buffer.byteLength(body)) });
-      res.end(body);
+    case 'tiny-envelope':
+      res.writeHead(200, { 'Content-Type': AUDIO, 'Content-Length': String(Buffer.byteLength(ERROR_BODY)) });
+      res.end(ERROR_BODY);
       return;
-    }
     // Honest error envelope — rejected by the content-type guard, before any
     // file is created. Seeded anyway, so this pins that the cleanup is blanket.
-    case 'json-header': {
-      const body = JSON.stringify({
-        'subsonic-response': { status: 'failed', error: { code: 70, message: 'Song not found' } },
-      });
-      res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': String(Buffer.byteLength(body)) });
+    case 'json-header':
+      res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': String(Buffer.byteLength(ERROR_BODY)) });
+      res.end(ERROR_BODY);
+      return;
+    // The other pre-pipeline throw: `!res.ok`. Also creates no file, also
+    // seeded, for the same reason.
+    case 'server-error':
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end('navidrome exploded');
+      return;
+    // More audio than the cap — the SUCCESS path that truncates. `capped()`
+    // returns normally, pipeline resolves, and the short file is kept with
+    // complete:false so outro analysis can veto itself.
+    case 'over-cap': {
+      const body = Buffer.alloc(MAX_BYTES * 16, 0x5a);
+      body.writeUInt8(0xff, 0);
+      res.writeHead(200, { 'Content-Type': AUDIO, 'Content-Length': String(body.length) });
       res.end(body);
       return;
     }
-    // Real (if short) audio — the success path, which must KEEP its file.
+    // Real audio SHORTER than the 1024-byte backstop window: re-read, found not
+    // to start with '{' or '<', and kept. The backstop's own false-positive edge.
+    case 'tiny-audio': {
+      const body = Buffer.alloc(512, 0x5a);
+      body.writeUInt8(0xff, 0);
+      res.writeHead(200, { 'Content-Type': AUDIO, 'Content-Length': String(body.length) });
+      res.end(body);
+      return;
+    }
+    // Real (if short) audio, over the backstop window and under the cap — the
+    // plain success path, which must KEEP its file.
     case 'ok': {
       const body = Buffer.alloc(2048, 0x5a);
       body.writeUInt8(0xff, 0); // not '{' or '<', so the small-file backstop stays clear
@@ -78,6 +101,10 @@ function respond(mode: Mode, res: ServerResponse): void {
 }
 
 const server = createServer((req, res) => {
+  // The cap case abandons the body mid-response, which resets the connection —
+  // an unhandled 'error' here would take the test process down with it.
+  req.on('error', () => {});
+  res.on('error', () => {});
   const id = new URL(req.url || '/', 'http://localhost').searchParams.get('id') || '';
   respond(id as Mode, res);
 });
@@ -105,6 +132,7 @@ before(async () => {
   const address = server.address();
   assert.ok(address && typeof address === 'object');
   process.env.STATE_DIR = tmpDir;
+  process.env.ANALYZE_MAX_BYTES = String(MAX_BYTES);
   process.env.NAVIDROME_URL = `http://127.0.0.1:${address.port}`;
   process.env.NAVIDROME_USER = 'test';
   process.env.NAVIDROME_PASS = 'test';
@@ -114,6 +142,7 @@ before(async () => {
 after(async () => {
   analyzer?.shutdown();
   await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+  rmSync(tmpDir, { recursive: true, force: true });
 });
 
 test('a download cut off mid-body leaves no partial file behind', async () => {
@@ -138,6 +167,30 @@ test('an error envelope caught on the content type also clears a stale staging f
   const dest = seed('json-header');
   await assert.rejects(analyzer.downloadCapped('json-header'), analyzer.NonAudioResponseError);
   assert.equal(existsSync(dest), false, 'cleanup is blanket — it does not depend on this throw having written a file');
+});
+
+test('a non-200 clears a stale staging file too', async () => {
+  const dest = seed('server-error');
+  await assert.rejects(analyzer.downloadCapped('server-error'), /download 500/);
+  assert.equal(existsSync(dest), false, 'the other pre-pipeline guard must not be an exception to the cleanup');
+});
+
+test('a download that hits the byte cap KEEPS its truncated file', async () => {
+  const { path, complete } = await analyzer.downloadCapped('over-cap');
+  assert.equal(path, stagedPath('over-cap'));
+  assert.equal(existsSync(path), true, 'the cap is a success, not a failure — the cleanup must not fire');
+  assert.equal(complete, false, 'a capped read is incomplete, which is what vetoes outro analysis');
+  assert.ok(
+    statSync(path).size >= MAX_BYTES,
+    `the kept file holds at least the cap (${statSync(path).size} bytes)`,
+  );
+});
+
+test('real audio shorter than the backstop window is kept', async () => {
+  const { path, complete } = await analyzer.downloadCapped('tiny-audio');
+  assert.equal(existsSync(path), true, 'the <1024 re-read must not condemn a short file that is real audio');
+  assert.equal(statSync(path).size, 512);
+  assert.equal(complete, true);
 });
 
 test('a successful download keeps its file for the caller to hand on', async () => {

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -16,6 +16,7 @@
 
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { existsSync, mkdirSync, createWriteStream, readFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { pipeline } from 'node:stream/promises';
 import { config } from '../config.js';
 import * as subsonic from './subsonic.js';
@@ -1075,6 +1076,34 @@ export async function downloadCapped(
     // exactly cap bytes is flagged incomplete too; erring that way only skips
     // outro analysis, never mis-measures it.)
     return { path: dest, complete: read < ANALYZE_MAX_BYTES };
+  } catch (err) {
+    // Drop the staging file on EVERY failure. `createWriteStream` truncates
+    // `dest` into existence the moment the pipeline starts, so three of the
+    // throws below it leave a file the caller never learns about: a pipeline
+    // rejection (the request timeout aborting mid-body is the common one, and
+    // it lands after up to ANALYZE_MAX_BYTES have been written), the
+    // `read === 0` guard, and the small-file non-audio backstop, which leaves
+    // a Subsonic error envelope sitting on disk named `.audio`. Only the
+    // SUCCESS path hands a path back, and the caller only ever cleans up paths
+    // it was handed — runAnalysisPass's one-ahead prefetch reduces a rejection
+    // to `{err}` and drops the filename on the floor — so nothing else can
+    // reach these.
+    //
+    // Blanket rather than per-throw on purpose: the two guards ABOVE the
+    // pipeline (`!res.ok`, the content-type check) create no file, `force`
+    // makes removing a path that was never created a no-op, and enumerating
+    // which throws happen to be past the `createWriteStream` line is exactly
+    // the distinction a later edit would get wrong. Best-effort — a cleanup
+    // that itself fails must not replace the real error.
+    //
+    // This is a disk leak, not a correctness one: every download truncates
+    // `dest` before writing, so a stale orphan is never read back. The bound
+    // is the pass's end-of-run `rm -rf analyze-tmp` (music/analyze.ts), which
+    // a crash, a mid-pass `up -d --build controller`, or a throw escaping the
+    // per-track handler all skip — and until then a flaky link accrues up to
+    // ANALYZE_MAX_BYTES per failure on the same volume the next download needs.
+    await rm(dest, { force: true }).catch(() => {});
+    throw err;
   } finally {
     clearTimeout(t);
   }

--- a/controller/src/music/analyzer.ts
+++ b/controller/src/music/analyzer.ts
@@ -1080,28 +1080,19 @@ export async function downloadCapped(
     // Drop the staging file on EVERY failure. `createWriteStream` truncates
     // `dest` into existence the moment the pipeline starts, so three of the
     // throws below it leave a file the caller never learns about: a pipeline
-    // rejection (the request timeout aborting mid-body is the common one, and
-    // it lands after up to ANALYZE_MAX_BYTES have been written), the
-    // `read === 0` guard, and the small-file non-audio backstop, which leaves
-    // a Subsonic error envelope sitting on disk named `.audio`. Only the
-    // SUCCESS path hands a path back, and the caller only ever cleans up paths
-    // it was handed — runAnalysisPass's one-ahead prefetch reduces a rejection
-    // to `{err}` and drops the filename on the floor — so nothing else can
-    // reach these.
+    // rejection, the `read === 0` guard, and the small-file non-audio backstop.
+    // Only the SUCCESS path hands a path back, and the caller only ever cleans
+    // up paths it was handed — runAnalysisPass's one-ahead prefetch reduces a
+    // rejection to `{err}` and drops the filename on the floor — so nothing
+    // else can reach these.
     //
     // Blanket rather than per-throw on purpose: the two guards ABOVE the
     // pipeline (`!res.ok`, the content-type check) create no file, `force`
     // makes removing a path that was never created a no-op, and enumerating
     // which throws happen to be past the `createWriteStream` line is exactly
     // the distinction a later edit would get wrong. Best-effort — a cleanup
-    // that itself fails must not replace the real error.
-    //
-    // This is a disk leak, not a correctness one: every download truncates
-    // `dest` before writing, so a stale orphan is never read back. The bound
-    // is the pass's end-of-run `rm -rf analyze-tmp` (music/analyze.ts), which
-    // a crash, a mid-pass `up -d --build controller`, or a throw escaping the
-    // per-track handler all skip — and until then a flaky link accrues up to
-    // ANALYZE_MAX_BYTES per failure on the same volume the next download needs.
+    // that itself fails must not replace the real error. The cap path is NOT
+    // a failure: `capped()` returns normally, so this never runs on it.
     await rm(dest, { force: true }).catch(() => {});
     throw err;
   } finally {


### PR DESCRIPTION
Salvaged from #1057, which was closed as too far behind to rebase. This fix was the one part of that branch worth keeping, and it stands on its own.

## What

`downloadCapped` in `music/analyzer.ts` creates its staging file with `createWriteStream`, but its `finally` only does `clearTimeout(t)`. Nothing removes the file when the download fails, so every failure leaves a partial `.audio` behind in `analyze-tmp`.

Three exits past `createWriteStream` leak:

- `pipeline(...)` rejects (timeout abort mid-body, connection reset)
- `read === 0` — "downloaded empty audio"
- the `read < 1024` backstop, where the file holds an error envelope wearing an audio content type

The size-cap path is deliberately untouched: `capped()` returns normally at `ANALYZE_MAX_BYTES`, the pipeline resolves, and the file is kept with `complete: false`, which the outro analysis depends on.

## Severity

Disk, not correctness. Every download truncates `dest` before writing, so a stale orphan is never read back. It's bounded by `runAnalysisPass`'s end-of-run `rm -rf analyze-tmp`, which a crash, a mid-pass `up -d --build controller`, or a throw escaping the per-track handler all skip. Until then a flaky link accrues up to `ANALYZE_MAX_BYTES` (12 MB default) per failure, on the same volume the next download needs.

## How

A single `catch` that removes `dest` with `force: true` and rethrows, rather than three targeted ones. `force: true` makes removing a never-created path a no-op, and enumerating which throws sit past the `createWriteStream` line is exactly the distinction a future edit gets wrong.

## Test

`scripts/analyzer-download-cleanup.test.ts`, 5 cases over loopback HTTP, no external network. Follows the `analyzer-path-fallback.test.ts` idiom: stand a server on 127.0.0.1, point `NAVIDROME_URL` and `STATE_DIR` at it and a temp dir, then dynamically import `analyzer.js` so its module-level `ANALYZE_TMP_DIR` resolves against the temp dir.

Each failing case seeds the destination file first, so it asserts the cleanup ran rather than the weaker "nothing happened to be written". The success case asserts the file is kept, guarding against an over-eager fix.

Reverting `analyzer.ts` to develop's version fails 4 of the 5:

```
✖ a download cut off mid-body leaves no partial file behind
✖ a 200 with no audio bytes leaves no zero-length file behind
✖ an error envelope wearing an audio content type leaves no file behind
✖ an error envelope caught on the content type also clears a stale staging file
✔ a successful download keeps its file for the caller to hand on
```

## Verification

`npm run lint` in `controller/` exit 0. `npm test` 965 tests, 964 pass. The one failure is `analyzer-python.test.ts`, which needs numpy; it fails identically on a clean `develop` checkout on the same machine.

## Noticed, not fixed here

`ANALYZE_MAX_BYTES` three lines above uses the idiom `controller/CLAUDE.md` bans:

```js
const ANALYZE_MAX_BYTES = parseInt(process.env.ANALYZE_MAX_BYTES || String(12 * 1024 * 1024), 10);
```

`ANALYZE_MAX_BYTES=ten` yields NaN, which makes `read >= NaN` always false (cap never fires, whole albums downloaded) and `complete: read < NaN` always false (every track flagged incomplete, so outro analysis goes off library-wide). Left out to keep this focused.
