### PR TITLE
fix(docker): build the web image on Node 24 to clear the TransformStream race

### DIFF
--- a/docker/Dockerfile.aio
+++ b/docker/Dockerfile.aio
@@ -30,6 +30,14 @@ RUN npm run build
 FROM caddy:2 AS caddybin
 
 # ---- node binary: lift Node 22 from the official image ----------------------
+# NOTE: still 22, while web/Dockerfile is on 24. One node binary serves BOTH the
+# controller and the bundled Next.js server here, so the AIO's web half carries
+# the TransformStream cancel race described in web/Dockerfile's header (#1535) —
+# a client that disconnects mid-render can 500 with
+# `controller[kState].transformAlgorithm is not a function`. Moving this to 24
+# is the fix, but it also moves the controller's runtime (better-sqlite3 /
+# sqlite-vec native builds), so it needs its own change with a full AIO build
+# behind it rather than riding the web-image fix.
 FROM node:22-bookworm-slim AS nodebin
 
 # ---- final: everything under the liquidsoap (Debian) base -------------------

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -469,5 +469,5 @@ automatically.
 ## What's intentionally not included
 
 - **A `curl | sh` installer.** The two-file install (`curl docker-compose.yml` + `curl .env.example`) is the deliberate "as simple as it can be without piping random scripts into your shell" line.
-- **Multi-arch (arm64) images.** Piper, Kokoro, and Chatterbox wheels are amd64-only. Pin a Linux/amd64 host.
+- **A fully arm64 stack.** The split-stack core — `subwave-{caddy,broadcast,controller,web}` — and the lean `subwave-analyzer` ARE published for `linux/arm64` as well as `linux/amd64`, so a Pi 5 / arm64 NAS runs them natively (Dockerfile.controller picks its Piper build off `$TARGETARCH`; Kokoro/onnx have arm64 wheels). What is amd64-only: the `subwave-aio` all-in-one images (the bundled Next.js build fails its arm64 cross-build under QEMU), `subwave-tts-heavy` (Chatterbox), and the heavy/CUDA analyzer variants. On arm64, run the split stack and leave those opt-ins off — or set `DOCKER_DEFAULT_PLATFORM=linux/amd64` and accept emulation.
 - **Multi-host / k8s.** SUB/WAVE is a personal radio station — one Icecast mount, one broadcast. Scaling horizontally would mean per-listener streams, which defeats the design.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,14 +1,30 @@
 # Multi-stage build for the Next.js listener UI.
 # Produces a slim standalone image (~150MB) suitable for production.
+#
+# Node 24 (LTS "Krypton"), NOT 22. Node 22 — including the newest 22.23.2 —
+# still carries the `TransformStream` shutdown race fixed upstream by
+# nodejs/node#62040: `reader.cancel()` clears the controller's algorithms while
+# a write is already in flight, so the pending write reaches
+# `transformStreamDefaultControllerPerformTransform` and throws
+# `TypeError: controller[kState].transformAlgorithm is not a function`. Next's
+# App Router streams every RSC response through a TransformStream, so a client
+# that disconnects mid-render trips it — and once the browser starts retrying,
+# every request fails and the UI shows "Can't reach the controller" (#1535,
+# seen on a Pi 5 / k3s arm64 deploy, but the race is not arch-specific —
+# reproduced under both linux/amd64 and linux/arm64). The fix shipped in
+# v24.15.0 and v25.8.1 and was never backported to the 22.x line. The floating
+# `24` tag always resolves to the newest 24.x, so it is comfortably past that
+# floor; the runner stage re-checks it at build time rather than trusting the
+# tag. Do not move this back to 22.
 
 # ---- deps ----
-FROM node:22-bookworm-slim AS deps
+FROM node:24-bookworm-slim AS deps
 WORKDIR /app
 COPY web/package.json web/package-lock.json ./
 RUN npm ci
 
 # ---- build ----
-FROM node:22-bookworm-slim AS build
+FROM node:24-bookworm-slim AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY web/ ./
@@ -38,7 +54,7 @@ ENV SUBWAVE_BUILD_VERSION=${SUBWAVE_BUILD_VERSION}
 RUN npm run build
 
 # ---- runner ----
-FROM node:22-bookworm-slim AS runner
+FROM node:24-bookworm-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -46,6 +62,11 @@ ENV PORT=7700
 ENV HOSTNAME=0.0.0.0
 
 RUN groupadd -r next && useradd -r -g next next
+
+# Regression guard for #1535 — fails the build if the base image's Node still
+# leaks the TransformStream cancel race (see the header and the script).
+COPY web/scripts/check-transformstream-race.mjs /tmp/check-transformstream-race.mjs
+RUN node /tmp/check-transformstream-race.mjs && rm /tmp/check-transformstream-race.mjs
 
 # Standalone output bundles only the runtime files Next.js needs.
 COPY --from=build --chown=next:next /app/.next/standalone ./

--- a/web/scripts/check-transformstream-race.mjs
+++ b/web/scripts/check-transformstream-race.mjs
@@ -1,0 +1,55 @@
+// Build-time guard for issue #1535 / nodejs/node#62036.
+//
+// Node's `TransformStream` had a shutdown race: `reader.cancel()` clears the
+// controller's algorithms via `transformStreamDefaultControllerClearAlgorithms`
+// while a write is already in flight, so the pending write still reaches
+// `transformStreamDefaultControllerPerformTransform` and throws
+// `TypeError: controller[kState].transformAlgorithm is not a function`.
+//
+// Next's App Router streams every RSC response through a TransformStream, so a
+// client that disconnects mid-render trips it and the whole page 500s. On a
+// Pi 5 / k3s arm64 deploy that turned into a retry loop: ~1800 of these in two
+// hours and a permanent "Can't reach the controller".
+//
+// Fixed upstream by nodejs/node#62040, shipped in v24.15.0 / v25.8.1 and never
+// backported to the 22.x line (22.23.2 still reproduces, on amd64 AND arm64).
+// This runs inside `web/Dockerfile`'s runner stage so a future base-image
+// change back to an affected runtime fails the build instead of shipping.
+//
+// Body is the upstream reproduction from nodejs/node#62036, verbatim in shape.
+import { TransformStream } from 'node:stream/web';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const stream = new TransformStream({
+  transform(chunk, controller) {
+    controller.enqueue(chunk);
+  },
+});
+
+await delay(50);
+
+const reader = stream.readable.getReader();
+const writer = stream.writable.getWriter();
+
+const pendingRead = reader.read();
+const pendingCancel = reader.cancel(new Error('client disconnected'));
+const pendingLateWrite = writer.write('late-write');
+
+const results = await Promise.allSettled([pendingRead, pendingCancel, pendingLateWrite]);
+
+const leaked = results.find(
+  (r) =>
+    r.status === 'rejected' &&
+    /transformAlgorithm is not a function/.test(String(r.reason?.message ?? r.reason)),
+);
+
+if (leaked) {
+  console.error(
+    `FAIL: ${process.version} leaks the TransformStream cancel race ` +
+      `(nodejs/node#62036) — ${leaked.reason?.message ?? leaked.reason}. ` +
+      'Use a Node release that carries nodejs/node#62040 (>= 24.15.0).',
+  );
+  process.exit(1);
+}
+
+console.log(`ok: ${process.version} carries the nodejs/node#62040 TransformStream fix`);


### PR DESCRIPTION
## The bug

The published `subwave-web` image failed every request on a Pi 5 / k3s arm64
deploy with:

```
⨯ TypeError: controller[kState].transformAlgorithm is not a function
```

`kState`/`transformAlgorithm` are Node internals, not Next's. This is
[nodejs/node#62036](https://github.com/nodejs/node/issues/62036): `reader.cancel()`
runs `transformStreamDefaultControllerClearAlgorithms` while a write is already
in flight, so the pending write still reaches
`transformStreamDefaultControllerPerformTransform` and calls a now-`undefined`
`transformAlgorithm`.

Next's App Router streams every RSC response through a `TransformStream`, so a
client that disconnects mid-render trips it. Once the browser starts retrying,
every request 500s and the UI shows "Can't reach the controller" — matching the
~1800 occurrences in two hours while controller and broadcast stayed healthy.

Fixed upstream by [nodejs/node#62040](https://github.com/nodejs/node/pull/62040),
shipped in **v24.15.0** and **v25.8.1**, and **never backported to the 22.x
line** — which is why rolling `web` back to `0.14.0` changed nothing.

**It is not arm64-specific.** `node:22-bookworm-slim` (v22.23.2) reproduces the
race under both `linux/amd64` and `linux/arm64`; the Pi deploy is just where it
was noticed.

## The change

- `web/Dockerfile`: all three stages `node:22-bookworm-slim` →
  `node:24-bookworm-slim` (LTS "Krypton"), with the reasoning in the header.
- `web/scripts/check-transformstream-race.mjs` + a `RUN` in the **runner** stage:
  the upstream reproduction as a build-time guard, so a later base-image change
  back to an affected runtime fails the build instead of shipping. It runs per
  target platform, so the arm64 leg checks the arm64 runtime.
- `docker/Dockerfile.aio`: comment only — see "Deliberately out of scope".
- `docs/deployment.md`: the "no multi-arch images" bullet was stale (the
  split-stack core and the lean analyzer have been multi-arch for a while);
  corrected to say which images are amd64-only and why.

No app code changed, and amd64 behaviour is unchanged apart from the runtime
major.

## Verified

Locally, with `docker buildx` + QEMU on this machine:

| Check | amd64 | arm64 |
| --- | --- | --- |
| Upstream repro on `node:22-bookworm-slim` (v22.23.2) | **throws** the exact `TypeError` | **throws** the exact `TypeError` |
| Upstream repro on `node:24-bookworm-slim` (v24.20.0) | clean | clean |
| `docker build -f web/Dockerfile` | pass | pass |
| Runner-stage guard output | `ok: v24.20.0 carries the nodejs/node#62040 TransformStream fix` | same |
| Guard as a negative control (forced onto Node 22) | exits 1 with the failure message | exits 1 with the failure message |
| Container runs non-root as `next`, `node -v` = v24.20.0 | pass | pass |
| `GET /` on port 7700 | 200 | 200 |
| 150 requests aborted mid-render → `transformAlgorithm` in logs | 0 | 0 |

`cd web && npm run lint` is clean (0 errors; the 5 warnings are pre-existing and
untouched by this branch).

## Inferred, not verified

- **The link from the runtime race to these specific HTTP 500s is inferred.** I
  could not reproduce it through an actual Next request on this machine: a
  control image built on Node 22 survived 600 concurrent aborted/cancelled RSC
  and page requests with zero occurrences. The race is timing-dependent and the
  reporter's box is slower with k3s networking in front of it. What *is* proven
  is that the runtime shipped in the image carries the defect that produces that
  exact error string, that nothing else in the stack can produce it, and that
  Node 24 does not.
- **Not validated on native Raspberry Pi hardware.** All arm64 work here is QEMU
  emulation. The real confirmation is the reporter's logs going quiet after
  pulling an image built from this branch.
- Node 24 is a runtime major bump for the web image. The Next.js build,
  standalone server, and page rendering were exercised as above, but not the
  full listener/admin surface.

## Deliberately out of scope

`docker/Dockerfile.aio` still lifts Node 22, so the all-in-one image's web half
carries the same race. One node binary there serves **both** the controller and
the bundled Next server, so moving it also moves the controller's native
builds (`better-sqlite3`, `sqlite-vec`) and needs a full AIO build behind it.
That is its own change; the exposure is now noted in the file. `Dockerfile.controller`
is untouched for the same reason — the controller does not serve RSC and was
healthy throughout.

Closes #1535
