### PR TITLE
feat(tts-heavy): release idle TTS models instead of pinning ~4GB forever (#1579)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,6 +264,29 @@ SITE_URL=
 # --profile tts-heavy.
 # TTS_HEAVY_ENGINES=pocket-tts     # or: chatterbox  |  chatterbox,pocket-tts
 #
+# How long an idle heavy-TTS engine stays loaded. Chatterbox is ~4GB resident
+# (weights, plus torch's CUDA context on a GPU host) and used to be held for
+# the life of the container whether or not the station had spoken all day —
+# the programme's idle pause stands the music down but has no reach into the
+# sidecar. After this many seconds without a spoken line the sidecar stops
+# that engine's worker and hands the memory back, reloading it on the next
+# line (or a little ahead of one: the controller warms the sidecar when the
+# idle pause releases, so the reload lands while the music returns rather than
+# on the first link). Empty = 1800 on cuda, 3600 on cpu; both sit far above
+# any gap a talking station produces, so this only fires when the station
+# really has gone quiet. 0 keeps the old always-resident behaviour — worth it
+# if you have RAM to spare and never want a cold reload. Per-engine overrides
+# win over the shared value. Only matters with --profile tts-heavy.
+# TTS_HEAVY_IDLE_UNLOAD_S=1800
+# CHATTERBOX_IDLE_UNLOAD_S=      # just Chatterbox (the expensive one)
+# POCKET_TTS_IDLE_UNLOAD_S=0     # e.g. keep the small, fast engine resident
+#
+# Seconds /speak waits for a cold engine to load before giving up and letting
+# the DJ fall through to its rescue voice. Raise it on a slow disk or a first
+# load that still has weights to fetch; the ceiling has to leave room inside
+# TTS_HEAVY_TIMEOUT_MS (180000) for the render that follows.
+# TTS_HEAVY_LOAD_TIMEOUT_S=90
+#
 # Own TTS server? There's nothing to set here — the *Remote* engine points the
 # DJ at any HTTP server that answers GET /health and returns rendered audio from
 # POST /speak (a GPU box, a Tailscale peer, a bridge in front of a vendor API

--- a/.env.example
+++ b/.env.example
@@ -270,13 +270,17 @@ SITE_URL=
 # the programme's idle pause stands the music down but has no reach into the
 # sidecar. After this many seconds without a spoken line the sidecar stops
 # that engine's worker and hands the memory back, reloading it on the next
-# line (or a little ahead of one: the controller warms the sidecar when the
-# idle pause releases, so the reload lands while the music returns rather than
-# on the first link). Empty = 1800 on cuda, 3600 on cpu; both sit far above
-# any gap a talking station produces, so this only fires when the station
-# really has gone quiet. 0 keeps the old always-resident behaviour — worth it
-# if you have RAM to spare and never want a cold reload. Per-engine overrides
-# win over the shared value. Only matters with --profile tts-heavy.
+# line — or ahead of one, since the controller warms the sidecar both when the
+# programme's idle pause releases and when the DJ decides to talk. The first
+# of those hides the reload completely but needs the idle pause switched ON
+# (Settings -> Stream, off by default); with it off you get only the second,
+# which overlaps the load with writing the script, so part of a cold reload is
+# still audible as a longer gap before the first line. Empty = 1800 on cuda,
+# 3600 on cpu; both sit far above any gap a talking station produces, so this
+# only fires when the station really has gone quiet. 0 keeps the old
+# always-resident behaviour — worth it if you have RAM to spare and never want
+# a cold reload. Per-engine overrides win over the shared value. Only matters
+# with --profile tts-heavy.
 # TTS_HEAVY_IDLE_UNLOAD_S=1800
 # CHATTERBOX_IDLE_UNLOAD_S=      # just Chatterbox (the expensive one)
 # POCKET_TTS_IDLE_UNLOAD_S=0     # e.g. keep the small, fast engine resident
@@ -284,7 +288,10 @@ SITE_URL=
 # Seconds /speak waits for a cold engine to load before giving up and letting
 # the DJ fall through to its rescue voice. Raise it on a slow disk or a first
 # load that still has weights to fetch; the ceiling has to leave room inside
-# TTS_HEAVY_TIMEOUT_MS (180000) for the render that follows.
+# TTS_HEAVY_TIMEOUT_MS (180000) for the render that follows. This is only a
+# CEILING — a load the sidecar abandons sooner (missing venv, fatal model
+# error) fails its caller straight away. Floored at 5; anything unparseable is
+# ignored with a warning rather than stopping the sidecar booting.
 # TTS_HEAVY_LOAD_TIMEOUT_S=90
 #
 # Own TTS server? There's nothing to set here — the *Remote* engine points the

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -267,6 +267,9 @@ services:
       - TTS_HEAVY_IDLE_UNLOAD_S=\${TTS_HEAVY_IDLE_UNLOAD_S:-}
       - CHATTERBOX_IDLE_UNLOAD_S=\${CHATTERBOX_IDLE_UNLOAD_S:-}
       - POCKET_TTS_IDLE_UNLOAD_S=\${POCKET_TTS_IDLE_UNLOAD_S:-}
+      # Seconds /speak waits for a cold engine to load before giving up and
+      # letting the DJ fall through to its rescue voice.
+      - TTS_HEAVY_LOAD_TIMEOUT_S=\${TTS_HEAVY_LOAD_TIMEOUT_S:-}
       # Optional — PocketTTS voice CLONING (#238): the cloning weights are
       # gated on HF; accept the terms at huggingface.co/kyutai/pocket-tts and
       # set HF_TOKEN. Without it, cloned .wav voices revert to a built-in.
@@ -578,6 +581,9 @@ services:
       - TTS_HEAVY_IDLE_UNLOAD_S=\${TTS_HEAVY_IDLE_UNLOAD_S:-}
       - CHATTERBOX_IDLE_UNLOAD_S=\${CHATTERBOX_IDLE_UNLOAD_S:-}
       - POCKET_TTS_IDLE_UNLOAD_S=\${POCKET_TTS_IDLE_UNLOAD_S:-}
+      # Seconds /speak waits for a cold engine to load before giving up and
+      # letting the DJ fall through to its rescue voice.
+      - TTS_HEAVY_LOAD_TIMEOUT_S=\${TTS_HEAVY_LOAD_TIMEOUT_S:-}
       # Optional — PocketTTS voice cloning (#238): accept the terms at
       # huggingface.co/kyutai/pocket-tts and set HF_TOKEN.
       - HF_TOKEN=\${HF_TOKEN:-}
@@ -838,6 +844,9 @@ services:
       - TTS_HEAVY_IDLE_UNLOAD_S=\${TTS_HEAVY_IDLE_UNLOAD_S:-}
       - CHATTERBOX_IDLE_UNLOAD_S=\${CHATTERBOX_IDLE_UNLOAD_S:-}
       - POCKET_TTS_IDLE_UNLOAD_S=\${POCKET_TTS_IDLE_UNLOAD_S:-}
+      # Seconds /speak waits for a cold engine to load before giving up and
+      # letting the DJ fall through to its rescue voice.
+      - TTS_HEAVY_LOAD_TIMEOUT_S=\${TTS_HEAVY_LOAD_TIMEOUT_S:-}
       # Optional — PocketTTS voice cloning (#238); weights gated on HF.
       - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
@@ -1265,13 +1274,17 @@ SITE_URL=
 # the programme's idle pause stands the music down but has no reach into the
 # sidecar. After this many seconds without a spoken line the sidecar stops
 # that engine's worker and hands the memory back, reloading it on the next
-# line (or a little ahead of one: the controller warms the sidecar when the
-# idle pause releases, so the reload lands while the music returns rather than
-# on the first link). Empty = 1800 on cuda, 3600 on cpu; both sit far above
-# any gap a talking station produces, so this only fires when the station
-# really has gone quiet. 0 keeps the old always-resident behaviour — worth it
-# if you have RAM to spare and never want a cold reload. Per-engine overrides
-# win over the shared value. Only matters with --profile tts-heavy.
+# line — or ahead of one, since the controller warms the sidecar both when the
+# programme's idle pause releases and when the DJ decides to talk. The first
+# of those hides the reload completely but needs the idle pause switched ON
+# (Settings -> Stream, off by default); with it off you get only the second,
+# which overlaps the load with writing the script, so part of a cold reload is
+# still audible as a longer gap before the first line. Empty = 1800 on cuda,
+# 3600 on cpu; both sit far above any gap a talking station produces, so this
+# only fires when the station really has gone quiet. 0 keeps the old
+# always-resident behaviour — worth it if you have RAM to spare and never want
+# a cold reload. Per-engine overrides win over the shared value. Only matters
+# with --profile tts-heavy.
 # TTS_HEAVY_IDLE_UNLOAD_S=1800
 # CHATTERBOX_IDLE_UNLOAD_S=      # just Chatterbox (the expensive one)
 # POCKET_TTS_IDLE_UNLOAD_S=0     # e.g. keep the small, fast engine resident
@@ -1279,7 +1292,10 @@ SITE_URL=
 # Seconds /speak waits for a cold engine to load before giving up and letting
 # the DJ fall through to its rescue voice. Raise it on a slow disk or a first
 # load that still has weights to fetch; the ceiling has to leave room inside
-# TTS_HEAVY_TIMEOUT_MS (180000) for the render that follows.
+# TTS_HEAVY_TIMEOUT_MS (180000) for the render that follows. This is only a
+# CEILING — a load the sidecar abandons sooner (missing venv, fatal model
+# error) fails its caller straight away. Floored at 5; anything unparseable is
+# ignored with a warning rather than stopping the sidecar booting.
 # TTS_HEAVY_LOAD_TIMEOUT_S=90
 #
 # Own TTS server? There's nothing to set here — the *Remote* engine points the

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -259,6 +259,14 @@ services:
       # Which engines to load (comma-separated). Each costs RAM + a first-boot
       # weight download; set a single engine if you only use one.
       - TTS_HEAVY_ENGINES=\${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
+      # Idle seconds before an engine's worker is stopped and its memory
+      # returned (0 = always resident). Empty picks the device-aware default:
+      # 1800 on cuda, 3600 on cpu. Reloads on the next spoken line, or ahead of
+      # one when the idle pause releases (#1579). Per-engine overrides:
+      # CHATTERBOX_IDLE_UNLOAD_S / POCKET_TTS_IDLE_UNLOAD_S.
+      - TTS_HEAVY_IDLE_UNLOAD_S=\${TTS_HEAVY_IDLE_UNLOAD_S:-}
+      - CHATTERBOX_IDLE_UNLOAD_S=\${CHATTERBOX_IDLE_UNLOAD_S:-}
+      - POCKET_TTS_IDLE_UNLOAD_S=\${POCKET_TTS_IDLE_UNLOAD_S:-}
       # Optional — PocketTTS voice CLONING (#238): the cloning weights are
       # gated on HF; accept the terms at huggingface.co/kyutai/pocket-tts and
       # set HF_TOKEN. Without it, cloned .wav voices revert to a built-in.
@@ -564,6 +572,12 @@ services:
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
       # Which engines to load (comma-separated); each costs RAM + weights.
       - TTS_HEAVY_ENGINES=\${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
+      # Idle seconds before an engine's worker is stopped and its memory
+      # returned (empty = 1800 cuda / 3600 cpu; 0 = always resident). See
+      # .env.example and #1579.
+      - TTS_HEAVY_IDLE_UNLOAD_S=\${TTS_HEAVY_IDLE_UNLOAD_S:-}
+      - CHATTERBOX_IDLE_UNLOAD_S=\${CHATTERBOX_IDLE_UNLOAD_S:-}
+      - POCKET_TTS_IDLE_UNLOAD_S=\${POCKET_TTS_IDLE_UNLOAD_S:-}
       # Optional — PocketTTS voice cloning (#238): accept the terms at
       # huggingface.co/kyutai/pocket-tts and set HF_TOKEN.
       - HF_TOKEN=\${HF_TOKEN:-}
@@ -818,6 +832,12 @@ services:
       - POCKET_TTS_VOICE=\${POCKET_TTS_VOICE:-alba}
       # Which engines to load (comma-separated); each costs RAM + weights.
       - TTS_HEAVY_ENGINES=\${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
+      # Idle seconds before an engine's worker is stopped and its memory
+      # returned (empty = 1800 cuda / 3600 cpu; 0 = always resident). See
+      # .env.example and #1579.
+      - TTS_HEAVY_IDLE_UNLOAD_S=\${TTS_HEAVY_IDLE_UNLOAD_S:-}
+      - CHATTERBOX_IDLE_UNLOAD_S=\${CHATTERBOX_IDLE_UNLOAD_S:-}
+      - POCKET_TTS_IDLE_UNLOAD_S=\${POCKET_TTS_IDLE_UNLOAD_S:-}
       # Optional — PocketTTS voice cloning (#238); weights gated on HF.
       - HF_TOKEN=\${HF_TOKEN:-}
     volumes:
@@ -1238,6 +1258,29 @@ SITE_URL=
 # never loads. Comma-separated; default loads both. Only matters with
 # --profile tts-heavy.
 # TTS_HEAVY_ENGINES=pocket-tts     # or: chatterbox  |  chatterbox,pocket-tts
+#
+# How long an idle heavy-TTS engine stays loaded. Chatterbox is ~4GB resident
+# (weights, plus torch's CUDA context on a GPU host) and used to be held for
+# the life of the container whether or not the station had spoken all day —
+# the programme's idle pause stands the music down but has no reach into the
+# sidecar. After this many seconds without a spoken line the sidecar stops
+# that engine's worker and hands the memory back, reloading it on the next
+# line (or a little ahead of one: the controller warms the sidecar when the
+# idle pause releases, so the reload lands while the music returns rather than
+# on the first link). Empty = 1800 on cuda, 3600 on cpu; both sit far above
+# any gap a talking station produces, so this only fires when the station
+# really has gone quiet. 0 keeps the old always-resident behaviour — worth it
+# if you have RAM to spare and never want a cold reload. Per-engine overrides
+# win over the shared value. Only matters with --profile tts-heavy.
+# TTS_HEAVY_IDLE_UNLOAD_S=1800
+# CHATTERBOX_IDLE_UNLOAD_S=      # just Chatterbox (the expensive one)
+# POCKET_TTS_IDLE_UNLOAD_S=0     # e.g. keep the small, fast engine resident
+#
+# Seconds /speak waits for a cold engine to load before giving up and letting
+# the DJ fall through to its rescue voice. Raise it on a slow disk or a first
+# load that still has weights to fetch; the ceiling has to leave room inside
+# TTS_HEAVY_TIMEOUT_MS (180000) for the render that follows.
+# TTS_HEAVY_LOAD_TIMEOUT_S=90
 #
 # Own TTS server? There's nothing to set here — the *Remote* engine points the
 # DJ at any HTTP server that answers GET /health and returns rendered audio from

--- a/controller/scripts/analyzer-python.test.ts
+++ b/controller/scripts/analyzer-python.test.ts
@@ -21,6 +21,7 @@ const SUITES = [
   'idle_release_test.py', // idle model release + heavy clock (#1099/#1204)
   'vocal_gate_test.py', // vocal-stem gate thresholds (#1125)
   'test_chatterbox_chunk.py', // chatterbox chunk_text (#1130)
+  'tts_heavy_idle_test.py', // tts-heavy idle unload + cold-engine health (#1579)
   'analyzer_noise_test.py', // decode-noise filter + capability loss (#1300)
   'analyzer_silence_test.py', // edge dead-air measurement (silence trim)
 ];

--- a/controller/scripts/tts-heavy-warm.test.ts
+++ b/controller/scripts/tts-heavy-warm.test.ts
@@ -1,0 +1,108 @@
+// Unit tests for warmHeavy() (audio/ttsHeavyClient.ts) — the call that asks the
+// tts-heavy sidecar to start reloading an engine its idle unload released
+// (#1579), so the model comes back before the DJ needs it rather than on the
+// line itself.
+//
+// The property under test is that it is TOTAL. Two callers fire it and neither
+// awaits it: the idle pause releasing (broadcast/stream-idle.ts, inside the
+// tick's try/catch, where a throw would hold the pause) and a talk slot firing
+// (broadcast/scheduler.ts). Nothing downstream depends on the result — a warm
+// that never lands just means the next render pays the model load itself,
+// which is the un-warmed behaviour — so every failure path has to resolve
+// quietly rather than reject. An unhandled rejection from a `void`-ed call is
+// how a memory optimisation takes the station down.
+//
+// globalThis.fetch swap, matching scripts/weather-settings-live.test.ts.
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.TTS_HEAVY_URL = 'http://tts-heavy.test:8080';
+const { warmHeavy } = await import('../src/audio/ttsHeavyClient.js');
+
+type Call = { url: string; method?: string; body?: string };
+
+function stubFetch(handler: (call: Call) => Promise<Response> | Response) {
+  const calls: Call[] = [];
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const call = {
+      url: String(input),
+      method: init?.method,
+      body: typeof init?.body === 'string' ? init.body : undefined,
+    };
+    calls.push(call);
+    return handler(call);
+  }) as typeof fetch;
+  return { calls, restore: () => { globalThis.fetch = original; } };
+}
+
+const ok = (body: unknown) =>
+  new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+test('warms every enabled engine with one unnamed POST', async () => {
+  const f = stubFetch(() => ok({ ok: true, warming: ['chatterbox'], disabled: [], loaded: [], cold: [] }));
+  try {
+    await warmHeavy();
+    assert.equal(f.calls.length, 1);
+    assert.match(f.calls[0].url, /\/warm$/);
+    assert.equal(f.calls[0].method, 'POST');
+    // The caller is a station-wide event and cannot know which persona speaks
+    // first, so it names no engine and the sidecar warms the lot.
+    assert.deepEqual(JSON.parse(f.calls[0].body || '{}'), { engine: '' });
+  } finally {
+    f.restore();
+  }
+});
+
+test('a sidecar that is down resolves quietly instead of rejecting', async () => {
+  const f = stubFetch(() => { throw new Error('ECONNREFUSED'); });
+  try {
+    // Not assert.doesNotReject-for-its-own-sake: stream-idle.ts fires this
+    // inside the tick's try/catch, and a throw there would be caught as an
+    // idle-transition failure and hold the programme paused.
+    await assert.doesNotReject(() => warmHeavy(), 'a down sidecar must not throw at its caller');
+  } finally {
+    f.restore();
+  }
+});
+
+test('an older image with no /warm route is a no-op, not an error', async () => {
+  const f = stubFetch(() => new Response('Not Found', { status: 404 }));
+  try {
+    await assert.doesNotReject(() => warmHeavy());
+  } finally {
+    f.restore();
+  }
+});
+
+test('a malformed body is swallowed — the reply is only ever logged', async () => {
+  const f = stubFetch(() => new Response('<html>nope</html>', { status: 200 }));
+  try {
+    await assert.doesNotReject(() => warmHeavy());
+  } finally {
+    f.restore();
+  }
+});
+
+test('no sidecar configured makes no request at all', async () => {
+  const f = stubFetch(() => ok({ ok: true, warming: [] }));
+  const saved = process.env.TTS_HEAVY_URL;
+  try {
+    // config is read once at import, so drive the same branch the way the
+    // module does: the URL is empty in every non-sidecar deployment, and
+    // warmHeavy must not manufacture a request to nowhere.
+    const { config } = await import('../src/config.js');
+    const original = config.ttsHeavy.url;
+    config.ttsHeavy.url = '';
+    try {
+      await warmHeavy();
+      assert.equal(f.calls.length, 0, 'no URL, no call');
+    } finally {
+      config.ttsHeavy.url = original;
+    }
+  } finally {
+    process.env.TTS_HEAVY_URL = saved;
+    f.restore();
+  }
+});

--- a/controller/scripts/tts_heavy_idle_test.py
+++ b/controller/scripts/tts_heavy_idle_test.py
@@ -291,6 +291,21 @@ def _cases():
             "an unparseable ceiling reads the default instead of raising"
         )
         assert reload_server(TTS_HEAVY_LOAD_TIMEOUT_S="45").LOAD_TIMEOUT_S == 45.0
+        # EMPTY is the important one, and it is not a typo — it is what every
+        # compose file supplies by default: `${TTS_HEAVY_LOAD_TIMEOUT_S:-}`
+        # sets the var to "", and os.environ.get(name, "90") returns "" rather
+        # than the default for a var that IS set. A bare float("") raises, so
+        # forwarding this knob (which is the other half of the same fix) would
+        # have crash-looped the sidecar on every stock install. Verified
+        # against the pre-fix module end to end: it never bound its port.
+        assert reload_server(TTS_HEAVY_LOAD_TIMEOUT_S="").LOAD_TIMEOUT_S == 90.0, (
+            "an empty var is 'not set', which is what compose passes by default"
+        )
+        for var in ("TTS_HEAVY_IDLE_UNLOAD_S", "CHATTERBOX_IDLE_UNLOAD_S", "POCKET_TTS_IDLE_UNLOAD_S"):
+            mod = reload_server(**{var: ""})
+            assert mod.idle_unload_seconds("chatterbox") == mod.IDLE_UNLOAD_CPU_S, (
+                f"{var}= (empty, the compose default) must read as unset, not 0"
+            )
         assert reload_server(TTS_HEAVY_LOAD_TIMEOUT_S="0").LOAD_TIMEOUT_S >= 5.0, (
             "0 would 503 every cold /speak — no load lands in no time at all — "
             "turning the idle unload into 'heavy voices stop working when the "
@@ -660,6 +675,46 @@ def _cases():
                 w.ready, w.cold, w.ready_meta = ready, cold, meta
 
     test("/health keeps cold engines routable and hides unready ones", lambda: run_async(case_health_lists_cold_engines()))
+
+    async def case_reloading_engine_stays_routable():
+        # A worker mid-RELOAD must stay in /health's `engines`. warm() clears
+        # `cold` and sets `_loading`, so between the wake and the load landing
+        # the engine was in NEITHER list and dropped out of `engines`
+        # altogether. The controller caches that list and routes on it, so for
+        # the 30-60s of a real Chatterbox reload it stopped routing to the
+        # engine and sent the DJ to its rescue voice — across exactly the
+        # window /warm exists to make inaudible, and on exactly the line the
+        # talk scheduler warmed the sidecar for. Seen live in the controller
+        # log as a `sidecar unavailable` / `available` flap around every warm.
+        #
+        # A worker that has NEVER loaded still stays out, which is the
+        # distinction the cold/not-ready split was drawn for: `_loading` is
+        # only set by warm(), warm() only runs on a `cold` worker, and only the
+        # idle unload makes one cold — so `_loading` implies the engine came up
+        # successfully at least once in this container's life. A booting or
+        # crash-looping worker has `_loading` False and is unaffected.
+        server.ENABLED_ENGINES = ["chatterbox", "pocket-tts"]
+        cb, pk = server.WORKERS["chatterbox"], server.WORKERS["pocket-tts"]
+        saved = [(w.ready, w.cold, w._loading) for w in (cb, pk)]
+        try:
+            cb.ready, cb.cold, cb._loading = False, False, True   # mid-reload
+            pk.ready, pk.cold, pk._loading = False, False, False  # never loaded
+            body = await server.health()
+            assert "chatterbox" in body["engines"], (
+                "an engine that is RELOADING must stay routable — /speak waits "
+                "out the load, and dropping it sends the DJ to its rescue voice "
+                "for the whole window /warm exists to hide"
+            )
+            assert "pocket-tts" not in body["engines"], (
+                "a worker that has never loaded still stays out"
+            )
+            assert body["cold"] == [], "reloading is not the same as released"
+            assert body["chatterbox_loaded"] is False, "and it is not resident yet"
+        finally:
+            for w, (ready, cold, loading) in zip((cb, pk), saved):
+                w.ready, w.cold, w._loading = ready, cold, loading
+
+    test("an engine mid-reload stays routable", lambda: run_async(case_reloading_engine_stays_routable()))
 
     def case_reset_keeps_meta_only_when_deliberate():
         w = make_worker()

--- a/controller/scripts/tts_heavy_idle_test.py
+++ b/controller/scripts/tts_heavy_idle_test.py
@@ -21,14 +21,26 @@
 #     voice instead of the station going quiet;
 #   - a worker that is DOWN (not cold) fails its caller at once rather than
 #     waiting out the load ceiling — degrading has to be immediate, and a
-#     90-second stall before the rescue voice is worse than no wait at all;
+#     90-second stall before the rescue voice is worse than no wait at all —
+#     and so does one whose load the supervisor has ABANDONED, which is the
+#     same silence arriving by a different route;
+#   - a RELOAD restarts the idle clock, so a worker /warm has just brought back
+#     survives the next tick. Without that the warm buys a whole model load and
+#     the tick 30s later throws it away, leaving the first line after the pause
+#     paying the cold start anyway — the feature's whole point, undone;
 #   - the window resolves per ENGINE, so an operator using one engine doesn't
-#     have the other's idle behaviour decided for them.
+#     have the other's idle behaviour decided for them;
+#   - every knob the sidecar reads is forwarded by all three compose files —
+#     there is no env_file: here, so an unwired knob is one an operator sets
+#     and watches do nothing;
+#   - a malformed seconds value warns and reads its default rather than raising
+#     at import, which would take the whole container (both engines) down.
 
 import asyncio
 import importlib.util
 import json
 import os
+import re
 import sys
 import types
 from pathlib import Path
@@ -178,6 +190,30 @@ async def wait_for(predicate, timeout=2.0, what="condition"):
     raise AssertionError(f"timed out waiting for {what}")
 
 
+def reload_server(**env):
+    """Re-exec server.py under a given env and hand back the fresh module.
+
+    The seconds knobs are read at IMPORT time, so the blast radius of a bad
+    value is "the sidecar never boots" — and the only way to test that is to
+    boot it. Returns a module object independent of the one the rest of the
+    file uses; nothing is started until a lifespan runs.
+    """
+    saved = {k: os.environ.get(k) for k in env}
+    os.environ.update(env)
+    try:
+        spec_ = importlib.util.spec_from_file_location("subwave_tts_heavy_reload", server_path)
+        assert spec_ and spec_.loader
+        mod = importlib.util.module_from_spec(spec_)
+        spec_.loader.exec_module(mod)
+        return mod
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
 def make_worker(name="chatterbox", idle_unload_s=0.0):
     return server.TtsWorker(
         name=name,
@@ -247,6 +283,23 @@ def _cases():
 
     test("junk window falls back; 0 and negatives disable", case_junk_and_zero)
 
+    def case_junk_ceiling_never_stops_the_boot():
+        # Read at import time, so a typo here doesn't misconfigure one knob —
+        # it stops the container, and BOTH engines go with it. Strictly worse
+        # than quietly reading the default.
+        assert reload_server(TTS_HEAVY_LOAD_TIMEOUT_S="90s").LOAD_TIMEOUT_S == 90.0, (
+            "an unparseable ceiling reads the default instead of raising"
+        )
+        assert reload_server(TTS_HEAVY_LOAD_TIMEOUT_S="45").LOAD_TIMEOUT_S == 45.0
+        assert reload_server(TTS_HEAVY_LOAD_TIMEOUT_S="0").LOAD_TIMEOUT_S >= 5.0, (
+            "0 would 503 every cold /speak — no load lands in no time at all — "
+            "turning the idle unload into 'heavy voices stop working when the "
+            "station goes quiet'. TTS_HEAVY_IDLE_UNLOAD_S=0 is how you ask for "
+            "pinned engines."
+        )
+
+    test("a junk load ceiling never stops the sidecar booting", case_junk_ceiling_never_stops_the_boot)
+
     # --- should_unload precedence ------------------------------------------
     def case_should_unload_guards():
         w = make_worker(idle_unload_s=60.0)
@@ -278,6 +331,26 @@ def _cases():
         )
 
     test("idle clock runs from the last render", case_render_clock_beats_load_clock)
+
+    def case_reload_restarts_the_idle_clock():
+        w = make_worker(idle_unload_s=60.0)
+        w.ready = True
+        # Spoke once, then the station went quiet long enough to be released.
+        w.last_spoke = server.time.monotonic() - 601.0
+        w.loaded_at = None
+        assert w.should_unload(), "the gap that causes the unload in the first place"
+        # …and the reload landed. `last_spoke` still holds the render from
+        # BEFORE the unload, which is by definition past the window — that gap
+        # is what unloaded the worker. Reading it alone made a freshly warmed
+        # engine measure as instantly idle.
+        w.loaded_at = server.time.monotonic()
+        assert not w.should_unload(), (
+            "a reload restarts the idle clock — otherwise /warm buys a whole "
+            "model load, the next tick throws it away, and the first line "
+            "after the pause pays the cold start anyway"
+        )
+
+    test("a reload restarts the idle clock", case_reload_restarts_the_idle_clock)
 
     # --- lifecycle ----------------------------------------------------------
     async def case_unload_then_wake():
@@ -391,6 +464,82 @@ def _cases():
 
     test("a down worker fails the render immediately", lambda: run_async(case_down_worker_fails_immediately()))
 
+    async def case_warm_survives_the_next_idle_tick():
+        # End to end for the clock reset above: the whole point of /warm is
+        # that the engine is READY when the room fills up. An idle loop that
+        # still measures from the pre-unload render undoes it within one tick,
+        # and the operator pays a 4GB load for nothing.
+        procs = install_fake_spawn([])
+        w = make_worker(idle_unload_s=60.0)
+        w.IDLE_TICK_S = 0.01
+        runner = asyncio.create_task(w.run())
+        idler = asyncio.create_task(w.idle_loop())
+        try:
+            await wait_for(lambda: w.ready, what="first load")
+            await w.speak({"id": "1", "text": "hi", "out": "/tmp/x.wav"})
+            # BOTH stamps age, because the clock is the later of the two — a
+            # station that has been quiet since the container booted.
+            w.last_spoke = server.time.monotonic() - 601.0
+            w.loaded_at = server.time.monotonic() - 700.0
+            await wait_for(lambda: w.cold, what="the idle unload")
+            assert w.unloads == 1
+
+            assert w.warm() is True, "the idle pause releasing arms the reload"
+            await wait_for(lambda: w.ready, what="the warm reload")
+            # Many ticks' worth at 10ms. Nothing may take the model away.
+            await asyncio.sleep(0.2)
+            assert w.ready and not w.cold, (
+                "a warmed engine survives the idle ticks — it was reloaded "
+                "seconds ago in anticipation of a room filling up"
+            )
+            assert w.unloads == 1, "and `unloads` didn't invent a second release"
+            assert len(procs) == 2, "one boot, one reload — no thrash"
+        finally:
+            runner.cancel()
+            idler.cancel()
+            await asyncio.gather(runner, idler, return_exceptions=True)
+
+    test("a warmed engine survives the idle ticks", lambda: run_async(case_warm_survives_the_next_idle_tick()))
+
+    async def case_abandoned_load_fails_before_the_ceiling():
+        # A cold worker whose start() cannot succeed (missing venv, fatal model
+        # error, OOM) must fail its caller the moment the supervisor gives up,
+        # NOT at LOAD_TIMEOUT_S. Waiting out the ceiling holds the DJ in
+        # silence for a load that is not coming, when the rescue chain was
+        # ready the whole time — and a worker that was merely down has always
+        # failed at once.
+        async def failing_exec(*_args, **_kwargs):
+            raise OSError("no such venv: /opt/chatterbox/bin/python")
+
+        saved_exec = asyncio.create_subprocess_exec
+        saved_ceiling = server.LOAD_TIMEOUT_S
+        asyncio.create_subprocess_exec = failing_exec
+        server.LOAD_TIMEOUT_S = 5.0
+        w = make_worker(idle_unload_s=60.0)
+        w.START_BACKOFF_S = 5.0  # long enough that a retry can't rescue the wait
+        w.cold = True
+        runner = asyncio.create_task(w.run())
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        try:
+            try:
+                await w.speak({"id": "1", "text": "hi", "out": "/tmp/x.wav"})
+                raise AssertionError("a load that cannot start must fail the render")
+            except RuntimeError:
+                pass
+            elapsed = loop.time() - started
+            assert elapsed < 2.0, (
+                f"the caller waited {elapsed:.1f}s of a {server.LOAD_TIMEOUT_S}s "
+                "ceiling for a load the supervisor had already abandoned"
+            )
+        finally:
+            server.LOAD_TIMEOUT_S = saved_ceiling
+            asyncio.create_subprocess_exec = saved_exec
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+    test("an abandoned load fails its caller without waiting out the ceiling", lambda: run_async(case_abandoned_load_fails_before_the_ceiling()))
+
     async def case_second_caller_joins_a_load():
         # The first caller arms the reload and clears `cold`; a second arriving
         # mid-load must wait for the same load, not read the cleared flag as
@@ -440,6 +589,41 @@ def _cases():
         assert not w.cold and w._wake.is_set(), "the supervisor was signalled"
 
     test("warm() starts a cold load once", case_warm_is_idempotent)
+
+    # --- operator surface ---------------------------------------------------
+    def case_every_knob_reaches_the_container():
+        # The service has NO `env_file:` — each compose file's `environment:`
+        # list is the whole surface — so a knob the sidecar reads but compose
+        # never forwards is one an operator can set in the root .env and watch
+        # do nothing, silently. #1579 shipped exactly that: three of its four
+        # new vars were wired up and TTS_HEAVY_LOAD_TIMEOUT_S was documented in
+        # .env.example and docs/tts-heavy.md but forwarded nowhere.
+        #
+        # One table (server.OPERATOR_ENV_KNOBS), three copies, same shape as
+        # max-listeners.test.ts and state-bootstrap.test.ts.
+        repo = Path(__file__).parents[2]
+        knobs = server.OPERATOR_ENV_KNOBS
+        assert len(knobs) >= 6, "the declared knob set looks truncated"
+
+        source = (repo / "docker" / "tts-heavy" / "server.py").read_text()
+        stale = [k for k in knobs if f'"{k}"' not in source]
+        assert not stale, f"declared but no longer read by the sidecar: {stale}"
+
+        for name in ("docker-compose.yml", "docker-compose.dev.yml", "docker-compose.byo.yml"):
+            text = (repo / name).read_text()
+            block = text.split("\n  tts-heavy:\n", 1)
+            assert len(block) == 2, f"{name} has no tts-heavy service"
+            # Up to the next top-level service key (two-space indent).
+            service = re.split(r"\n  [a-z][a-z0-9-]*:\n", block[1])[0]
+            missing = [k for k in knobs if f"- {k}=" not in service]
+            assert not missing, (
+                f"{name} does not pass {', '.join(missing)} into tts-heavy, so "
+                "setting it in the root .env does nothing. Add it to the "
+                "service's environment: list and re-run "
+                "`npm --prefix cli run embed-assets`."
+            )
+
+    test("every operator knob reaches the container in all three composes", case_every_knob_reaches_the_container)
 
     # --- /health contract ---------------------------------------------------
     async def case_health_lists_cold_engines():
@@ -548,6 +732,7 @@ def _cases():
     test("/speak on an engine that won't load answers 503", lambda: run_async(case_speak_503_on_dead_engine()))
 
     async def case_warm_endpoint():
+        saved_enabled = list(server.ENABLED_ENGINES)
         server.ENABLED_ENGINES = ["chatterbox"]
         cb = server.WORKERS["chatterbox"]
         saved = (cb.ready, cb.cold)
@@ -555,17 +740,29 @@ def _cases():
             cb.ready, cb.cold = False, True
             body = await server.warm(server.WarmRequest(engine=""))
             assert body["warming"] == ["chatterbox"], "an empty engine warms everything enabled"
+            assert body["loaded"] == [] and body["cold"] == [], (
+                "residency is REPORTED, not promised — warm() cleared `cold` "
+                "and the load hasn't landed yet"
+            )
             body = await server.warm(server.WarmRequest(engine=""))
             assert body["warming"] == [], "a second warm reports it started nothing"
+
+            # A name this image knows but TTS_HEAVY_ENGINES never loaded. It
+            # must not read as "already warm" — that is the one answer an
+            # operator asking why their engine won't come back must not get.
+            body = await server.warm(server.WarmRequest(engine="pocket-tts"))
+            assert body["warming"] == [] and body["disabled"] == ["pocket-tts"]
+
             try:
                 await server.warm(server.WarmRequest(engine="nope"))
                 raise AssertionError("expected an HTTPException")
             except HTTPException as e:
-                assert e.status_code == 400
+                assert e.status_code == 400, "a typo is still a 400, not a quiet no-op"
         finally:
             cb.ready, cb.cold = saved
+            server.ENABLED_ENGINES = saved_enabled
 
-    test("/warm arms cold engines and rejects unknown ones", lambda: run_async(case_warm_endpoint()))
+    test("/warm arms cold engines, names disabled ones, rejects unknown ones", lambda: run_async(case_warm_endpoint()))
 
 
 if __name__ == "__main__":

--- a/controller/scripts/tts_heavy_idle_test.py
+++ b/controller/scripts/tts_heavy_idle_test.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+# Unit test for the tts-heavy sidecar's idle unload (#1579) — the mechanism
+# that hands Chatterbox's ~4GB back while the station is quiet and loads it
+# again on demand. Pure stdlib: fastapi/pydantic are stubbed and the worker
+# subprocess is faked, so no torch, no model, no network, no port.
+# Run: `python3 scripts/tts_heavy_idle_test.py` (exit 0 = pass).
+#
+# What this pins down, in the order it matters:
+#   - a cold engine stays in /health's `engines`. This is the one-way door: the
+#     controller caches that list and routes on it, so an engine dropped while
+#     unloaded would never be asked to speak and so would never wake;
+#   - a crashed or still-booting engine stays OUT of it, which is the reason
+#     `cold` and `not ready` cannot be one flag;
+#   - the unload is a process exit (#1204: an in-process release leaves torch
+#     resident), and run() treats that exit as deliberate — no crash warning,
+#     no eager respawn;
+#   - a render in flight, or one that has merely claimed the worker, blocks the
+#     unload;
+#   - /speak on a cold worker loads it and succeeds; a load that never arrives
+#     is a 503, which is what makes the controller fall through to its rescue
+#     voice instead of the station going quiet;
+#   - a worker that is DOWN (not cold) fails its caller at once rather than
+#     waiting out the load ceiling — degrading has to be immediate, and a
+#     90-second stall before the rescue voice is worse than no wait at all;
+#   - the window resolves per ENGINE, so an operator using one engine doesn't
+#     have the other's idle behaviour decided for them.
+
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+
+
+class HTTPException(Exception):
+    def __init__(self, status_code, detail):
+        super().__init__(str(detail))
+        self.status_code = status_code
+        self.detail = detail
+
+
+class FastAPI:
+    def __init__(self, **_kwargs):
+        pass
+
+    def get(self, _path):
+        return lambda fn: fn
+
+    def post(self, _path):
+        return lambda fn: fn
+
+
+class BaseModel:
+    def __init__(self, **values):
+        for key, value in values.items():
+            setattr(self, key, value)
+
+
+fastapi = types.ModuleType("fastapi")
+fastapi.FastAPI = FastAPI
+fastapi.HTTPException = HTTPException
+pydantic = types.ModuleType("pydantic")
+pydantic.BaseModel = BaseModel
+pydantic.Field = lambda **_kwargs: None
+sys.modules["fastapi"] = fastapi
+sys.modules["pydantic"] = pydantic
+
+# Load with a clean env so the module-level defaults are the shipped ones.
+for _var in (
+    "TTS_HEAVY_IDLE_UNLOAD_S",
+    "CHATTERBOX_IDLE_UNLOAD_S",
+    "POCKET_TTS_IDLE_UNLOAD_S",
+    "TTS_HEAVY_DEVICE",
+    "TTS_HEAVY_ENGINES",
+):
+    os.environ.pop(_var, None)
+
+server_path = Path(__file__).parents[2] / "docker" / "tts-heavy" / "server.py"
+spec = importlib.util.spec_from_file_location("subwave_tts_heavy_server", server_path)
+assert spec and spec.loader
+server = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(server)
+
+failures = 0
+
+
+def test(name, fn):
+    global failures
+    try:
+        fn()
+        print(f"  ✓ {name}")
+    except Exception as err:  # noqa: BLE001 — a failed assert is a reported case
+        failures += 1
+        print(f"  ✗ {name}\n      {err}")
+
+
+class FakeStdin:
+    def __init__(self, proc):
+        self.proc = proc
+
+    def write(self, data):
+        self.proc.written.append(data)
+        # Every request gets one canned success back, which is all the idle
+        # bookkeeping cares about; the render itself is the worker's business.
+        req = json.loads(data.decode())
+        self.proc.feed({"id": req.get("id"), "ok": True, "path": req.get("out"), "duration_s": 1.0})
+
+    async def drain(self):
+        return None
+
+
+class FakeProc:
+    """An asyncio.subprocess.Process stand-in: real StreamReaders, a stdin that
+    answers requests, and a wait() that only returns once terminate() is called
+    — the same shape run() supervises."""
+
+    def __init__(self, ready_msg=None, fail_ready=False):
+        self.stdout = asyncio.StreamReader()
+        self.stderr = asyncio.StreamReader()
+        self.stdin = FakeStdin(self)
+        self.returncode = None
+        self.written = []
+        self.terminated = False
+        self._exited = asyncio.Event()
+        # Set by a test that needs to act in the window between terminate()
+        # and the supervisor observing the exit — the race the idle latch
+        # exists for, which is otherwise too fast to step into.
+        self.hold_exit: asyncio.Event | None = None
+        if fail_ready:
+            # Worker dies before announcing readiness (a fatal model load).
+            self.stdout.feed_eof()
+            self.stderr.feed_eof()
+        else:
+            self.feed(ready_msg or {"ready": True, "voice_cloning": True})
+
+    def feed(self, obj):
+        self.stdout.feed_data((json.dumps(obj) + "\n").encode())
+
+    def terminate(self):
+        self.terminated = True
+        self.exit(code=-15)
+
+    def exit(self, code=0):
+        if self.returncode is None:
+            self.returncode = code
+            self.stdout.feed_eof()
+            self.stderr.feed_eof()
+            self._exited.set()
+
+    async def wait(self):
+        await self._exited.wait()
+        if self.hold_exit is not None:
+            await self.hold_exit.wait()
+        return self.returncode
+
+
+def install_fake_spawn(procs):
+    """Hand out one FakeProc per start(); records them in `procs`."""
+
+    async def fake_exec(*_args, **_kwargs):
+        proc = FakeProc()
+        procs.append(proc)
+        return proc
+
+    asyncio.create_subprocess_exec = fake_exec
+    return procs
+
+
+async def wait_for(predicate, timeout=2.0, what="condition"):
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"timed out waiting for {what}")
+
+
+def make_worker(name="chatterbox", idle_unload_s=0.0):
+    return server.TtsWorker(
+        name=name,
+        python="/nonexistent/python",
+        script="/nonexistent/worker.py",
+        env_extra={},
+        idle_unload_s=idle_unload_s,
+    )
+
+
+def run_async(coro):
+    return asyncio.run(coro)
+
+
+def main():
+    real_exec = asyncio.create_subprocess_exec
+    try:
+        _cases()
+    finally:
+        asyncio.create_subprocess_exec = real_exec
+
+    print("✓ tts_heavy_idle_test.py passed" if not failures else f"✗ {failures} case(s) failed")
+    return 1 if failures else 0
+
+
+def _cases():
+    # --- window resolution --------------------------------------------------
+    def case_per_engine_env_beats_shared():
+        os.environ["TTS_HEAVY_IDLE_UNLOAD_S"] = "900"
+        os.environ["CHATTERBOX_IDLE_UNLOAD_S"] = "120"
+        try:
+            assert server.idle_unload_seconds("chatterbox") == 120.0, "per-engine var must win"
+            assert server.idle_unload_seconds("pocket-tts") == 900.0, "shared var covers the rest"
+        finally:
+            os.environ.pop("TTS_HEAVY_IDLE_UNLOAD_S", None)
+            os.environ.pop("CHATTERBOX_IDLE_UNLOAD_S", None)
+
+    test("per-engine idle var beats the shared one", case_per_engine_env_beats_shared)
+
+    def case_device_default():
+        server.DEVICE = "cuda"
+        try:
+            assert server.idle_unload_seconds("chatterbox") == server.IDLE_UNLOAD_CUDA_S, (
+                "cuda chatterbox takes the tighter window — VRAM contention is the urgent case"
+            )
+            # PocketTTS' venv is CPU-torch whatever the sidecar's device says.
+            assert server.idle_unload_seconds("pocket-tts") == server.IDLE_UNLOAD_CPU_S, (
+                "pocket-tts is never on the GPU, so the device must not move its window"
+            )
+        finally:
+            server.DEVICE = "cpu"
+
+    test("device-aware default applies to chatterbox only", case_device_default)
+
+    def case_junk_and_zero():
+        os.environ["TTS_HEAVY_IDLE_UNLOAD_S"] = "soon"
+        try:
+            assert server.idle_unload_seconds("chatterbox") == server.IDLE_UNLOAD_CPU_S, (
+                "a junk value falls back to the default rather than disabling the feature"
+            )
+            os.environ["TTS_HEAVY_IDLE_UNLOAD_S"] = "-5"
+            assert server.idle_unload_seconds("chatterbox") == 0.0, "a negative window means off"
+            os.environ["TTS_HEAVY_IDLE_UNLOAD_S"] = "0"
+            assert server.idle_unload_seconds("chatterbox") == 0.0, "0 means always resident"
+        finally:
+            os.environ.pop("TTS_HEAVY_IDLE_UNLOAD_S", None)
+
+    test("junk window falls back; 0 and negatives disable", case_junk_and_zero)
+
+    # --- should_unload precedence ------------------------------------------
+    def case_should_unload_guards():
+        w = make_worker(idle_unload_s=60.0)
+        assert not w.should_unload(), "a worker that never loaded has nothing to unload"
+        w.ready = True
+        w.loaded_at = server.time.monotonic() - 10.0
+        assert not w.should_unload(), "inside the window it stays loaded"
+        w.loaded_at = server.time.monotonic() - 61.0
+        assert w.should_unload(), "past the window it is releasable"
+        w._inflight = 1
+        assert not w.should_unload(), "a claimed worker is never unloaded under a render"
+        w._inflight = 0
+        w.cold = True
+        assert not w.should_unload(), "an already-cold worker is not unloaded twice"
+        w.cold = False
+        w.idle_unload_s = 0.0
+        assert not w.should_unload(), "0 means the feature is off"
+
+    test("should_unload honours every guard", case_should_unload_guards)
+
+    def case_render_clock_beats_load_clock():
+        w = make_worker(idle_unload_s=60.0)
+        w.ready = True
+        w.loaded_at = server.time.monotonic() - 600.0
+        w.last_spoke = server.time.monotonic() - 5.0
+        assert not w.should_unload(), (
+            "the clock runs from the last RENDER; a long-loaded but recently used "
+            "worker is busy, not idle"
+        )
+
+    test("idle clock runs from the last render", case_render_clock_beats_load_clock)
+
+    # --- lifecycle ----------------------------------------------------------
+    async def case_unload_then_wake():
+        procs = install_fake_spawn([])
+        w = make_worker(idle_unload_s=60.0)
+        runner = asyncio.create_task(w.run())
+        try:
+            await wait_for(lambda: w.ready, what="first load")
+            assert len(procs) == 1, "one worker process on boot"
+
+            # Age past the window and let one idle tick run.
+            w.loaded_at = server.time.monotonic() - 601.0
+            w.IDLE_TICK_S = 0.01
+            idler = asyncio.create_task(w.idle_loop())
+            try:
+                await wait_for(lambda: w.cold, what="the idle unload")
+            finally:
+                idler.cancel()
+
+            assert procs[0].terminated, "the reclaim is a process exit, not an in-process del"
+            assert not w.ready, "a cold worker is not ready"
+            await wait_for(lambda: w.proc is None, what="run() to observe the exit")
+            assert len(procs) == 1, "a deliberate stop must NOT be respawned eagerly"
+            assert w.unloads == 1
+
+            # …and the next render brings it back.
+            msg = await w.speak({"id": "1", "text": "hi", "out": "/tmp/x.wav"})
+            assert msg["ok"], "a cold worker loads on demand and renders"
+            assert len(procs) == 2, "the wake spawned a fresh worker"
+            assert not w.cold and w.ready, "the woken worker is hot again"
+        finally:
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+    test("idle unload stops the process; the next render wakes it", lambda: run_async(case_unload_then_wake()))
+
+    async def case_crash_is_not_cold():
+        procs = install_fake_spawn([])
+        w = make_worker(idle_unload_s=0.0)
+        runner = asyncio.create_task(w.run())
+        try:
+            await wait_for(lambda: w.ready, what="first load")
+            w.RUN_BACKOFF_S = 0.01
+            procs[0].exit(code=1)  # died on its own — nobody asked
+            await wait_for(lambda: len(procs) == 2, what="the crash respawn")
+            assert not w.cold, (
+                "a crash must not read as an idle unload — cold means loadable on "
+                "demand, and /health advertises it"
+            )
+        finally:
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+    test("a crash respawns and is never marked cold", lambda: run_async(case_crash_is_not_cold()))
+
+    async def case_inflight_blocks_unload():
+        procs = install_fake_spawn([])
+        w = make_worker(idle_unload_s=60.0)
+        runner = asyncio.create_task(w.run())
+        try:
+            await wait_for(lambda: w.ready, what="first load")
+            w.loaded_at = server.time.monotonic() - 601.0
+            w.IDLE_TICK_S = 0.01
+            # Hold the worker the way a render in flight does.
+            async with w.lock:
+                w._inflight = 1
+                idler = asyncio.create_task(w.idle_loop())
+                try:
+                    await asyncio.sleep(0.1)
+                    assert not w.cold, "an idle tick must stand down under a claimed worker"
+                finally:
+                    idler.cancel()
+                    await asyncio.gather(idler, return_exceptions=True)
+            assert not procs[0].terminated, "the render's process survived the tick"
+        finally:
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+    test("a claimed worker blocks the unload", lambda: run_async(case_inflight_blocks_unload()))
+
+    async def case_down_worker_fails_immediately():
+        procs = install_fake_spawn([])
+        w = make_worker(idle_unload_s=60.0)
+        runner = asyncio.create_task(w.run())
+        try:
+            await wait_for(lambda: w.ready, what="first load")
+            w.last_spoke = None
+            # Down, not cold: booting, or crash-looping. Nobody armed a load.
+            w.ready = False
+            loop = asyncio.get_running_loop()
+            started = loop.time()
+            try:
+                await w.speak({"id": "1", "text": "hi", "out": "/tmp/x.wav"})
+                raise AssertionError("a down worker must fail the render")
+            except RuntimeError:
+                pass
+            elapsed = loop.time() - started
+            assert elapsed < 1.0, (
+                f"a down worker must fail AT ONCE (took {elapsed:.1f}s) — the rescue "
+                "chain is what keeps the station talking, and LOAD_TIMEOUT_S of "
+                "silence before reaching it is worse than the cold start it covers"
+            )
+            assert w.last_spoke is not None, (
+                "the idle clock tracks DEMAND: a run of failing renders is the worst "
+                "moment to pull the engine out from under the retries"
+            )
+            assert w._inflight == 0, "a failed render must release its claim"
+        finally:
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+    test("a down worker fails the render immediately", lambda: run_async(case_down_worker_fails_immediately()))
+
+    async def case_second_caller_joins_a_load():
+        # The first caller arms the reload and clears `cold`; a second arriving
+        # mid-load must wait for the same load, not read the cleared flag as
+        # "down" and bail to Piper while the engine is on its way back.
+        procs = install_fake_spawn([])
+        w = make_worker(idle_unload_s=60.0)
+        runner = asyncio.create_task(w.run())
+        try:
+            await wait_for(lambda: w.ready, what="first load")
+            w.loaded_at = server.time.monotonic() - 601.0
+            w.IDLE_TICK_S = 0.01
+            idler = asyncio.create_task(w.idle_loop())
+            try:
+                await wait_for(lambda: w.cold, what="the idle unload")
+            finally:
+                idler.cancel()
+                await asyncio.gather(idler, return_exceptions=True)
+
+            first = asyncio.create_task(w.speak({"id": "1", "text": "a", "out": "/tmp/a.wav"}))
+            await wait_for(lambda: w._loading or w.ready, what="the load to arm")
+            second = asyncio.create_task(w.speak({"id": "2", "text": "b", "out": "/tmp/b.wav"}))
+            got = await asyncio.gather(first, second)
+            assert all(m["ok"] for m in got), "both renders ride the one reload"
+        finally:
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+    test("a second caller joins an in-flight load", lambda: run_async(case_second_caller_joins_a_load()))
+
+    async def case_ensure_ready_gives_up():
+        w = make_worker(idle_unload_s=60.0)
+        w.cold = True  # cold, but with no supervisor running to answer the wake
+        try:
+            await w.ensure_ready(timeout_s=0.05)
+            raise AssertionError("a load that never arrives must fail its caller")
+        except RuntimeError:
+            pass
+        assert not w.cold, "the wake was armed even though nothing answered it"
+
+    test("a wake that never loads raises rather than hanging", lambda: run_async(case_ensure_ready_gives_up()))
+
+    def case_warm_is_idempotent():
+        w = make_worker(idle_unload_s=60.0)
+        w.cold = True
+        assert w.warm() is True, "warming a cold worker starts the load"
+        assert w.warm() is False, "warming a warm worker is a no-op the caller can see"
+        assert not w.cold and w._wake.is_set(), "the supervisor was signalled"
+
+    test("warm() starts a cold load once", case_warm_is_idempotent)
+
+    # --- /health contract ---------------------------------------------------
+    async def case_health_lists_cold_engines():
+        server.ENABLED_ENGINES = ["chatterbox", "pocket-tts"]
+        cb, pk = server.WORKERS["chatterbox"], server.WORKERS["pocket-tts"]
+        saved = [(w.ready, w.cold, dict(w.ready_meta)) for w in (cb, pk)]
+        try:
+            cb.ready, cb.cold = False, True       # idle-unloaded
+            pk.ready, pk.cold = False, False      # still booting / crash-looping
+            body = await server.health()
+            assert "chatterbox" in body["engines"], (
+                "a cold engine MUST stay routable — the controller caches this list "
+                "and only ever wakes an engine by calling /speak on it"
+            )
+            assert "pocket-tts" not in body["engines"], (
+                "a not-yet-ready engine stays out, so /speak isn't called on a worker "
+                "that can't answer"
+            )
+            assert body["cold"] == ["chatterbox"]
+            assert body["chatterbox_loaded"] is False, (
+                "*_loaded is residency, and a cold engine is not resident"
+            )
+
+            # Capability metadata outlives a deliberate stop.
+            pk.ready, pk.cold = False, True
+            pk.ready_meta = {"voice_cloning": True}
+            body = await server.health()
+            assert body["pocket_voice_cloning"] is True, (
+                "cloning is a property of the image, not of the process — flickering "
+                "it to unknown every idle window would make the admin warning worse"
+            )
+        finally:
+            for w, (ready, cold, meta) in zip((cb, pk), saved):
+                w.ready, w.cold, w.ready_meta = ready, cold, meta
+
+    test("/health keeps cold engines routable and hides unready ones", lambda: run_async(case_health_lists_cold_engines()))
+
+    def case_reset_keeps_meta_only_when_deliberate():
+        w = make_worker()
+        w.ready_meta = {"voice_cloning": True}
+        w._reset(keep_meta=True)
+        assert w.ready_meta == {"voice_cloning": True}, "a deliberate stop keeps capabilities"
+        w._reset()
+        assert w.ready_meta == {}, "a crash clears them — they're genuinely unknown again"
+
+    test("_reset keeps capabilities across an unload, drops them on a crash", case_reset_keeps_meta_only_when_deliberate)
+
+    async def case_wake_racing_the_unload_is_not_a_crash():
+        # A render arriving in the window between the idle terminate and run()
+        # observing the exit clears `cold` legitimately. run() must still read
+        # that exit as the stop IT asked for — otherwise it logs a crash and
+        # sits through a restart backoff before the caller's engine comes back.
+        procs = install_fake_spawn([])
+        w = make_worker(idle_unload_s=60.0)
+        w.RUN_BACKOFF_S = 5.0  # long enough that taking the crash path shows up
+        runner = asyncio.create_task(w.run())
+        try:
+            await wait_for(lambda: w.ready, what="first load")
+            procs[0].hold_exit = asyncio.Event()  # freeze run() inside proc.wait()
+            w.loaded_at = server.time.monotonic() - 601.0
+            w.IDLE_TICK_S = 0.01
+            idler = asyncio.create_task(w.idle_loop())
+            try:
+                await wait_for(lambda: w.cold, what="the idle unload")
+            finally:
+                idler.cancel()
+                await asyncio.gather(idler, return_exceptions=True)
+            assert w._stopped_by_idle, "the idle unload latched its own stop"
+
+            w.warm()  # the racing render, before run() has seen the exit
+            assert not w.cold, "the wake cleared `cold`, which run() must NOT read"
+            procs[0].hold_exit.set()  # now let the supervisor see the exit
+
+            await wait_for(lambda: len(procs) == 2, timeout=1.0, what="an immediate respawn")
+            assert w.ready_meta != {}, "the deliberate stop kept its capabilities"
+        finally:
+            runner.cancel()
+            await asyncio.gather(runner, return_exceptions=True)
+
+    test("a wake racing the unload doesn't read as a crash", lambda: run_async(case_wake_racing_the_unload_is_not_a_crash()))
+
+    # --- /speak -------------------------------------------------------------
+    async def case_speak_503_on_dead_engine():
+        server.ENABLED_ENGINES = ["chatterbox", "pocket-tts"]
+        w = server.WORKERS["chatterbox"]
+        saved = (w.ready, w.cold, w.idle_unload_s)
+        try:
+            w.ready, w.cold, w._loading = False, False, False  # down
+            try:
+                await server.speak(
+                    server.SpeakRequest(
+                        engine="chatterbox", text="hi", voice="", reference_wav="",
+                        out="/tmp/subwave-tts-test.wav",
+                    )
+                )
+                raise AssertionError("expected an HTTPException")
+            except HTTPException as e:
+                assert e.status_code == 503, (
+                    f"an engine that can't render is 'service unavailable', not a 500 "
+                    f"(got {e.status_code}) — the controller reads it and falls through "
+                    "to its rescue voice"
+                )
+        finally:
+            w.ready, w.cold, w.idle_unload_s = saved
+
+    test("/speak on an engine that won't load answers 503", lambda: run_async(case_speak_503_on_dead_engine()))
+
+    async def case_warm_endpoint():
+        server.ENABLED_ENGINES = ["chatterbox"]
+        cb = server.WORKERS["chatterbox"]
+        saved = (cb.ready, cb.cold)
+        try:
+            cb.ready, cb.cold = False, True
+            body = await server.warm(server.WarmRequest(engine=""))
+            assert body["warming"] == ["chatterbox"], "an empty engine warms everything enabled"
+            body = await server.warm(server.WarmRequest(engine=""))
+            assert body["warming"] == [], "a second warm reports it started nothing"
+            try:
+                await server.warm(server.WarmRequest(engine="nope"))
+                raise AssertionError("expected an HTTPException")
+            except HTTPException as e:
+                assert e.status_code == 400
+        finally:
+            cb.ready, cb.cold = saved
+
+    test("/warm arms cold engines and rejects unknown ones", lambda: run_async(case_warm_endpoint()))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/controller/src/audio/tts.ts
+++ b/controller/src/audio/tts.ts
@@ -9,7 +9,7 @@ import * as kokoro from './kokoro.js';
 import { applyEdgeFades } from './wav-edges.js';
 import * as chatterbox from './chatterbox.js';
 import * as pocketTts from './pocketTts.js';
-import { heavyEnabledEngines } from './ttsHeavyClient.js';
+import { heavyColdEngines, heavyEnabledEngines } from './ttsHeavyClient.js';
 import * as remoteTts from './remoteTts.js';
 import { normalizeForSpeech } from './speech-text.js';
 import { scrubCjkForSpeech } from './spoken-script-policy.js';
@@ -618,6 +618,12 @@ export function availableEngines() {
     // badge separate "engine off" (sidecar up, engine disabled) from "sidecar
     // off" (whole sidecar down). See engineMeta.engineStatus.
     heavyEnabled: heavyEnabledEngines(),
+    // Which of those the sidecar has idle-unloaded (#1579): still available —
+    // the next line just pays a model load first — so this changes nothing
+    // about routing and is here only so the admin badge can say "cold" rather
+    // than leaving an operator to read `docker stats` and guess. Same
+    // null-means-unknown rule as heavyEnabled.
+    heavyCold: heavyColdEngines(),
     // Whether PocketTTS can clone voices (gated weights present). null = not
     // yet known. The admin UI uses this to warn that a cloned .wav voice will
     // silently revert to a built-in when cloning is unavailable (issue #238).

--- a/controller/src/audio/ttsHeavyClient.ts
+++ b/controller/src/audio/ttsHeavyClient.ts
@@ -136,6 +136,11 @@ export async function warmHeavy(): Promise<void> {
       // is a station-wide event and can't know which persona speaks first.
       body: JSON.stringify({ engine: '' }),
       timeoutMs: WARM_TIMEOUT_MS,
+      // The deadline covers the body read too, like the probe above. Nobody
+      // awaits this call, so a body that never drains would otherwise sit on
+      // undici's ~300s default holding a socket and a dangling promise for a
+      // reply we only log.
+      bodyDeadline: true,
     });
     if (!res.ok) return;
     const body = (await res.json()) as { warming?: string[] };

--- a/controller/src/audio/ttsHeavyClient.ts
+++ b/controller/src/audio/ttsHeavyClient.ts
@@ -20,6 +20,10 @@ import { fetchWithTimeout } from '../util/fetch-timeout.js';
 import { cachedHealthProbe } from '../util/health-probe.js';
 
 const PROBE_TIMEOUT_MS = 5_000;
+// /warm only ARMS a load and returns; it never waits for the model. Short
+// ceiling on purpose — a slow warm is not worth holding anything for, because
+// the render path reloads on its own if this call never lands.
+const WARM_TIMEOUT_MS = 5_000;
 
 export type RemoteEngine = 'chatterbox' | 'pocket-tts';
 
@@ -39,7 +43,14 @@ export type ProbeMeta = { voiceCloning: boolean | null };
 // this engine disabled via TTS_HEAVY_ENGINES". `enabled` is the sidecar's
 // configured engine list; null when the sidecar is unreachable OR is an older
 // image that doesn't report the field (so callers fall back to old behaviour).
-let cachedHealth: { up: boolean; enabled: string[] | null } = { up: false, enabled: null };
+// `cold` is the engines the sidecar's idle unload has parked (#1579) — still
+// routable, but their next line pays a model load. null when unknown: the
+// sidecar is down, or is an older image that doesn't report the field.
+let cachedHealth: { up: boolean; enabled: string[] | null; cold: string[] | null } = {
+  up: false,
+  enabled: null,
+  cold: null,
+};
 
 // The tts-heavy sidecar's configured engines (TTS_HEAVY_ENGINES). Returns null
 // when not in sidecar mode, the sidecar is unreachable, or it's too old to
@@ -48,6 +59,14 @@ let cachedHealth: { up: boolean; enabled: string[] | null } = { up: false, enabl
 export function heavyEnabledEngines(): string[] | null {
   if (!config.ttsHeavy.url) return null;
   return cachedHealth.up ? cachedHealth.enabled : null;
+}
+
+// Engines the sidecar has idle-unloaded (#1579). Same null-means-unknown rule
+// as heavyEnabledEngines(). Diagnostic only — a cold engine is still
+// available, so nothing routes on this.
+export function heavyColdEngines(): string[] | null {
+  if (!config.ttsHeavy.url) return null;
+  return cachedHealth.up ? cachedHealth.cold : null;
 }
 
 // One /health probe. `available` is true iff the sidecar reports ok and lists
@@ -62,20 +81,27 @@ async function probeOnce(engine: RemoteEngine): Promise<{ available: boolean; me
   try {
     const res = await fetchWithTimeout(`${url}/health`, { timeoutMs: PROBE_TIMEOUT_MS, bodyDeadline: true });
     if (!res.ok) {
-      cachedHealth = { up: false, enabled: null };
+      cachedHealth = { up: false, enabled: null, cold: null };
       return miss;
     }
     const body = (await res.json()) as {
       ok?: boolean;
       engines?: string[];
       enabled?: string[];
+      cold?: string[];
       pocket_voice_cloning?: boolean | null;
     };
     // Refresh the sidecar-wide snapshot on every probe (see cachedHealth).
     cachedHealth = {
       up: !!body.ok,
       enabled: Array.isArray(body.enabled) ? body.enabled : null,
+      cold: Array.isArray(body.cold) ? body.cold : null,
     };
+    // `engines` is what the sidecar says we may route to, which by design
+    // includes an idle-unloaded engine (it is one on-demand load from
+    // speaking). Do NOT subtract `cold` here: treating a cold engine as
+    // unavailable would stop the dispatcher ever calling /speak on it, and a
+    // sidecar only ever wakes an engine because someone asked it to (#1579).
     const available =
       !!body.ok && Array.isArray(body.engines) && body.engines.includes(engine);
     const voiceCloning =
@@ -84,8 +110,42 @@ async function probeOnce(engine: RemoteEngine): Promise<{ available: boolean; me
         : null;
     return { available, meta: { voiceCloning } };
   } catch {
-    cachedHealth = { up: false, enabled: null };
+    cachedHealth = { up: false, enabled: null, cold: null };
     return miss;
+  }
+}
+
+// Ask the sidecar to start reloading anything its idle unload parked, without
+// waiting for the load to finish (#1579).
+//
+// This is what keeps the unload from being heard: broadcast/stream-idle.ts
+// calls it the moment the programme's idle pause releases, so the model comes
+// back while the music does rather than on the first spoken line, minutes
+// later. Deliberately total — it resolves on every failure path (no sidecar
+// configured, sidecar down, an older image with no /warm route) because
+// nothing downstream depends on it: a warm that never lands just means the
+// next render pays the load itself, which is the un-warmed behaviour.
+export async function warmHeavy(): Promise<void> {
+  const url = config.ttsHeavy.url;
+  if (!url) return;
+  try {
+    const res = await fetchWithTimeout(`${url}/warm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      // No engine named: warm everything the sidecar has enabled. The caller
+      // is a station-wide event and can't know which persona speaks first.
+      body: JSON.stringify({ engine: '' }),
+      timeoutMs: WARM_TIMEOUT_MS,
+    });
+    if (!res.ok) return;
+    const body = (await res.json()) as { warming?: string[] };
+    // Only worth a line when it actually started something — an already-warm
+    // sidecar is the common case and says nothing.
+    if (Array.isArray(body.warming) && body.warming.length > 0) {
+      console.log(`[tts-heavy] warming idle-unloaded engine(s): ${body.warming.join(', ')}`);
+    }
+  } catch {
+    /* see above — a failed warm costs the next render a model load, nothing more */
   }
 }
 

--- a/controller/src/broadcast/scheduler.ts
+++ b/controller/src/broadcast/scheduler.ts
@@ -34,6 +34,7 @@ import * as session from './session.js';
 import * as djAgent from './dj-agent.js';
 import * as programme from './programme.js';
 import { cleanupOldVoices } from '../audio/tts.js';
+import { warmHeavy } from '../audio/ttsHeavyClient.js';
 import { shouldFire } from './dj-gate.js';
 import { speakClockAllowed, stationIdDaypartStamp } from './clock-policy.js';
 import { talkOnlyBetweenTracks, withTalkAir } from './talk-air.js';
@@ -939,6 +940,21 @@ function talkEligible(kind: TalkKind, now: Date, rolled: SessionRoll | null): bo
 // switch, the clock switch and the frequency ladder already carry, by the same
 // mechanism (the manual route never reaches the gate).
 async function runTalkSlot(plan: Extract<TalkPlan, { act: 'fire' }>) {
+  // The station has just decided it is going to talk this minute, which is the
+  // earliest honest signal that a heavy engine the sidecar idle-unloaded
+  // (#1579) is about to be needed. The idle-pause release
+  // (broadcast/stream-idle.ts) is the other signal and the better one — it
+  // buys minutes — but it only exists when stream.idleWhenEmpty is ON, and
+  // that defaults OFF, so a stock station warmed the sidecar nowhere at all
+  // and paid every reload as a stall on the line itself. From here the load at
+  // least overlaps writing the script and rendering it.
+  //
+  // Fired at the FIRE, never on an open window: the talk rows cover ~50
+  // minutes of the hour, so warming whenever a window is open would reload the
+  // model within a tick of every unload and quietly switch the feature off.
+  // Fire-and-forget and total, exactly like the idle-pause call — a warm that
+  // fails costs the render a model load, which is the un-warmed behaviour.
+  void warmHeavy();
   return withTalkAir(plan.air, () => runTalkSlotInner(plan));
 }
 

--- a/controller/src/broadcast/stream-idle.ts
+++ b/controller/src/broadcast/stream-idle.ts
@@ -30,6 +30,7 @@
 // scripts/stream-idle.test.ts.
 
 import * as settings from '../settings.js';
+import { warmHeavy } from '../audio/ttsHeavyClient.js';
 import { gatedListenerCount, refresh, setStreamIdle } from './listeners.js';
 import { idleOn, idleOff, idleStatus } from './liquidsoap-control.js';
 import { queue } from './queue.js';
@@ -80,6 +81,15 @@ async function tick() {
       );
     } else if (action === 'resume') {
       await idleOff();
+      // The tts-heavy sidecar unloads an idle engine on its own clock (#1579)
+      // and reloads it on demand, which on a cold Chatterbox is 30-60s — long
+      // enough to be heard if it lands on the first link after the room fills
+      // up. Start that load HERE instead, where we already know the pause is
+      // releasing and the first spoken line is still minutes away. Deliberately
+      // not awaited and never throws: the render path reloads on its own if
+      // this does nothing, so it must not be able to delay idleOff()'s state
+      // update or trip the catch below into holding the pause.
+      void warmHeavy();
       queue.log(
         'scheduler',
         count !== null && count > 0

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -230,6 +230,9 @@ services:
       - TTS_HEAVY_IDLE_UNLOAD_S=${TTS_HEAVY_IDLE_UNLOAD_S:-}
       - CHATTERBOX_IDLE_UNLOAD_S=${CHATTERBOX_IDLE_UNLOAD_S:-}
       - POCKET_TTS_IDLE_UNLOAD_S=${POCKET_TTS_IDLE_UNLOAD_S:-}
+      # Seconds /speak waits for a cold engine to load before giving up and
+      # letting the DJ fall through to its rescue voice.
+      - TTS_HEAVY_LOAD_TIMEOUT_S=${TTS_HEAVY_LOAD_TIMEOUT_S:-}
       # Optional — PocketTTS voice cloning (#238): accept the terms at
       # huggingface.co/kyutai/pocket-tts and set HF_TOKEN.
       - HF_TOKEN=${HF_TOKEN:-}

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -224,6 +224,12 @@ services:
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
       # Which engines to load (comma-separated); each costs RAM + weights.
       - TTS_HEAVY_ENGINES=${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
+      # Idle seconds before an engine's worker is stopped and its memory
+      # returned (empty = 1800 cuda / 3600 cpu; 0 = always resident). See
+      # .env.example and #1579.
+      - TTS_HEAVY_IDLE_UNLOAD_S=${TTS_HEAVY_IDLE_UNLOAD_S:-}
+      - CHATTERBOX_IDLE_UNLOAD_S=${CHATTERBOX_IDLE_UNLOAD_S:-}
+      - POCKET_TTS_IDLE_UNLOAD_S=${POCKET_TTS_IDLE_UNLOAD_S:-}
       # Optional — PocketTTS voice cloning (#238): accept the terms at
       # huggingface.co/kyutai/pocket-tts and set HF_TOKEN.
       - HF_TOKEN=${HF_TOKEN:-}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -184,6 +184,12 @@ services:
       - POCKET_TTS_VOICE=${POCKET_TTS_VOICE:-alba}
       # Which engines to load (comma-separated); each costs RAM + weights.
       - TTS_HEAVY_ENGINES=${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
+      # Idle seconds before an engine's worker is stopped and its memory
+      # returned (empty = 1800 cuda / 3600 cpu; 0 = always resident). See
+      # .env.example and #1579.
+      - TTS_HEAVY_IDLE_UNLOAD_S=${TTS_HEAVY_IDLE_UNLOAD_S:-}
+      - CHATTERBOX_IDLE_UNLOAD_S=${CHATTERBOX_IDLE_UNLOAD_S:-}
+      - POCKET_TTS_IDLE_UNLOAD_S=${POCKET_TTS_IDLE_UNLOAD_S:-}
       # Optional — PocketTTS voice cloning (#238); weights gated on HF.
       - HF_TOKEN=${HF_TOKEN:-}
     volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -190,6 +190,9 @@ services:
       - TTS_HEAVY_IDLE_UNLOAD_S=${TTS_HEAVY_IDLE_UNLOAD_S:-}
       - CHATTERBOX_IDLE_UNLOAD_S=${CHATTERBOX_IDLE_UNLOAD_S:-}
       - POCKET_TTS_IDLE_UNLOAD_S=${POCKET_TTS_IDLE_UNLOAD_S:-}
+      # Seconds /speak waits for a cold engine to load before giving up and
+      # letting the DJ fall through to its rescue voice.
+      - TTS_HEAVY_LOAD_TIMEOUT_S=${TTS_HEAVY_LOAD_TIMEOUT_S:-}
       # Optional — PocketTTS voice cloning (#238); weights gated on HF.
       - HF_TOKEN=${HF_TOKEN:-}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -250,6 +250,14 @@ services:
       # Which engines to load (comma-separated). Each costs RAM + a first-boot
       # weight download; set a single engine if you only use one.
       - TTS_HEAVY_ENGINES=${TTS_HEAVY_ENGINES:-chatterbox,pocket-tts}
+      # Idle seconds before an engine's worker is stopped and its memory
+      # returned (0 = always resident). Empty picks the device-aware default:
+      # 1800 on cuda, 3600 on cpu. Reloads on the next spoken line, or ahead of
+      # one when the idle pause releases (#1579). Per-engine overrides:
+      # CHATTERBOX_IDLE_UNLOAD_S / POCKET_TTS_IDLE_UNLOAD_S.
+      - TTS_HEAVY_IDLE_UNLOAD_S=${TTS_HEAVY_IDLE_UNLOAD_S:-}
+      - CHATTERBOX_IDLE_UNLOAD_S=${CHATTERBOX_IDLE_UNLOAD_S:-}
+      - POCKET_TTS_IDLE_UNLOAD_S=${POCKET_TTS_IDLE_UNLOAD_S:-}
       # Optional — PocketTTS voice CLONING (#238): the cloning weights are
       # gated on HF; accept the terms at huggingface.co/kyutai/pocket-tts and
       # set HF_TOKEN. Without it, cloned .wav voices revert to a built-in.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -258,6 +258,9 @@ services:
       - TTS_HEAVY_IDLE_UNLOAD_S=${TTS_HEAVY_IDLE_UNLOAD_S:-}
       - CHATTERBOX_IDLE_UNLOAD_S=${CHATTERBOX_IDLE_UNLOAD_S:-}
       - POCKET_TTS_IDLE_UNLOAD_S=${POCKET_TTS_IDLE_UNLOAD_S:-}
+      # Seconds /speak waits for a cold engine to load before giving up and
+      # letting the DJ fall through to its rescue voice.
+      - TTS_HEAVY_LOAD_TIMEOUT_S=${TTS_HEAVY_LOAD_TIMEOUT_S:-}
       # Optional — PocketTTS voice CLONING (#238): the cloning weights are
       # gated on HF; accept the terms at huggingface.co/kyutai/pocket-tts and
       # set HF_TOKEN. Without it, cloned .wav voices revert to a built-in.

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -472,6 +472,30 @@ class TtsWorker:
         self._wake.set()
         return True
 
+    def routable(self) -> bool:
+        """Whether the controller may still send this engine a /speak.
+
+        Three states qualify, and the third is the one that is easy to miss:
+        READY (obviously), COLD (one on-demand load away — dropping it is the
+        one-way door /health's comment describes), and RELOADING. A worker
+        between `warm()` and the load landing has had `cold` cleared and
+        `ready` not yet set, so it belonged to neither list and fell out of
+        `engines` entirely — for the whole 30-60s of a real Chatterbox reload
+        the controller stopped routing to it and the DJ took its rescue voice,
+        across exactly the window /warm exists to make inaudible and on
+        exactly the line the talk scheduler warmed the sidecar for. /speak
+        already handles this state correctly: ensure_ready() waits the load
+        out.
+
+        A worker that has never loaded still stays out, which is the whole
+        point of splitting `cold` from `not ready`. `_loading` is only set by
+        warm(), warm() only runs on a `cold` worker, and only the idle unload
+        makes one cold — so `_loading` implies this engine came up
+        successfully at least once. A booting or crash-looping worker has it
+        False and is advertised exactly as before.
+        """
+        return self.ready or self.cold or self._loading
+
     def idle_for(self) -> float:
         """Seconds since this worker last had something to do.
 
@@ -629,15 +653,20 @@ async def health():
     # state: what is resident right now, and what is merely loadable.
     ready_engines: list[str] = []
     cold_engines: list[str] = []
+    routable_engines: list[str] = []
     for name in ENABLED_ENGINES:
         worker = WORKERS[name]
         if worker.ready:
             ready_engines.append(name)
         elif worker.cold:
             cold_engines.append(name)
+        # Routability is the worker's own question and includes a THIRD state
+        # neither list above covers — mid-reload. See TtsWorker.routable().
+        if worker.routable():
+            routable_engines.append(name)
     return {
         "ok": True,
-        "engines": ready_engines + cold_engines,
+        "engines": routable_engines,
         # What TTS_HEAVY_ENGINES asked for, regardless of load state.
         "enabled": ENABLED_ENGINES,
         # Unloaded by the idle policy — usable, but the next line pays a load.

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -10,16 +10,24 @@ over stdin/stdout; an asyncio.Lock per worker serialises requests. No audio
 over the wire — the sidecar writes the WAV to the absolute `out` path on the
 shared /var/sub-wave volume and the controller hands that path to Liquidsoap.
 
+Engines do not stay resident forever: after TTS_HEAVY_IDLE_UNLOAD_S without
+a render the supervisor stops that engine's worker and reloads it on the next
+/speak (or ahead of one, on /warm). See the idle-unload block below for why
+the reclaim is a process exit rather than an in-process release (#1579).
+
 Endpoints:
-  GET  /health   → {ok, engines, chatterbox_loaded, pocket_loaded}
+  GET  /health   → {ok, engines, cold, chatterbox_loaded, pocket_loaded}
   POST /speak    → {ok, path, duration_s}
     body: {engine, text, voice?, reference_wav?, out}
+  POST /warm     → {ok, warming, engines}
+    body: {engine?}   (omitted / empty = every enabled engine)
 """
 
 import asyncio
 import json
 import logging
 import os
+import time
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -68,6 +76,67 @@ logging.basicConfig(
 )
 log = logging.getLogger("tts-heavy")
 
+# --- idle unload (#1579) ----------------------------------------------------
+# Chatterbox is ~4GB resident — weights plus, on CUDA, torch's context — and it
+# used to be held for the life of the container whether or not the station had
+# spoken in twelve hours. The programme's idle pause (stream.idleAfterMinutes)
+# stands the MUSIC down when the room empties but has no reach in here, which
+# is the specific surprise operators hit. So each worker gets its own idle
+# clock: after this many seconds without a render, stop it; reload on the next
+# /speak, or ahead of one on /warm.
+#
+# The reclaim is a PROCESS EXIT, not an in-process `del model`, and that is the
+# whole design. #1204 established on the analyzer that dropping the model
+# singletons leaves torch's imported modules — and on CUDA its context —
+# resident until the process ends, so an in-process release hands back only
+# part of the memory and the operator still sees gigabytes pinned. Exiting is
+# also nearly free here: run() is already a restart supervisor, so "unload"
+# is one terminate away and the workers themselves need no idle protocol.
+#
+# The window must sit well ABOVE the station's natural talk cadence or the
+# reload becomes the new normal: the talk scheduler can offer the segment
+# director a minute every five, so a five-minute window would thrash a station
+# that is merely between links rather than idle. Thirty minutes of total
+# silence is three times the idle-pause default and unreachable by a station
+# that is on air and talking. CUDA is tighter than CPU because VRAM contention
+# is urgent in a way that host RAM is not, and a GPU reload is the fast one.
+IDLE_UNLOAD_CUDA_S = 1800.0
+IDLE_UNLOAD_CPU_S = 3600.0
+
+# Per-engine, not per-sidecar: this container carries both engines, and an
+# operator who uses one and not the other should not have the unused engine's
+# idle behaviour decide the used one's. A specific var beats the shared one,
+# which beats the device-aware default; 0 (or negative) means always resident,
+# i.e. the pre-#1579 behaviour.
+_IDLE_ENV_BY_ENGINE = {
+    "chatterbox": "CHATTERBOX_IDLE_UNLOAD_S",
+    "pocket-tts": "POCKET_TTS_IDLE_UNLOAD_S",
+}
+
+
+def idle_unload_seconds(engine: str) -> float:
+    """Resolve one engine's idle window in seconds. 0 disables."""
+    for name in (_IDLE_ENV_BY_ENGINE.get(engine), "TTS_HEAVY_IDLE_UNLOAD_S"):
+        raw = os.environ.get(name, "").strip() if name else ""
+        if not raw:
+            continue
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            log.warning(f"{name}={raw!r} is not a number; ignoring")
+    # PocketTTS' venv is CPU-torch by construction (see Dockerfile.tts-heavy),
+    # so chatterbox is the only engine TTS_HEAVY_DEVICE can actually move.
+    if engine == "chatterbox" and DEVICE == "cuda":
+        return IDLE_UNLOAD_CUDA_S
+    return IDLE_UNLOAD_CPU_S
+
+
+# How long /speak waits for a cold worker to finish loading before giving up
+# and letting the caller fall through the controller's rescue chain. Chatterbox
+# is 30-60s from a warm HF cache; the ceiling leaves the rest of the client's
+# 180s TTS_HEAVY_TIMEOUT_MS budget for the inference that follows.
+LOAD_TIMEOUT_S = float(os.environ.get("TTS_HEAVY_LOAD_TIMEOUT_S", "90"))
+
 
 class TtsWorker:
     """Async wrapper around a long-lived stdio TTS worker subprocess.
@@ -75,40 +144,99 @@ class TtsWorker:
     Same line protocol as the controller's in-process TS clients; no
     multiplexing — one request in flight per worker, gated by a lock. run()
     supervises the lifecycle so a crash (OOM, fatal model error) recovers
-    without bouncing the container.
+    without bouncing the container, and so an idle unload (#1579) can stop the
+    worker and park the supervisor until something needs the engine again.
     """
 
     # START_BACKOFF applies when start() itself fails (model load error,
     # missing venv); RUN_BACKOFF when the worker exited after a clean start.
     START_BACKOFF_S = 5.0
     RUN_BACKOFF_S = 2.0
+    # How often the idle clock is checked. Coarse on purpose: the windows are
+    # tens of minutes, and every tick that finds nothing to do is pure noise.
+    IDLE_TICK_S = 30.0
 
-    def __init__(self, name: str, python: str, script: str, env_extra: dict[str, str] | None = None):
+    def __init__(
+        self,
+        name: str,
+        python: str,
+        script: str,
+        env_extra: dict[str, str] | None = None,
+        idle_unload_s: float = 0.0,
+    ):
         self.name = name
         self.python = python
         self.script = script
         self.env_extra = env_extra or {}
+        self.idle_unload_s = idle_unload_s
         self.proc: asyncio.subprocess.Process | None = None
         self.lock = asyncio.Lock()
         self.ready = False
         # Ready message minus the `ready` flag — per-engine capability
-        # metadata (e.g. pocket-tts' voice_cloning, #238). Cleared on restart.
+        # metadata (e.g. pocket-tts' voice_cloning, #238). Cleared on a crash,
+        # KEPT across an idle unload — see _reset().
         self.ready_meta: dict[str, Any] = {}
+        # Idle-unload state. `cold` is "stopped on purpose, loadable on
+        # demand", which is a different thing from `not ready` ("booting, or
+        # crash-looping, and not usable"). They cannot share one flag because
+        # /health has to keep advertising a cold engine to the controller
+        # while still hiding a broken one — see health().
+        self.cold = False
+        # Latched by the idle unload, consumed by run() when it sees the exit.
+        # run() cannot read `cold` for this: a /speak or /warm arriving in the
+        # milliseconds between the terminate and the exit being observed
+        # clears `cold` legitimately, and the supervisor would then log a
+        # crash and sit through a restart backoff for a stop it asked for.
+        self._stopped_by_idle = False
+        self.unloads = 0
+        self.last_spoke: float | None = None
+        self.loaded_at: float | None = None
+        self._wake = asyncio.Event()
+        # True between arming a reload and that load landing (or failing).
+        # Lets a second caller that arrives mid-load wait for it instead of
+        # being told the worker is down.
+        self._loading = False
+        # Renders that have claimed this worker but not finished. An unload
+        # must never race one: it would kill a render mid-flight and cost the
+        # caller a rescue, for memory the next tick would have freed anyway.
+        self._inflight = 0
 
     async def run(self) -> None:
-        """Keep the worker alive forever; on cancellation (lifespan teardown)
-        terminate the running subprocess before bubbling up."""
+        """Keep the worker alive; on cancellation (lifespan teardown) terminate
+        the running subprocess before bubbling up.
+
+        A worker parked cold by the idle unload waits here — no process, no
+        memory — until ensure_ready()/warm() sets the wake event."""
         try:
             while True:
+                if self.cold:
+                    await self._wake.wait()
+                self._wake.clear()
                 try:
                     await self.start()
                 except Exception as e:
                     log.error(f"[{self.name}] start failed: {e}")
+                    # The load attempt is over. Callers waiting on it are
+                    # released to their rescue voice now rather than sitting
+                    # through the backoff and a second attempt.
+                    self._loading = False
                     self._reset()
                     await asyncio.sleep(self.START_BACKOFF_S)
                     continue
                 assert self.proc is not None
                 code = await self.proc.wait()
+                deliberate = self._stopped_by_idle
+                self._stopped_by_idle = False
+                if deliberate:
+                    # We asked for this exit: no warning, no backoff, and no
+                    # respawn until the engine is wanted again (which, if a
+                    # render woke it while it was dying, has already happened
+                    # and the next loop starts it straight back up).
+                    log.info(
+                        f"[{self.name}] worker stopped (idle unload) — memory released",
+                    )
+                    self._reset(keep_meta=True)
+                    continue
                 log.warning(
                     f"[{self.name}] worker exited with code={code}; restarting in {self.RUN_BACKOFF_S}s",
                 )
@@ -118,10 +246,19 @@ class TtsWorker:
             self._terminate()
             raise
 
-    def _reset(self) -> None:
+    def _reset(self, keep_meta: bool = False) -> None:
         self.ready = False
         self.proc = None
-        self.ready_meta = {}
+        self.loaded_at = None
+        # ready_meta survives a DELIBERATE stop (keep_meta). What it carries
+        # (pocket-tts' voice_cloning, #238) is a property of the image, not of
+        # this process, and the controller reads a missing flag as "unknown"
+        # and drops the operator warning that cloned voices won't take effect.
+        # Flickering that off every idle window would make the admin UI worse
+        # about a fact that did not change. A crash still clears it — there the
+        # capability genuinely is unknown until the worker re-reports it.
+        if not keep_meta:
+            self.ready_meta = {}
 
     def _terminate(self) -> None:
         if self.proc and self.proc.returncode is None:
@@ -163,6 +300,10 @@ class TtsWorker:
             raise
         self.ready_meta = {k: v for k, v in msg.items() if k != "ready"}
         log.info(f"[{self.name}] ready {self.ready_meta or ''}".rstrip())
+        # Seeds the idle clock: a worker that loads and is never asked to speak
+        # is idle from the moment it came up, not from an unset stamp.
+        self.loaded_at = time.monotonic()
+        self._loading = False
         self.ready = True
 
     async def _await_message(self) -> dict[str, Any]:
@@ -208,6 +349,109 @@ class TtsWorker:
             # that, any stray stdout would crash the next /speak call.
             return await self._await_message()
 
+    async def speak(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """One render, loading the worker first if the idle unload parked it."""
+        # Claimed before anything can await, so an idle tick that is already
+        # running sees the claim and stands down instead of unloading the
+        # worker out from under this call.
+        self._inflight += 1
+        try:
+            await self.ensure_ready()
+            return await self.request(payload)
+        finally:
+            # The idle clock tracks DEMAND, not success: a run of failing
+            # renders is the worst moment to unload the engine underneath the
+            # retries, and a caller that asked is a caller that may ask again.
+            self.last_spoke = time.monotonic()
+            self._inflight -= 1
+
+    async def ensure_ready(self, timeout_s: float | None = None) -> None:
+        """Wake a cold worker and wait out its load. No-op when already up.
+
+        Only a COLD worker (or one already loading for someone else) is worth
+        waiting for. A worker that is merely not ready is booting or
+        crash-looping, and that caller has to hear it AT ONCE: the controller's
+        rescue chain is what keeps the station talking, and a minute and a half
+        of silence before reaching it is far worse than the cold start this
+        wait exists to cover. That is also the pre-#1579 behaviour for a
+        sidecar whose engine is down, and it should not change.
+
+        Deliberately OUTSIDE the request lock, for the same reason: a wake that
+        never arrives must fail its caller rather than park an HTTP request on
+        a lock behind a model that is not coming back."""
+        if self.ready:
+            return
+        if not (self.warm() or self._loading):
+            raise RuntimeError(f"[{self.name}] worker not ready")
+        deadline = time.monotonic() + (LOAD_TIMEOUT_S if timeout_s is None else timeout_s)
+        while time.monotonic() < deadline:
+            if self.ready:
+                return
+            await asyncio.sleep(0.25)
+        raise RuntimeError(f"[{self.name}] worker did not load in time")
+
+    def warm(self) -> bool:
+        """Start a cold worker's reload WITHOUT waiting for it. True when this
+        call is what started it.
+
+        Synchronous and non-blocking on purpose: the controller fires it when
+        the programme's idle pause releases, so the load overlaps with the room
+        filling up instead of landing on the first spoken line."""
+        if not self.cold:
+            return False
+        log.info(f"[{self.name}] cold — loading on demand")
+        # Cleared BEFORE the event so run(), which re-checks the flag at the
+        # top of its loop, cannot go back to sleep on a stale read.
+        self.cold = False
+        self._loading = True
+        self._wake.set()
+        return True
+
+    def idle_for(self) -> float:
+        """Seconds since this worker last had something to do."""
+        since = self.last_spoke if self.last_spoke is not None else self.loaded_at
+        return 0.0 if since is None else time.monotonic() - since
+
+    def should_unload(self) -> bool:
+        """Whether an idle tick may stop this worker right now. Pure, so the
+        precedence between the guards is unit-pinned rather than inferred from
+        the loop."""
+        if self.idle_unload_s <= 0:
+            return False
+        if not self.ready or self.cold:
+            return False
+        if self._inflight:
+            return False
+        return self.idle_for() >= self.idle_unload_s
+
+    async def idle_loop(self) -> None:
+        """Stop the worker after idle_unload_s without a render, so run() parks
+        it cold and the memory goes back to the host. Never respawns eagerly —
+        the reload is paid by whoever next wants the engine."""
+        if self.idle_unload_s <= 0:
+            return
+        while True:
+            await asyncio.sleep(self.IDLE_TICK_S)
+            if not self.should_unload():
+                continue
+            async with self.lock:
+                # Re-check under the lock: a render may have landed, or
+                # claimed the worker, while we waited to acquire it.
+                if not self.should_unload():
+                    continue
+                log.info(
+                    f"[{self.name}] idle {int(self.idle_unload_s)}s without a render — "
+                    "unloading; reloads on the next /speak or /warm",
+                )
+                self.unloads += 1
+                # Latch first, then flip the flags, then kill: run() reads the
+                # latch to tell this exit from a crash, and request() must stop
+                # admitting work before the process goes away under it.
+                self._stopped_by_idle = True
+                self.cold = True
+                self.ready = False
+                self._terminate()
+
 
 chatterbox_worker = TtsWorker(
     name="chatterbox",
@@ -218,6 +462,7 @@ chatterbox_worker = TtsWorker(
         "CHATTERBOX_REFERENCE_WAV": os.environ.get("CHATTERBOX_REFERENCE_WAV", ""),
         "HF_HOME": CHATTERBOX_HF_HOME,
     },
+    idle_unload_s=idle_unload_seconds("chatterbox"),
 )
 
 pocket_worker = TtsWorker(
@@ -228,7 +473,15 @@ pocket_worker = TtsWorker(
         "POCKET_TTS_VOICE": POCKET_TTS_DEFAULT_VOICE,
         "HF_HOME": POCKET_HF_HOME,
     },
+    idle_unload_s=idle_unload_seconds("pocket-tts"),
 )
+
+# Name → worker, so /health, /speak and /warm all resolve an engine the same
+# way instead of each carrying its own if/elif over the two names.
+WORKERS: dict[str, TtsWorker] = {
+    "chatterbox": chatterbox_worker,
+    "pocket-tts": pocket_worker,
+}
 
 
 @asynccontextmanager
@@ -238,10 +491,20 @@ async def lifespan(_app: FastAPI):
     # probe would see "connection refused" for the entire boot.
     log.info(f"enabled engines: {', '.join(ENABLED_ENGINES)}")
     tasks = []
-    if "chatterbox" in ENABLED_ENGINES:
-        tasks.append(asyncio.create_task(chatterbox_worker.run(), name="chatterbox-run"))
-    if "pocket-tts" in ENABLED_ENGINES:
-        tasks.append(asyncio.create_task(pocket_worker.run(), name="pocket-tts-run"))
+    for name in ENABLED_ENGINES:
+        worker = WORKERS[name]
+        tasks.append(asyncio.create_task(worker.run(), name=f"{name}-run"))
+        # Engines start loaded — an operator who restarts the container is
+        # asking for a station that can talk, not one that pays a cold load on
+        # its first line. The idle clock takes it from there.
+        if worker.idle_unload_s > 0:
+            tasks.append(asyncio.create_task(worker.idle_loop(), name=f"{name}-idle"))
+            log.info(
+                f"[{name}] idle unload armed — releases after "
+                f"{int(worker.idle_unload_s)}s without a render",
+            )
+        else:
+            log.info(f"[{name}] idle unload disabled — model stays resident")
     try:
         yield
     finally:
@@ -263,30 +526,63 @@ class SpeakRequest(BaseModel):
     out: str
 
 
+class WarmRequest(BaseModel):
+    # Empty means every enabled engine — the controller fires /warm on a
+    # station-wide event (the idle pause releasing) and does not track which
+    # persona will speak first.
+    engine: str = ""
+
+
 @app.get("/health")
 async def health():
-    # `engines` lists engines *currently ready*, not the static set — the
-    # controller's probe (audio/ttsHeavyClient.ts) keys readiness on
-    # `engines.includes(<name>)`, so advertising a still-booting or crashed
-    # engine would cause failed /speak calls instead of clean fall-throughs
-    # to Piper. The *_loaded booleans are operator diagnostics.
+    # `engines` lists engines the controller may ROUTE TO, which is not the
+    # same as engines loaded right now. Its probe (audio/ttsHeavyClient.ts)
+    # keys availability on `engines.includes(<name>)` and caches the result,
+    # and tts.ts reads that cached boolean to decide whether the engine is a
+    # usable voice slot at all. So:
+    #
+    #   - a still-booting or crash-looping engine stays OUT, as before —
+    #     advertising it would buy failed /speak calls instead of clean
+    #     fall-throughs to Piper;
+    #   - an engine parked COLD by the idle unload stays IN, because it is
+    #     one on-demand load away from speaking. Dropping it here would be a
+    #     one-way door: the controller would reroute to the rescue chain,
+    #     never call /speak again, and so never wake the engine — memory
+    #     freed, voice gone for good (#1579).
+    #
+    # `cold` and the *_loaded booleans are the operator's view of the same
+    # state: what is resident right now, and what is merely loadable.
     ready_engines: list[str] = []
-    if chatterbox_worker.ready:
-        ready_engines.append("chatterbox")
-    if pocket_worker.ready:
-        ready_engines.append("pocket-tts")
+    cold_engines: list[str] = []
+    for name in ENABLED_ENGINES:
+        worker = WORKERS[name]
+        if worker.ready:
+            ready_engines.append(name)
+        elif worker.cold:
+            cold_engines.append(name)
     return {
         "ok": True,
-        "engines": ready_engines,
+        "engines": ready_engines + cold_engines,
         # What TTS_HEAVY_ENGINES asked for, regardless of load state.
         "enabled": ENABLED_ENGINES,
+        # Unloaded by the idle policy — usable, but the next line pays a load.
+        "cold": cold_engines,
+        # Per-engine idle window in seconds (0 = always resident), and how
+        # many times each has been released, so an operator can confirm the
+        # reclaim is happening rather than inferring it from `docker stats`.
+        "idle_unload_s": {name: WORKERS[name].idle_unload_s for name in ENABLED_ENGINES},
+        "unloads": {name: WORKERS[name].unloads for name in ENABLED_ENGINES},
         "chatterbox_loaded": chatterbox_worker.ready,
         "pocket_loaded": pocket_worker.ready,
         # PocketTTS zero-shot cloning capability — false when the gated
         # weights weren't available at load (no HF_TOKEN), so cloned .wav
-        # voices don't silently revert to a built-in (#238). None until ready.
+        # voices don't silently revert to a built-in (#238). None until the
+        # worker has reported once; a cold worker keeps its last answer
+        # (_reset) because the image's capabilities didn't change with it.
         "pocket_voice_cloning": (
-            pocket_worker.ready_meta.get("voice_cloning") if pocket_worker.ready else None
+            pocket_worker.ready_meta.get("voice_cloning")
+            if (pocket_worker.ready or pocket_worker.cold)
+            else None
         ),
     }
 
@@ -311,14 +607,14 @@ async def speak(req: SpeakRequest):
         )
 
     if req.engine == "chatterbox":
-        msg = await chatterbox_worker.request({
+        payload = {
             "id": "1",
             "text": text,
             "reference_wav": req.reference_wav or "",
             "out": req.out,
-        })
+        }
     elif req.engine == "pocket-tts":
-        msg = await pocket_worker.request({
+        payload = {
             "id": "1",
             "text": text,
             "voice": req.voice or POCKET_TTS_DEFAULT_VOICE,
@@ -326,9 +622,20 @@ async def speak(req: SpeakRequest):
             # empty value as "use the built-in voice".
             "reference_wav": req.reference_wav or "",
             "out": req.out,
-        })
+        }
     else:
         raise HTTPException(400, f"unknown engine: {req.engine}")
+
+    # speak() loads the worker first when the idle unload parked it (#1579).
+    # A worker that is down, or one whose load doesn't arrive inside
+    # LOAD_TIMEOUT_S, becomes a 503 rather than an unhandled 500: the
+    # controller reads any non-2xx the same way, but a "service unavailable"
+    # is what actually happened and is what the operator needs to see in the
+    # log next to the Piper line that replaced it.
+    try:
+        msg = await WORKERS[req.engine].speak(payload)
+    except RuntimeError as e:
+        raise HTTPException(503, str(e))
 
     if not msg.get("ok"):
         raise HTTPException(500, msg.get("error") or "worker failed")
@@ -342,4 +649,29 @@ async def speak(req: SpeakRequest):
         "voice_used": msg.get("voice_used"),
         "fell_back": msg.get("fell_back", False),
         "fell_back_reason": msg.get("fell_back_reason"),
+    }
+
+
+@app.post("/warm")
+async def warm(req: WarmRequest):
+    """Start reloading any cold engine, without waiting for the load.
+
+    This is what keeps the idle unload from being heard. The controller calls
+    it when the programme's idle pause releases (broadcast/stream-idle.ts), so
+    a room that has just filled up reloads the model while the music comes
+    back rather than stalling the first spoken line. Returns immediately and
+    is safe to call at any time — an engine that is already up is a no-op,
+    and a load that then fails is handled exactly as a cold /speak would be.
+    """
+    wanted = [req.engine] if req.engine else list(ENABLED_ENGINES)
+    unknown = [e for e in wanted if e not in WORKERS]
+    if unknown:
+        raise HTTPException(400, f"unknown engine: {unknown[0]}")
+    warming = [e for e in wanted if e in ENABLED_ENGINES and WORKERS[e].warm()]
+    return {
+        "ok": True,
+        # Engines this call actually started loading (already-warm ones are
+        # absent, which is the answer to "did I need to do this?").
+        "warming": warming,
+        "engines": [e for e in ENABLED_ENGINES if WORKERS[e].ready],
     }

--- a/docker/tts-heavy/server.py
+++ b/docker/tts-heavy/server.py
@@ -19,7 +19,7 @@ Endpoints:
   GET  /health   → {ok, engines, cold, chatterbox_loaded, pocket_loaded}
   POST /speak    → {ok, path, duration_s}
     body: {engine, text, voice?, reference_wav?, out}
-  POST /warm     → {ok, warming, engines}
+  POST /warm     → {ok, warming, disabled, loaded, cold}
     body: {engine?}   (omitted / empty = every enabled engine)
 """
 
@@ -114,16 +114,62 @@ _IDLE_ENV_BY_ENGINE = {
 }
 
 
+# The operator-facing env knobs, DECLARED rather than inferred from the reads
+# below (they go through helpers now, so grepping for os.environ finds only
+# half of them). This service has no `env_file:` — its `environment:` list in
+# each compose file is the entire surface — so a name here that is missing from
+# one of those files is a setting the operator can put in the root .env and
+# watch do nothing. #1579 shipped exactly that with TTS_HEAVY_LOAD_TIMEOUT_S.
+# scripts/tts_heavy_idle_test.py drives all three compose copies off this tuple.
+#
+# Everything else server.py reads is an image-internal path (the per-worker
+# CHATTERBOX_PYTHON / _WORKER / _HF_HOME set in env_extra or the Dockerfile),
+# not something an operator sets. CHATTERBOX_REFERENCE_WAV is the one judgement
+# call: it is read here as the worker's built-in default, but in sidecar mode
+# every /speak carries the persona's own reference_wav in its body, so the env
+# default is unreachable in practice and has never been forwarded or
+# documented. Left as it was — widening it is its own change, not #1579's.
+OPERATOR_ENV_KNOBS = (
+    "TTS_HEAVY_DEVICE",
+    "TTS_HEAVY_ENGINES",
+    "POCKET_TTS_VOICE",
+    "TTS_HEAVY_IDLE_UNLOAD_S",
+    "CHATTERBOX_IDLE_UNLOAD_S",
+    "POCKET_TTS_IDLE_UNLOAD_S",
+    "TTS_HEAVY_LOAD_TIMEOUT_S",
+)
+
+
+def _parse_seconds(name: str) -> float | None:
+    """One seconds-valued env var, or None when it is unset or unparseable.
+
+    EVERY seconds knob in this file reads through here, and none of them may
+    raise. A container that refuses to boot over `TTS_HEAVY_LOAD_TIMEOUT_S=90s`
+    takes BOTH engines down and the station loses its heavy voices entirely,
+    which is strictly worse than one knob quietly reading its default. Warn,
+    coerce to the pre-existing behaviour, keep serving — the same posture the
+    state bootstrap takes for the same reason.
+    """
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        log.warning(f"{name}={raw!r} is not a number; ignoring")
+        return None
+
+
 def idle_unload_seconds(engine: str) -> float:
     """Resolve one engine's idle window in seconds. 0 disables."""
     for name in (_IDLE_ENV_BY_ENGINE.get(engine), "TTS_HEAVY_IDLE_UNLOAD_S"):
-        raw = os.environ.get(name, "").strip() if name else ""
-        if not raw:
+        if not name:
             continue
-        try:
-            return max(0.0, float(raw))
-        except ValueError:
-            log.warning(f"{name}={raw!r} is not a number; ignoring")
+        value = _parse_seconds(name)
+        # A junk value falls through to the next source rather than disabling
+        # the feature: an unreadable window is no window at all, not zero.
+        if value is not None:
+            return max(0.0, value)
     # PocketTTS' venv is CPU-torch by construction (see Dockerfile.tts-heavy),
     # so chatterbox is the only engine TTS_HEAVY_DEVICE can actually move.
     if engine == "chatterbox" and DEVICE == "cuda":
@@ -135,7 +181,12 @@ def idle_unload_seconds(engine: str) -> float:
 # and letting the caller fall through the controller's rescue chain. Chatterbox
 # is 30-60s from a warm HF cache; the ceiling leaves the rest of the client's
 # 180s TTS_HEAVY_TIMEOUT_MS budget for the inference that follows.
-LOAD_TIMEOUT_S = float(os.environ.get("TTS_HEAVY_LOAD_TIMEOUT_S", "90"))
+_LOAD_TIMEOUT_ENV = _parse_seconds("TTS_HEAVY_LOAD_TIMEOUT_S")
+# Floored rather than read raw: 0 would 503 every cold /speak (no load lands in
+# no time at all), turning the idle unload into "the heavy voices stop working
+# once the station goes quiet". An operator who wants the engines pinned says
+# so with TTS_HEAVY_IDLE_UNLOAD_S=0, which is the honest way to ask for it.
+LOAD_TIMEOUT_S = max(5.0, _LOAD_TIMEOUT_ENV) if _LOAD_TIMEOUT_ENV is not None else 90.0
 
 
 class TtsWorker:
@@ -381,12 +432,26 @@ class TtsWorker:
         a lock behind a model that is not coming back."""
         if self.ready:
             return
-        if not (self.warm() or self._loading):
+        # warm() is the side effect, not the predicate: it clears `cold`, arms
+        # `_loading` and wakes the supervisor. Hoisted out of the `if` so that
+        # is visible to the next reader.
+        started = self.warm()
+        if not (started or self._loading):
             raise RuntimeError(f"[{self.name}] worker not ready")
         deadline = time.monotonic() + (LOAD_TIMEOUT_S if timeout_s is None else timeout_s)
         while time.monotonic() < deadline:
             if self.ready:
                 return
+            if not self._loading:
+                # The supervisor gave up on this load — start() raised (missing
+                # venv, fatal model error, OOM) and cleared the flag. Sitting
+                # out the rest of the ceiling would hold the caller in silence
+                # waiting for a load that is not coming; degrade NOW, which is
+                # what the rescue chain is for and what a worker that was
+                # merely down has always done. start() clears the flag and sets
+                # `ready` in one synchronous run, so a load that SUCCEEDED can
+                # never be observed through this branch.
+                raise RuntimeError(f"[{self.name}] worker failed to load")
             await asyncio.sleep(0.25)
         raise RuntimeError(f"[{self.name}] worker did not load in time")
 
@@ -408,9 +473,19 @@ class TtsWorker:
         return True
 
     def idle_for(self) -> float:
-        """Seconds since this worker last had something to do."""
-        since = self.last_spoke if self.last_spoke is not None else self.loaded_at
-        return 0.0 if since is None else time.monotonic() - since
+        """Seconds since this worker last had something to do.
+
+        The LATER of the two stamps, never `last_spoke` alone. A RELOAD resets
+        this clock, and it has to: `last_spoke` still holds the render from
+        before the unload, which is by definition already past the window —
+        that gap is what unloaded the worker in the first place. Reading it
+        alone meant a worker /warm had just brought back measured as idle
+        immediately and was dropped again on the very next tick, so the warm
+        bought a full model load and gave nothing back. The /speak path hid
+        this, because it stamps `last_spoke` on its way out.
+        """
+        stamps = [t for t in (self.last_spoke, self.loaded_at) if t is not None]
+        return 0.0 if not stamps else time.monotonic() - max(stamps)
 
     def should_unload(self) -> bool:
         """Whether an idle tick may stop this worker right now. Pure, so the
@@ -667,11 +742,24 @@ async def warm(req: WarmRequest):
     unknown = [e for e in wanted if e not in WORKERS]
     if unknown:
         raise HTTPException(400, f"unknown engine: {unknown[0]}")
+    # A name this image knows but TTS_HEAVY_ENGINES did not ask for has no
+    # worker to wake. Reported rather than just missing from `warming`, where
+    # it read identically to "already warm" — the one answer an operator
+    # checking why their engine never comes back must not be given.
+    disabled = [e for e in wanted if e not in ENABLED_ENGINES]
     warming = [e for e in wanted if e in ENABLED_ENGINES and WORKERS[e].warm()]
     return {
         "ok": True,
         # Engines this call actually started loading (already-warm ones are
         # absent, which is the answer to "did I need to do this?").
         "warming": warming,
-        "engines": [e for e in ENABLED_ENGINES if WORKERS[e].ready],
+        # Named, known, but not enabled in this container — nothing to warm,
+        # and not an error.
+        "disabled": disabled,
+        # Residency right now, the same thing /health's *_loaded booleans say.
+        # Deliberately NOT called `engines`: on /health that key means
+        # ROUTABLE and includes a cold engine, and one name answering two
+        # questions is how a caller ends up reading the wrong one.
+        "loaded": [e for e in ENABLED_ENGINES if WORKERS[e].ready],
+        "cold": [e for e in ENABLED_ENGINES if WORKERS[e].cold],
     }

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -406,13 +406,23 @@ Three things worth knowing:
   five minutes), so the release only fires when the station has genuinely gone
   quiet. Shortening the window to a few minutes converts a memory problem into
   a latency problem.
-- **You mostly won't hear it.** When the idle pause releases, the controller
-  tells the sidecar to start reloading straight away — so the model comes back
-  while the music does, minutes before the first link.
+- **How much of it you hear depends on the idle pause.** The controller warms
+  the sidecar from two places. The good one is the idle pause releasing
+  (**Settings → Stream → pause when the room is empty**): the reload starts as
+  the room fills up, minutes before the first link, and you hear nothing at
+  all. That switch is **off by default**, though — so on a stock station the
+  only warm is the second one, fired the minute the DJ decides to talk, where
+  the load merely overlaps writing and rendering the script. Expect part of a
+  cold Chatterbox reload to be audible as a longer-than-usual gap before the
+  first line after a quiet stretch. **If the idle unload matters to you, turn
+  the idle pause on as well** — the two features were built for the same quiet
+  station and they work best together.
 - **Nothing goes silent if the reload fails.** A load that doesn't arrive in
-  `TTS_HEAVY_LOAD_TIMEOUT_S` (90 s) returns a `503`, the DJ falls through to its
-  rescue voice exactly as it would for a sidecar that was down, and the music
-  never stops either way.
+  `TTS_HEAVY_LOAD_TIMEOUT_S` (90 s, settable in the root `.env`) returns a
+  `503`, and a load the sidecar abandons sooner than that — a missing venv, a
+  fatal model error — returns one straight away rather than holding the line
+  for the full ceiling. Either way the DJ falls through to its rescue voice
+  exactly as it would for a sidecar that was down, and the music never stops.
 
 The container log names each release and each wake, and `GET /health` carries
 the same state: `cold: [...]` is the engines currently unloaded (still listed in
@@ -426,12 +436,25 @@ docker exec sub-wave-controller wget -qO- http://tts-heavy:8080/health
 # {"ok":true,"engines":["chatterbox"],"cold":["chatterbox"],"unloads":{"chatterbox":3},...}
 ```
 
+The admin **Settings → Voice** engine badge says the same thing in one word:
+a released engine reads `idle · loads on demand` rather than `ready`. It stays
+selectable, because it is still a working voice.
+
 To force a reload by hand — before a show, say — `POST /warm`:
 
 ```bash
 docker exec sub-wave-controller wget -qO- --post-data '{"engine":""}' \
   --header 'Content-Type: application/json' http://tts-heavy:8080/warm
+# {"ok":true,"warming":["chatterbox"],"disabled":[],"loaded":[],"cold":[]}
 ```
+
+It returns at once without waiting for the load. `warming` is what this call
+started — empty means there was nothing to do, which is the normal answer on a
+station that is already talking. `disabled` names an engine you asked for that
+`TTS_HEAVY_ENGINES` never loaded, so a typo'd profile doesn't read as "already
+warm". `loaded` is residency this second and `cold` is what is still released;
+note that `/health`'s `engines` means something different — everything the DJ
+may route to, cold engines included.
 
 ---
 

--- a/docs/tts-heavy.md
+++ b/docs/tts-heavy.md
@@ -373,9 +373,65 @@ load. If a persona is still pointed at the disabled engine, its `/speak` calls
 return a clean `503` and the DJ falls back to Piper — nothing goes silent.
 
 `GET /health` on the sidecar reports `enabled: [...]` (what it was told to load)
-alongside `engines: [...]` (what's currently ready), so you can confirm the
-selection took. An empty or all-typo value falls back to loading both, so a bad
-entry never silently disables all heavy TTS.
+alongside `engines: [...]` (what it can speak with right now), so you can
+confirm the selection took. An empty or all-typo value falls back to loading
+both, so a bad entry never silently disables all heavy TTS.
+
+### Let an idle engine go (memory back while the station is quiet)
+
+`TTS_HEAVY_ENGINES` is the answer for an engine you *never* want. For one you
+want at 8pm and not at 4am, the sidecar releases it on its own.
+
+Chatterbox is around 4 GB resident — the weights, plus torch's CUDA context on
+a GPU host — and it used to hold that for the life of the container whether or
+not the station had said a word all day. The programme's idle pause
+(**Settings → Stream → pause when the room is empty**) stands the *music* down,
+but it has no reach into this container, so the engines stayed warm through the
+whole quiet stretch. Now each engine keeps its own idle clock: after
+`TTS_HEAVY_IDLE_UNLOAD_S` seconds without a spoken line, its worker is stopped
+and the memory goes back to the host.
+
+```ini
+# root .env — seconds; empty = 1800 on cuda, 3600 on cpu; 0 = always resident
+TTS_HEAVY_IDLE_UNLOAD_S=1800
+# CHATTERBOX_IDLE_UNLOAD_S=      # per-engine overrides win over the shared value
+# POCKET_TTS_IDLE_UNLOAD_S=0     # e.g. keep the small, fast engine loaded
+```
+
+Three things worth knowing:
+
+- **The reload is real, and it is paid by whoever speaks next** — 30–60 s for a
+  Chatterbox that has to come back from a warm cache. The defaults sit far
+  above any gap a talking station produces (the DJ can be offered a slot every
+  five minutes), so the release only fires when the station has genuinely gone
+  quiet. Shortening the window to a few minutes converts a memory problem into
+  a latency problem.
+- **You mostly won't hear it.** When the idle pause releases, the controller
+  tells the sidecar to start reloading straight away — so the model comes back
+  while the music does, minutes before the first link.
+- **Nothing goes silent if the reload fails.** A load that doesn't arrive in
+  `TTS_HEAVY_LOAD_TIMEOUT_S` (90 s) returns a `503`, the DJ falls through to its
+  rescue voice exactly as it would for a sidecar that was down, and the music
+  never stops either way.
+
+The container log names each release and each wake, and `GET /health` carries
+the same state: `cold: [...]` is the engines currently unloaded (still listed in
+`engines`, because they are one on-demand load from speaking), `unloads` counts
+the releases per engine, and `chatterbox_loaded` / `pocket_loaded` say what is
+resident this second. That is the honest way to confirm the reclaim — watching
+`docker stats` alone can't tell a released model from a quiet one.
+
+```bash
+docker exec sub-wave-controller wget -qO- http://tts-heavy:8080/health
+# {"ok":true,"engines":["chatterbox"],"cold":["chatterbox"],"unloads":{"chatterbox":3},...}
+```
+
+To force a reload by hand — before a show, say — `POST /warm`:
+
+```bash
+docker exec sub-wave-controller wget -qO- --post-data '{"engine":""}' \
+  --header 'Content-Type: application/json' http://tts-heavy:8080/warm
+```
 
 ---
 

--- a/web/components/admin/tts/engineMeta.ts
+++ b/web/components/admin/tts/engineMeta.ts
@@ -47,6 +47,9 @@ export interface EngineStatus {
 // list (TTS_HEAVY_ENGINES), null when it's unreachable or not in use.
 export interface EngineAvailability {
   heavyEnabled?: string[] | null;
+  // Sidecar engines the idle unload has released (#1579). Still usable — the
+  // next line just pays a model load first — so this NEVER affects `state`.
+  heavyCold?: string[] | null;
   cloudByProvider?: Record<string, boolean>;
   [engine: string]: boolean | string[] | null | Record<string, boolean> | undefined;
 }
@@ -79,7 +82,18 @@ export function engineStatus(
         : { label: 'ready', tone: 'ok', state: 'ready' };
     case 'chatterbox':
     case 'pocket-tts': {
-      if (a[id] !== false) return { label: 'ready', tone: 'ok', state: 'ready' };
+      if (a[id] !== false) {
+        // Released by the sidecar's idle unload (#1579). state stays 'ready'
+        // and the tone stays 'ok' on purpose: nothing is wrong and nothing is
+        // unavailable — the engine is one on-demand load from speaking, and
+        // muting the card would tell the operator to go and fix a station that
+        // is working. The badge exists so the reclaim is visible here instead
+        // of only in `docker stats`.
+        const cold = Array.isArray(a.heavyCold) ? a.heavyCold : null;
+        return cold?.includes(id)
+          ? { label: 'idle · loads on demand', tone: 'ok', state: 'ready' }
+          : { label: 'ready', tone: 'ok', state: 'ready' };
+      }
       // The sidecar's configured engine list says WHY: deliberately disabled vs
       // still loading vs the whole sidecar down.
       const name = ENGINE_META[id]?.label || id;


### PR DESCRIPTION
Closes #1579.

`tts-heavy` loaded Chatterbox at startup and kept it resident for the life of the container — on a CUDA host a permanent ~4GB, held whether or not the station had spoken in twelve hours. The programme's idle pause reaches the music chain only, so the one setting that sounds like it should help does nothing here; that's the surprise the report actually hit.

Each engine now keeps its own idle clock. After `TTS_HEAVY_IDLE_UNLOAD_S` without a render its worker is stopped and the memory goes back to the host; it loads again on the next `/speak`, or ahead of one on the new `POST /warm`, which the controller fires the moment the idle pause releases — so the reload lands while the music returns rather than on the first spoken link.

## The reclaim is a process exit

Not an in-process `del model`. #1204 settled this on the analyzer: dropping the model singletons leaves torch's imported modules — and on CUDA its context — resident until the process ends, so an in-process release hands back only part of the memory and the operator still sees gigabytes pinned. It is also nearly free here, because `run()` was already a restart supervisor: "unload" is one `terminate()` away and the worker scripts need no idle protocol of their own.

## Three things the design turns on

**A cold engine stays inside `/health`'s `engines`.** This is the one-way door and the least obvious part. `ttsHeavyClient.probeOnce` keys availability on `engines.includes(engine)`, caches it, and `tts.ts` reads that cached boolean to decide whether the engine is a usable voice slot at all. An engine dropped from the list while unloaded would never be asked to speak, and a sidecar only ever wakes an engine because someone called `/speak` on it — memory freed, voice gone for good. So `cold` and `not ready` are separate flags: a still-booting or crash-looping engine stays out exactly as before, while a cold one stays in and pays a load on its next line.

**The window sits well above the station's natural talk cadence.** The talk scheduler can offer the segment director a minute every five, so a short window would thrash a station that is merely between links rather than idle — converting a memory problem into a latency problem, which is the trade-off the issue flagged. Defaults are 1800s on cuda (VRAM contention is the urgent case, and a GPU reload is the fast one) and 3600s on cpu; both are unreachable by a station that is on air and talking. `0` restores the always-resident behaviour, and per-engine overrides mean an operator using one engine doesn't have the other's idle behaviour decided for them.

**Degrading stays immediate.** Only a cold worker — or one already loading for another caller — is waited for. A worker that is merely down fails its caller at once, which is the pre-existing behaviour and must not change: the rescue chain is what keeps the station talking, and 90s of silence before reaching it is worse than the cold start the wait exists to cover. A load that never arrives inside `TTS_HEAVY_LOAD_TIMEOUT_S` is a `503` rather than an unhandled `500`. Music never stops for any of it.

## Operator surface

```ini
# root .env — empty = 1800 on cuda / 3600 on cpu; 0 = always resident
TTS_HEAVY_IDLE_UNLOAD_S=1800
# CHATTERBOX_IDLE_UNLOAD_S=
# POCKET_TTS_IDLE_UNLOAD_S=0
# TTS_HEAVY_LOAD_TIMEOUT_S=90
```

`/health` carries the state so the reclaim is confirmable rather than inferred from `docker stats`: `cold: [...]`, `unloads: {engine: n}`, `idle_unload_s: {engine: s}`, and the existing `*_loaded` booleans now meaning residency. `pocket_voice_cloning` deliberately survives a cold stop — cloning is a property of the image, not of the process, and flickering it to unknown every idle window would make the admin warning worse about a fact that didn't change. `availableEngines()` gains `heavyCold` alongside `heavyEnabled`; nothing routes on it.

## Testing

`controller/scripts/tts_heavy_idle_test.py` — 17 dependency-free cases (fastapi/pydantic stubbed, worker subprocess faked), registered in the existing `analyzer-python.test.ts` shim. It pins the cold-engine health contract, the crash-vs-cold distinction, the in-flight and claimed-worker guards, the fail-fast path, a second caller joining an in-flight load, and the wake-racing-the-unload latch — that last one verified to fail against the pre-fix logic.

Also smoke-tested end to end against a real uvicorn server with a stand-in worker: boot resident at 165MB RSS → idle release (process gone, `cold: ["chatterbox"]`, `engines` unchanged) → `/speak` loads on demand and renders a WAV → release again → `/warm` returns in 7ms while the load runs behind it. Full `npm test` 1123/1123, controller and web lint clean, schema mirror unchanged, CLI assets regenerated.
