### PR TITLE
fix(library): survive a stale Navidrome socket instead of failing the count

### DIFF
--- a/controller/scripts/subsonic-retry-safety.test.ts
+++ b/controller/scripts/subsonic-retry-safety.test.ts
@@ -1,0 +1,225 @@
+// Regression coverage for PR #1640's stale-socket policy. These use a real
+// loopback HTTP server because a fetch stub that throws before dispatch cannot
+// model the dangerous case: Navidrome commits a mutation, then its response is
+// lost. Reads and explicitly idempotent operations retry; unknown writes do not.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer, type ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+type RequestHandler = (endpoint: string, url: URL, res: ServerResponse) => void;
+
+const stateRoot = mkdtempSync(join(tmpdir(), 'subwave-subsonic-retry-review-'));
+let handler: RequestHandler = (_endpoint, _url, res) => ok(res);
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url || '/', 'http://127.0.0.1');
+  const endpoint = url.pathname.split('/').pop() || '';
+  handler(endpoint, url, res);
+});
+
+await new Promise<void>((resolve, reject) => {
+  server.once('error', reject);
+  server.listen(0, '127.0.0.1', () => resolve());
+});
+
+const address = server.address() as AddressInfo;
+process.env.STATE_DIR = stateRoot;
+process.env.NAVIDROME_URL = `http://127.0.0.1:${address.port}`;
+process.env.NAVIDROME_USER = 'review-fixture';
+process.env.NAVIDROME_PASS = 'review-fixture-secret';
+
+const subsonic = await import('../src/music/subsonic.js');
+const realWarn = console.warn;
+
+function response(payload: Record<string, unknown> = {}) {
+  return { 'subsonic-response': { status: 'ok', ...payload } };
+}
+
+function ok(res: ServerResponse, payload: Record<string, unknown> = {}) {
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(response(payload)));
+}
+
+function loseCommittedResponse(res: ServerResponse) {
+  // The application has already mutated its state. Closing the downstream TCP
+  // connection now models a response lost after a committed Navidrome write.
+  res.socket?.destroy();
+}
+
+test.beforeEach(() => {
+  console.warn = () => {};
+});
+
+test.afterEach(() => {
+  console.warn = realWarn;
+});
+
+test.after(async () => {
+  await new Promise<void>((resolve, reject) => server.close(err => err ? reject(err) : resolve()));
+  rmSync(stateRoot, { recursive: true, force: true });
+});
+
+test('a lost read response is retried once over real localhost HTTP', async () => {
+  let requests = 0;
+  handler = (endpoint, _url, res) => {
+    assert.equal(endpoint, 'getAlbumList2');
+    requests += 1;
+    if (requests === 1) return loseCommittedResponse(res);
+    ok(res, { albumList2: { album: [{ id: 'album-1' }] } });
+  };
+
+  const albums = await subsonic.getAlbumList(0, 500);
+
+  assert.equal(requests, 2);
+  assert.deepEqual(albums, [{ id: 'album-1' }]);
+});
+
+test('an explicitly idempotent star retries after its response is lost', async () => {
+  let requests = 0;
+  let starred = false;
+  handler = (endpoint, _url, res) => {
+    assert.equal(endpoint, 'star');
+    requests += 1;
+    starred = true;
+    if (requests === 1) return loseCommittedResponse(res);
+    ok(res);
+  };
+
+  await subsonic.star('song-a');
+
+  assert.equal(requests, 2);
+  assert.equal(starred, true);
+});
+
+test('playlist create is not replayed after its committed response is lost', async () => {
+  const playlists: Array<{ id: string; name: string; songs: string[] }> = [];
+  let createRequests = 0;
+  handler = (endpoint, url, res) => {
+    if (endpoint === 'createPlaylist') {
+      createRequests += 1;
+      const playlist = {
+        id: `playlist-${createRequests}`,
+        name: url.searchParams.get('name') || '',
+        songs: url.searchParams.getAll('songId'),
+      };
+      playlists.push(playlist);
+      if (createRequests === 1) return loseCommittedResponse(res);
+      return ok(res, { playlist });
+    }
+    assert.equal(endpoint, 'updatePlaylist');
+    ok(res);
+  };
+
+  await subsonic.createPlaylist('response-loss-create', ['song-a']).catch(() => null);
+
+  assert.equal(createRequests, 1, 'an ambiguous create must not be sent twice');
+  assert.equal(playlists.length, 1, 'Navidrome should contain one created playlist');
+});
+
+test('playlist append is not duplicated after its committed response is lost', async () => {
+  const songs = ['song-a'];
+  let appendRequests = 0;
+  handler = (endpoint, url, res) => {
+    assert.equal(endpoint, 'updatePlaylist');
+    appendRequests += 1;
+    songs.push(...url.searchParams.getAll('songIdToAdd'));
+    if (appendRequests === 1) return loseCommittedResponse(res);
+    ok(res);
+  };
+
+  await subsonic.addToPlaylist('playlist-append', ['song-b']).catch(() => null);
+
+  assert.equal(appendRequests, 1, 'an ambiguous append must not be sent twice');
+  assert.deepEqual(songs, ['song-a', 'song-b']);
+});
+
+test('positional removal is not applied to the shifted playlist a second time', async () => {
+  const songs = ['song-a', 'song-b', 'song-c'];
+  let removeRequests = 0;
+  handler = (endpoint, url, res) => {
+    assert.equal(endpoint, 'updatePlaylist');
+    removeRequests += 1;
+    const indexes = url.searchParams.getAll('songIndexToRemove').map(Number);
+    for (const index of [...indexes].sort((a, b) => b - a)) songs.splice(index, 1);
+    if (removeRequests === 1) return loseCommittedResponse(res);
+    ok(res);
+  };
+
+  await subsonic.removeFromPlaylist('playlist-remove', [1]).catch(() => null);
+
+  assert.equal(removeRequests, 1, 'an ambiguous positional removal must not be sent twice');
+  assert.deepEqual(songs, ['song-a', 'song-c']);
+});
+
+test('ping performs only its initial transport attempt plus one retry', async () => {
+  let requests = 0;
+  handler = (endpoint, _url, res) => {
+    assert.equal(endpoint, 'ping');
+    requests += 1;
+    loseCommittedResponse(res);
+  };
+
+  const result = await subsonic.ping();
+
+  assert.equal(result.ok, false);
+  assert.equal(requests, 2, 'ping must not nest two shared retries inside its outer retry');
+});
+
+test('ping keeps its two-request ceiling when transport loss is followed by HTTP failure', async () => {
+  let requests = 0;
+  handler = (endpoint, _url, res) => {
+    assert.equal(endpoint, 'ping');
+    requests += 1;
+    if (requests === 1) return loseCommittedResponse(res);
+    res.writeHead(503, { 'content-type': 'text/plain' });
+    res.end('temporarily unavailable');
+  };
+
+  const result = await subsonic.ping();
+
+  assert.equal(result.ok, false);
+  assert.equal(requests, 2);
+});
+
+test('ping preserves one retry for a fast HTTP response failure', async () => {
+  let requests = 0;
+  handler = (endpoint, _url, res) => {
+    assert.equal(endpoint, 'ping');
+    requests += 1;
+    if (requests === 1) {
+      res.writeHead(503, { 'content-type': 'text/plain' });
+      res.end('temporarily unavailable');
+      return;
+    }
+    ok(res);
+  };
+
+  const result = await subsonic.ping();
+
+  assert.equal(result.ok, true);
+  assert.equal(requests, 2);
+});
+
+test('ping keeps its two-request ceiling when HTTP failure is followed by transport loss', async () => {
+  let requests = 0;
+  handler = (endpoint, _url, res) => {
+    assert.equal(endpoint, 'ping');
+    requests += 1;
+    if (requests === 1) {
+      res.writeHead(503, { 'content-type': 'text/plain' });
+      res.end('temporarily unavailable');
+      return;
+    }
+    loseCommittedResponse(res);
+  };
+
+  const result = await subsonic.ping();
+
+  assert.equal(result.ok, false);
+  assert.equal(requests, 2);
+});

--- a/controller/scripts/subsonic-stale-socket.test.ts
+++ b/controller/scripts/subsonic-stale-socket.test.ts
@@ -7,8 +7,7 @@
 //
 // Three things are pinned here, each one easy to "simplify" back out:
 //   1. a FAST transport failure is retried once, so the walk survives it;
-//   2. a SLOW one is not — it may already have been served, and mutations ride
-//      the same chokepoint;
+//   2. a SLOW one is not — only the stale-socket-shaped failure gets a retry;
 //   3. the error an operator finally sees names the endpoint, the origin and the
 //      underlying code, and never the URL, which carries the auth token.
 
@@ -27,8 +26,8 @@ process.env.NAVIDROME_PASS = 'hunter2';
 
 const subsonic = await import('../src/music/subsonic.js');
 
-// Mirrors the constant in subsonic.ts: the boundary between "never landed" and
-// "may have been served".
+// Mirrors the constant in subsonic.ts: the boundary for a stale-socket-shaped
+// failure. Delivery safety is decided separately by each call site.
 const STALE_SOCKET_RETRY_MS = 2_000;
 
 const realFetch = globalThis.fetch;

--- a/controller/scripts/subsonic-stale-socket.test.ts
+++ b/controller/scripts/subsonic-stale-socket.test.ts
@@ -1,0 +1,140 @@
+// A pooled keep-alive socket Navidrome has already closed fails the next request
+// on it instantly with undici's bare `TypeError: fetch failed`. ping() and
+// pingWith() each carried their own workaround; every real call had none, so the
+// library count — thousands of back-to-back album requests kicked off from an
+// idle admin page — died on its first request and reported "fetch failed", with
+// no endpoint, no origin and no errno to act on.
+//
+// Three things are pinned here, each one easy to "simplify" back out:
+//   1. a FAST transport failure is retried once, so the walk survives it;
+//   2. a SLOW one is not — it may already have been served, and mutations ride
+//      the same chokepoint;
+//   3. the error an operator finally sees names the endpoint, the origin and the
+//      underlying code, and never the URL, which carries the auth token.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const stateRoot = mkdtempSync(join(tmpdir(), 'subwave-subsonic-socket-'));
+process.env.STATE_DIR = stateRoot;
+// config.ts reads these at import time; the client builds its URL from them.
+process.env.NAVIDROME_URL = 'http://navidrome.test:4533';
+process.env.NAVIDROME_USER = 'dj';
+process.env.NAVIDROME_PASS = 'hunter2';
+
+const subsonic = await import('../src/music/subsonic.js');
+
+// Mirrors the constant in subsonic.ts: the boundary between "never landed" and
+// "may have been served".
+const STALE_SOCKET_RETRY_MS = 2_000;
+
+const realFetch = globalThis.fetch;
+const realWarn = console.warn;
+
+function socketClosed() {
+  const err: any = new TypeError('fetch failed');
+  err.cause = Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' });
+  return err;
+}
+
+function albumListOk() {
+  return new Response(
+    JSON.stringify({ 'subsonic-response': { status: 'ok', albumList2: { album: [{ id: 'a1' }] } } }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+function withFetch(stub: (url: string) => Promise<any>) {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: any) => {
+    const url = String(input);
+    calls.push(url);
+    return stub(url);
+  }) as any;
+  return calls;
+}
+
+test.afterEach(() => {
+  globalThis.fetch = realFetch;
+  console.warn = realWarn;
+});
+
+test.after(() => rmSync(stateRoot, { recursive: true, force: true }));
+
+test('a fast socket failure is retried once and the call succeeds', async () => {
+  console.warn = () => {};
+  let n = 0;
+  const calls = withFetch(async () => {
+    n += 1;
+    if (n === 1) throw socketClosed();
+    return albumListOk();
+  });
+
+  const albums = await subsonic.getAlbumList(0, 500);
+
+  assert.equal(calls.length, 2, 'the dead socket costs one retry, not the walk');
+  assert.deepEqual(albums, [{ id: 'a1' }]);
+});
+
+test('a second fast failure gives up, naming endpoint, origin and errno', async () => {
+  console.warn = () => {};
+  const calls = withFetch(async () => { throw socketClosed(); });
+
+  const err = await subsonic.getAlbumList(0, 500).then(
+    () => null,
+    (e: any) => e,
+  );
+
+  assert.ok(err, 'a sustained outage still fails');
+  assert.equal(calls.length, 2, 'exactly one retry');
+  assert.match(err.message, /getAlbumList2/, 'names the endpoint');
+  assert.match(err.message, /http:\/\/navidrome\.test:4533/, 'names the origin');
+  assert.match(err.message, /UND_ERR_SOCKET/, 'carries the underlying code');
+  assert.match(err.message, /other side closed/, 'carries the underlying reason');
+  assert.notEqual(err.message, 'fetch failed', 'never the bare undici message');
+});
+
+test('the error never leaks the auth token or password', async () => {
+  console.warn = () => {};
+  const calls = withFetch(async () => { throw socketClosed(); });
+
+  const err = await subsonic.getAlbumList(0, 500).then(() => null, (e: any) => e);
+
+  // The request URL carries `u`, `t` and `s`; the message must carry none of it.
+  assert.ok(!err.message.includes('hunter2'));
+  assert.ok(!err.message.includes('?'), 'no query string in the message');
+  const token = new URL(calls[0]).searchParams.get('t');
+  assert.ok(token && !err.message.includes(token), 'no salted token in the message');
+});
+
+test('a slow transport failure is not retried', async (t) => {
+  console.warn = () => {};
+  t.mock.timers.enable({ apis: ['Date'] });
+  const calls = withFetch(async () => {
+    // Past the fast-failure boundary: this request may already have been served.
+    t.mock.timers.tick(STALE_SOCKET_RETRY_MS + 500);
+    throw socketClosed();
+  });
+
+  const err = await subsonic.getAlbumList(0, 500).then(() => null, (e: any) => e);
+
+  assert.ok(err);
+  assert.equal(calls.length, 1, 'a slow failure is reported, never repeated');
+});
+
+test('a timeout keeps its own message and is never retried', async () => {
+  console.warn = () => {};
+  const calls = withFetch(async () => {
+    const err: any = new Error('The operation was aborted due to timeout');
+    err.name = 'TimeoutError';
+    throw err;
+  });
+
+  const err = await subsonic.getAlbumList(0, 500).then(() => null, (e: any) => e);
+
+  assert.equal(calls.length, 1, 'a timeout already waited the full budget');
+  assert.match(err.message, /timed out after \d+ms/);
+});

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -82,12 +82,20 @@ function extractCount(sub, songs) {
 // A pooled keep-alive socket Navidrome has already closed fails the next request
 // on it instantly, before a byte is written, and undici reports the bare
 // `fetch failed`. ping() and pingWith() each already worked around it; this is
-// the same rule at the one chokepoint every call goes through, so a walk of
-// thousands of albums no longer dies on the first idle socket. Bounded to a FAST
-// failure, which is what says the request never landed — a slow one may have been
-// served, and mutations ride this path too.
+// the same mechanism at the one chokepoint every call goes through, so a walk of
+// thousands of albums no longer dies on the first idle socket. A FAST failure is
+// characteristic of the stale-socket case, but cannot prove a request did not
+// reach Navidrome. Only explicitly safe operations may spend the retry.
 const STALE_SOCKET_RETRY_MS = 2_000;
 const STALE_SOCKET_BACKOFF_MS = 250;
+
+type CallOptions = {
+  retryFastTransport?: boolean;
+};
+
+// Reads and operations that are explicitly idempotent opt in at their call
+// site. An unknown/new endpoint gets no replay unless its safety is reviewed.
+const RETRY_FAST_TRANSPORT: Readonly<CallOptions> = { retryFastTransport: true };
 
 // undici collapses every connect/socket error into `TypeError: fetch failed`, so
 // name the endpoint, the origin and the underlying code. Never the URL — it
@@ -105,7 +113,11 @@ function describeTransportError(endpoint: string, err: any): Error {
 }
 
 // Bounded fetch: a hung Navidrome must not pin the admin routes behind it (#786).
-async function boundedFetch(endpoint: string, url: string) {
+async function boundedFetch(
+  endpoint: string,
+  url: string,
+  { retryFastTransport = false }: CallOptions = {},
+) {
   for (let attempt = 0; ; attempt++) {
     const started = Date.now();
     try {
@@ -116,7 +128,7 @@ async function boundedFetch(endpoint: string, url: string) {
           `Subsonic ${endpoint} timed out after ${config.navidrome.timeoutMs}ms — is Navidrome responding?`,
         );
       }
-      if (attempt === 0 && Date.now() - started < STALE_SOCKET_RETRY_MS) {
+      if (retryFastTransport && attempt === 0 && Date.now() - started < STALE_SOCKET_RETRY_MS) {
         console.warn(
           `[subsonic] ${endpoint}: ${err?.message || err} — retrying once (stale pooled socket)`,
         );
@@ -128,11 +140,11 @@ async function boundedFetch(endpoint: string, url: string) {
   }
 }
 
-async function call(endpoint, params = {}) {
+async function call(endpoint, params = {}, options: CallOptions = {}) {
   const started = Date.now();
   try {
     const url = buildUrl(endpoint, params);
-    const res = await boundedFetch(endpoint, url);
+    const res = await boundedFetch(endpoint, url, options);
     if (!res.ok) {
       // First 200 chars of the body, so triage sees the real server message.
       let body = '';
@@ -160,10 +172,10 @@ async function call(endpoint, params = {}) {
   }
 }
 
-// Connectivity + auth check against config.navidrome. Never throws.
-// call() already retries a stale pooled socket; this outer retry covers the rest
-// of a fast failure (an instant HTTP error), and a slow one is not retried since
-// a second wait can't change the answer.
+// Connectivity + auth check against config.navidrome. Never throws. ping owns
+// one retry across transport and HTTP/API failures instead of opting into the
+// shared transport retry and nesting the two budgets. One ping therefore never
+// sends more than two requests.
 const PING_RETRY_IF_FASTER_THAN_MS = 2_000;
 
 export async function ping(): Promise<{ ok: boolean; reason?: string }> {
@@ -267,18 +279,22 @@ const rejectArchive = (arr: any[]) =>
 // operator can review a blocked track; queue.push still refuses it. Every
 // airing path takes the default and never sees blocked songs.
 export async function search(query, { songCount = 20, songOffset = 0, includeBlocked = false } = {}) {
-  const r = await call('search3', { query, songCount, songOffset, artistCount: 5, albumCount: 5 });
+  const r = await call(
+    'search3',
+    { query, songCount, songOffset, artistCount: 5, albumCount: 5 },
+    RETRY_FAST_TRANSPORT,
+  );
   const songs = (r.searchResult3?.song || []).filter((s) => !isStationArchive(s));
   return includeBlocked ? songs : blocklist.rejectBlocked(songs);
 }
 
 export async function getRandomSongs({ size = 20, genre, fromYear, toYear }: { size?: number; genre?: string; fromYear?: number; toYear?: number } = {}) {
-  const r = await call('getRandomSongs', { size, genre, fromYear, toYear });
+  const r = await call('getRandomSongs', { size, genre, fromYear, toYear }, RETRY_FAST_TRANSPORT);
   return rejectArchive(r.randomSongs?.song || []);
 }
 
 export async function getSongsByGenre(genre, { count = 20, offset = 0 } = {}) {
-  const r = await call('getSongsByGenre', { genre, count, offset });
+  const r = await call('getSongsByGenre', { genre, count, offset }, RETRY_FAST_TRANSPORT);
   return rejectArchive(r.songsByGenre?.song || []);
 }
 
@@ -323,7 +339,7 @@ const GENRES_TTL_MS = 5 * 60 * 1000;
 // only moves on a Navidrome rescan. Failures are NOT cached — they propagate.
 export async function getGenres() {
   if (genresCache && Date.now() - genresCache.at < GENRES_TTL_MS) return genresCache.genres;
-  const r = await call('getGenres');
+  const r = await call('getGenres', {}, RETRY_FAST_TRANSPORT);
   const genres = r.genres?.genre || [];
   genresCache = { genres, at: Date.now() };
   return genres;
@@ -427,7 +443,7 @@ export async function resolveArtist(name, { artistCount = 10 } = {}) {
 }
 
 export async function getSimilarSongs(id, { count = 20 } = {}) {
-  const r = await call('getSimilarSongs2', { id, count });
+  const r = await call('getSimilarSongs2', { id, count }, RETRY_FAST_TRANSPORT);
   return rejectArchive(r.similarSongs2?.song || []);
 }
 
@@ -446,7 +462,7 @@ export async function supportsSonicSimilarity(): Promise<boolean> {
   if (sonicExtCache && Date.now() - sonicExtCache.at < EXT_PROBE_TTL_MS) return sonicExtCache.ok;
   let ok = false;
   try {
-    const r = await call('getOpenSubsonicExtensions');
+    const r = await call('getOpenSubsonicExtensions', {}, RETRY_FAST_TRANSPORT);
     const exts = r.openSubsonicExtensions || [];
     ok = exts.some((e: any) => (typeof e === 'string' ? e : e?.name) === 'sonicSimilarity');
   } catch {
@@ -457,23 +473,23 @@ export async function supportsSonicSimilarity(): Promise<boolean> {
 }
 
 export async function getSonicSimilarTracks(id, { count = 20 } = {}) {
-  const r = await call('getSonicSimilarTracks', { id, count });
+  const r = await call('getSonicSimilarTracks', { id, count }, RETRY_FAST_TRANSPORT);
   return rejectArchive(sonicSimilarSongs(r));
 }
 
 export async function getStarred() {
-  const r = await call('getStarred2');
+  const r = await call('getStarred2', {}, RETRY_FAST_TRANSPORT);
   return rejectArchive(r.starred2?.song || []);
 }
 
 // Star write-back for the listener like feature (#991) — mirrors the player
 // heart into Navidrome. Idempotent server-side.
 export async function star(id) {
-  await call('star', { id });
+  await call('star', { id }, RETRY_FAST_TRANSPORT);
 }
 
 export async function unstar(id) {
-  await call('unstar', { id });
+  await call('unstar', { id }, RETRY_FAST_TRANSPORT);
 }
 
 // Play reporting for Navidrome (#1298). submission=false is the "now playing"
@@ -494,31 +510,35 @@ export async function scrobble(
 }
 
 export async function getAlbumList(offset = 0, size = 500) {
-  const r = await call('getAlbumList2', { type: 'alphabeticalByName', size, offset });
+  const r = await call(
+    'getAlbumList2',
+    { type: 'alphabeticalByName', size, offset },
+    RETRY_FAST_TRANSPORT,
+  );
   return r.albumList2?.album || [];
 }
 
 export async function getRecentlyAddedAlbums({ size = 20 } = {}) {
-  const r = await call('getAlbumList2', { type: 'newest', size });
+  const r = await call('getAlbumList2', { type: 'newest', size }, RETRY_FAST_TRANSPORT);
   return r.albumList2?.album || [];
 }
 
 // Albums by play count. `offset` rotates the window — the top-N list barely
 // moves, so an offset-less read pins the same albums forever.
 export async function getFrequentAlbums({ size = 20, offset = 0 } = {}) {
-  const r = await call('getAlbumList2', { type: 'frequent', size, offset });
+  const r = await call('getAlbumList2', { type: 'frequent', size, offset }, RETRY_FAST_TRANSPORT);
   return r.albumList2?.album || [];
 }
 
 export async function getArtistInfo(id, { count = 10 } = {}) {
-  const r = await call('getArtistInfo2', { id, count });
+  const r = await call('getArtistInfo2', { id, count }, RETRY_FAST_TRANSPORT);
   return r.artistInfo2 || null;
 }
 
 // Last.fm "top songs" for an artist, intersected with the library. Keyed by
 // artist NAME, not id.
 export async function getTopSongs(artistName, { count = 10 } = {}) {
-  const r = await call('getTopSongs', { artist: artistName, count });
+  const r = await call('getTopSongs', { artist: artistName, count }, RETRY_FAST_TRANSPORT);
   return rejectArchive(r.topSongs?.song || []);
 }
 
@@ -561,24 +581,28 @@ export async function getRecentSongsByArtist(
 }
 
 export async function getAlbum(id) {
-  const r = await call('getAlbum', { id });
+  const r = await call('getAlbum', { id }, RETRY_FAST_TRANSPORT);
   return rejectArchive(r.album?.song || []);
 }
 
 // Single song lookup. The Child carries albumId, which is how manual album
 // tagging resolves a whole album from one track id.
 export async function getSong(id) {
-  const r = await call('getSong', { id });
+  const r = await call('getSong', { id }, RETRY_FAST_TRANSPORT);
   return r.song || null;
 }
 
 export async function getArtist(id) {
-  const r = await call('getArtist', { id });
+  const r = await call('getArtist', { id }, RETRY_FAST_TRANSPORT);
   return r.artist || null;
 }
 
 export async function searchArtists(query, { artistCount = 5 } = {}) {
-  const r = await call('search3', { query, artistCount, albumCount: 0, songCount: 0 });
+  const r = await call(
+    'search3',
+    { query, artistCount, albumCount: 0, songCount: 0 },
+    RETRY_FAST_TRANSPORT,
+  );
   return r.searchResult3?.artist || [];
 }
 
@@ -603,7 +627,7 @@ export async function getArtistLastfmTags(id, { count = 20 } = {}) {
 // response shapes normalise to a string.
 export async function getLyrics(songId) {
   try {
-    const r = await call('getLyricsBySongId', { id: songId });
+    const r = await call('getLyricsBySongId', { id: songId }, RETRY_FAST_TRANSPORT);
     // Modern: { lyricsList: { structuredLyrics: [{ line: [{ value }] }] } }
     const structured = r.lyricsList?.structuredLyrics;
     if (Array.isArray(structured) && structured.length) {
@@ -633,7 +657,7 @@ export async function getStructuredLyrics(
   songId,
 ): Promise<{ synced: boolean; lines: Array<{ startMs: number; text: string }> } | null> {
   try {
-    const r = await call('getLyricsBySongId', { id: songId });
+    const r = await call('getLyricsBySongId', { id: songId }, RETRY_FAST_TRANSPORT);
     const structured = r.lyricsList?.structuredLyrics;
     if (!Array.isArray(structured) || structured.length === 0) return null;
     // Several versions may exist (languages, synced + unsynced); only a synced
@@ -672,7 +696,7 @@ export async function* iterateAllSongs() {
     if (albums.length === 0) break;
     for (const album of albums) {
       try {
-        const r = await call('getAlbum', { id: album.id });
+        const r = await call('getAlbum', { id: album.id }, RETRY_FAST_TRANSPORT);
         const isCompilation = typeof r.album?.isCompilation === 'boolean' ? r.album.isCompilation : null;
         const ord = r.album?.originalReleaseDate?.year;
         const originalYear = Number.isFinite(ord) && ord > 0 ? ord : null;
@@ -709,12 +733,12 @@ export async function* iterateAllSongs() {
 }
 
 export async function getPlaylists() {
-  const r = await call('getPlaylists');
+  const r = await call('getPlaylists', {}, RETRY_FAST_TRANSPORT);
   return r.playlists?.playlist || [];
 }
 
 export async function getPlaylist(id) {
-  const r = await call('getPlaylist', { id });
+  const r = await call('getPlaylist', { id }, RETRY_FAST_TRANSPORT);
   return rejectArchive(r.playlist?.entry || []);
 }
 

--- a/controller/src/music/subsonic.ts
+++ b/controller/src/music/subsonic.ts
@@ -79,22 +79,60 @@ function extractCount(sub, songs) {
   return 0;
 }
 
-async function call(endpoint, params = {}) {
-  const started = Date.now();
-  try {
-    const url = buildUrl(endpoint, params);
-    // Bounded fetch: a hung Navidrome must not pin the admin routes behind it (#786).
-    let res;
+// A pooled keep-alive socket Navidrome has already closed fails the next request
+// on it instantly, before a byte is written, and undici reports the bare
+// `fetch failed`. ping() and pingWith() each already worked around it; this is
+// the same rule at the one chokepoint every call goes through, so a walk of
+// thousands of albums no longer dies on the first idle socket. Bounded to a FAST
+// failure, which is what says the request never landed — a slow one may have been
+// served, and mutations ride this path too.
+const STALE_SOCKET_RETRY_MS = 2_000;
+const STALE_SOCKET_BACKOFF_MS = 250;
+
+// undici collapses every connect/socket error into `TypeError: fetch failed`, so
+// name the endpoint, the origin and the underlying code. Never the URL — it
+// carries the auth token.
+function describeTransportError(endpoint: string, err: any): Error {
+  const cause = err?.cause;
+  const code = cause?.code || cause?.errno || null;
+  const detail = cause?.message && cause.message !== err?.message ? cause.message : null;
+  let origin = config.navidrome.url;
+  try { origin = new URL(config.navidrome.url).origin; } catch { /* keep as configured */ }
+  return new Error(
+    `Subsonic ${endpoint} could not reach ${origin}: ${err?.message || 'fetch failed'}`
+    + `${code ? ` (${code})` : ''}${detail ? ` — ${detail}` : ''}`,
+  );
+}
+
+// Bounded fetch: a hung Navidrome must not pin the admin routes behind it (#786).
+async function boundedFetch(endpoint: string, url: string) {
+  for (let attempt = 0; ; attempt++) {
+    const started = Date.now();
     try {
-      res = await fetch(url, { signal: AbortSignal.timeout(config.navidrome.timeoutMs) });
-    } catch (err) {
+      return await fetch(url, { signal: AbortSignal.timeout(config.navidrome.timeoutMs) });
+    } catch (err: any) {
       if (err?.name === 'TimeoutError' || err?.name === 'AbortError') {
         throw new Error(
           `Subsonic ${endpoint} timed out after ${config.navidrome.timeoutMs}ms — is Navidrome responding?`,
         );
       }
-      throw err;
+      if (attempt === 0 && Date.now() - started < STALE_SOCKET_RETRY_MS) {
+        console.warn(
+          `[subsonic] ${endpoint}: ${err?.message || err} — retrying once (stale pooled socket)`,
+        );
+        await new Promise(resolve => setTimeout(resolve, STALE_SOCKET_BACKOFF_MS));
+        continue;
+      }
+      throw describeTransportError(endpoint, err);
     }
+  }
+}
+
+async function call(endpoint, params = {}) {
+  const started = Date.now();
+  try {
+    const url = buildUrl(endpoint, params);
+    const res = await boundedFetch(endpoint, url);
     if (!res.ok) {
       // First 200 chars of the body, so triage sees the real server message.
       let body = '';
@@ -123,8 +161,9 @@ async function call(endpoint, params = {}) {
 }
 
 // Connectivity + auth check against config.navidrome. Never throws.
-// A failure that lands instantly gets ONE retry (stale pooled fetch socket);
-// a slow failure does not, since a second wait can't change the answer.
+// call() already retries a stale pooled socket; this outer retry covers the rest
+// of a fast failure (an instant HTTP error), and a slow one is not retried since
+// a second wait can't change the answer.
 const PING_RETRY_IF_FASTER_THAN_MS = 2_000;
 
 export async function ping(): Promise<{ ok: boolean; reason?: string }> {


### PR DESCRIPTION
Reported on Discord against 1.13:

> 1.13 - Re-Count not working. All I get is "Couldn't count the library: fetch failed — showing the previous count." Counting with just the "Start Tagging" seems to work fine though.

## What was happening

`fetch failed` is undici's opaque message for a transport-level failure — the request never got a reply. The controller passed that string straight through to `coverage.scanError`, so the operator saw it with no endpoint, no host and no errno to act on.

The count walks Navidrome through `subsonic.iterateAllSongs()`. A per-album `getAlbum` failure there is caught and skipped, but the `getAlbumList2` page fetch is not — one failure kills the whole scan, and `scanError` is what the panel renders.

The trigger is a failure mode this codebase had already diagnosed twice. On `ping()`:

> *A failure that lands instantly gets ONE retry (stale pooled fetch socket)*

and again on `pingWith()`: *"the aborted teardown of a stalled attempt is what un-wedges a stale socket pool."* A keep-alive socket Navidrome has already closed fails the next request on it instantly. Both connectivity probes worked around it; **every real call had no such tolerance.** Re-Count is the ideal way to hit it — pressed from an idle admin page, its very first request reuses a dead pooled socket and the walk dies on request one.

That is also why Start Tagging looked fine: the tagger walks Navidrome from a *separate child process* with a fresh connection pool, and the `coverage.refresh()` firing at its exit runs while that traffic is still warm, so nothing has gone idle.

## The change

The rule moves into `call()`, the one chokepoint every Subsonic request goes through, rather than becoming a third copy at a call site.

- **A transport failure that lands inside 2s is retried once.** Bounded to a *fast* failure deliberately: that is what says the request never landed. A slow one may already have been served, and scrobbles, stars and playlist writes ride the same path.
- **Transport errors are named.** `Subsonic getAlbumList2 could not reach http://navidrome:4533: fetch failed (UND_ERR_SOCKET) — other side closed` instead of `fetch failed`, so a socket error is distinguishable from an `EAI_AGAIN` DNS problem without guessing. Origin only, never the URL — it carries the salted auth token.
- `ping()` keeps its outer retry for a fast HTTP failure; its comment no longer claims to own the socket rule.

## Deliberately unchanged

- **A failed `getAlbum` is still skipped silently**, so a flaky Navidrome undercounts the total with no warning. Pre-existing, and it affects the tagger's walk identically — worth its own issue rather than being folded in here.
- **A sustained outage still aborts the whole scan** rather than recording a partial figure. That is correct: a truncated count published as `coverage.total` would poison every percentage on the panel.

## Tests

`controller/scripts/subsonic-stale-socket.test.ts` pins the three things that are easy to simplify back out:

1. a fast transport failure is retried once and the walk survives it;
2. a slow one is **not** retried;
3. the error an operator sees names the endpoint, the origin and the code, and never the token or password.

Plus the timeout path keeping its own message and not being retried.

Lint clean (`eslint . && tsc --noEmit`, 0 errors). Full controller suite: 1615 pass, 0 fail.
