### PR TITLE
docs(skills): clarify custom feed tool contract

### DIFF
--- a/controller/scripts/analyzer-python.test.ts
+++ b/controller/scripts/analyzer-python.test.ts
@@ -1,12 +1,15 @@
 // Shim that folds the pure-stdlib Python suites into `npm test`'s *.test.ts
 // auto-discovery, so they actually run with the rest of the suite instead of
 // only when someone remembers `python3 scripts/<file>.py`. Each suite is
-// deliberately dependency-free (no torch / demucs / librosa / audio), so a
-// plain python3 is the only requirement; a box without one skips cleanly
-// (exit 0) rather than failing the suite — CI runs lint only, so this gate is
-// for contributors' own `npm test` runs.
+// lightweight and isolated from the analyzer runtime (no torch / demucs /
+// librosa / audio). Two numerical suites use NumPy; when it is unavailable,
+// this shim installs the pinned test-only wheel into a temporary directory, so
+// a clean checkout's `npm test` is reproducible without modifying the user's
+// Python environment. A box without python3 still skips cleanly (exit 0).
 
 import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -28,11 +31,34 @@ if (probe.error || probe.status !== 0) {
   process.exit(0);
 }
 
+const NUMPY_VERSION = '2.5.2';
+const pythonEnv = { ...process.env };
+let depsDir: string | null = null;
+const numpyProbe = spawnSync('python3', ['-c', 'import numpy'], { stdio: 'ignore' });
+if (numpyProbe.status !== 0) {
+  depsDir = mkdtempSync(join(tmpdir(), 'subwave-python-test-deps-'));
+  console.log(`— installing test dependency numpy==${NUMPY_VERSION}`);
+  const install = spawnSync(
+    'python3',
+    ['-m', 'pip', 'install', '--disable-pip-version-check', '--no-input', '--target', depsDir, `numpy==${NUMPY_VERSION}`],
+    { stdio: 'inherit' },
+  );
+  if (install.error || install.status !== 0) {
+    console.error(`✗ could not install test dependency numpy==${NUMPY_VERSION}`);
+    process.exit(1);
+  }
+  pythonEnv.PYTHONPATH = pythonEnv.PYTHONPATH ? `${depsDir}:${pythonEnv.PYTHONPATH}` : depsDir;
+}
+
 const failed: string[] = [];
-for (const file of SUITES) {
-  console.log(`— ${file}`);
-  const { status } = spawnSync('python3', [join(scriptsDir, file)], { stdio: 'inherit' });
-  if (status !== 0) failed.push(file);
+try {
+  for (const file of SUITES) {
+    console.log(`— ${file}`);
+    const { status } = spawnSync('python3', [join(scriptsDir, file)], { stdio: 'inherit', env: pythonEnv });
+    if (status !== 0) failed.push(file);
+  }
+} finally {
+  if (depsDir) rmSync(depsDir, { recursive: true, force: true });
 }
 
 if (failed.length > 0) {

--- a/controller/scripts/skill-tool-loading.test.ts
+++ b/controller/scripts/skill-tool-loading.test.ts
@@ -1,0 +1,92 @@
+// Regression coverage for issue #1526: frontmatter is configuration for a
+// sibling tool.mjs, not an instruction for the loader to fetch a URL or invent a
+// tool for a prompt-only skill.
+//
+// Run: `npm test -- skill-tool-loading`.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// config.ts and the modules pulled in by segment-tools.ts resolve state paths at
+// module scope, so fixtures and STATE_DIR must exist before dynamic imports.
+const STATE_DIR = mkdtempSync(join(tmpdir(), 'skill-tool-loading-'));
+process.env.STATE_DIR = STATE_DIR;
+
+function writeSkill(slug: string, skillMd: string, tool?: string) {
+  const dir = join(STATE_DIR, 'skills', slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'SKILL.md'), skillMd);
+  if (tool) writeFileSync(join(dir, 'tool.mjs'), tool);
+}
+
+const giveawayConfig = {
+  name: 'giveaway',
+  label: 'Giveaway watch',
+  cooldown: '30m',
+  feed: 'https://example.test/giveaways.rss',
+  feedMaxItems: '7',
+  editorialNote: 'local prizes only',
+};
+
+writeSkill('giveaway', `---
+name: giveaway
+label: Giveaway watch
+cooldown: 30m
+feed: https://example.test/giveaways.rss
+feedMaxItems: 7
+editorialNote: local prizes only
+---
+Share one worthwhile local giveaway when the feed has one.
+`, `export default async function (_ctx, _state, _services, config) {
+  return { receivedConfig: config };
+}
+`);
+
+writeSkill('feed-notes', `---
+name: feed-notes
+label: Feed notes
+feed: https://example.test/notes.rss
+feedMaxItems: 4
+---
+Write a timeless line from this brief alone.
+`);
+
+const { loadSkills } = await import('../src/skills/loader.js');
+const { buildSegmentTools } = await import('../src/llm/internal/tools/segment-tools.js');
+const caps = await loadSkills();
+
+const giveaway = caps.find(cap => cap.kind === 'giveaway');
+const feedNotes = caps.find(cap => cap.kind === 'feed-notes');
+
+assert.ok(giveaway, 'custom skill with tool.mjs loaded');
+assert.ok(feedNotes, 'prompt-only skill loaded');
+
+test('a non-News custom tool is named and receives all frontmatter as config', async () => {
+  assert.equal(giveaway.toolName, 'skill_giveaway');
+  assert.equal(typeof giveaway.toolFn, 'function');
+  assert.deepEqual(giveaway.config, giveawayConfig);
+
+  const tools = buildSegmentTools({ time: {} }, {}, caps);
+  assert.ok(tools.skill_giveaway, 'custom tool is registered in the segment tool set');
+
+  const result = await tools.skill_giveaway.execute({});
+  assert.deepEqual(result, { receivedConfig: giveawayConfig });
+});
+
+test('feed frontmatter without tool.mjs stays prompt-only', () => {
+  assert.deepEqual(feedNotes.config, {
+    name: 'feed-notes',
+    label: 'Feed notes',
+    feed: 'https://example.test/notes.rss',
+    feedMaxItems: '4',
+  });
+  assert.equal(feedNotes.toolFn, undefined);
+  assert.equal(feedNotes.toolName, undefined);
+
+  const tools = buildSegmentTools({ time: {} }, {}, [feedNotes]);
+  assert.equal(tools.skill_feed_notes, undefined);
+  assert.deepEqual(Object.keys(tools), []);
+});

--- a/controller/scripts/voice-air-events.test.ts
+++ b/controller/scripts/voice-air-events.test.ts
@@ -11,7 +11,7 @@
 // Run: `npm test -- voice-air-events`.
 
 import assert from 'node:assert/strict';
-import test from 'node:test';
+import test, { after } from 'node:test';
 import { createServer, type Server } from 'node:http';
 import { mkdtempSync, writeFileSync, rmSync, unlinkSync, existsSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -38,6 +38,20 @@ const { notifySpoken, notifyQueued } = await import('../src/broadcast/voice-even
 const { setCache } = await import('../src/settings/store.js');
 
 const MARKER = config.liquidsoap.voicePlayingFile;
+after(() => resetVoiceMarkers());
+
+// awaitVoiceAir deliberately unrefs its production timeout so a controller can
+// shut down without waiting up to 20 seconds. A test awaiting only that timer
+// needs one referenced handle of its own or Node 22 correctly ends the subprocess
+// with the promise still pending. Keep that test support local to this file.
+async function keepProcessAliveUntil<T>(promise: Promise<T>): Promise<T> {
+  const keepAlive = setInterval(() => {}, 1_000);
+  try {
+    return await promise;
+  } finally {
+    clearInterval(keepAlive);
+  }
+}
 
 function writeMarker(m: Record<string, unknown>) {
   writeFileSync(MARKER, JSON.stringify(m));
@@ -165,7 +179,7 @@ test('a clip whose marker never comes reports an unknown air time', async () => 
   writeMarker({ voiceId: 'someone-else', channel: 'say', startedAt: 1770000400 });
   // Marker support is present (the file exists), so this one really does wait —
   // and then reports "unknown" rather than inventing a stamp.
-  assert.equal(await awaitVoiceAir('seg-4', 120), null);
+  assert.equal(await keepProcessAliveUntil(awaitVoiceAir('seg-4', 120)), null);
 });
 
 // --- the fan-out ----------------------------------------------------------

--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -287,6 +287,31 @@ export const configFields = {
 };
 ```
 
+> **Frontmatter does not fetch anything by itself.** Keys such as `feed:` and
+> `feedMaxItems:` are ordinary strings passed to the sibling `tool.mjs` as
+> `config`; they are not fetch declarations. A `SKILL.md` with those keys but no
+> `tool.mjs` remains prompt-only: it gets no `skill_<slug>` tool, performs no
+> automatic request, and receives no injected feed data.
+
+For a custom RSS-backed skill, add a sibling `tool.mjs` that reads those values
+and deliberately calls the shared feed service (frontmatter values arrive as
+strings, so convert numeric values yourself):
+
+```js
+export default async function (_ctx, _state, services, config) {
+  const maxItems = config.feedMaxItems ? Number(config.feedMaxItems) : undefined;
+  const headlines = await services.fetchHeadlines({
+    feedUrl: config.feed || undefined,
+    maxItems,
+  });
+  return { headlines };
+}
+```
+
+For production use, copy or adapt the built-in News `tool.mjs`; it also handles
+headline deduplication and the no-fresh-items case. The feed URL only has meaning
+because that tool reads it and calls `services.fetchHeadlines`.
+
 **`configFields` reference.** A flat `{ key: { … } }` map, up to 8 entries per
 skill. Each entry takes:
 

--- a/docs/custom-skills.md
+++ b/docs/custom-skills.md
@@ -299,7 +299,10 @@ strings, so convert numeric values yourself):
 
 ```js
 export default async function (_ctx, _state, services, config) {
-  const maxItems = config.feedMaxItems ? Number(config.feedMaxItems) : undefined;
+  const parsedMax = Number(config.feedMaxItems);
+  const maxItems = Number.isInteger(parsedMax) && parsedMax >= 1 && parsedMax <= 50
+    ? parsedMax
+    : undefined;
   const headlines = await services.fetchHeadlines({
     feedUrl: config.feed || undefined,
     maxItems,

--- a/web/components/manual/CustomSkills.tsx
+++ b/web/components/manual/CustomSkills.tsx
@@ -193,6 +193,33 @@ export const configFields = {
   feed:         { type: 'url',    label: 'News feed · RSS 2.0' },
   feedMaxItems: { type: 'number', label: 'Max items', min: 1, max: 50, integer: true },
 };`}</CodeBlock>
+        <div className="bs-callout">
+          <div className="bs-eyebrow">FRONTMATTER IS CONFIG, NOT A FETCH</div>
+          <p>
+            Adding <code className="bs-code-inline">feed:</code> or{' '}
+            <code className="bs-code-inline">feedMaxItems:</code> to{' '}
+            <code className="bs-code-inline">SKILL.md</code> does not fetch or inject
+            anything by itself. Without a sibling <code className="bs-code-inline">tool.mjs</code>,
+            the skill stays prompt-only and gets no generated{' '}
+            <code className="bs-code-inline">skill_&lt;slug&gt;</code> tool.
+          </p>
+        </div>
+        <p>
+          For a custom RSS-backed skill, add the sibling tool and have it read those
+          config strings and call <code className="bs-code-inline">services.fetchHeadlines</code>:
+        </p>
+        <CodeBlock>{`export default async function (_ctx, _state, services, config) {
+  const maxItems = config.feedMaxItems ? Number(config.feedMaxItems) : undefined;
+  const headlines = await services.fetchHeadlines({
+    feedUrl: config.feed || undefined,
+    maxItems,
+  });
+  return { headlines };
+}`}</CodeBlock>
+        <p className="text-muted">
+          Copy or adapt the built-in News <code className="bs-code-inline">tool.mjs</code>{' '}
+          when you also want its fresh-headline deduplication behaviour.
+        </p>
         <p>
           The call is timeout-guarded and any error degrades cleanly to &ldquo;no
           data&rdquo;; a slow or broken skill can never hang the station. With no{' '}

--- a/web/components/manual/CustomSkills.tsx
+++ b/web/components/manual/CustomSkills.tsx
@@ -209,7 +209,10 @@ export const configFields = {
           config strings and call <code className="bs-code-inline">services.fetchHeadlines</code>:
         </p>
         <CodeBlock>{`export default async function (_ctx, _state, services, config) {
-  const maxItems = config.feedMaxItems ? Number(config.feedMaxItems) : undefined;
+  const parsedMax = Number(config.feedMaxItems);
+  const maxItems = Number.isInteger(parsedMax) && parsedMax >= 1 && parsedMax <= 50
+    ? parsedMax
+    : undefined;
   const headlines = await services.fetchHeadlines({
     feedUrl: config.feed || undefined,
     maxItems,


### PR DESCRIPTION
## Problem

A custom skill that contains `feed:` and `feedMaxItems:` in its front matter does not fetch RSS data on its own. News works because it has its own companion data tool, which made the custom-skill behavior easy to misread.

## Approach

- Add a controller regression test covering a non-News custom skill with a sibling `tool.mjs`.
- Verify that the generated tool receives all front-matter values, and that a feed-configured skill without `tool.mjs` stays prompt-only.
- Update the repository guide and in-product manual to show the supported RSS pattern: a companion tool reads its config and calls the shared headline-fetching service.
- Keep URL fetching explicit in local tool code. No production loader, News, or feed-service behavior changes.
- Make the controller test suite self-contained under the checked Node and Python environment through test-only setup.

## Acceptance criteria

- [x] A non-News sibling tool is registered as `skill_<slug>`.
- [x] The tool receives complete front matter, including string-valued `feedMaxItems`.
- [x] Feed settings without a sibling tool do not create a tool or fetch data.
- [x] Built-in News behavior is unchanged.
- [x] Both documentation surfaces explain the explicit companion-tool RSS pattern.
- [x] Focused tests, full controller tests, and controller and web lint pass.

## Verification

- `cd controller && npm test -- skill-tool-loading` , passed, 2/2 tests.
- `cd controller && npm test -- voice-air-events` , passed, 15/15 tests.
- `cd controller && npm test -- news-feed` , passed, 12/12 tests.
- `cd controller && npm test` , passed, 893 tests with no failures or cancellations.
- `cd controller && npm run lint` , passed with no errors. Existing warnings remain.
- `cd web && npm run lint` , passed with no errors. Existing warnings remain.
- `git diff --check` , passed.

## Notes

The branch has a clean three-way merge with current `develop`. The in-product manual was not browser-tested because the local development server hit an environment-specific Turbopack symlink error; its lint and typecheck passed.

Fixes #1526