### PR TITLE
feat(web): add a custom era range to the show editor (#1599)

### DIFF
--- a/controller/src/schemas/show.ts
+++ b/controller/src/schemas/show.ts
@@ -160,8 +160,15 @@ function showStringList(opts: {
 // the load path's repairEraWindow (below) so the two can never disagree about
 // what a valid year is. null / '' means "open end". A numeric string is
 // accepted because that is what an <input type="number"> posts.
+//
+// `validEraYear` is EXPORTED so it rides the mirror into the admin show
+// editor's add-a-range control (#1599), which has to refuse a year the save
+// would then reject. It owns only the integer-and-range test; the editor keeps
+// its own trim, because eraYearOf deliberately does not trim (' ' reaching the
+// wire is a malformed post, not an open end) and a draft box legitimately holds
+// whitespace mid-keystroke.
 const eraYearOf = (v: unknown): number | null => (v == null || v === '' ? null : Number(v));
-const validEraYear = (n: number | null): boolean =>
+export const validEraYear = (n: number | null): boolean =>
   n == null || (Number.isInteger(n) && n >= SHOW_YEAR_MIN && n <= SHOW_YEAR_MAX);
 
 const showYear = z

--- a/docs/discord-open-suggestions.md
+++ b/docs/discord-open-suggestions.md
@@ -9,8 +9,8 @@ Captured 2026-09-06 — 65 of 125 threads, checked against all 334 issues (28 op
 | Status | Count | Meaning |
 | --- | ---: | --- |
 | ✅ Shipped | 6 | Delivered on `develop`; the thread can be closed out. |
-| 🔨 Tracked | 13 | An **open** GitHub issue covers it. |
-| 🟡 Partly covered | 20 | Related work has landed, but the specific ask has not. |
+| 🔨 Tracked | 14 | An **open** GitHub issue covers it. |
+| 🟡 Partly covered | 19 | Related work has landed, but the specific ask has not. |
 | ⬜ No issue | 26 | Nothing on GitHub — needs filing or an explicit reply. |
 
 Open GitHub issues doing the most work here: [#1485](https://github.com/perminder-klair/subwave/issues/1485) (the follow-up tracker, 5 threads), [#1486](https://github.com/perminder-klair/subwave/issues/1486) (CarPlay + Android Auto, 2 threads) and [#1400](https://github.com/perminder-klair/subwave/issues/1400) (skill-aimed banter, 2 threads).
@@ -501,9 +501,9 @@ PwrBlackout · 2026-08-10
 
 > i have a "new music monday" show that i want to only play 2026 music. the API already allows me to manually pass in "fromYear" and "toYear", the UI even shows that…
 
-**🟡 Partly covered** — Era resolution itself was fixed (#842, #1418). Exposing the API's fromYear/toYear as a show-level UI control is not tracked.
+**🔨 Tracked** — #1599 is the open issue, and it is exactly this ask: an add-a-range control beside the show editor's decade chips, so a single year ("2026 only") or an open-ended window is reachable from the admin UI rather than only through a hand-written PATCH. Implemented and in review, not yet on `develop`. Era resolution itself was fixed earlier (#842, #1418). Moves to ✅ Shipped when #1599 closes.
 
-Refs: [#842](https://github.com/perminder-klair/subwave/issues/842) · [#1418](https://github.com/perminder-klair/subwave/issues/1418)
+Refs: [#1599](https://github.com/perminder-klair/subwave/issues/1599) *(open)* · [#842](https://github.com/perminder-klair/subwave/issues/842) · [#1418](https://github.com/perminder-klair/subwave/issues/1418)
 
 ### [Skill-blocks, triggered at a specific time](https://discord.com/channels/1514647956333002812/1536054559045062866)
 

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -44,7 +44,10 @@ import {
   TAG_RE,
   TOPIC_MAX,
   VOCAL_OPTIONS,
+  YEAR_MAX,
+  YEAR_MIN,
   eraLabelOf,
+  resolveEraDraft,
   sameEra,
 } from './types';
 import type { EraWindow, Persona, PlaylistIndexStatus, Show, ShowsFormValues, SkillOption, ThemeOption } from './types';
@@ -213,6 +216,23 @@ export function ShowEditor({
   // retyping "trance" once per trance sub-genre. Committing the typed
   // text (Enter/Add) still clears: there the draft *is* the thing consumed.
   const addGenreFromSuggestion = (g: string) => addGenre(g, { keepDraft: true });
+
+  // The custom era range's own text buffers (#1599) — same deal as genreDraft:
+  // remounted per show, not form data. The error is only raised on Add, so
+  // half-typed "20" doesn't scold anyone mid-keystroke.
+  const [eraFrom, setEraFrom] = useState('');
+  const [eraTo, setEraTo] = useState('');
+  const [eraDraftError, setEraDraftError] = useState('');
+  const addEraRange = () => {
+    const current: EraWindow[] = erasCtl.field.value ?? [];
+    if (current.length >= FILTER_VALUES_MAX) return;
+    const r = resolveEraDraft(eraFrom, eraTo, current);
+    if ('error' in r) { setEraDraftError(r.error); return; }
+    // A range spelling out a decade lands in the same array the chips write to,
+    // so it lights that chip rather than appearing twice.
+    erasCtl.field.onChange([...current, r.window]);
+    setEraFrom(''); setEraTo(''); setEraDraftError('');
+  };
   // Genres no track carries. The controller resolves free text onto the nearest
   // library tag, silently broadening the show ("Pop Punk" → "Pop") or dropping the
   // filter — invisible on air unless said here. Mirrors show-filter.normGenre so UI
@@ -233,6 +253,11 @@ export function ShowEditor({
 
   const guestIds: string[] = guestsCtl.field.value ?? [];
   const eras: EraWindow[] = erasCtl.field.value ?? [];
+  // Windows matching no decade preset. They get their own removable chips, and
+  // they are the slice of the schema's cap the decade row cannot see — it caps
+  // on what IT has selected, so without this the chips would still offer a
+  // ninth window on an `eras` array already at FILTER_VALUES_MAX.
+  const customEras = eras.filter(e => !DECADES.some(d => sameEra(e, d)));
 
   // Guests group — a chip/card multi-select has no single labelable element,
   // so it names itself via aria-labelledby/groupProps, same convention as
@@ -484,6 +509,7 @@ export function ShowEditor({
               <ChipRow
                 options={DECADES.map(d => ({ key: d.key, label: d.label }))}
                 selected={DECADES.filter(d => eras.some(e => sameEra(e, d))).map(d => d.key)}
+                cap={FILTER_VALUES_MAX - customEras.length}
                 onToggle={key => {
                   const d = DECADES.find(x => x.key === key)!;
                   const existing = eras.find(e => sameEra(e, d));
@@ -494,11 +520,12 @@ export function ShowEditor({
                   );
                 }}
               />
-              {/* Custom windows (set via the API — no preset matches) stay
-                  visible and removable so they can't silently constrain picks. */}
-              {eras.some(e => !DECADES.some(d => sameEra(e, d))) && (
+              {/* Custom windows — the ones below matching no decade preset —
+                  stay visible and removable so they can't silently constrain
+                  picks. Set here or via the API; the display is the same. */}
+              {customEras.length > 0 && (
                 <div className="flex flex-wrap gap-1">
-                  {eras.filter(e => !DECADES.some(d => sameEra(e, d))).map((e, i) => (
+                  {customEras.map((e, i) => (
                     <button
                       key={`${e.fromYear ?? ''}-${e.toYear ?? ''}-${i}`}
                       type="button"
@@ -511,10 +538,54 @@ export function ShowEditor({
                   ))}
                 </div>
               )}
+              {/* Add a range the decade chips can't spell — a single year
+                  ("2026 only"), a span across two decades, or an open end
+                  ("2026 and later"). Both inputs are plain one-offs inside the
+                  group: they carry their own aria-label because the group title
+                  names the whole field, not either box. */}
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <Input
+                  id={`${uid}-show-era-from`}
+                  type="number" inputMode="numeric"
+                  min={YEAR_MIN} max={YEAR_MAX}
+                  aria-label="custom era start year"
+                  className="w-[7.5rem] flex-none"
+                  value={eraFrom}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setEraFrom(e.target.value); setEraDraftError(''); }}
+                  onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addEraRange(); } }}
+                  placeholder="from"
+                  disabled={eras.length >= FILTER_VALUES_MAX}
+                />
+                <span aria-hidden="true" className="text-[12px] text-muted">–</span>
+                <Input
+                  id={`${uid}-show-era-to`}
+                  type="number" inputMode="numeric"
+                  min={YEAR_MIN} max={YEAR_MAX}
+                  aria-label="custom era end year"
+                  className="w-[7.5rem] flex-none"
+                  value={eraTo}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) => { setEraTo(e.target.value); setEraDraftError(''); }}
+                  onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addEraRange(); } }}
+                  placeholder="to"
+                  disabled={eras.length >= FILTER_VALUES_MAX}
+                />
+                <Btn
+                  className="min-h-9 flex-none sm:min-h-0"
+                  onClick={addEraRange}
+                  disabled={(!eraFrom.trim() && !eraTo.trim()) || eras.length >= FILTER_VALUES_MAX}
+                >
+                  Add range
+                </Btn>
+              </div>
+              {eraDraftError && (
+                <span role="alert" className="field-hint text-vermilion">{eraDraftError}</span>
+              )}
             </div>
             <FieldDescription {...erasAria.descriptionProps}>
               Pick any decades, even non-adjacent ones ({'"'}90s + 2010s{'"'}).
-              None selected = any era.
+              Or add your own range — a single year (2026 to 2026), or one
+              side left blank for an open end. Up to {FILTER_VALUES_MAX}{' '}
+              windows; none selected = any era.
             </FieldDescription>
             <FieldError {...erasAria.errorProps} errors={erasCtl.fieldState.error ? [erasCtl.fieldState.error] : undefined} />
           </Field>

--- a/web/components/admin/shows/ShowEditor.tsx
+++ b/web/components/admin/shows/ShowEditor.tsx
@@ -223,6 +223,16 @@ export function ShowEditor({
   const [eraFrom, setEraFrom] = useState('');
   const [eraTo, setEraTo] = useState('');
   const [eraDraftError, setEraDraftError] = useState('');
+  // EVERY write to `eras` goes through here, because every write can falsify
+  // the draft error. That message is a verdict on one Add press against the
+  // array as it stood: untoggle the decade chip a range collided with and
+  // "That range is already selected." is still standing — inside a live
+  // region, over a range that would now add cleanly. Clearing it inside each
+  // handler instead only holds until someone adds a third.
+  const setEras = (next: EraWindow[]) => {
+    erasCtl.field.onChange(next);
+    setEraDraftError('');
+  };
   const addEraRange = () => {
     const current: EraWindow[] = erasCtl.field.value ?? [];
     if (current.length >= FILTER_VALUES_MAX) return;
@@ -230,8 +240,8 @@ export function ShowEditor({
     if ('error' in r) { setEraDraftError(r.error); return; }
     // A range spelling out a decade lands in the same array the chips write to,
     // so it lights that chip rather than appearing twice.
-    erasCtl.field.onChange([...current, r.window]);
-    setEraFrom(''); setEraTo(''); setEraDraftError('');
+    setEras([...current, r.window]);
+    setEraFrom(''); setEraTo('');
   };
   // Genres no track carries. The controller resolves free text onto the nearest
   // library tag, silently broadening the show ("Pop Punk" → "Pop") or dropping the
@@ -254,9 +264,13 @@ export function ShowEditor({
   const guestIds: string[] = guestsCtl.field.value ?? [];
   const eras: EraWindow[] = erasCtl.field.value ?? [];
   // Windows matching no decade preset. They get their own removable chips, and
-  // they are the slice of the schema's cap the decade row cannot see — it caps
-  // on what IT has selected, so without this the chips would still offer a
-  // ninth window on an `eras` array already at FILTER_VALUES_MAX.
+  // they are the slice of the schema's cap the decade row cannot see — that row
+  // caps on what IT has selected, and 8 chips against a FILTER_VALUES_MAX of 15
+  // never reach it on their own. Handing it the REMAINING budget is required BY
+  // this feature rather than tidying alongside it: before the add-a-range
+  // control, filling `eras` took 15 API-set windows, and now the operator can
+  // fill it right here — at which point an uncapped chip row offers a 16th, the
+  // schema refuses the save, and nothing on screen says why.
   const customEras = eras.filter(e => !DECADES.some(d => sameEra(e, d)));
 
   // Guests group — a chip/card multi-select has no single labelable element,
@@ -513,7 +527,7 @@ export function ShowEditor({
                 onToggle={key => {
                   const d = DECADES.find(x => x.key === key)!;
                   const existing = eras.find(e => sameEra(e, d));
-                  erasCtl.field.onChange(
+                  setEras(
                     existing
                       ? eras.filter(e => e !== existing)
                       : [...eras, { fromYear: d.from, toYear: d.to }],
@@ -529,7 +543,7 @@ export function ShowEditor({
                     <button
                       key={`${e.fromYear ?? ''}-${e.toYear ?? ''}-${i}`}
                       type="button"
-                      onClick={() => erasCtl.field.onChange(eras.filter(x => x !== e))}
+                      onClick={() => setEras(eras.filter(x => x !== e))}
                       className="min-h-9 border border-ink bg-ink px-2 py-0.5 text-[12px] text-bg sm:min-h-0"
                       title="Remove this custom era window"
                     >

--- a/web/components/admin/shows/types.ts
+++ b/web/components/admin/shows/types.ts
@@ -15,6 +15,8 @@ import {
   SHOW_TAG_RE,
   SHOW_TOPIC_MAX,
   SHOW_VOCALS,
+  SHOW_YEAR_MAX,
+  SHOW_YEAR_MIN,
   TAGS_PER_SHOW_LIMIT,
 } from '@/lib/schemas.generated';
 
@@ -29,6 +31,10 @@ export const EXCLUDED_PLAYLISTS_MAX = EXCLUDED_PLAYLISTS_PER_SHOW;
 export const TAGS_MAX = TAGS_PER_SHOW_LIMIT;
 export const TAG_MAX = SHOW_TAG_MAX;
 export const TAG_RE = SHOW_TAG_RE;
+// The era-window year bounds the schema's own showYear enforces. Restating
+// them here would let the Add button accept a year the save then refuses.
+export const YEAR_MIN = SHOW_YEAR_MIN;
+export const YEAR_MAX = SHOW_YEAR_MAX;
 
 /** How much the panel knows about the live Navidrome playlist index.
  *
@@ -159,7 +165,40 @@ export function sameEra(a: EraWindow, b: { from: number | null; to: number | nul
   const bt = 'to' in b ? b.to : b.toYear;
   return a.fromYear === bf && a.toYear === bt;
 }
-/** Preset label ("90s") or the raw window ("1975–1984") for a custom one set via API. */
+/** Resolve the add-a-range inputs into a window to push onto `eras` (#1599).
+ *
+ * Returns a reason rather than throwing: the two inputs sit inside the eras
+ * group, so a bad draft is reported next to the Add button and nothing reaches
+ * the form array. Either bound may be blank — an open-ended "2026+" is a legal
+ * window — but a window with NO bound is the absent state the schema drops,
+ * not a filter. Duplicates are refused rather than appended so that a range
+ * spelling out a decade lights that chip instead of stacking beside it. */
+export function resolveEraDraft(
+  from: string,
+  to: string,
+  existing: EraWindow[],
+): { window: EraWindow } | { error: string } {
+  const parse = (raw: string): number | null | undefined => {
+    const v = raw.trim();
+    if (!v) return null;
+    const n = Number(v);
+    return Number.isInteger(n) && n >= YEAR_MIN && n <= YEAR_MAX ? n : undefined;
+  };
+  const fromYear = parse(from);
+  const toYear = parse(to);
+  if (fromYear === undefined || toYear === undefined) {
+    return { error: `Years must be whole numbers between ${YEAR_MIN} and ${YEAR_MAX}.` };
+  }
+  if (fromYear == null && toYear == null) return { error: 'Enter a start year, an end year, or both.' };
+  if (fromYear != null && toYear != null && fromYear > toYear) {
+    return { error: 'The start year must not be after the end year.' };
+  }
+  const w = { fromYear, toYear };
+  if (existing.some(e => sameEra(e, w))) return { error: 'That range is already selected.' };
+  return { window: w };
+}
+
+/** Preset label ("90s") or the raw window ("1975–1984") for a custom one. */
 export function eraLabelOf(e: EraWindow): string {
   const hit = DECADES.find(d => sameEra(e, d));
   if (hit) return hit.label;

--- a/web/components/admin/shows/types.ts
+++ b/web/components/admin/shows/types.ts
@@ -18,6 +18,7 @@ import {
   SHOW_YEAR_MAX,
   SHOW_YEAR_MIN,
   TAGS_PER_SHOW_LIMIT,
+  validEraYear,
 } from '@/lib/schemas.generated';
 
 export const NAME_MAX = SHOW_NAME_MAX;
@@ -31,8 +32,10 @@ export const EXCLUDED_PLAYLISTS_MAX = EXCLUDED_PLAYLISTS_PER_SHOW;
 export const TAGS_MAX = TAGS_PER_SHOW_LIMIT;
 export const TAG_MAX = SHOW_TAG_MAX;
 export const TAG_RE = SHOW_TAG_RE;
-// The era-window year bounds the schema's own showYear enforces. Restating
-// them here would let the Add button accept a year the save then refuses.
+// The era-window year bounds the schema's own showYear enforces. Re-exported
+// for the <input min/max> and the error copy only — the TEST itself is the
+// schema's own `validEraYear`, imported rather than re-derived from these two,
+// so the Add button can never accept a year the save then refuses.
 export const YEAR_MIN = SHOW_YEAR_MIN;
 export const YEAR_MAX = SHOW_YEAR_MAX;
 
@@ -172,17 +175,24 @@ export function sameEra(a: EraWindow, b: { from: number | null; to: number | nul
  * the form array. Either bound may be blank — an open-ended "2026+" is a legal
  * window — but a window with NO bound is the absent state the schema drops,
  * not a filter. Duplicates are refused rather than appended so that a range
- * spelling out a decade lights that chip instead of stacking beside it. */
+ * spelling out a decade lights that chip instead of stacking beside it.
+ *
+ * The year test is the schema's own `validEraYear` off the mirror, never a
+ * local re-derivation of it around YEAR_MIN/YEAR_MAX: half the rule restated
+ * is half the rule free to drift. */
 export function resolveEraDraft(
   from: string,
   to: string,
   existing: EraWindow[],
 ): { window: EraWindow } | { error: string } {
   const parse = (raw: string): number | null | undefined => {
+    // The trim is the editor's, not the schema's: a draft box legitimately
+    // holds whitespace mid-keystroke, while `eraYearOf` on the wire reads a
+    // blank-but-not-empty string as malformed rather than as an open end.
     const v = raw.trim();
     if (!v) return null;
     const n = Number(v);
-    return Number.isInteger(n) && n >= YEAR_MIN && n <= YEAR_MAX ? n : undefined;
+    return validEraYear(n) ? n : undefined;
   };
   const fromYear = parse(from);
   const toYear = parse(to);

--- a/web/lib/schemas.generated.ts
+++ b/web/lib/schemas.generated.ts
@@ -3867,8 +3867,15 @@ function showStringList(opts: {
 // the load path's repairEraWindow (below) so the two can never disagree about
 // what a valid year is. null / '' means "open end". A numeric string is
 // accepted because that is what an <input type="number"> posts.
+//
+// `validEraYear` is EXPORTED so it rides the mirror into the admin show
+// editor's add-a-range control (#1599), which has to refuse a year the save
+// would then reject. It owns only the integer-and-range test; the editor keeps
+// its own trim, because eraYearOf deliberately does not trim (' ' reaching the
+// wire is a malformed post, not an open end) and a draft box legitimately holds
+// whitespace mid-keystroke.
 const eraYearOf = (v: unknown): number | null => (v == null || v === '' ? null : Number(v));
-const validEraYear = (n: number | null): boolean =>
+export const validEraYear = (n: number | null): boolean =>
   n == null || (Number.isInteger(n) && n >= SHOW_YEAR_MIN && n <= SHOW_YEAR_MAX);
 
 const showYear = z

--- a/web/scripts/verify-forms.py
+++ b/web/scripts/verify-forms.py
@@ -1744,11 +1744,42 @@ def shows(page):
 
         assert not save.is_disabled(), "Save show stayed disabled once the overlap was fixed"
 
-        # 4. Save — a genuinely valid show persists through a real POST /shows
+        # 4. Eras — a custom window beside a decade chip (#1599). Both year
+        #    boxes sit INSIDE the eras group (fieldAria's groupProps carries no
+        #    id), so they are found by their own aria-label and every assertion
+        #    stays scoped to the group, per this file's one convention.
+        eras_group = dialog.locator('[aria-labelledby$=".eras-label"]')
+        eras_group.wait_for()
+        eras_group.get_by_role("button", name="90s").click()
+
+        era_from = dialog.get_by_label("custom era start year")
+        era_to = dialog.get_by_label("custom era end year")
+        add_range = dialog.get_by_role("button", name="Add range")
+
+        # A range spelling out a decade already lit is refused rather than
+        # stacked beside its chip — the duplicate the schema would drop anyway.
+        era_from.fill("1990")
+        era_to.fill("1999")
+        add_range.click()
+        assert "already selected" in eras_group.get_by_role("alert").inner_text(), \
+            "adding a range equal to a lit decade chip was not refused"
+
+        # The window the chips cannot spell: one year.
+        era_from.fill("2026")
+        era_to.fill("2026")
+        add_range.click()
+        eras_group.get_by_role("button", name="2026–2026").wait_for()
+
+        # 5. Save — a genuinely valid show persists through a real POST /shows
         #    round trip.
         save.click()
         dialog.wait_for(state="detached")
-        assert SHOW_VERIFY_NAME in api("/settings"), "new show did not persist"
+        saved = find_show(SHOW_VERIFY_NAME)
+        assert saved, "new show did not persist"
+        assert saved.get("eras") == [
+            {"fromYear": 1990, "toYear": 1999},
+            {"fromYear": 2026, "toYear": 2026},
+        ], f"chip + custom era window did not both persist: {saved.get('eras')!r}"
     finally:
         # Runs whether the assertions above passed or raised — a failed run
         # must not leave "Verify Show" behind to poison the NEXT run, and a

--- a/web/scripts/verify-forms.py
+++ b/web/scripts/verify-forms.py
@@ -1676,10 +1676,10 @@ def shows(page):
     finally:
         page.unroute("**/settings", mock_settings_get)
 
-    # 2 & 3, and the final valid save — one continuous "Add show" session,
+    # 2, 3 & 4, and the final valid save — one continuous "Add show" session,
     # against the REAL (unmocked) controller. Wrapped in try/finally like
     # skills()/blockrules()/imaging()/personas() — a real, persisted show is
-    # created in step 4 below, and a run that fails partway through must not
+    # created in step 5 below, and a run that fails partway through must not
     # leave it behind to poison the next run.
     try:
         page.goto(f"{WEB}/admin/shows")
@@ -1770,6 +1770,31 @@ def shows(page):
         add_range.click()
         eras_group.get_by_role("button", name="2026–2026").wait_for()
 
+        # The OPEN-ENDED window — one bound left blank, which is a legal filter
+        # and the only shape eraLabelOf renders through its no-toYear branch.
+        # Driven separately because a closed range proves nothing about it: the
+        # blank side has to survive parse() as null rather than as a refusal.
+        era_from.fill("2030")
+        era_to.fill("")
+        add_range.click()
+        eras_group.get_by_role("button", name="2030+").wait_for()
+
+        # Acceptance criterion 2 of #1599 — toggling a decade chip must not
+        # disturb the custom windows sharing the array with it. Wait on the
+        # chip's own aria-pressed before counting, so the assertion reads
+        # settled state rather than racing the re-render.
+        eras_group.get_by_role("button", name="90s").click()
+        eras_group.get_by_role("button", name="90s", pressed=False).wait_for()
+        for label in ("2026–2026", "2030+"):
+            assert eras_group.get_by_role("button", name=label).count() == 1, \
+                f"untoggling a decade chip dropped the custom era window {label}"
+
+        # Re-light it for the save below. It lands at the END of the array now:
+        # untoggling REMOVED that window and toggling APPENDS a fresh one, which
+        # is exactly why the assertion spells the order out rather than sorting.
+        eras_group.get_by_role("button", name="90s").click()
+        eras_group.get_by_role("button", name="90s", pressed=True).wait_for()
+
         # 5. Save — a genuinely valid show persists through a real POST /shows
         #    round trip.
         save.click()
@@ -1777,9 +1802,10 @@ def shows(page):
         saved = find_show(SHOW_VERIFY_NAME)
         assert saved, "new show did not persist"
         assert saved.get("eras") == [
-            {"fromYear": 1990, "toYear": 1999},
             {"fromYear": 2026, "toYear": 2026},
-        ], f"chip + custom era window did not both persist: {saved.get('eras')!r}"
+            {"fromYear": 2030, "toYear": None},
+            {"fromYear": 1990, "toYear": 1999},
+        ], f"chip + custom era windows did not all persist: {saved.get('eras')!r}"
     finally:
         # Runs whether the assertions above passed or raised — a failed run
         # must not leave "Verify Show" behind to poison the NEXT run, and a


### PR DESCRIPTION
Closes #1599.

## What changed

`ShowEditor`'s eras field now has an **add-a-range** control beside the decade chips: two year inputs and an *Add range* button, writing onto the same `eras` array the chips write to. That makes "new music Monday, 2026 only" reachable from the admin UI — previously it needed a hand-written PATCH, and an API-set window rendered read-only (visible and removable, but not addable).

Either side may be left blank, since an open-ended `{fromYear: 2026, toYear: null}` is a legal window. Adding a range that spells out a decade is refused rather than appended, so it lights that chip instead of stacking a duplicate beside it — `sameEra` already answered that question.

## Why it's shaped this way

- **The year test is the schema's own, imported — not restated.** `validEraYear` is now `export`ed from `controller/src/schemas/show.ts` and rides the generated mirror into `resolveEraDraft`, replacing the local `Number.isInteger(n) && n >= YEAR_MIN && n <= YEAR_MAX`. `types.ts` still re-exports `SHOW_YEAR_MIN`/`SHOW_YEAR_MAX`, but only for the `<input min/max>` and the error copy — the *rule* has one definition. The editor keeps its own `trim()`, deliberately: `eraYearOf` on the wire does **not** trim (`' '` is a malformed post, not an open end) while a draft box legitimately holds whitespace mid-keystroke, so the two were never quite the same predicate and the restatement was live drift, not just duplication. `web/lib/schemas.generated.ts` was regenerated with `cd controller && npm run gen:schemas` and committed; it is never hand-edited.

- **The cap prop is required BY this feature, not polish alongside it.** `eras` is already capped at `SHOW_FILTER_VALUES_MAX` by the schema, so no second limit was added. But the decade `ChipRow` caps on what *it* has selected, which cannot see custom windows. `SHOW_FILTER_VALUES_MAX` is **15** and `DECADES` has **8** entries, so that row alone can never reach the cap — an earlier version of this description said the chips would offer "a ninth window", which is not the boundary. The window at risk is a **sixteenth**. Before the add-a-range control, filling `eras` took 15 API-set windows; now the operator can fill it entirely from this UI, at which point an uncapped chip row offers that sixteenth, the schema refuses the save, and nothing on screen says why. Hence `cap={FILTER_VALUES_MAX - customEras.length}`. For any show with no custom windows, `cap` is 15 — the `ChipRow` default — so the behaviour is unchanged.

- **The draft resolver is pure** (`resolveEraDraft` in `shows/types.ts`, next to `sameEra`/`eraLabelOf`) and returns a reason rather than throwing; the error only appears on Add, so a half-typed `20` doesn't scold anyone mid-keystroke.

- **Every write to `eras` clears the draft error.** The message is a verdict on one Add press against the array *as it stood*: with the 90s chip lit, typing `1990`/`1999` is refused as a duplicate — but untoggling that chip used to leave "That range is already selected." standing, inside a live region, over a range that would now add cleanly. All three writers (Add, the chip `onToggle`, the custom-chip remove) now go through one `setEras` helper that clears it, rather than each handler remembering to.

- The two inputs carry their own `aria-label` — the eras group title names the whole field, not either box.

## Verification

**Run here, passing:**

- `npm run lint` in `web/` — 0 errors (5 pre-existing warnings, none in changed files).
- `npm run lint` in `controller/` — 0 errors (pre-existing `no-explicit-any` warnings only).
- `cd controller && npm run gen:schemas` produces a file **byte-identical** to the committed `web/lib/schemas.generated.ts`, so CI's mirror-drift job is satisfied.
- `cd controller && npm test -- schema` — 352/352.

**Written and NOT run: `web/scripts/verify-forms.py shows`.**

The check now drives the whole flow — toggle the 90s chip; confirm re-adding `1990–1999` is refused as a duplicate; add the single-year window `2026–2026`; add the **open-ended** window `2030+` (one bound blank — the only shape `eraLabelOf` renders through its no-`toYear` branch, and the only one that exercises `parse()` returning `null` on one side); untoggle the 90s chip and assert both custom windows survive it (#1599's second acceptance criterion, which had no assertion behind it); re-light it; save; and read the show back through the controller as `[{2026,2026},{2030,null},{1990,1999}]`.

None of that has been executed against this branch. `verify-forms.py` needs the isolated verify stack (controller `:7791`, web `:7793`) plus `SUBWAVE_VERIFY_ALLOW_DESTRUCTIVE=1`, and it makes destructive writes — it cannot run in CI or from a bare checkout. **Before merge**, someone with the verify stack up should run:

```
SUBWAVE_VERIFY_ALLOW_DESTRUCTIVE=1 python3 web/scripts/verify-forms.py shows
```

`web/CLAUDE.md` is explicit that this run is the evidence for a forms PR. Treat the PR as unverified until its output is posted here.

## Docs

`docs/discord-open-suggestions.md` still carried this thread as *"🟡 Partly covered — … Exposing the API's fromYear/toYear as a show-level UI control is not tracked."* Moved to **🔨 Tracked** against #1599, with the at-a-glance counts adjusted (13→14 Tracked, 20→19 Partly covered).
