### PR TITLE
fix(requests): stop operator queue presses shutting the listener request line

### DIFF
--- a/controller/scripts/studio-request-line.test.ts
+++ b/controller/scripts/studio-request-line.test.ts
@@ -1,0 +1,116 @@
+// An operator's studio push must not consume a listener's request slot.
+//
+// `POST /dj/queue-track` pushes `requestedBy: 'studio'`, and it has to: that
+// field is the discriminator four air-path behaviours key off — the #447 length
+// cap (queue.ts `maxDurationSec`), the show-boundary cut (`resolveBoundaryCut`),
+// the bed's `BedReason` and the sub-crossfade warning — and an explicit
+// operator action wants every one of those exemptions.
+//
+// `routes/request.ts` then counted the same truthiness as "a listener is
+// waiting in line" (`upcoming.filter(i => i.requestedBy).length` against
+// `settings.requests.maxPending`, default 6). So six presses of Queue on air
+// shut the listener request line for as long as those six tracks took to play,
+// answering every listener "The request queue's full — try again in a few
+// minutes" with nothing in the refusal, the response or the booth log naming
+// the real cause. FR 4's album block would have made that the normal case: one
+// press, a whole record, the line shut for the length of the album.
+//
+// The fix is a second field rather than a second meaning on the first one, so
+// the two questions stay separable — and `queue.pendingListenerRequests()` is
+// the one place that asks the second.
+//
+// Run: npm test -- studio-request-line
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { queue } from '../src/broadcast/queue.js';
+
+// push() persists a JSON snapshot and kicks the drain (TTS render + the handoff
+// file Liquidsoap polls). Neither is part of the contract here, and both would
+// touch disk or block on a poll timeout in a bare test process — the same
+// neutralisation scripts/request-dedup.test.ts uses.
+(queue as any).persist = () => {};
+(queue as any).drainToLiquidsoap = async () => {};
+
+function reset() {
+  queue.upcoming = [];
+  queue.current = null;
+}
+
+const listenerTrack = (n: number) => ({ id: `listener-${n}`, title: `Listener ${n}`, artist: 'Someone' });
+const studioTrack = (n: number) => ({ id: `studio-${n}`, title: `Studio ${n}`, artist: 'Operator' });
+
+test('a listener request counts toward the pending line', async () => {
+  reset();
+  await queue.push({ track: listenerTrack(1), requestedBy: 'alice' });
+  await queue.push({ track: listenerTrack(2), requestedBy: 'bob' });
+  assert.equal(queue.pendingListenerRequests(), 2);
+});
+
+test('an AI pick does not — it is nobody waiting', async () => {
+  reset();
+  await queue.push({ track: listenerTrack(1), requestedBy: null, aiPicked: true });
+  assert.equal(queue.pendingListenerRequests(), 0);
+});
+
+test('a studio push does not, even though it carries requestedBy', async () => {
+  reset();
+  // Exactly what POST /dj/queue-track sends.
+  await queue.push({ track: studioTrack(1), requestedBy: 'studio', operator: true, allowDuplicate: true });
+  assert.equal(queue.upcoming.length, 1, 'the track is queued as normal');
+  assert.equal(queue.upcoming[0].requestedBy, 'studio', 'and keeps the air-path discriminator');
+  assert.equal(queue.pendingListenerRequests(), 0, 'but is not a listener in the line');
+});
+
+test('the bug: a full block of studio pushes leaves the request line open', async () => {
+  reset();
+  // maxPending's default is 6. Before the fix these six shut the line.
+  for (let n = 0; n < 6; n++) {
+    await queue.push({ track: studioTrack(n), requestedBy: 'studio', operator: true, allowDuplicate: true });
+  }
+  assert.equal(queue.upcoming.length, 6);
+  assert.equal(queue.pendingListenerRequests(), 0, 'six operator presses are not six pending requests');
+});
+
+test('the two are counted independently in one queue', async () => {
+  reset();
+  await queue.push({ track: studioTrack(1), requestedBy: 'studio', operator: true, allowDuplicate: true });
+  await queue.push({ track: listenerTrack(1), requestedBy: 'alice' });
+  await queue.push({ track: studioTrack(2), requestedBy: 'studio', operator: true, allowDuplicate: true });
+  await queue.push({ track: listenerTrack(2), requestedBy: 'bob' });
+  assert.equal(queue.upcoming.length, 4);
+  assert.equal(queue.pendingListenerRequests(), 2, 'only the two listener requests');
+});
+
+// The cap bounds how deep the LINE gets, not how far down it Liquidsoap has
+// reached: a request already handed over is still a listener waiting to hear
+// their song, so narrowing this to `!sent` would under-count and let the queue
+// grow past maxPending.
+test('a sent-but-unaired listener request is still pending', async () => {
+  reset();
+  await queue.push({ track: listenerTrack(1), requestedBy: 'alice' });
+  queue.upcoming[0].sent = true;
+  assert.equal(queue.pendingListenerRequests(), 1);
+});
+
+// maxPending bounds what is still WAITING. A request that reached air has been
+// served, and counting it would hold a slot shut for the length of the track.
+test('a request on air is no longer pending', async () => {
+  reset();
+  await queue.push({ track: listenerTrack(1), requestedBy: 'alice' });
+  queue.current = queue.upcoming.shift()!;
+  assert.equal(queue.pendingListenerRequests(), 0);
+});
+
+// The field is absent on every item in a queue.json written before it existed.
+// Absent must read as "not known to be an operator push" — i.e. the old
+// behaviour — rather than as false-y-therefore-listener in one place and
+// operator in another. A recovered snapshot only survives 2h (queue.recover's
+// cutoff), so this degrades and then heals on its own.
+test('an item recovered without the field counts as it did before', () => {
+  reset();
+  queue.upcoming = [
+    { track: studioTrack(1), requestedBy: 'studio', queuedAt: new Date().toISOString() },
+  ] as any;
+  assert.equal(queue.pendingListenerRequests(), 1);
+});

--- a/controller/src/broadcast/queue.ts
+++ b/controller/src/broadcast/queue.ts
@@ -616,9 +616,10 @@ class Queue {
   // the line if the real seam lands too far from it — the forecast is made from
   // the on-air track's remaining play and goes badly wrong when the pick misses
   // that seam and auto.m3u fills the slot.
-  async push({ track, requestedBy = null, intent = null, introScript = null, introKind = 'dj-speak', introPersona = null, aiPicked = false, allowDuplicate = false, linkPrev = null, linkClockAt = null }: {
+  async push({ track, requestedBy = null, operator = false, intent = null, introScript = null, introKind = 'dj-speak', introPersona = null, aiPicked = false, allowDuplicate = false, linkPrev = null, linkClockAt = null }: {
     track: Track;
     requestedBy?: string | null;
+    operator?: boolean;
     intent?: string | null;
     introScript?: string | null;
     introKind?: string;
@@ -660,7 +661,7 @@ class Queue {
       }
     }
     const item = {
-      track, requestedBy, intent, introScript, introKind, introPersona, aiPicked,
+      track, requestedBy, operator, intent, introScript, introKind, introPersona, aiPicked,
       // Only stamp a back-announce target when there's actually an intro/link to
       // air against it; a bare track carries no claim about what preceded it.
       linkPrev: (introScript && linkPrev)
@@ -3076,6 +3077,33 @@ class Queue {
       if (item.track?.id) ids.add(item.track.id);
     }
     return ids;
+  }
+
+  // How many LISTENER requests are queued and unaired — what
+  // `settings.requests.maxPending` is a bound on.
+  //
+  // `routes/request.ts` used to count `upcoming.filter(i => i.requestedBy)`
+  // inline, and that read every operator push as a listener waiting in line,
+  // because `POST /dj/queue-track` pushes `requestedBy: 'studio'` on purpose:
+  // that string is the discriminator four air-path exemptions key off (the
+  // #447 length cap, the show-boundary cut, the bed's request reason, the
+  // sub-crossfade warning), and an explicit operator action wants all four.
+  // The cost was paid on a surface with no connection to any of them — six
+  // manual Queue presses reached the default `maxPending` of 6 and answered
+  // every listener "The request queue's full" for as long as those tracks took
+  // to air, with nothing in the refusal or the booth log naming the cause.
+  //
+  // The fix is one question asked in one place rather than a second meaning
+  // hung on `requestedBy`: an operator push carries `operator: true` and is not
+  // a request the queue is holding on a listener's behalf. Counting `!sent`
+  // would be the wrong narrowing — a sent-but-unaired request is still a
+  // listener waiting, and the cap is about how deep the line gets, not about
+  // how far down it Liquidsoap has already reached.
+  //
+  // The on-air track is deliberately NOT counted: `maxPending` bounds what is
+  // still waiting, and a request that is playing has been served.
+  pendingListenerRequests(): number {
+    return this.upcoming.filter(i => i.requestedBy && !i.operator).length;
   }
 
   // Honest acknowledgement for a listener request whose resolved track is

--- a/controller/src/broadcast/queue/types.ts
+++ b/controller/src/broadcast/queue/types.ts
@@ -64,6 +64,25 @@ export interface Track {
 export interface QueueItem {
   track: Track;
   requestedBy?: string | null;
+  // This item was queued by the OPERATOR, not by a listener. It exists because
+  // `requestedBy` cannot answer that question: the studio queue pushes
+  // `requestedBy: 'studio'` precisely so it inherits the four exemptions that
+  // discriminator carries (the #447 length cap, the show-boundary cut, the
+  // bed's request reason, the sub-crossfade warning), and every one of those
+  // is right for an operator push. What is NOT right is `routes/request.ts`
+  // reading the same truthiness as "a listener is waiting" — six manual Queue
+  // presses then filled `requests.maxPending` and shut the listener request
+  // line, with nothing in the refusal naming the cause.
+  //
+  // So the origin gets its own field rather than overloading that one, and the
+  // two questions stay separable. Read ONLY by `pendingListenerRequests()`;
+  // nothing on the air path may branch on it, or the exemptions above quietly
+  // acquire a second discriminator that can disagree with the first.
+  //
+  // ABSENT means "not known to be an operator push", which is what an item
+  // recovered from a `queue.json` written before this field reads as — i.e.
+  // exactly the old behaviour, for the ≤2h such a snapshot survives.
+  operator?: boolean;
   intent?: string | null;
   introScript?: string | null;
   introKind?: string;

--- a/controller/src/routes/dj.ts
+++ b/controller/src/routes/dj.ts
@@ -1013,7 +1013,15 @@ router.post('/dj/queue-track', requireAdmin, async (req, res) => {
   try {
     // Explicit operator action — bypass the request/AI dedup guard (#619) so a
     // deliberate manual queue always fires, even for an already-queued track.
-    const queuePosition = await queue.push({ track, requestedBy: 'studio', allowDuplicate: true });
+    //
+    // `requestedBy: 'studio'` earns the four air-path exemptions a request has
+    // (length cap, show-boundary cut, bed reason, sub-crossfade warning);
+    // `operator: true` says it is not a listener waiting in line, so it does
+    // not consume a `requests.maxPending` slot. The two are separate questions
+    // — see queue.pendingListenerRequests().
+    const queuePosition = await queue.push({
+      track, requestedBy: 'studio', operator: true, allowDuplicate: true,
+    });
     if (queuePosition === -2) {
       // The never-play blocklist is absolute — even manual queueing is refused
       // (operator's call). Unblock in admin → Library → Blocked to re-audition.

--- a/controller/src/routes/request.ts
+++ b/controller/src/routes/request.ts
@@ -835,7 +835,10 @@ router.post('/request', validatePublicBody(listenerRequestSchema), async (req, r
       retryAfter,
     });
   }
-  const pendingCount = queue.upcoming.filter((i: any) => i.requestedBy).length;
+  // LISTENER requests only — an operator's own studio push carries
+  // `requestedBy: 'studio'` for the air-path exemptions and must not consume a
+  // slot in the listener queue. See queue.pendingListenerRequests().
+  const pendingCount = queue.pendingListenerRequests();
   if (pendingCount >= (Number(cfg.maxPending) || 6)) {
     res.setHeader('Retry-After', String(retryAfter));
     return res.status(429).json({


### PR DESCRIPTION
Found while planning FR 4 of #1622. It is a live bug today, independent of that feature, so it ships on its own.

## The bug

`POST /dj/queue-track` pushes `requestedBy: 'studio'`, and `routes/request.ts` counted the listener request queue as:

```js
const pendingCount = queue.upcoming.filter((i) => i.requestedBy).length;
```

So an operator's own Queue presses fill the listener request line. Six of them reach the default `requests.maxPending` of 6, and every listener is answered **"The request queue's full — try again in a few minutes"** for as long as those tracks take to air. Nothing in the refusal or the booth log names the cause.

## Why `requestedBy` can't just be narrowed

That string is the discriminator four air-path behaviours key off, and an explicit operator action wants all four:

- the #447 length cap exemption (`queue.ts:1038`, `:1583`)
- the show-boundary cut exemption (`queue.ts:1324`)
- the bed's `request` reason (`queue.ts:864`)
- the sub-crossfade warning (`queue.ts:734`)

So the origin gets its own field rather than a second meaning hung on that one. `operator: true` is read by exactly one thing — `queue.pendingListenerRequests()` — and nothing on the air path may branch on it, or those four exemptions quietly acquire a second discriminator that can disagree with the first. That constraint is written on the field.

## Two narrowings deliberately not made

- **A sent-but-unaired request still counts.** `maxPending` bounds how deep the line gets, not how far down it Liquidsoap has already reached.
- **An item from a pre-upgrade `queue.json` reads as the old behaviour** rather than being guessed at. The field is optional; absent means "not known to be an operator push", and such a snapshot survives ≤2h anyway.

## Verification

- `npm run lint` in `controller` — 0 errors.
- `npm test` — 1510 pass / 0 fail, including 8 new tests in `scripts/studio-request-line.test.ts`. Three were verified red with the `!i.operator` term removed.
