### PR TITLE
feat(search): allow pinning a SearXNG engines list

### DIFF
--- a/controller/scripts/settings-patch-schema.test.ts
+++ b/controller/scripts/settings-patch-schema.test.ts
@@ -377,6 +377,22 @@ test('search.baseUrl TYPE-checks where scrobble.listenbrainz.baseUrl coerces', (
   assert.equal(searchPatchSchema.parse({ baseUrl: 'http://x/' }).baseUrl, 'http://x/');
 });
 
+// #1353. New field, so it takes the trimmed posture rather than search.apiKey's
+// raw one — nothing shipped depends on the old storage behaviour here.
+test('search.searxngEngines trims, caps and defaults to empty', () => {
+  assert.equal(searchPatchSchema.parse({ searxngEngines: '  google, wikipedia  ' }).searxngEngines,
+    'google, wikipedia');
+  assert.equal(searchPatchSchema.parse({ searxngEngines: '' }).searxngEngines, '');
+  // Absent stays absent — update() only writes the key when the patch names it,
+  // so an unset pin can never be clobbered by a save from another panel.
+  assert.equal('searxngEngines' in searchPatchSchema.parse({ provider: 'searxng' }), false);
+  assert.equal(searchPatchSchema.safeParse({ searxngEngines: 'x'.repeat(501) }).success, false);
+  assert.equal(
+    searchPatchSchema.safeParse({ searxngEngines: 'x'.repeat(501) }).error?.issues[0]?.message,
+    'search.searxngEngines must be 0-500 chars',
+  );
+});
+
 test('search.apiKey stringifies null to "null" and does NOT trim', () => {
   // Not a good design, but the shipping one, and a secret field is the last
   // place to change storage behaviour by accident.

--- a/controller/scripts/web-search-searxng.test.ts
+++ b/controller/scripts/web-search-searxng.test.ts
@@ -1,13 +1,15 @@
-// Unit tests for the pure SearXNG response parser. SearXNG's JSON shape is
-// non-trivial (results[], answers[], infoboxes[], suggestions[]) so we pin
-// the mapping with recorded fixtures rather than handwritten objects.
+// Unit tests for the two pure halves of the SearXNG backend: the response
+// parser and the query-URL builder. SearXNG's JSON shape is non-trivial
+// (results[], answers[], infoboxes[], suggestions[]) so we pin the mapping
+// with recorded fixtures rather than handwritten objects; the URL builder is
+// pinned directly so the query shape needs no fetch mock.
 // Run: `tsx scripts/web-search-searxng.test.ts` (folded into `npm test`).
 
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { parseSearxngResponse } from '../src/skills/web-search.js';
+import { buildSearxngUrl, parseSearxngResponse } from '../src/skills/web-search.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const fixture = (name: string) =>
@@ -88,6 +90,48 @@ async function main() {
     assert.equal(expected('searxng', 'week', 'Foo'), 'searxng:week:foo');
     assert.equal(expected('searxng', '', 'Foo'), 'searxng::foo');
   });
+
+  console.log('buildSearxngUrl:');
+
+  // #1353. The engine pin is optional and must be invisible when unset — an
+  // `engines=` param sent empty is NOT the same as no param: SearXNG's
+  // parse_generic() reads an empty list as "no engines matched" and answers
+  // with nothing, where omitting the param uses the instance defaults.
+  await test('omits engines= entirely when the pin is unset', () => {
+    for (const engines of [undefined, '', '   ']) {
+      const url = buildSearxngUrl({ baseUrl: 'http://searx.lan:8888', query: 'Aphex Twin', engines });
+      assert.equal(url.searchParams.has('engines'), false, `engines=${JSON.stringify(engines)}`);
+      assert.equal(url.toString(), 'http://searx.lan:8888/search?q=Aphex+Twin&format=json');
+    }
+  });
+
+  await test('sends the pin verbatim, spaces and commas intact', () => {
+    const url = buildSearxngUrl({
+      baseUrl: 'http://searx.lan:8888',
+      query: 'Aphex Twin',
+      engines: '  google, duckduckgo web, wikipedia  ',
+    });
+    // Trimmed at the ends only. The inner spaces are load-bearing: a SearXNG
+    // engine name is its `name:` field, e.g. 'duckduckgo web'.
+    assert.equal(url.searchParams.get('engines'), 'google, duckduckgo web, wikipedia');
+  });
+
+  await test('the pin rides alongside time_range, not instead of it', () => {
+    const url = buildSearxngUrl({
+      baseUrl: 'http://searx.lan:8888',
+      query: 'Aphex Twin',
+      recency: 'week',
+      engines: 'wikipedia',
+    });
+    assert.equal(url.searchParams.get('time_range'), 'week');
+    assert.equal(url.searchParams.get('engines'), 'wikipedia');
+    assert.equal(url.searchParams.get('format'), 'json');
+  });
+
+  await test('a base URL with a path still resolves to /search', () => {
+    const url = buildSearxngUrl({ baseUrl: 'http://searx.lan:8888/', query: 'x' });
+    assert.equal(url.pathname, '/search');
+  });
 }
 
 main().then(() => {
@@ -95,5 +139,5 @@ main().then(() => {
     console.error(`\n${failures} test(s) failed`);
     process.exit(1);
   }
-  console.log('\nAll parseSearxngResponse tests passed.');
+  console.log('\nAll SearXNG web-search tests passed.');
 });

--- a/controller/src/schemas/settings.ts
+++ b/controller/src/schemas/settings.ts
@@ -333,6 +333,13 @@ export const SETTINGS_LOUDNESS_SOURCES = [
 
 export const SETTINGS_SEARCH_PROVIDERS = ['duckduckgo', 'tavily', 'brave', 'searxng'] as const;
 
+/**
+ * Cap for the optional SearXNG `engines=` pin. Generous on purpose — the value
+ * is a comma-separated list of SearXNG `name:` fields, so a dozen engines with
+ * multi-word names still fits well inside it.
+ */
+export const SETTINGS_SEARXNG_ENGINES_MAX = 500;
+
 export const CROSSFADE_DURATION_BOUNDS: SettingsNumericBound = { min: 0, max: 30 };
 // −23 (EBU R128 broadcast) … −9 (very loud); −14 is the streaming standard.
 export const LOUDNESS_TARGET_LUFS_BOUNDS: SettingsNumericBound = { min: -23, max: -9 };
@@ -618,6 +625,14 @@ export const searchPatchSchema = settingsBlockOf({
     })
     .transform((raw) => String(raw).trim()),
   apiKey: settingsRawStringLike(200, 'search.apiKey must be 0-200 chars'),
+  // Optional comma-separated SearXNG engine pin (#1353), appended as the
+  // `engines=` query param when non-empty. New field, so it takes the trimmed
+  // posture rather than search.apiKey's raw one — there is no stored behaviour
+  // to preserve here, and a stray space around a name is a typo, not a value.
+  searxngEngines: settingsTrimmedString(
+    SETTINGS_SEARXNG_ENGINES_MAX,
+    `search.searxngEngines must be 0-${SETTINGS_SEARXNG_ENGINES_MAX} chars`,
+  ),
 });
 
 const scrobbleLastfmSchema = settingsBlockOf({

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -879,6 +879,10 @@ export async function load() {
         : DEFAULTS.search.provider,
       apiKey: typeof stored.search?.apiKey === 'string' ? stored.search.apiKey : '',
       baseUrl: typeof stored.search?.baseUrl === 'string' ? stored.search.baseUrl : DEFAULTS.search.baseUrl,
+      searxngEngines:
+        typeof stored.search?.searxngEngines === 'string'
+          ? stored.search.searxngEngines
+          : DEFAULTS.search.searxngEngines,
     },
     embedding: {
       enabled:
@@ -1703,6 +1707,7 @@ export async function update(patch) {
     const sr = parseSettingsPatchKey<Record<string, unknown>>('search', patch.search);
     if (sr.provider !== undefined) next.search.provider = sr.provider as string;
     if (sr.baseUrl !== undefined) next.search.baseUrl = sr.baseUrl as string;
+    if (sr.searxngEngines !== undefined) next.search.searxngEngines = sr.searxngEngines as string;
     // 'set' is the redaction sentinel from getRedacted() — ignore it so a
     // round-tripped form doesn't overwrite the real key. Tested against the RAW
     // patch value, not the parsed one: the sentinel means "leave the stored

--- a/controller/src/settings/defaults.ts
+++ b/controller/src/settings/defaults.ts
@@ -467,6 +467,9 @@ export const DEFAULTS = {
     provider: 'duckduckgo',
     apiKey: '',
     baseUrl: '',
+    // Optional comma-separated SearXNG engine pin (#1353). Empty means "send no
+    // engines= param", i.e. the instance's own default engine set.
+    searxngEngines: '',
   },
   skills: {
     enabled: {},

--- a/controller/src/skills/web-search.ts
+++ b/controller/src/skills/web-search.ts
@@ -14,6 +14,8 @@
 //     (issue #623). Same key resolution as Tavily; metered billing with $5/mo
 //     of free credits (~1,000 queries), so the 30-min memo matters here too.
 //   - searxng — self-hosted meta-search, keyless, needs settings.search.baseUrl.
+//     settings.search.searxngEngines optionally pins the engine set for these
+//     calls only (#1353), leaving the instance's browser traffic on its defaults.
 //
 // All backends return the same shape — { answer, results: [{ title, content }] }
 // — so callers don't have to branch. searchWeb() wraps every call in a 30-min
@@ -148,10 +150,12 @@ export async function searxngSearch(
   const baseUrl = (settings.get().search?.baseUrl || '').trim();
   if (!baseUrl) throw new Error('SearXNG baseUrl not configured');
 
-  const url = new URL('/search', baseUrl);
-  url.searchParams.set('q', query);
-  url.searchParams.set('format', 'json');
-  if (recency) url.searchParams.set('time_range', recency);
+  const url = buildSearxngUrl({
+    baseUrl,
+    query,
+    recency,
+    engines: settings.get().search?.searxngEngines || '',
+  });
 
   const res = await fetchWithTimeout(url, {
     headers: {
@@ -162,6 +166,29 @@ export async function searxngSearch(
   if (!res.ok) throw new Error(`SearXNG HTTP ${res.status}`);
   const data = await res.json();
   return parseSearxngResponse(data);
+}
+
+// Pure URL builder for a SearXNG query. Exported alongside parseSearxngResponse
+// so the query shape can be pinned without mocking fetch.
+//
+// `engines` is the optional operator pin (settings.search.searxngEngines, #1353):
+// a comma-separated list of SearXNG `name:` fields, sent as SearXNG's per-request
+// `engines=` param so one instance can serve a narrow, deterministic engine set
+// to the controller while browser traffic keeps the instance-wide defaults.
+// Empty means the param is omitted entirely — the pre-#1353 behaviour.
+export function buildSearxngUrl(opts: {
+  baseUrl: string;
+  query: string;
+  recency?: 'day' | 'week' | 'month';
+  engines?: string;
+}): URL {
+  const url = new URL('/search', opts.baseUrl);
+  url.searchParams.set('q', opts.query);
+  url.searchParams.set('format', 'json');
+  if (opts.recency) url.searchParams.set('time_range', opts.recency);
+  const engines = (opts.engines || '').trim();
+  if (engines) url.searchParams.set('engines', engines);
+  return url;
 }
 
 // Pure parser for SearXNG's JSON response. Maps the SearXNG shape

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -492,6 +492,7 @@ export default function SettingsPanel() {
         // round-trips through POST harmlessly (settings.update ignores 'set').
         apiKey: v.search?.apiKey ?? '',
         baseUrl: v.search?.baseUrl ?? '',
+        searxngEngines: v.search?.searxngEngines ?? '',
       },
       embedding: {
         enabled: v.embedding?.enabled ?? true,

--- a/web/components/admin/settings/SearchSection.tsx
+++ b/web/components/admin/settings/SearchSection.tsx
@@ -9,6 +9,7 @@ import { Label } from '../../ui/label';
 import {
   Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectGroup,
 } from '../../ui/select';
+import { SETTINGS_SEARXNG_ENGINES_MAX } from '@/lib/schemas.generated';
 import { Card, Btn, Pill } from '../ui';
 import {
   SectionHeader, SaveBar, KeyStatus, KeyTestResult,
@@ -68,7 +69,10 @@ export function SearchSection({ data, form, setForm, busy, saveSettings, adminFe
         ? { apiKey: form.search.apiKey }
         : {}),
       ...(form.search.provider === 'searxng'
-        ? { baseUrl: form.search.baseUrl ?? '' }
+        ? {
+            baseUrl: form.search.baseUrl ?? '',
+            searxngEngines: form.search.searxngEngines ?? '',
+          }
         : {}),
     },
   });
@@ -83,7 +87,8 @@ export function SearchSection({ data, form, setForm, busy, saveSettings, adminFe
         && form.search.apiKey !== 'set'
         && form.search.apiKey !== (savedSearch.apiKey || ''))
     || (provider === 'searxng'
-        && (form.search.baseUrl ?? '') !== (savedSearch.baseUrl || ''));
+        && ((form.search.baseUrl ?? '') !== (savedSearch.baseUrl || '')
+            || (form.search.searxngEngines ?? '') !== (savedSearch.searxngEngines || '')));
   const apiKeySet = form.search.apiKey === 'set' || !!data.env?.SEARCH_API_KEY;
 
   const testApiKey = async () => {
@@ -239,6 +244,29 @@ export function SearchSection({ data, form, setForm, busy, saveSettings, adminFe
                 <div className="field-hint">
                   Self-hosted SearXNG instance. No API key required. Ensure JSON format is
                   enabled in your SearXNG <code>settings.yml</code>.
+                </div>
+              </div>
+
+              <div className="field">
+                <Label>Engines (optional)</Label>
+                <Input
+                  type="text"
+                  placeholder="google, duckduckgo web, wikipedia"
+                  maxLength={SETTINGS_SEARXNG_ENGINES_MAX}
+                  value={form.search.searxngEngines ?? ''}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    setForm(f => ({ ...f, search: { ...f.search, searxngEngines: e.target.value } }))
+                  }
+                  className="max-w-[360px]"
+                />
+                <div className="field-hint">
+                  Comma-separated list restricting which engines SearXNG queries for
+                  SUB/WAVE&apos;s calls only — your browser traffic keeps the instance
+                  defaults. Leave blank to use the full default engine set. Names must
+                  match the <code>name:</code> field in SearXNG&apos;s{' '}
+                  <code>settings.yml</code> exactly (e.g. <code>duckduckgo web</code>,
+                  not the internal <code>engine:</code> module id): SearXNG silently
+                  ignores a name it doesn&apos;t recognise rather than erroring.
                 </div>
               </div>
             </>

--- a/web/components/admin/settings/registry.ts
+++ b/web/components/admin/settings/registry.ts
@@ -257,6 +257,7 @@ export const SETTINGS_INDEX: readonly IndexEntry[] = [
   { label: 'Provider', section: 'search', card: 'Provider', keywords: 'duckduckgo tavily brave searxng live facts' },
   { label: 'API key', section: 'search', card: 'Provider', keywords: 'tavily brave token search_api_key' },
   { label: 'SearXNG URL', section: 'search', card: 'Provider', keywords: 'self hosted meta search json' },
+  { label: 'Engines', section: 'search', card: 'Provider', keywords: 'searxng engines pin restrict google duckduckgo wikipedia' },
 
   // ── likes ──────────────────────────────────────────────────────────────────
   { label: 'Enabled', section: 'likes', card: 'Heart button', keywords: 'heart like listener tap' },

--- a/web/components/admin/settings/shared.tsx
+++ b/web/components/admin/settings/shared.tsx
@@ -149,6 +149,8 @@ export interface SearchForm {
   provider: string;
   apiKey: string;
   baseUrl: string;
+  /** Optional comma-separated SearXNG engine pin (#1353); '' = instance default. */
+  searxngEngines: string;
 }
 
 export interface EmbeddingEnrichmentForm {

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -2373,6 +2373,13 @@ export const SETTINGS_LOUDNESS_SOURCES = [
 
 export const SETTINGS_SEARCH_PROVIDERS = ['duckduckgo', 'tavily', 'brave', 'searxng'] as const;
 
+/**
+ * Cap for the optional SearXNG `engines=` pin. Generous on purpose — the value
+ * is a comma-separated list of SearXNG `name:` fields, so a dozen engines with
+ * multi-word names still fits well inside it.
+ */
+export const SETTINGS_SEARXNG_ENGINES_MAX = 500;
+
 export const CROSSFADE_DURATION_BOUNDS: SettingsNumericBound = { min: 0, max: 30 };
 // −23 (EBU R128 broadcast) … −9 (very loud); −14 is the streaming standard.
 export const LOUDNESS_TARGET_LUFS_BOUNDS: SettingsNumericBound = { min: -23, max: -9 };
@@ -2658,6 +2665,14 @@ export const searchPatchSchema = settingsBlockOf({
     })
     .transform((raw) => String(raw).trim()),
   apiKey: settingsRawStringLike(200, 'search.apiKey must be 0-200 chars'),
+  // Optional comma-separated SearXNG engine pin (#1353), appended as the
+  // `engines=` query param when non-empty. New field, so it takes the trimmed
+  // posture rather than search.apiKey's raw one — there is no stored behaviour
+  // to preserve here, and a stray space around a name is a typo, not a value.
+  searxngEngines: settingsTrimmedString(
+    SETTINGS_SEARXNG_ENGINES_MAX,
+    `search.searxngEngines must be 0-${SETTINGS_SEARXNG_ENGINES_MAX} chars`,
+  ),
 });
 
 const scrobbleLastfmSchema = settingsBlockOf({


### PR DESCRIPTION
Closes #1353.

## Why

A self-hosted SearXNG instance shared between browser traffic and SUB/WAVE's `searchArtistNews` calls has to serve two audiences with different tolerances. #1353 measured that on a live instance over 24h: `startpage` was ~100% CAPTCHA-walled, the default `duckduckgo` engine mixed CAPTCHA with a parser bug in that SearXNG version, and `brave` came in around 20% success behind 429s. None of it is latency — bumping `outgoing.request_timeout` from 3s to 5s made no measurable difference — so the operator's only levers were instance-wide `settings.yml` edits that also degrade the browser side, or a second SearXNG.

SearXNG already supports the narrow fix: a per-request `engines=` param.

## What

- **`settings.search.searxngEngines`** — a new optional string, comma-separated SearXNG engine names. `searxngSearch()` appends it as `engines=` when non-empty. Empty or unset omits the param entirely, which is today's behaviour to the byte.
- **The empty case is deliberately "no param", not `engines=`** — SearXNG's `parse_generic()` reads an empty list as "no engines matched" and answers with nothing, where omitting it uses the instance defaults. The test pins `undefined`, `''` and `'   '` all producing the same untouched URL.
- **Query construction moved into a pure `buildSearxngUrl()`**, exported beside the existing `parseSearxngResponse()` for the same reason: the shape can be pinned without mocking fetch.
- **Schema + patch registry** — `searchPatchSchema` gains the field with the `settingsTrimmedString` posture (500-char cap, `SETTINGS_SEARXNG_ENGINES_MAX`), rather than `search.apiKey`'s raw `String(x)` one. The field is new, so there is no shipped storage behaviour to preserve, and a space around an engine name is a typo. Inner spaces survive — a SearXNG engine name is its `name:` field, e.g. `duckduckgo web`. `load()` coerces a non-string to `''` so an absent or hand-mangled setting keeps the pre-change behaviour; `update()` only writes the key when the patch names it. Mirror regenerated with `npm run gen:schemas`.
- **Admin UI** — a text field under the SearXNG base URL, shown only for the `searxng` provider, with `maxLength` read from the mirrored cap rather than a hand-copied literal. The hint names the gotcha from the issue: SearXNG silently *skips* a name it doesn't recognise instead of erroring, so the internal `engine:` module id (`google_cse`) falls back to the full default set with no signal. Also registered in the settings search index.

## Scope note

The **Test** button's probe endpoint (`POST /settings/search/test-searxng`) is unchanged and still queries with the instance defaults, so a green Test does not confirm the engine names are valid. Wiring the pin through the probe would turn it into a real check on the exact silent-fallback failure above — worth doing, but it is a change to what that button means and belongs in its own PR.

## Verification

- `controller`: `npm run lint` clean (0 errors), `npm test` **996/996 passing**.
- `web`: `npm run lint` clean (0 errors).
- New tests: four `buildSearxngUrl` cases in `scripts/web-search-searxng.test.ts` (param omitted when unset, verbatim pin with inner spaces, coexistence with `time_range`, path resolution) and one `searchPatchSchema` case in `scripts/settings-patch-schema.test.ts` (trim, absent-stays-absent, cap message).
