### PR TITLE
fix(tts): add a Slovak row to the voice preview table (#1108)

### DIFF
--- a/controller/scripts/preview-text.test.ts
+++ b/controller/scripts/preview-text.test.ts
@@ -35,6 +35,18 @@ async function main() {
     assert.equal(localizedPreviewText('हिन्दी'), localizedPreviewText('hi'));
   });
 
+  console.log('slovak (#1108):');
+  await test('Slovak matches by name, native name and ISO code', () => {
+    const sample = 'Počúvate SUB/WAVE. Toto je ukážka hlasu.';
+    assert.equal(localizedPreviewText('Slovak'), sample);
+    assert.equal(localizedPreviewText('slovenčina'), sample);
+    assert.equal(localizedPreviewText('sk'), sample);
+  });
+  await test('Slovak is not the English default and not the Czech sample', () => {
+    assert.notEqual(localizedPreviewText('Slovak'), localizedPreviewText('English'));
+    assert.notEqual(localizedPreviewText('Slovak'), localizedPreviewText('Czech'));
+  });
+
   console.log('fallback contract:');
   await test('empty / undefined → null (caller uses the English default)', () => {
     assert.equal(localizedPreviewText(''), null);
@@ -49,7 +61,7 @@ async function main() {
 
   console.log('table invariants:');
   await test('every sample keeps the station name untranslated', () => {
-    for (const lang of ['Spanish', 'French', 'German', 'Japanese', 'Chinese', 'Arabic', 'Hebrew', 'Hindi', 'Punjabi']) {
+    for (const lang of ['Spanish', 'French', 'German', 'Japanese', 'Chinese', 'Arabic', 'Hebrew', 'Hindi', 'Punjabi', 'Slovak']) {
       const sample = localizedPreviewText(lang);
       assert.ok(sample && sample.includes('SUB/WAVE'), `${lang} sample must mention SUB/WAVE verbatim`);
     }

--- a/controller/src/audio/preview-text.ts
+++ b/controller/src/audio/preview-text.ts
@@ -38,6 +38,9 @@ const ENTRIES: PreviewEntry[] = [
     sample: 'Ви слухаєте SUB/WAVE. Це зразок голосу.' },
   { keys: ['czech', 'cestina', 'cs'],
     sample: 'Posloucháte SUB/WAVE. Toto je ukázka hlasu.' },
+  // 'slovencina' is the normalized form of "slovenčina" (diacritics stripped).
+  { keys: ['slovak', 'slovencina', 'sk'],
+    sample: 'Počúvate SUB/WAVE. Toto je ukážka hlasu.' },
   { keys: ['swedish', 'svenska', 'sv'],
     sample: 'Du lyssnar på SUB/WAVE. Det här är ett röstprov.' },
   { keys: ['norwegian', 'norsk', 'no', 'nb'],


### PR DESCRIPTION
Fixes #1108.

## The bug

A persona set to Slovak auditioned in English. The persona editor's "Play sample" button resolves its sentence through the static table in `controller/src/audio/preview-text.ts`; Slovak had no row, so `localizedPreviewText()` returned `null` and `tts.speak` fell through to `DEFAULT_PREVIEW_TEXT`. That is why the reporter saw it on every engine (Omnivoice, Supertonic, ElevenLabs, OpenAI) while Czech and Hungarian — both of which have rows — auditioned correctly, and why the on-air DJ was unaffected: production speech goes through the persona's `languageDirective`, not this table.

## The fix

One row, next to Czech, with the table's usual three key shapes:

```ts
{ keys: ['slovak', 'slovencina', 'sk'],
  sample: 'Počúvate SUB/WAVE. Toto je ukážka hlasu.' },
```

`slovenčina` reaches the `slovencina` key through the existing diacritic-stripping normalizer, so the native spelling matches without a separate entry. "SUB/WAVE" stays untranslated, per the proper-noun rule the rest of the table follows.

## Tests

`controller/scripts/preview-text.test.ts` gains a `slovak (#1108)` block pinning all three key shapes, plus the regression itself — Slovak must not equal the English default, and must not equal the Czech sample. Slovak also joins the station-name invariant list.

```
$ npm run lint      # 0 errors
$ npm test -- preview
  ✓ Slovak matches by name, native name and ISO code
  ✓ Slovak is not the English default and not the Czech sample
  … 11 passed, 0 failed
```
