### PR TITLE
feat(web): heart and never-play on play-history rows (#1600)

### DIFF
--- a/web/components/admin/library/HistoryTab.tsx
+++ b/web/components/admin/library/HistoryTab.tsx
@@ -22,10 +22,13 @@ function playDayLabel(iso: string): string {
 }
 
 // A play is an air-time snapshot, not a library row, so the thumb and the shared
-// row actions get a Track composed from it. `trackId` is null for a track that has
-// since left the library: the thumb still gets the words for its letter tile, but
-// there is nothing left to heart, block or queue, so those rows render no action
-// cluster at all rather than three dead buttons.
+// row actions get a Track composed from it. `trackId` is null when the annotated
+// URI carried no `subsonic_id` — untracked auto-playlist plays, mainly (see the
+// `sourceTrackId` note in broadcast/queue.ts). Nothing is ever nulled after the
+// fact, so this says nothing about whether the track is still in the library: a
+// removed track keeps its id here and its actions fail at the server. The thumb
+// still gets the words for its letter tile, but an id-less play has nothing to
+// heart, block or queue, so it renders the dash below instead of dead buttons.
 function historyTrack(p: PlayEntry): Track {
   return {
     id: p.trackId || '',
@@ -113,7 +116,13 @@ export function HistoryTab({
                     <span className="hidden w-24 shrink-0 text-right text-[11px] text-muted sm:block" title="how it was picked">
                       {playSourceLabel(p)}
                     </span>
-                    {p.trackId && (
+                    {!p.trackId ? (
+                      /* Says WHY the row is action-less. Without it an operator
+                         cannot tell a play with no id from buttons that failed to
+                         render — which is the work the old disabled Queue button's
+                         tooltip was doing. */
+                      <span className="shrink-0 text-[11px] text-muted" title="no track id recorded for this play">—</span>
+                    ) : (
                       /* Three buttons where there was one, so Queue drops to its icon
                          below sm: — the row still has to leave the title readable on a
                          phone. */

--- a/web/components/admin/library/HistoryTab.tsx
+++ b/web/components/admin/library/HistoryTab.tsx
@@ -8,8 +8,9 @@ import { num } from '../LibraryTaggingPanel';
 import { SkeletonRows } from '@/components/ui/skeleton';
 import { EmptyState } from '@/components/ui/empty-state';
 import { PAGE_SIZE } from './types';
-import type { PlayEntry, Track } from './types';
+import type { BlockType, LikeIndex, PlayEntry, Track } from './types';
 import { Thumb } from './bits';
+import { BlockMenu, HeartButton, likeStateFor } from './row-actions';
 
 function playDayLabel(iso: string): string {
   const d = new Date(iso);
@@ -20,13 +21,30 @@ function playDayLabel(iso: string): string {
   return d.toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' });
 }
 
+// A play is an air-time snapshot, not a library row, so the thumb and the shared
+// row actions get a Track composed from it. `trackId` is null for a track that has
+// since left the library: the thumb still gets the words for its letter tile, but
+// there is nothing left to heart, block or queue, so those rows render no action
+// cluster at all rather than three dead buttons.
+function historyTrack(p: PlayEntry): Track {
+  return {
+    id: p.trackId || '',
+    title: p.title || undefined,
+    artist: p.artist || undefined,
+    album: p.album || undefined,
+  };
+}
+
 function playSourceLabel(p: PlayEntry): string {
   if (p.source === 'request') return p.requestedBy ? `request · ${p.requestedBy}` : 'request';
   if (p.source === 'ai') return 'DJ pick';
   return 'auto';
 }
 
-export function HistoryTab({ rows, total, page, setPage, loading, queuing, onQueue, onRefresh }: {
+export function HistoryTab({
+  rows, total, page, setPage, loading, queuing, onQueue, onRefresh,
+  likeIndex, liking, onToggleLike, blocking, onBlock,
+}: {
   rows: PlayEntry[] | null;
   total: number;
   page: number;
@@ -35,6 +53,14 @@ export function HistoryTab({ rows, total, page, setPage, loading, queuing, onQue
   queuing: string | null;
   onQueue: (t: Track) => void;
   onRefresh: () => void;
+  // Same actions, same handlers and same optimistic cache as the Browse rows —
+  // the heart state comes from the shared index, so a heart set on either tab
+  // shows on the other with no refetch (#1600).
+  likeIndex: LikeIndex;
+  liking: string | null;
+  onToggleLike: (t: Track, liked: boolean) => void;
+  blocking: string | null;
+  onBlock: (t: Track, type: BlockType) => void;
 }) {
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   return (
@@ -66,6 +92,7 @@ export function HistoryTab({ rows, total, page, setPage, loading, queuing, onQue
               const prev = i > 0 ? rows[i - 1] : null;
               const prevDay = prev ? playDayLabel(prev.playedAt) : null;
               const time = new Date(p.playedAt).toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
+              const track = historyTrack(p);
               return (
                 <Fragment key={p.id}>
                   {day !== prevDay && (
@@ -75,7 +102,7 @@ export function HistoryTab({ rows, total, page, setPage, loading, queuing, onQue
                     <span className="mono-num w-11 shrink-0 text-[11px] text-muted" title={new Date(p.playedAt).toLocaleString('en-GB')}>
                       {time}
                     </span>
-                    <Thumb track={{ id: p.trackId || '', title: p.title || undefined, artist: p.artist || undefined, album: p.album || undefined }} />
+                    <Thumb track={track} />
                     <div className="min-w-0 flex-1">
                       <div className="lib-title">{p.title || 'unknown'}</div>
                       <div className="lib-artist">{p.artist || ''}{p.album ? ` · ${p.album}` : ''}</div>
@@ -86,14 +113,35 @@ export function HistoryTab({ rows, total, page, setPage, loading, queuing, onQue
                     <span className="hidden w-24 shrink-0 text-right text-[11px] text-muted sm:block" title="how it was picked">
                       {playSourceLabel(p)}
                     </span>
-                    <Btn
-                      sm
-                      onClick={() => onQueue({ id: p.trackId!, title: p.title || undefined, artist: p.artist || undefined, album: p.album || undefined })}
-                      disabled={!p.trackId || !!queuing}
-                      title={p.trackId ? 'queue this track again' : 'no track id recorded for this play'}
-                    >
-                      {queuing && queuing === p.trackId ? '…' : <><ListPlus size={12} /> Queue</>}
-                    </Btn>
+                    {p.trackId && (
+                      /* Three buttons where there was one, so Queue drops to its icon
+                         below sm: — the row still has to leave the title readable on a
+                         phone. */
+                      <span className="flex shrink-0 items-center gap-1.5">
+                        <HeartButton
+                          track={track}
+                          like={likeStateFor(track, likeIndex)}
+                          busy={liking === track.id}
+                          onToggle={onToggleLike}
+                        />
+                        <BlockMenu
+                          track={track}
+                          busy={blocking === track.id}
+                          disabled={!!blocking}
+                          onBlock={onBlock}
+                        />
+                        <Btn
+                          sm
+                          onClick={() => onQueue(track)}
+                          disabled={!!queuing}
+                          title="queue this track again"
+                        >
+                          {queuing === track.id ? '…' : (
+                            <><ListPlus size={12} /><span className="hidden sm:inline"> Queue</span></>
+                          )}
+                        </Btn>
+                      </span>
+                    )}
                   </div>
                 </Fragment>
               );

--- a/web/components/admin/library/TrackTable.tsx
+++ b/web/components/admin/library/TrackTable.tsx
@@ -22,6 +22,7 @@ import {
   unblockLabel,
   useDismissOnOutside,
 } from './bits';
+import { BlockMenu, HeartButton, likeStateFor } from './row-actions';
 import { ManualTagEditor } from './ManualTagEditor';
 
 interface TrackTableProps {
@@ -53,19 +54,6 @@ interface TrackTableProps {
   liking: string | null;
   onToggleLike: (t: Track, liked: boolean) => void;
   onClearLikes: (t: Track) => void;
-}
-
-// The actions column is a FIXED grid track (.lib-row in globals.css). Uncapped, a
-// heavily-liked track widens the cluster until the actions overlap mood/energy.
-const countLabel = (n: number) => (n > 99 ? '99+' : String(n));
-
-// Inline `likedByOperator`/`likeCount` if the row has them, else the shared index.
-function likeStateFor(t: Track, index: LikeIndex): { liked: boolean; count: number } {
-  if (t.likedByOperator != null || t.likeCount != null) {
-    return { liked: !!t.likedByOperator, count: t.likeCount ?? 0 };
-  }
-  const hit = index[t.id];
-  return { liked: !!hit?.operator, count: hit?.count ?? 0 };
 }
 
 export function TrackTable(p: TrackTableProps) {
@@ -202,26 +190,13 @@ export function TrackTable(p: TrackTableProps) {
                 onToggleLike={p.onToggleLike}
                 onClearLikes={p.onClearLikes}
               />
-              <Btn
-                sm
+              <HeartButton
                 className="hidden sm:inline-flex"
-                onClick={() => p.onToggleLike(t, like.liked)}
-                disabled={p.liking === t.id}
-                title={like.liked ? 'Remove your heart' : 'Heart this track'}
-                aria-pressed={like.liked}
-                aria-label={like.liked ? `unlike ${t.title || 'track'}` : `like ${t.title || 'track'}`}
-              >
-                {p.liking === t.id ? '…' : (
-                  <span className="inline-flex items-center gap-1">
-                    <Heart
-                      size={12}
-                      className={cn(like.liked && 'fill-vermilion text-vermilion')}
-                    />
-                    {/* Count is every like on the song; the fill is the operator's own. */}
-                    {like.count > 0 && <span className="mono-num text-[10px]">{countLabel(like.count)}</span>}
-                  </span>
-                )}
-              </Btn>
+                track={t}
+                like={like}
+                busy={p.liking === t.id}
+                onToggle={p.onToggleLike}
+              />
               <Btn sm className="hidden sm:inline-flex" onClick={() => p.onQueue(t)} disabled={!!p.queuing} title="Queue on air">
                 {p.queuing === t.id ? '…' : <ListPlus size={12} />}
               </Btn>
@@ -396,56 +371,6 @@ export function RowActionsMenu({
                 </button>
               )}
             </>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// The server resolves album/artist ids from the track id, so the row only needs t.id.
-// No confirm dialog: blocking is one-click reversible from the Blocked tab.
-function BlockMenu({ track, busy, disabled, onBlock, className }: {
-  track: Track;
-  busy: boolean;
-  disabled: boolean;
-  onBlock: (t: Track, type: BlockType) => void;
-  className?: string;
-}) {
-  const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const pick = (type: BlockType) => { setOpen(false); onBlock(track, type); };
-  useDismissOnOutside(open, () => setOpen(false), rootRef, triggerRef);
-
-  return (
-    <div ref={rootRef} className={cn('relative', className)}>
-      <Btn
-        ref={triggerRef}
-        sm
-        onClick={() => setOpen(o => !o)}
-        disabled={disabled}
-        title="Never play this on air"
-        aria-expanded={open}
-        aria-haspopup="true"
-      >
-        {busy ? '…' : <Ban size={12} />}
-      </Btn>
-      {open && (
-        <div className="absolute top-full right-0 z-50 mt-1 max-w-[calc(100vw-2rem)] min-w-[200px] rounded-md border bg-popover p-1 text-popover-foreground shadow-md">
-          <button type="button" className="block w-full rounded px-2.5 py-1.5 text-left text-[12px] hover:bg-[var(--ink-soft)] hover:text-ink" onClick={() => pick('track')}>
-            Never play this track
-          </button>
-          {track.album && (
-            <button type="button" className="block w-full rounded px-2.5 py-1.5 text-left text-[12px] hover:bg-[var(--ink-soft)] hover:text-ink" onClick={() => pick('album')}>
-              Never play this album
-            </button>
-          )}
-          {track.artist && (
-            <button type="button" className="block w-full rounded px-2.5 py-1.5 text-left text-[12px] hover:bg-[var(--ink-soft)] hover:text-ink" onClick={() => pick('artist')}>
-              Never play this artist
-              <span className="block text-[10px] text-muted">primary credit only — collabs filed under other artists still play</span>
-            </button>
           )}
         </div>
       )}

--- a/web/components/admin/library/row-actions.tsx
+++ b/web/components/admin/library/row-actions.tsx
@@ -12,8 +12,10 @@ import { cn } from '../../../lib/cn';
 import type { BlockType, LikeIndex, Track } from './types';
 import { useDismissOnOutside } from './bits';
 
-// The actions column is a FIXED grid track (.lib-row in globals.css). Uncapped, a
-// heavily-liked track widens the cluster until the actions overlap mood/energy.
+// Capped for the Browse grid, where the actions column is a FIXED track (.lib-row
+// in globals.css): uncapped, a heavily-liked track widens the cluster until the
+// actions overlap mood/energy. History rows are a plain flex row and would survive
+// a wider count, but one cap keeps the heart the same size on both.
 const countLabel = (n: number) => (n > 99 ? '99+' : String(n));
 
 // Inline `likedByOperator`/`likeCount` if the row has them, else the shared index.

--- a/web/components/admin/library/row-actions.tsx
+++ b/web/components/admin/library/row-actions.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+// The heart and the never-play menu, lifted out of TrackTable so the Play
+// history rows offer the same two actions (#1600). Both are pure presentational
+// pieces taking an explicit Track: history rows are PlayEntry, so their caller
+// composes one from the air-time snapshot before rendering these.
+
+import { useRef, useState } from 'react';
+import { Ban, Heart } from 'lucide-react';
+import { Btn } from '../ui';
+import { cn } from '../../../lib/cn';
+import type { BlockType, LikeIndex, Track } from './types';
+import { useDismissOnOutside } from './bits';
+
+// The actions column is a FIXED grid track (.lib-row in globals.css). Uncapped, a
+// heavily-liked track widens the cluster until the actions overlap mood/energy.
+const countLabel = (n: number) => (n > 99 ? '99+' : String(n));
+
+// Inline `likedByOperator`/`likeCount` if the row has them, else the shared index.
+// A history row never has them, so it always reads the index — which is what makes
+// a heart set on the Browse tab show up here without a refetch.
+export function likeStateFor(t: Track, index: LikeIndex): { liked: boolean; count: number } {
+  if (t.likedByOperator != null || t.likeCount != null) {
+    return { liked: !!t.likedByOperator, count: t.likeCount ?? 0 };
+  }
+  const hit = index[t.id];
+  return { liked: !!hit?.operator, count: hit?.count ?? 0 };
+}
+
+export function HeartButton({ track, like, busy, onToggle, className }: {
+  track: Track;
+  like: { liked: boolean; count: number };
+  busy: boolean;
+  onToggle: (t: Track, liked: boolean) => void;
+  className?: string;
+}) {
+  return (
+    <Btn
+      sm
+      className={className}
+      onClick={() => onToggle(track, like.liked)}
+      disabled={busy}
+      title={like.liked ? 'Remove your heart' : 'Heart this track'}
+      aria-pressed={like.liked}
+      aria-label={like.liked ? `unlike ${track.title || 'track'}` : `like ${track.title || 'track'}`}
+    >
+      {busy ? '…' : (
+        <span className="inline-flex items-center gap-1">
+          <Heart size={12} className={cn(like.liked && 'fill-vermilion text-vermilion')} />
+          {/* Count is every like on the song; the fill is the operator's own. */}
+          {like.count > 0 && <span className="mono-num text-[10px]">{countLabel(like.count)}</span>}
+        </span>
+      )}
+    </Btn>
+  );
+}
+
+// The server resolves album/artist ids from the track id, so the row only needs t.id.
+// No confirm dialog: blocking is one-click reversible from the Blocked tab.
+export function BlockMenu({ track, busy, disabled, onBlock, className }: {
+  track: Track;
+  busy: boolean;
+  disabled: boolean;
+  onBlock: (t: Track, type: BlockType) => void;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const pick = (type: BlockType) => { setOpen(false); onBlock(track, type); };
+  useDismissOnOutside(open, () => setOpen(false), rootRef, triggerRef);
+
+  return (
+    <div ref={rootRef} className={cn('relative', className)}>
+      <Btn
+        ref={triggerRef}
+        sm
+        onClick={() => setOpen(o => !o)}
+        disabled={disabled}
+        title="Never play this on air"
+        aria-expanded={open}
+        aria-haspopup="true"
+      >
+        {busy ? '…' : <Ban size={12} />}
+      </Btn>
+      {open && (
+        <div className="absolute top-full right-0 z-50 mt-1 max-w-[calc(100vw-2rem)] min-w-[200px] rounded-md border bg-popover p-1 text-popover-foreground shadow-md">
+          <button type="button" className="block w-full rounded px-2.5 py-1.5 text-left text-[12px] hover:bg-[var(--ink-soft)] hover:text-ink" onClick={() => pick('track')}>
+            Never play this track
+          </button>
+          {track.album && (
+            <button type="button" className="block w-full rounded px-2.5 py-1.5 text-left text-[12px] hover:bg-[var(--ink-soft)] hover:text-ink" onClick={() => pick('album')}>
+              Never play this album
+            </button>
+          )}
+          {track.artist && (
+            <button type="button" className="block w-full rounded px-2.5 py-1.5 text-left text-[12px] hover:bg-[var(--ink-soft)] hover:text-ink" onClick={() => pick('artist')}>
+              Never play this artist
+              <span className="block text-[10px] text-muted">primary credit only — collabs filed under other artists still play</span>
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/components/admin/library/tabs/HistoryTabContainer.tsx
+++ b/web/components/admin/library/tabs/HistoryTabContainer.tsx
@@ -13,7 +13,9 @@ import { PAGE_SIZE } from '../types';
 // the cross-list operations mean anything here. Do not "fix" the omission by
 // filing it under rows.
 export default function HistoryTabContainer() {
-  const { queuing, queueTrack } = useLibrary();
+  const {
+    queuing, queueTrack, likeIndex, liking, toggleLike, blocking, blockTrack,
+  } = useLibrary();
   const [page, setPage] = useState(0);
 
   const q = useAdminQuery<{ total: number; rows: PlayEntry[] }>({
@@ -38,6 +40,13 @@ export default function HistoryTabContainer() {
       queuing={queuing}
       onQueue={queueTrack}
       onRefresh={() => { void q.refetch(); }}
+      // Heart and never-play come straight off the provider, so a history row
+      // shares the Browse rows' optimistic updates and their one like index.
+      likeIndex={likeIndex}
+      liking={liking}
+      onToggleLike={toggleLike}
+      blocking={blocking}
+      onBlock={blockTrack}
     />
   );
 }


### PR DESCRIPTION
Closes #1600.

## What changed

The heart button and the three-way never-play menu are lifted out of `TrackTable.tsx` into a new `web/components/admin/library/row-actions.tsx`, and the Play history rows render the same two components.

- `row-actions.tsx` — `HeartButton`, `BlockMenu` and `likeStateFor`. `BlockMenu` and `likeStateFor` move verbatim; `HeartButton` is the same markup with its busy/disabled state taken as a prop instead of read off `TrackTableProps`. Both components take an explicit `Track` and a `className`, so `TrackTable` keeps its `hidden sm:inline-flex` collapse-to-overflow-menu layout while history rows show them at every width.
- `HistoryTab.tsx` — a `PlayEntry` is an air-time snapshot, so `historyTrack()` composes the `Track` the thumb and the two actions take. The Queue button drops to its icon below `sm:` now that there are three buttons where there was one.
- `HistoryTabContainer.tsx` — `likeIndex`, `liking`, `toggleLike`, `blocking` and `blockTrack` come straight off `LibraryContext`, the same handlers the Browse rows use.

## Why it's one code path

Both actions go through the provider, so a history row gets the Browse rows' optimistic like patch, the block toast's Undo, and the shared `['library','likeIndex']` entry — a heart set on either tab shows on the other with no refetch, and every history row for the same track lights up at once. The phone overflow menu in `TrackTable` still owns its own copy of the menu-item markup; that is a different control (it also carries queue/edit/retag/clear-likes), not a second block implementation.

## Rows with no track id

A `PlayEntry` can carry a null `trackId`, and it means one specific thing: the annotated URI that aired carried no `subsonic_id` — untracked auto-playlist plays, mainly, per the `sourceTrackId` note in `broadcast/queue.ts`. Nothing ever nulls the column after the fact, so it says nothing about whether the track is still in the library.

Those rows render a muted dash titled *"no track id recorded for this play"* instead of the action cluster: hiding the permanently-disabled Queue button is right, but the sentence it carried was doing work — without it an operator cannot tell a play with no id from buttons that failed to render.

A track that has since **left** the library is the other case, and it is not handled here: the play keeps its id, so the row shows all three actions and they fail at the server (block 404s; the heart records against a dead id). Detecting that needs a resolve check the row does not have.

## Two things deliberately left alone

- History rows carry no `blockedBy` stamp, so a track you have already blocked still shows the block menu rather than an Unblock button. Stamping them would mean filing the history query under the `['library','rows']` key family, which `HistoryTabContainer` documents as wrong — a `PlayEntry` is not a `Track`. The cost is in the follow-ups below.
- The block/heart handlers are untouched; this is a render-side change only.

## Follow-ups, not in this PR

Each of these is real, none is caused by the extraction, and all three want their own change.

- **The heart from History stores a thinner snapshot than the same heart from Browse.** `resolveSnapshot` (`routes/likes.ts`) short-circuits on `if (b.title || b.artist)` and returns the body's `genre`/`year`/`duration`, on the stated premise that "the admin library always posts the row it already has". A history row only has `{id, title, artist, album}`, so the body still trips that branch and the `db.getTrack` fallback that would have filled the other three never runs. Nothing breaks — `/library/liked` re-enriches from the index, and the picker's `listener-liked` pool treats unknown length the way `belowTrackFloor` treats every unmeasured row — but the stored snapshot is poorer than it needs to be. The fix belongs in `resolveSnapshot` (merge rather than short-circuit), not at this call site.
- **An already-blocked history row offers Block and gets a 409, with no route back off the list.** `TrackTable` swaps the menu for a one-click Undo whenever `blockedBy` is set; a history row can never take that branch, so re-blocking returns `already blocked` as an error toast. (Checked: the 409 throws before `notify.undo`, so there is no hazard of the undo toast lifting a block the operator did not create.) Worth solving alongside whatever gives history rows a block state.
- **No `verify-library.py` check covers the new surface.** `like_toggle` and `blocked_marks` were each added when these controls landed on Browse, and the cross-tab property this PR claims is exactly what they exist to pin. Deliberately not written here rather than written unverified. Note for whoever adds it: history rows have no `.lib-row`, and both existing checks scope their selectors under it, so it needs its own scope rather than a reuse.

## Verification

`npm run lint` in `web/` is clean (only the five pre-existing warnings in `playlist-builder/generate.ts` and `ai-elements/file-tree.tsx`). `node --test web/scripts/audit-admin-query.test.mjs` passes 9/9. `node web/scripts/audit-admin-query.mjs` reports one violation — `components/admin/settings/BrainSection.tsx:162`, pre-existing on `develop` and untouched here. No controller changes, so no `npm test` run.
