### PR TITLE
fix(settings): return saved talk placement

### DIFF
--- a/controller/scripts/settings-talk-placement-route.test.ts
+++ b/controller/scripts/settings-talk-placement-route.test.ts
@@ -1,0 +1,69 @@
+// The authenticated GET /settings response contract for Talk placement (#1638).
+// Persistence and air-policy coverage live in talk-air.test.ts; this file pins
+// the read projection the admin form uses after save, on its poll, and on reload.
+//
+// Run: `npm test -- settings-talk-placement-route`.
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const stateRoot = mkdtempSync(path.join(tmpdir(), 'subwave-settings-talk-placement-'));
+process.env.STATE_DIR = stateRoot;
+process.env.ADMIN_USER = 'test-admin';
+process.env.ADMIN_PASS = 'test-pass';
+
+const express = (await import('express')).default;
+const settings = await import('../src/settings.js');
+const { router } = await import('../src/routes/settings/core.js');
+
+const app = express();
+app.use(express.json());
+app.use(router);
+const server = createServer(app);
+await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+server.unref();
+const base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+const authorization = `Basic ${Buffer.from('test-admin:test-pass').toString('base64')}`;
+
+async function getSettings() {
+  const res = await fetch(`${base}/settings`, { headers: { authorization } });
+  const body = await res.json() as {
+    values?: {
+      djTalkOnlyBetweenTracks?: boolean;
+      tts?: Record<string, unknown> & { defaultEngine?: string };
+    };
+  };
+  assert.equal(res.status, 200, JSON.stringify(body));
+  assert.ok(body.values);
+  assert.ok(body.values.tts);
+  return body.values;
+}
+
+test('GET /settings returns false for the default Talk placement', async () => {
+  await settings.load();
+  const values = await getSettings();
+  assert.equal(values.djTalkOnlyBetweenTracks, false);
+});
+
+test('GET /settings returns saved Talk placement without changing Voice engine', async () => {
+  const defaultEngine = settings.get().tts.defaultEngine;
+  await settings.update({ djTalkOnlyBetweenTracks: true } as never);
+
+  const values = await getSettings();
+  assert.equal(values.djTalkOnlyBetweenTracks, true);
+  assert.equal(values.tts!.defaultEngine, defaultEngine);
+  assert.equal('djTalkOnlyBetweenTracks' in values.tts!, false, 'Talk placement stays a top-level value');
+
+  await settings.update({ djTalkOnlyBetweenTracks: false } as never);
+  assert.equal((await getSettings()).djTalkOnlyBetweenTracks, false);
+});
+
+test.after(async () => {
+  await new Promise<void>(resolve => server.close(() => resolve()));
+  rmSync(stateRoot, { recursive: true, force: true });
+});

--- a/controller/src/routes/settings/core.ts
+++ b/controller/src/routes/settings/core.ts
@@ -122,6 +122,7 @@ router.get('/settings', requireAdmin, async (req, res) => {
         activePersonaId: s.activePersonaId,
         shows: s.shows,
         schedule: s.schedule,
+        djTalkOnlyBetweenTracks: s.djTalkOnlyBetweenTracks,
         tts: s.tts,
         llm: s.llm,
         search: s.search,


### PR DESCRIPTION
## Problem

Talk Placement was saved as `djTalkOnlyBetweenTracks`, but `GET /settings` did not return that value. After the settings screen refetched or polled, it fell back to “Any Time” and could leave the Voice Engine section marked unsaved.

## Change

- Return `djTalkOnlyBetweenTracks` as an explicit top-level member of the authenticated settings response.
- Add a route regression test for the default value, true/false save-and-read round trips, top-level response placement, and unchanged TTS default engine.

The response remains an explicit allowlist. No TTS form, persistence, broadcast-policy, schema, dependency, or generated-file changes were made.

## Acceptance criteria

- [x] `GET /settings` returns `values.djTalkOnlyBetweenTracks` from normalized settings.
- [x] A saved true value survives the client’s authoritative refetch and polling path, and false reads back as false.
- [x] Changing Talk Placement does not change `tts.defaultEngine`; the shared TTS dirty state clears after the successful refetch.
- [x] Missing or old data still resolves to false, which renders as “Any Time.”
- [x] Controller and web lint/typechecks pass, with no generated artifact changes.

## Verification

- `cd controller && npm test -- settings-talk-placement-route` passed, 2 tests.
- `cd controller && npm test -- talk-air` passed, 4 tests.
- `cd controller && npm run lint` passed, with 708 existing warnings.
- `cd web && npm run lint` passed, with 5 existing warnings.
- `cd controller && npm test` passed on rerun, 1,612 tests.
- Schema and theme generation drift checks passed.
- `git diff --check` passed.
- An authenticated API round trip confirmed true and false persistence, top-level response placement, and an unchanged Piper engine. The implementer also completed a browser flow through save, poll, and reload. The reviewer could not reach Settings in a fresh local controller because it redirected to Navidrome onboarding.

## Review

Approved. The reviewer found the two-file diff matches the agreed scope and the endpoint regression fails on the base behavior.

Closes #1638