### PR TITLE
feat: one-field DJ Brain setup, wizard preset, and native cloud speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ https://github.com/user-attachments/assets/0a2ba78a-eda3-44c1-adce-bfa78ae992cd
 </tr>
 </table>
 
+## Hosted, or bring your own station
+
+Don't want to run a language model? **[SUB/WAVE DJ Brain](https://my.getsubwave.com/brain)**
+is a metered brain (and optional cloud voice) for the station you already self-host: one
+key, pasted once, from £5/month. **[SUB/WAVE Hosted](https://my.getsubwave.com/)** runs the
+whole station for you at `yourname.getsubwave.com`. Both fund the project; the software
+here stays complete and free either way.
+
 ## Live demo
 
 - **Project site** — [getsubwave.com](https://www.getsubwave.com/)

--- a/app/docs/store/RELEASE-NOTES-1.5.0.md
+++ b/app/docs/store/RELEASE-NOTES-1.5.0.md
@@ -1,0 +1,61 @@
+# SUB/WAVE 1.5.0 — store release notes
+
+Drafts for the three surfaces. Copy the block you need.
+
+---
+
+## App Store — "What's New" (iOS, public)
+
+Password-protected stations are now first-class. Add a station that sits behind a
+login and SUB/WAVE keeps the username and password in the iOS keychain, separate
+from the saved address, so your station list never carries a secret in it. A
+station that rejects your login now says so plainly instead of failing silently.
+
+Also in this release:
+
+• Like the track that's on air. One tap from the player, straight to the station.
+• Pick your stream quality. Choose MP3 or AAC per station from the SIGNAL row in
+  the back panel, and SUB/WAVE remembers the choice for each one.
+• Remove a saved station without hunting for the gesture. There's a button now.
+• Steadier playback on patchy signal. The player buffers deeper before it starts
+  and reloads the stream cleanly when the connection stutters, instead of
+  stalling in place.
+• Now-playing matches what you're hearing. The track and artwork used to run a
+  little ahead of the audio; they're aligned to your actual position in the
+  stream now.
+• Playback pauses when your headphones or car stereo disconnect, rather than
+  jumping to the speaker.
+
+---
+
+## TestFlight — "What to Test"
+
+New in this build: station credentials, track likes, and stream format choice.
+
+Worth putting through its paces:
+
+• Add a station behind HTTP Basic Auth. Check it connects, survives a restart,
+  and that removing the station clears the stored login. Try a wrong password
+  and confirm you get a clear message.
+• If you had a credentialed station saved in 1.4.0, confirm it still works after
+  upgrading. The login is migrated into the keychain on first launch.
+• Tap the like button on an on-air track and confirm it registers at the station.
+• Back panel > SIGNAL: switch between MP3 and AAC. Confirm the choice sticks per
+  station. (Opus and FLAC are Android only. iOS cannot demux the Ogg container,
+  so they're hidden here by design.)
+• Play on cellular in a weak-signal spot and see whether it rides through a
+  dropout instead of stalling.
+• Disconnect headphones or leave CarPlay mid-track and confirm it pauses rather
+  than switching to the phone speaker.
+
+---
+
+## Play Store — "Release notes" (500 char limit)
+
+Stations that need a login are now first-class: credentials are stored in Android
+keystore, kept out of your saved station list, and a rejected login says so.
+
+Also: like the on-air track, pick your stream format per station (MP3, AAC, Opus
+or FLAC where the station offers it), remove saved stations with a real button,
+steadier playback on weak signal, and now-playing that matches what you're
+actually hearing.

--- a/cli/src/commands/setup.ts
+++ b/cli/src/commands/setup.ts
@@ -291,8 +291,13 @@ async function detectOllamaUrl(): Promise<string | null> {
   return null;
 }
 
-const LLM_PROVIDER_OPTIONS: Array<{ value: LlmProvider | 'later'; label: string; hint: string }> = [
+// 'dj-brain' is a preset, not a provider: it resolves to openai-compatible
+// pointed at the hosted SUB/WAVE DJ Brain (my.getsubwave.com/brain), so the
+// controller never learns a new provider id.
+const DJ_BRAIN_BASE_URL = 'https://my.getsubwave.com/v1';
+const LLM_PROVIDER_OPTIONS: Array<{ value: LlmProvider | 'later' | 'dj-brain'; label: string; hint: string }> = [
   { value: 'ollama',            label: 'Ollama — local homelab',          hint: 'no API key — point at your homelab box' },
+  { value: 'dj-brain',          label: 'SUB/WAVE DJ Brain — hosted',       hint: 'no model to run — one key from my.getsubwave.com/brain, from £5/mo' },
   { value: 'openai-compatible', label: 'OpenAI-compatible — self-hosted',  hint: 'llama.cpp, vLLM, LM Studio — your own server URL' },
   { value: 'locca',             label: 'locca — local llama.cpp',          hint: 'no API key — defaults to the host locca server' },
   { value: 'anthropic',         label: 'Anthropic — Claude',               hint: 'needs ANTHROPIC_API_KEY' },
@@ -320,13 +325,23 @@ const EXAMPLE_MODEL: Record<Exclude<LlmProvider, 'ollama'>, string> = {
 
 async function collectLlm(): Promise<LlmChoice> {
   header('LLM provider');
-  const choice = exitIfCancelled(await p.select<LlmProvider | 'later'>({
+  const choice = exitIfCancelled(await p.select<LlmProvider | 'later' | 'dj-brain'>({
     message: 'Which LLM should the AI DJ talk to?',
     initialValue: 'ollama',
     options: LLM_PROVIDER_OPTIONS,
   }), { backOnCancel: false });
 
   if (choice === 'later') return { provider: null };
+
+  if (choice === 'dj-brain') {
+    info(`Get a key at ${accent('https://my.getsubwave.com/brain')} — the same key also unlocks the cloud voice tier in admin → Settings → DJ Brain.`);
+    const apiKey = exitIfCancelled(await p.password({
+      message: 'DJ Brain access token',
+      mask: '*',
+      validate: (v: string) => (!v ? 'required' : undefined),
+    }), { backOnCancel: false });
+    return { provider: 'openai-compatible', baseUrl: DJ_BRAIN_BASE_URL, model: 'dj-brain', apiKey };
+  }
 
   if (choice === 'ollama') {
     const detected = await detectOllamaUrl();

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -106,6 +106,51 @@ async function main() {
     assert.equal(isQuotaOrAuthError({ code: 'ECONNRESET' }), false);
   });
 
+  // ---- DJ Brain monthly cap: a 429 that does not clear until the month rolls ----
+  // Measured against the hosted brain: the station retried each capped call
+  // three times, on every pick / link / ident, for the rest of the month. The
+  // wall is the calendar, so same-leg retry can only add latency.
+  await test('DJ Brain monthly token cap 429 → quota/auth, NOT transient', () => {
+    const e: any = { statusCode: 429, message: 'Monthly token budget reached (783/500).' };
+    assert.equal(isQuotaOrAuthError(e), true);
+    assert.equal(isTransient(e), false);    // no same-leg retry
+    assert.equal(isUnreachable(e), false);   // the brain answered
+  });
+  await test('the other three brain cap wordings classify too', () => {
+    for (const msg of [
+      'Monthly spoken-character budget reached (1,200,000/1,200,000).',
+      'Overage runaway ceiling reached (40,000,000 tokens, 2x the plan budget).',
+      'This key has no cloud-voice budget — the plan is LLM-only.',
+    ]) {
+      assert.equal(isQuotaOrAuthError({ statusCode: 429, message: msg }), true, msg);
+      assert.equal(isTransient({ statusCode: 429, message: msg }), false, msg);
+    }
+  });
+  await test('the machine-readable code wins when the message is reworded', () => {
+    // Parsed body (SDK `data`) and raw JSON string (`responseBody`) both work,
+    // so a future rewording cannot silently switch the retries back on.
+    const parsed: any = { statusCode: 429, message: 'nothing quota-shaped here', data: { error: { code: 'monthly_cap' } } };
+    assert.equal(isQuotaOrAuthError(parsed), true);
+    assert.equal(isTransient(parsed), false);
+    const raw: any = { statusCode: 429, message: 'nothing quota-shaped here', responseBody: '{"error":{"code":"monthly_cap"}}' };
+    assert.equal(isQuotaOrAuthError(raw), true);
+    const garbage: any = { statusCode: 429, message: 'slow down', responseBody: 'not json' };
+    assert.equal(isQuotaOrAuthError(garbage), false);
+  });
+  await test('an ORDINARY rate-limit 429 stays transient — the whole point', () => {
+    const plain: any = { statusCode: 429, message: 'Rate limit exceeded, please slow down' };
+    assert.equal(isQuotaOrAuthError(plain), false);
+    assert.equal(isTransient(plain), true);   // still worth a same-leg retry
+    const bare: any = { statusCode: 429, message: 'Too Many Requests' };
+    assert.equal(isQuotaOrAuthError(bare), false);
+    assert.equal(isTransient(bare), true);
+  });
+  await test('the cap 429 survives the AI_RetryError wrapper (unwrapSdkError)', () => {
+    const wrapped: any = { message: 'AI_RetryError', lastError: { statusCode: 429, message: 'Monthly token budget reached (783/500).' } };
+    assert.equal(isQuotaOrAuthError(wrapped), true);
+    assert.equal(isTransient(wrapped), false);
+  });
+
   // ---- upstream-overload gate: STAYS transient (retry first), THEN fails over (#671) ----
   console.log('isUpstreamOverloaded (reachable gateway relays a saturated upstream → retry, then fail over):');
   await test('OpenRouter "Upstream error from <provider>: ResourceExhausted" → upstream-overload', () => {

--- a/controller/scripts/llm-pure.test.ts
+++ b/controller/scripts/llm-pure.test.ts
@@ -23,7 +23,7 @@ import { personaToneDirectives, normalizeDial, DIAL_NEUTRAL, validatePersonasStr
 import { lengthMode, lengthPhrase } from '../src/llm/internal/prompts/system.js';
 import { showMusicLean } from '../src/llm/internal/prompts/picker.js';
 import { planSchema } from '../src/llm/internal/prompts/programme.js';
-import { modelForCloudRequest, resolveCloudModel, resolveCloudProvider, sharedCloudApiKeyForRequest } from '../src/llm/internal/speech/cloud-speech.js';
+import { modelForCloudRequest, resolveCloudModel, resolveCloudProvider, sharedCloudApiKeyForRequest, speedDirective } from '../src/llm/internal/speech/cloud-speech.js';
 
 let failures = 0;
 function test(name: string, fn: () => void | Promise<void>) {
@@ -1073,6 +1073,27 @@ async function main() {
   });
 
   // ---- showMusicLean: soft lean vs strict genre lock (shared by both pick paths) ----
+  // ---- speedDirective: where the computed cloud-TTS speed is applied ----
+  // At most one of body/atempo is ever non-null — the cloud engine either sends
+  // `speed` upstream OR stretches locally, never both. Guards the issue #942
+  // fix (compat servers stretch locally) AND its sendSpeed escape hatch.
+  console.log('speedDirective (send `speed` upstream vs. local ffmpeg atempo):');
+  await test('openai-compatible + sendSpeed off → stretch locally, body omitted', () => {
+    assert.deepEqual(speedDirective('openai-compatible', false, 1.4), { body: null, atempo: 1.4 });
+  });
+  await test('openai-compatible + sendSpeed on → send speed upstream, no local stretch', () => {
+    assert.deepEqual(speedDirective('openai-compatible', true, 1.4), { body: 1.4, atempo: null });
+  });
+  await test('non-compat providers always send speed upstream (sendSpeed irrelevant)', () => {
+    assert.deepEqual(speedDirective('openai', false, 1.4), { body: 1.4, atempo: null });
+    assert.deepEqual(speedDirective('elevenlabs', false, 0.9), { body: 0.9, atempo: null });
+  });
+  await test('unity speed (1.0) → nothing anywhere, for every provider/flag combo', () => {
+    assert.deepEqual(speedDirective('openai-compatible', false, 1.0), { body: null, atempo: null });
+    assert.deepEqual(speedDirective('openai-compatible', true, 1.0), { body: null, atempo: null });
+    assert.deepEqual(speedDirective('openai', false, 1.0), { body: null, atempo: null });
+  });
+
   console.log('showMusicLean (soft lean vs strict genre lock):');
   const SOFT_GENRE_LINE = '\n\nMusic steer for this show — lean toward Jazz. These are preferences, not hard filters: break them only when the flow genuinely demands it.';
   await test('no show → empty string', () => {

--- a/controller/src/llm/internal/core/pure.ts
+++ b/controller/src/llm/internal/core/pure.ts
@@ -29,6 +29,11 @@ interface ErrorLike {
   // AI_RetryError wrapper — the real APICallError lives here (see unwrapSdkError).
   lastError?: ErrorLike;
   errors?: ErrorLike[];
+  // Parsed/raw upstream error body — the AI SDK attaches these to
+  // APICallError, and they carry the machine-readable `error.code` that
+  // isQuotaOrAuthError prefers over message-sniffing.
+  data?: unknown;
+  responseBody?: unknown;
   // Diagnostics fields truncationError attaches / failureDiagnostics reads.
   text?: unknown;
   finishReason?: unknown;
@@ -390,6 +395,26 @@ export function isUnreachable(err: ErrorLike | null | undefined): boolean {
 // "can only afford" are OpenRouter's per-request affordability 402, which
 // carries no "insufficient"/"quota" token, so it is matched by text too.
 const QUOTA_RE = /usage limit|quota|exceeded your current|insufficient[ _]?(quota|funds|credit|balance)|requires more credits|can only afford|upgrade for higher|out of credit|payment required/i;
+// SUB/WAVE DJ Brain's monthly cap. It answers 429 with `error.code:
+// "monthly_cap"` and a "Monthly … budget reached" / "Overage runaway ceiling"
+// / "no cloud-voice budget" message — a wall that does not move until the
+// calendar month rolls, so retrying the same leg is pure latency (measured:
+// three attempts per pick, per link and per ident for the rest of the month).
+// Ordinary "slow down" 429s carry none of these and stay transient.
+const BRAIN_CAP_CODE = 'monthly_cap';
+const BRAIN_CAP_RE = /monthly [\w-]+ budget reached|overage runaway ceiling reached|no cloud-voice budget/i;
+
+// The upstream's machine-readable error code, when the SDK preserved the
+// parsed (or raw) body. Preferred over message-sniffing because a reworded
+// message must not silently re-enable the retries this exists to stop.
+function upstreamErrorCode(err: ErrorLike): string {
+  const body = err.data ?? err.responseBody;
+  const parsed = typeof body === 'string'
+    ? (() => { try { return JSON.parse(body); } catch { return null; } })()
+    : body;
+  const code = (parsed as { error?: { code?: unknown } } | null)?.error?.code;
+  return typeof code === 'string' ? code : (typeof err.code === 'string' ? err.code : '');
+}
 const AUTH_RE = /invalid[ _]?api[ _]?key|incorrect[ _]?api[ _]?key|unauthorized|authentication (failed|error)|forbidden|api key (not|is|was) /i;
 
 export function isQuotaOrAuthError(err: ErrorLike | null | undefined): boolean {
@@ -405,6 +430,9 @@ export function isQuotaOrAuthError(err: ErrorLike | null | undefined): boolean {
   const msg = String(err.message || err.cause?.message || '');
   if (AUTH_RE.test(msg)) return true;
   if (QUOTA_RE.test(msg)) return true;
+  // DJ Brain monthly cap — by code first, message second (see BRAIN_CAP_RE).
+  if (upstreamErrorCode(err) === BRAIN_CAP_CODE) return true;
+  if (BRAIN_CAP_RE.test(msg)) return true;
   return false;
 }
 

--- a/controller/src/llm/internal/speech/cloud-speech.ts
+++ b/controller/src/llm/internal/speech/cloud-speech.ts
@@ -172,6 +172,25 @@ function clampSpeed(speed: any, provider: string) {
   return Math.min(hi, Math.max(lo, n));
 }
 
+// Where the computed speech `speed` gets applied. Pure so the routing decision
+// is unit-pinned in scripts/llm-pure.test.ts rather than inferred from the call
+// site. Returns what to put in the request body's `speed` field (`body`, null =
+// omit it) and the ffmpeg atempo factor to stretch the rendered audio locally
+// (`atempo`, null = skip). At most one is ever non-null:
+//   speed === 1.0 (unity)          → { body: null,  atempo: null }  nothing to do
+//   non-compat provider            → { body: speed, atempo: null }  server honours speed
+//   openai-compatible + sendSpeed  → { body: speed, atempo: null }  told to honour it
+//   openai-compatible + !sendSpeed → { body: null,  atempo: speed } stretch locally (issue #942)
+export function speedDirective(
+  provider: string,
+  sendSpeed: boolean,
+  speed: number,
+): { body: number | null; atempo: number | null } {
+  if (speed === 1.0) return { body: null, atempo: null };
+  if (provider === 'openai-compatible' && !sendSpeed) return { body: null, atempo: speed };
+  return { body: speed, atempo: null };
+}
+
 // Minimal language-name → ISO 639-1 map for the ElevenLabs `language` param
 // (its language_code). OpenAI's gpt-4o-mini-tts takes a free-text instruction
 // instead, so it needs no map. Best-effort — an unknown name falls through to
@@ -364,15 +383,22 @@ export async function speak(
   // sent when it differs from default so default stations are unaffected and
   // providers that ignore the field never see it.
   //
-  // openai-compatible servers NEVER receive `speed` — implementations are
-  // wildly uneven (#942: a Chatterbox shim behind LiteLLM produced comb-filtered
-  // "echo chamber" audio with broken mp3 frame timestamps whenever `speed` was
-  // present, and daypart energy makes it non-unity most of the day). The server
-  // renders at 1x and the rate is applied locally via ffmpeg atempo below, so
-  // every knob still works without the fragile server-side path.
+  // openai-compatible servers default to NOT receiving `speed` — implementations
+  // are wildly uneven (#942: a Chatterbox shim behind LiteLLM produced
+  // comb-filtered "echo chamber" audio with broken mp3 frame timestamps whenever
+  // `speed` was present, and daypart energy makes it non-unity most of the day).
+  // The server renders at 1x and the rate is applied locally via ffmpeg atempo
+  // below, so every knob still works without the fragile server-side path.
+  //
+  // Escape hatch: tts.cloud.sendSpeed puts a compat server back on the native
+  // `speed` field and skips the local stretch — for a server that honours it
+  // cleanly (e.g. the hosted DJ Brain voice), where native speed beats
+  // time-stretch artifacts. openai / elevenlabs always take the field.
+  // speedDirective() owns the routing (unit-pinned in scripts/llm-pure.test.ts).
   const isCompat = c.provider === 'openai-compatible';
   const speed = clampSpeed(config.tts.cloudSpeed * (speedScale != null ? speedScale : 1), c.provider);
-  const stretchLocally = isCompat && speed !== 1.0;
+  const rate = speedDirective(c.provider, !!c.sendSpeed, speed);
+  const stretchLocally = rate.atempo != null;
 
   // ElevenLabs voice_settings — expressive knobs the operator tunes in the
   // Cloud TTS section of admin → Settings (issue #696). Only spread when the
@@ -422,7 +448,7 @@ export async function speak(
     model: speechModel(c),
     text,
     voice: c.voice || undefined,
-    ...(speed !== 1.0 && !isCompat ? { speed } : {}),
+    ...(rate.body != null ? { speed: rate.body } : {}),
     // Persona character (soul) + language → provider-native delivery hint
     // (issues #579 / #558).
     ...deliveryHint({ language, soul }, c.provider, c.model),

--- a/controller/src/settings.ts
+++ b/controller/src/settings.ts
@@ -768,6 +768,10 @@ export async function load() {
           typeof stored.tts?.cloud?.voiceUseSpeakerBoost === 'boolean'
             ? stored.tts.cloud.voiceUseSpeakerBoost
             : DEFAULTS.tts.cloud.voiceUseSpeakerBoost,
+        sendSpeed:
+          typeof stored.tts?.cloud?.sendSpeed === 'boolean'
+            ? stored.tts.cloud.sendSpeed
+            : DEFAULTS.tts.cloud.sendSpeed,
         // Fish Audio controls — lenient load for hand-edited/older settings.
         // Only the Fish provider sends these fields on the wire.
         temperature:
@@ -1634,6 +1638,12 @@ export async function update(patch) {
       }
       if (c.voiceUseSpeakerBoost !== undefined) {
         next.tts.cloud.voiceUseSpeakerBoost = !!c.voiceUseSpeakerBoost;
+      }
+      // openai-compatible: send `speed` upstream vs. stretch locally (see
+      // speedDirective / issue #942). Plain boolean coercion — only consulted on
+      // the compat path, inert elsewhere.
+      if (c.sendSpeed !== undefined) {
+        next.tts.cloud.sendSpeed = !!c.sendSpeed;
       }
       // Fish Audio synthesis controls. Clamp numeric knobs like the existing
       // ElevenLabs sliders; reject an unknown enum so a typo cannot silently

--- a/controller/src/settings/defaults.ts
+++ b/controller/src/settings/defaults.ts
@@ -278,6 +278,15 @@ export const DEFAULTS = {
       voiceStyle: 0,
       voiceSimilarityBoost: 0.75,
       voiceUseSpeakerBoost: true,
+      // openai-compatible only: send the computed speech `speed` upstream in the
+      // request body instead of applying it locally via ffmpeg atempo. Off by
+      // default because compat servers are uneven with the field (issue #942:
+      // some shims produced comb-filtered audio when `speed` was present), so we
+      // stretch locally when unsure. Turn it on when the server honours `speed`
+      // natively — e.g. the hosted DJ Brain voice — since native speed beats
+      // time-stretch artifacts. Inert for openai / elevenlabs (they always send
+      // speed). See speedDirective() in llm/internal/speech/cloud-speech.ts.
+      sendSpeed: false,
       // Fish Audio S2.1 controls. Persisted alongside the shared cloud config so
       // switching providers preserves the tuning, but sent only for fish-audio.
       temperature: 0.7,

--- a/web/app/onboarding/page.tsx
+++ b/web/app/onboarding/page.tsx
@@ -6,13 +6,22 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import { Suspense } from 'react';
 import WizardShell from '@/components/onboarding/WizardShell';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '/api';
 
 type Status = { needsSetup: boolean; setupCompletedAt: string | null };
 
-export default function SetupPage() {
+// `?rerun=1` re-opens the wizard on a station that is already set up — the
+// "already set up" card below links to it. Nothing is bypassed by the flag:
+// WizardShell still gates on ADMIN_USER/ADMIN_PASS exactly as it does on a
+// first run, and POST /onboarding/save is admin-gated on the controller. It
+// only decides which of the two views this page renders, so a re-run is worth
+// no more than reloading the page.
+function SetupPageInner() {
+  const rerun = useSearchParams().get('rerun') === '1';
   const [status, setStatus] = useState<Status | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -34,7 +43,7 @@ export default function SetupPage() {
     );
   }
   if (!status) return <div role="status" className="p-8 text-sm text-ink/60">Loading…</div>;
-  if (status.needsSetup) return <WizardShell />;
+  if (status.needsSetup || rerun) return <WizardShell />;
 
   // Setup already complete.
   return (
@@ -68,6 +77,20 @@ export default function SetupPage() {
           Docs
         </Link>
       </div>
+      <p className="mt-6 text-sm text-ink/70">
+        Changing music server, or switching the DJ to a hosted brain?{' '}
+        <Link href="/onboarding?rerun=1" className="bs-link">Run the wizard again</Link>{' '}
+        — it walks the same steps and overwrites what you confirm.
+      </p>
     </div>
+  );
+}
+
+// useSearchParams needs a Suspense boundary in the App Router.
+export default function SetupPage() {
+  return (
+    <Suspense fallback={<div role="status" className="p-8 text-sm text-ink/60">Loading…</div>}>
+      <SetupPageInner />
+    </Suspense>
   );
 }

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -40,6 +40,7 @@ import { Advanced, SectionChromeProvider } from './settings/section-chrome';
 import { SettingsSearch, type SettingsJump } from './settings/SettingsSearch';
 import { TtsSection } from './settings/TtsSection';
 import { LlmSection } from './settings/LlmSection';
+import { BrainSection } from './settings/BrainSection';
 import { SearchSection } from './settings/SearchSection';
 import { LibrarySection } from './settings/LibrarySection';
 import { StationSection } from './settings/StationSection';
@@ -911,6 +912,12 @@ export default function SettingsPanel() {
           <>
             {activeSection === 'tts' && data.tts && (
               <TtsSection
+                data={data} form={form} setForm={updateForm} busy={busy}
+                saveSettings={saveSettings} fieldErrors={fieldErrors} adminFetch={adminFetch} refresh={refresh}
+              />
+            )}
+            {activeSection === 'brain' && (
+              <BrainSection
                 data={data} form={form} setForm={updateForm} busy={busy}
                 saveSettings={saveSettings} fieldErrors={fieldErrors} adminFetch={adminFetch} refresh={refresh}
               />

--- a/web/components/admin/settings/BrainSection.tsx
+++ b/web/components/admin/settings/BrainSection.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import type { ChangeEvent } from 'react';
+import { useState } from 'react';
+import { Input } from '../../ui/input';
+import { Label } from '../../ui/label';
+import { cn } from '../../../lib/cn';
+import { Card, Btn } from '../ui';
+import {
+  SectionHeader, SaveBar, KeyTestResult,
+  type SectionProps,
+} from './shared';
+
+interface BrainSectionProps extends SectionProps {
+  adminFetch: (path: string, init?: RequestInit) => Promise<Response>;
+  refresh: () => void;
+}
+
+// One-field setup for the hosted "DJ Brain" — a single OpenAI-compatible proxy
+// that fronts BOTH the chat LLM and the cloud TTS voice. The operator pastes one
+// base URL + one access token here and Save wires both settings blocks at once:
+// settings.llm as provider 'openai-compatible', and settings.tts.cloud as an
+// enabled 'openai-compatible' voice with sendSpeed on (the DJ Brain voice
+// honours the native `speed` field, so we skip the local atempo stretch). A
+// convenience wrapper over the LLM provider + TTS voice sections — either can
+// still be tuned individually there.
+export function BrainSection({ data, form, saveSettings, adminFetch, refresh, busy }: BrainSectionProps) {
+  // Prefill from whatever the two blocks already hold, but only when they're
+  // actually pointed at an openai-compatible endpoint — otherwise the fields
+  // would show an unrelated OpenAI / ElevenLabs model id.
+  const llmCompat = form.llm.provider === 'openai-compatible';
+  const ttsCompat = form.tts.cloud.provider === 'openai-compatible';
+  // The LLM form keeps one base URL per provider (providerBaseUrls), so the
+  // compat entry is the one this section shares with the voice.
+  const llmCompatBaseUrl = form.llm.providerBaseUrls?.['openai-compatible'] ?? '';
+  const [baseUrl, setBaseUrl] = useState(
+    llmCompat ? llmCompatBaseUrl : (ttsCompat ? form.tts.cloud.baseUrl : ''),
+  );
+  const [token, setToken] = useState('');
+  const [chatModel, setChatModel] = useState(llmCompat ? form.llm.model : '');
+  const [voiceModel, setVoiceModel] = useState(ttsCompat ? form.tts.cloud.model : '');
+  const [voiceName, setVoiceName] = useState(ttsCompat ? form.tts.cloud.voice : '');
+
+  const [test, setTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
+  const [testing, setTesting] = useState(false);
+
+  // Redaction sentinel from getRedacted(): 'set' means a token is already on
+  // file for that block. Both blocks share the same DJ Brain token in practice.
+  const values = (data.values ?? {}) as Record<string, unknown>;
+  const llmKeys = ((values.llm as { keys?: Record<string, unknown> } | undefined)?.keys) || {};
+  const llmKeyOnFile = llmKeys['openai-compatible'] === 'set';
+  const ttsCloud = (values.tts as { cloud?: { apiKey?: unknown } } | undefined)?.cloud;
+  const ttsKeyOnFile = ttsCloud?.apiKey === 'set';
+  const keysOnFile = llmKeyOnFile && ttsKeyOnFile;
+
+  // Reuse the LLM openai-compatible probe (POST /settings/llm/probe-compat) to
+  // verify the base URL + token + chat model before saving.
+  const testConnection = async () => {
+    if (!baseUrl.trim()) { setTest({ ok: false, message: 'Enter a Base URL first', latencyMs: 0 }); return; }
+    if (!chatModel.trim()) { setTest({ ok: false, message: 'Enter a Chat model first', latencyMs: 0 }); return; }
+    setTesting(true);
+    setTest(null);
+    try {
+      const r = await adminFetch('/settings/llm/probe-compat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ apiKey: token.trim(), baseUrl: baseUrl.trim(), model: chatModel.trim() }),
+      });
+      setTest(await r.json() as { ok: boolean; message: string; latencyMs: number });
+    } catch (e) {
+      setTest({ ok: false, message: e instanceof Error ? e.message : String(e), latencyMs: 0 });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const save = async () => {
+    const url = baseUrl.trim();
+    // The hosted DJ Brain exposes `dj-brain` / `dj-brain-voice` — fall back to
+    // those when the operator leaves a model blank so a bare one-field setup
+    // still saves (the compat blocks reject an empty model id).
+    const chat = chatModel.trim() || 'dj-brain';
+    const voiceM = voiceModel.trim() || 'dj-brain-voice';
+    const voiceV = voiceName.trim();
+    const typedToken = token.trim();
+    await saveSettings({
+      llm: {
+        provider: 'openai-compatible',
+        baseUrl: url,
+        model: chat,
+        // Only send the key when one was typed — an absent apiKey leaves the
+        // stored token untouched (settings.update routes it via applyInlineKey,
+        // and the redaction sentinel is a no-op there too).
+        ...(typedToken ? { apiKey: typedToken } : {}),
+      },
+      tts: {
+        cloud: {
+          enabled: true,
+          provider: 'openai-compatible',
+          baseUrl: url,
+          model: voiceM,
+          voice: voiceV,
+          // DJ Brain voice honours native `speed`, so skip the local atempo
+          // stretch (issue #942 escape hatch).
+          sendSpeed: true,
+          ...(typedToken ? { apiKey: typedToken } : {}),
+        },
+      },
+    });
+    setToken('');
+    refresh();
+  };
+
+  return (
+    <>
+      <SectionHeader
+        eyebrow="dj brain"
+        title="One URL and one token wire the DJ's brain and its voice."
+        sub="The hosted DJ Brain fronts the chat LLM and the cloud TTS voice behind a single OpenAI-compatible proxy. Paste its base URL and access token once — Save configures both the LLM provider and Cloud TTS in one go. You can still fine-tune each under LLM provider and TTS voice."
+      />
+
+      <Card title="DJ Brain endpoint" sub="shared by the brain (LLM) + voice (TTS)">
+        <div className="grid gap-[18px]">
+          <div className="field">
+            <Label>Base URL</Label>
+            <Input
+              value={baseUrl}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setBaseUrl(e.target.value)}
+              placeholder="https://my.getsubwave.com/v1"
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">
+              Your DJ Brain proxy, including the <code>/v1</code> suffix. Used as
+              the base URL for both the LLM and the cloud voice.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>Access token</Label>
+            <div className="flex items-stretch gap-2">
+              <Input
+                type="password"
+                value={token}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setToken(e.target.value)}
+                placeholder={keysOnFile ? '•••••• (on file)' : 'Access token'}
+                className="max-w-[360px]"
+              />
+              <Btn onClick={testConnection} disabled={testing || !baseUrl.trim()}>
+                {testing ? 'Testing…' : 'Test connection'}
+              </Btn>
+            </div>
+            <div className="field-hint">
+              The access token for your DJ Brain. Saved to <code>settings.json</code>
+              {' '}for both the LLM and the voice. Leave blank to keep the token
+              already on file.
+            </div>
+          </div>
+          {test && <KeyTestResult result={test} />}
+
+          <div className="field">
+            <Label>Chat model</Label>
+            <Input
+              value={chatModel}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setChatModel(e.target.value)}
+              placeholder="dj-brain"
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">
+              The model id the brain writes scripts and picks tracks with.
+              Defaults to <code>dj-brain</code> if left blank.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>Voice model</Label>
+            <Input
+              value={voiceModel}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setVoiceModel(e.target.value)}
+              placeholder="dj-brain-voice"
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">
+              The model id that renders the DJ&apos;s speech. Defaults to{' '}
+              <code>dj-brain-voice</code> if left blank.
+            </div>
+          </div>
+
+          <div className="field">
+            <Label>Voice name <span className="font-normal text-muted normal-case">(optional)</span></Label>
+            <Input
+              value={voiceName}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setVoiceName(e.target.value)}
+              placeholder="voice id (optional)"
+              className="max-w-[360px]"
+            />
+            <div className="field-hint">
+              A specific voice on the DJ Brain, if it exposes more than one. Leave
+              blank to let the server pick its default.
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              'field flex items-start gap-2.5 border bg-[var(--ink-softer)] p-3',
+              keysOnFile ? 'border-[var(--accent)]' : 'border-[var(--danger)]',
+            )}
+          >
+            <span
+              className={cn(
+                'mt-1 size-1.5 flex-none rounded-full',
+                keysOnFile ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
+              )}
+            />
+            <div className="grid gap-0.5">
+              <span
+                className={cn(
+                  'text-[11px] font-bold tracking-[0.12em] uppercase',
+                  keysOnFile ? 'text-[color:var(--accent)]' : 'text-[var(--danger)]',
+                )}
+              >
+                {keysOnFile ? 'DJ Brain token on file' : 'DJ Brain token not set'}
+              </span>
+              <span className="text-[11px] leading-[1.5] text-muted">
+                {keysOnFile
+                  ? 'Both the brain and the voice have a token saved. Leave the field blank to keep it.'
+                  : 'No token saved yet for the brain and/or the voice. Paste it above and Save.'}
+              </span>
+            </div>
+          </div>
+        </div>
+      </Card>
+
+      <SaveBar
+        note="Wires both settings.llm and settings.tts.cloud. Applies to the next LLM call and the next spoken line, no restart."
+        busy={busy}
+        onSave={save}
+        saveLabel="Save DJ Brain"
+      />
+    </>
+  );
+}

--- a/web/components/admin/settings/BrainSection.tsx
+++ b/web/components/admin/settings/BrainSection.tsx
@@ -68,6 +68,29 @@ export function BrainSection({ data, form, saveSettings, adminFetch, refresh, bu
   const ttsCloud = (values.tts as { cloud?: { apiKey?: unknown } } | undefined)?.cloud;
   const ttsKeyOnFile = ttsCloud?.apiKey === 'set';
   const keysOnFile = llmKeyOnFile && ttsKeyOnFile;
+  // Three states, not two. A section that says a flat red "token not set" while
+  // the brain half is genuinely configured reads as broken — which is exactly
+  // what an operator sees straight after the onboarding wizard, since that
+  // wires settings.llm and leaves the voice for this section. Name the half
+  // that is missing, and keep red for "neither".
+  const keyState: 'both' | 'partial' | 'none' =
+    keysOnFile ? 'both' : (llmKeyOnFile || ttsKeyOnFile) ? 'partial' : 'none';
+  const missingHalf = llmKeyOnFile ? 'voice (Cloud TTS)' : 'brain (LLM)';
+  const KEY_TONE = {
+    both: { border: 'border-[var(--accent)]', dot: 'bg-[var(--accent)]', text: 'text-[color:var(--accent)]' },
+    partial: { border: 'border-[var(--warn,var(--accent))]', dot: 'bg-[var(--warn,var(--accent))]', text: 'text-[color:var(--warn,var(--accent))]' },
+    none: { border: 'border-[var(--danger)]', dot: 'bg-[var(--danger)]', text: 'text-[var(--danger)]' },
+  }[keyState];
+  const keyTitle = {
+    both: 'DJ Brain token on file',
+    partial: `DJ Brain token on file for the ${llmKeyOnFile ? 'brain' : 'voice'} only`,
+    none: 'DJ Brain token not set',
+  }[keyState];
+  const keyBlurb = {
+    both: 'Both the brain and the voice have a token saved. Leave the field blank to keep it.',
+    partial: `The ${llmKeyOnFile ? 'brain (LLM)' : 'voice (Cloud TTS)'} has a token saved; the ${missingHalf} does not. Paste it above and Save to wire both.`,
+    none: 'No token saved yet for the brain or the voice. Paste it above and Save.',
+  }[keyState];
 
   // Reuse the LLM openai-compatible probe (POST /settings/llm/probe-compat) to
   // verify the base URL + token + chat model before saving.
@@ -223,29 +246,15 @@ export function BrainSection({ data, form, saveSettings, adminFetch, refresh, bu
           <div
             className={cn(
               'field flex items-start gap-2.5 border bg-[var(--ink-softer)] p-3',
-              keysOnFile ? 'border-[var(--accent)]' : 'border-[var(--danger)]',
+              KEY_TONE.border,
             )}
           >
-            <span
-              className={cn(
-                'mt-1 size-1.5 flex-none rounded-full',
-                keysOnFile ? 'bg-[var(--accent)]' : 'bg-[var(--danger)]',
-              )}
-            />
+            <span className={cn('mt-1 size-1.5 flex-none rounded-full', KEY_TONE.dot)} />
             <div className="grid gap-0.5">
-              <span
-                className={cn(
-                  'text-[11px] font-bold tracking-[0.12em] uppercase',
-                  keysOnFile ? 'text-[color:var(--accent)]' : 'text-[var(--danger)]',
-                )}
-              >
-                {keysOnFile ? 'DJ Brain token on file' : 'DJ Brain token not set'}
+              <span className={cn('text-[11px] font-bold tracking-[0.12em] uppercase', KEY_TONE.text)}>
+                {keyTitle}
               </span>
-              <span className="text-[11px] leading-[1.5] text-muted">
-                {keysOnFile
-                  ? 'Both the brain and the voice have a token saved. Leave the field blank to keep it.'
-                  : 'No token saved yet for the brain and/or the voice. Paste it above and Save.'}
-              </span>
+              <span className="text-[11px] leading-[1.5] text-muted">{keyBlurb}</span>
             </div>
           </div>
         </div>

--- a/web/components/admin/settings/BrainSection.tsx
+++ b/web/components/admin/settings/BrainSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ChangeEvent } from 'react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import { cn } from '../../../lib/cn';
@@ -43,6 +43,22 @@ export function BrainSection({ data, form, saveSettings, adminFetch, refresh, bu
 
   const [test, setTest] = useState<{ ok: boolean; message: string; latencyMs: number } | null>(null);
   const [testing, setTesting] = useState(false);
+
+  // This section's fields are plain local state, not FormState, so the panel's
+  // form-vs-baseline diff can never see an edit here. SettingsPanel only mounts
+  // the save slot while SOMETHING is dirty, so without reporting it ourselves
+  // SaveBar portals into nothing and the section renders no Save button at all
+  // — the same reason LlmSection/TtsSection/LibrarySection pass `dirty` for
+  // their own local key inputs. Compare against the values we mounted with
+  // rather than against `form`, so a save (which refreshes `form`) settles
+  // back to clean instead of latching dirty forever.
+  const initial = useRef({ baseUrl, chatModel, voiceModel, voiceName });
+  const dirty =
+    !!token.trim() ||
+    baseUrl !== initial.current.baseUrl ||
+    chatModel !== initial.current.chatModel ||
+    voiceModel !== initial.current.voiceModel ||
+    voiceName !== initial.current.voiceName;
 
   // Redaction sentinel from getRedacted(): 'set' means a token is already on
   // file for that block. Both blocks share the same DJ Brain token in practice.
@@ -107,6 +123,11 @@ export function BrainSection({ data, form, saveSettings, adminFetch, refresh, bu
         },
       },
     });
+    initial.current = { baseUrl: url, chatModel: chat, voiceModel: voiceM, voiceName: voiceV };
+    setBaseUrl(url);
+    setChatModel(chat);
+    setVoiceModel(voiceM);
+    setVoiceName(voiceV);
     setToken('');
     refresh();
   };
@@ -235,6 +256,7 @@ export function BrainSection({ data, form, saveSettings, adminFetch, refresh, bu
         busy={busy}
         onSave={save}
         saveLabel="Save DJ Brain"
+        dirty={dirty}
       />
     </>
   );

--- a/web/components/admin/settings/registry.ts
+++ b/web/components/admin/settings/registry.ts
@@ -10,7 +10,7 @@
 
 import {
   Radio, Palette, Cpu, Mic, Library, Search,
-  Activity, Archive, Save, AlertTriangle, Heart, Music2,
+  Activity, Archive, Save, AlertTriangle, Heart, Music2, BrainCircuit,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
@@ -60,6 +60,15 @@ export const SECTIONS = [
   {
     id: 'theme', group: 'the station', label: 'Skin & Themes',
     hint: 'player skin · palette', icon: Palette,
+    formKeys: [],
+  },
+  {
+    // One-field setup for the hosted DJ Brain: writes both `llm` and
+    // `tts.cloud` in a single save, but owns neither slice — the LLM provider
+    // and TTS voice sections keep the dirty tracking for those keys, and this
+    // one holds local state only, so it lists no formKeys.
+    id: 'brain', group: 'the dj', label: 'DJ Brain',
+    hint: 'one field · brain + voice', icon: BrainCircuit,
     formKeys: [],
   },
   {

--- a/web/components/onboarding/steps.tsx
+++ b/web/components/onboarding/steps.tsx
@@ -215,6 +215,14 @@ const llmStepSchema = z.object({
   }
 });
 
+// The hosted DJ Brain is a preset over the openai-compatible provider, not a
+// provider of its own: one click fills base URL + model, the operator pastes
+// the token, and everything downstream (probe, save, admin) is the ordinary
+// compat path. Voice comes later from admin → Settings → DJ Brain.
+const DJ_BRAIN_BASE_URL = 'https://my.getsubwave.com/v1';
+const DJ_BRAIN_MODEL = 'dj-brain';
+const DJ_BRAIN_SIGNUP_URL = 'https://my.getsubwave.com/brain';
+
 export function LlmStep({ w }: { w: WizardController }) {
   const [busy, setBusy] = useState(false);
   const form = useZodForm(llmStepSchema, {
@@ -232,8 +240,15 @@ export function LlmStep({ w }: { w: WizardController }) {
   const isOllama = provider === 'ollama';
   const isLocca = provider === 'locca';
   const isCustom = provider === 'openai-compatible';
+  const isDjBrain = isCustom && baseUrl.trim() === DJ_BRAIN_BASE_URL;
 
   const providerField = useController({ control, name: 'provider' });
+  const useDjBrain = () => {
+    form.setValue('provider', 'openai-compatible', { shouldValidate: true });
+    form.setValue('baseUrl', DJ_BRAIN_BASE_URL, { shouldValidate: true });
+    form.setValue('model', DJ_BRAIN_MODEL, { shouldValidate: true });
+    form.setValue('ollamaUrl', '', { shouldValidate: true });
+  };
   const modelField = useController({ control, name: 'model' });
   const modelAria = fieldAria('llm-model', modelField.fieldState.error);
 
@@ -282,6 +297,19 @@ export function LlmStep({ w }: { w: WizardController }) {
         blurb="The DJ talks between tracks. Ollama running on the host is the homelab default — no API key needed."
       />
       <div className="grid gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3 border border-ink bg-accent-soft p-3">
+          <div className="grid gap-0.5">
+            <span className={WIZARD_LABEL_CLASS}>No model to run?</span>
+            <span className="text-sm text-ink">
+              SUB/WAVE DJ Brain is a hosted brain for this station — one key, from £5/month.{' '}
+              <a href={DJ_BRAIN_SIGNUP_URL} target="_blank" rel="noreferrer" className="underline">Get a key</a>
+              {isDjBrain ? ', then paste it below.' : '.'}
+            </span>
+          </div>
+          <Button type="button" variant={isDjBrain ? 'solid' : 'outline'} onClick={useDjBrain} disabled={isDjBrain}>
+            {isDjBrain ? '✓ Using DJ Brain' : 'Use DJ Brain'}
+          </Button>
+        </div>
         {/* Bare span, not FieldLabel: ProviderSelector renders its own
             role="radiogroup" aria-label, and a wrapping <label> around a
             radiogroup of buttons hijacks clicks. Raw useController (not
@@ -310,7 +338,7 @@ export function LlmStep({ w }: { w: WizardController }) {
             control={control}
             name="baseUrl"
             label="Base URL"
-            description="e.g. http://localhost:8080/v1 (llama.cpp / vLLM / LM Studio)"
+            description={isDjBrain ? 'The hosted DJ Brain proxy' : 'e.g. http://localhost:8080/v1 (llama.cpp / vLLM / LM Studio)'}
           />
         )}
         {isLocca && (
@@ -329,7 +357,11 @@ export function LlmStep({ w }: { w: WizardController }) {
             label="API key"
             type="password"
             autoComplete="off"
-            description="Stored in state/secrets.env (mode 0600), not in settings.json"
+            description={isDjBrain
+              ? 'Your DJ Brain access token from my.getsubwave.com/brain — stored in settings.json'
+              : isCustom
+                ? 'Optional for most self-hosted servers — stored in settings.json'
+                : 'Stored in state/secrets.env (mode 0600), not in settings.json'}
           />
         )}
         {/* Bare span, not FieldLabel: the combobox trigger is a <button>, and

--- a/web/components/onboarding/useWizard.ts
+++ b/web/components/onboarding/useWizard.ts
@@ -226,6 +226,14 @@ export function useWizard() {
         // admin LLM panel omits the field the same way unless one is typed.
         baseUrl: data.llm.baseUrl,
         ollamaUrl: data.llm.ollamaUrl,
+        // The one exception: openai-compatible has no env var, its key lives
+        // inline in settings.llm.apiKey (applyInlineKey). Sent ONLY when the
+        // operator typed one this run — still absent otherwise, so #1351's
+        // "re-running onboarding clears the key" can't come back. This is the
+        // path the hosted DJ Brain preset in LlmStep relies on.
+        ...(data.llm.provider === 'openai-compatible' && data.llm.apiKey
+          ? { apiKey: data.llm.apiKey }
+          : {}),
       },
       tts: {
         defaultEngine: data.tts.defaultEngine,


### PR DESCRIPTION
## What

- **admin → Settings → DJ Brain**: one base URL + one token configure both `settings.llm` (openai-compatible) and `settings.tts.cloud` in a single save, with a Test connection button reusing `/settings/llm/probe-compat`.
- **Onboarding wizard (web + CLI `setup`)**: a "Use DJ Brain" preset on the LLM step fills the openai-compatible provider with `https://my.getsubwave.com/v1` / `dj-brain`; the operator pastes the token. Voice stays local Kokoro (the £5 tier); the cloud voice is enabled later from the admin section.
- **`tts.cloud.sendSpeed`** (default `false`): lets a compat server that honours `speed` natively take the field instead of the local atempo stretch from #942. `speedDirective()` in `cloud-speech.ts` owns the routing; four cases pinned in `llm-pure.test.ts`.
- The web wizard now sends `llm.apiKey` for openai-compatible **only when one was typed**, so the preset's token is saved without reintroducing #1351.
- README: short "Hosted, or bring your own station" section.

## Verification

- `controller`: `npm run lint` clean, `npm test` 1123/1123 pass.
- `web`: `npm run lint` clean (0 errors).
- `cli`: `tsc --noEmit` clean.