### PR TITLE
chore: sync lockfile versions and keep release-please updating them

### DIFF
--- a/.claude/skills/subwave-app-android-release/SKILL.md
+++ b/.claude/skills/subwave-app-android-release/SKILL.md
@@ -216,7 +216,11 @@ on EAS; you don't need to rebuild to re-share.
 - **Another test build of the same version** (the common case): change nothing
   and rebuild — internal APKs install over each other regardless of build number.
 - **New marketing version** (e.g. `1.0.0` → `1.1.0`, what users see): edit
-  `expo.version` in `app/app.json` first, commit, then rebuild.
+  `expo.version` in `app/app.json` first, commit, then rebuild. That bump is
+  four fields — `app/app.json`, `app/package.json`, and **both** version fields
+  in `app/package-lock.json` (`.version` and `.packages[""].version`). See the
+  iOS skill's version section; `app` is outside release-please, so nothing keeps
+  them in step for you.
 
 Unlike Apple, **Play won't reject a same-`versionName` upload** — it keys
 releases on `versionCode` (which `autoIncrement` always bumps), so you *can*

--- a/.claude/skills/subwave-app-ios-release/SKILL.md
+++ b/.claude/skills/subwave-app-ios-release/SKILL.md
@@ -166,6 +166,15 @@ Decide which kind of release this is:
   `expo.version` in `app/app.json` first (e.g. `1.0.0` → `1.1.0`), commit, then
   release. The build number still auto-increments under it.
 
+A version bump is **four fields, not one**: `expo.version` in `app/app.json`,
+`version` in `app/package.json`, and **both** version fields in
+`app/package-lock.json` (top-level `.version` *and* `.packages[""].version` —
+npm writes the same number twice). `app` is deliberately outside
+`release-please-config.json`, since its marketing version tracks store
+submissions rather than the monorepo's release train, so nothing bumps these for
+you. Edit the lockfile's two lines by hand; do **not** run `npm install` to do
+it, which rewrites unrelated entries.
+
 **Live-app gotcha — once a marketing version is released on the App Store, you
 can't ship to the public store again under that same version.** `--auto-submit`
 (or `eas submit`) will fail at the submission step with:

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subwave-app",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subwave-app",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "dependencies": {
         "@bacons/apple-targets": "^5.0.0",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "subwave-cli",
-  "version": "0.35.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "subwave-cli",
-      "version": "0.35.0",
+      "version": "1.13.0",
       "dependencies": {
         "@clack/prompts": "0.8.2",
         "picocolors": "^1.1.1"

--- a/controller/package-lock.json
+++ b/controller/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-wave-controller",
-  "version": "1.11.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-wave-controller",
-      "version": "1.11.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.27",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -17,13 +17,43 @@
         },
         {
           "type": "json",
+          "path": "controller/package-lock.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "controller/package-lock.json",
+          "jsonpath": "$.packages[''].version"
+        },
+        {
+          "type": "json",
           "path": "web/package.json",
           "jsonpath": "$.version"
         },
         {
           "type": "json",
+          "path": "web/package-lock.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "web/package-lock.json",
+          "jsonpath": "$.packages[''].version"
+        },
+        {
+          "type": "json",
           "path": "cli/package.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "cli/package-lock.json",
+          "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "cli/package-lock.json",
+          "jsonpath": "$.packages[''].version"
         },
         {
           "type": "generic",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sub-wave-web",
-  "version": "1.7.0",
+  "version": "1.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sub-wave-web",
-      "version": "1.7.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## The drift

Measured against `origin/develop` — `package.json` version vs the lockfile's, which a `lockfileVersion: 3` file stores **twice**, at `.version` and `.packages[""].version`:

| package | package.json | lockfile | |
| --- | --- | --- | --- |
| root | 1.13.0 | 1.13.0 | ok |
| mcp-subwave | 0.2.0 | 0.2.0 | ok |
| controller | 1.13.0 | 1.11.0 | stale |
| web | 1.13.0 | 1.7.0 | stale |
| cli | 1.13.0 | 0.35.0 | stale, worst |
| app | 1.5.0 | 1.4.0 | stale |

## Why it happened

`release-please-config.json` bumps `controller`, `web` and `cli` `package.json` through `extra-files` with jsonpath `$.version`, and never touches their lockfiles. The root stayed in step only because `release-type: node` handles the root lockfile natively, via release-please's dedicated `PackageLockJson` updater. `app` is outside that config entirely.

## What this PR does

**1. One-off sync.** Every stale version field brought into line with its `package.json`. Only the version fields changed — no `npm install`, no dependency resolution churn, no `lockfileVersion` change. The diff is exactly 2 changed lines per lockfile, 8 in total.

**2. Stop it re-drifting.** Six new `extra-files` entries, two per managed lockfile — one for `$.version`, one for `$.packages[''].version`. A single entry per file would fix only the top-level field and leave the second one drifting silently, which is the failure this PR exists to close.

## Verifying the config actually works

The `json` extra-file updater warns-and-skips on a path it cannot resolve, so a wrong jsonpath fails *quietly* — worth confirming rather than assuming. Checked against release-please 17.11.2 (what `release-please-action@v4` resolves):

- `type: "json"` dispatches to `GenericJson` (`strategies/base.js`), which resolves the path with **jsonpath-plus**. It handles the empty-string key: `$.packages[''].version` resolves and writes.
- **Two entries on the same path compose, they don't clobber.** `mergeUpdates` (`updaters/composite.js`) groups updates by path and chains same-path updaters into a `CompositeUpdater`, so the second updater sees the first's output.
- Simulating a 1.13.0 → 1.14.0 release against this branch's config and the real files: all nine json entries resolve, no skip warnings, and every lockfile lands both fields on 1.14.0.

## What about `app`

**Deliberately left out of `release-please-config.json`.** `app` isn't merely unconfigured, it's on a different version *line* — 1.5.0 against the monorepo's 1.13.0 — and it's bumped by hand: `1d0723de` ("chore(app): release 1.5.0") touched only `app/app.json` and `app/package.json`, because Expo's marketing version tracks App Store / Play submissions and native fingerprint shifts, not conventional commits.

Adding it to `extra-files` would rewrite `app` from 1.5.0 to 1.13.0 on the next release — a store-visible version jump that can't be walked back, and one the release skills warn about explicitly. So its lockfile is synced here as a one-off, and the mechanism that keeps it in step going forward is documentation instead: both app release skills now state that the hand bump is four fields — `app/app.json`, `app/package.json`, and *both* version fields in `app/package-lock.json` — edited by hand rather than via `npm install`.

## Checks

- `controller` lint: pass (0 errors; 687 pre-existing warnings)
- `web` lint: pass (0 errors, 5 pre-existing warnings)
- `mcp-subwave` lint: pass
- `controller` tests: **1425 passed, 0 failed**
- `npm ci` resolves against the hand-edited lockfiles in `controller`, `cli`, `web` and `mcp-subwave` — and left every lockfile byte-identical to the committed 2-line change
