### PR TITLE
fix(web): hide alpha DJ Brain settings behind runtime flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,8 @@ SITE_URL=
 # TZ=Europe/London
 
 # Web
+# SUBWAVE_DJ_BRAIN_ENABLED=false   # true reveals the alpha DJ Brain admin settings
+#                                  # Runtime flag; recreate the web container after changing.
 # SUBWAVE_HOMEPAGE=player          # or 'landing' for the marketing host
 # SUBWAVE_INDEX_ALL=1              # index the shared docs/news/catalog pages on
 #                                  # THIS domain too; default points their

--- a/cli/src/assets.generated.ts
+++ b/cli/src/assets.generated.ts
@@ -210,6 +210,7 @@ services:
     environment:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=\${SUBWAVE_HOMEPAGE:-player}
+      - SUBWAVE_DJ_BRAIN_ENABLED=\${SUBWAVE_DJ_BRAIN_ENABLED:-false}
       # RUNTIME source of truth for absolute URLs (canonicals, og:url,
       # robots.txt, sitemap.xml) — the generic image serves any domain.
       - SITE_URL=\${SITE_URL:-}
@@ -550,6 +551,7 @@ services:
     environment:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=\${SUBWAVE_HOMEPAGE:-player}
+      - SUBWAVE_DJ_BRAIN_ENABLED=\${SUBWAVE_DJ_BRAIN_ENABLED:-false}
       - SITE_URL=\${SITE_URL:-}
       # Set to 1 to keep the shared product pages (landing, docs, news,
       # catalogs) self-canonical + in this install's sitemap instead of
@@ -1086,6 +1088,8 @@ SITE_URL=
 # TZ=Europe/London
 
 # Web
+# SUBWAVE_DJ_BRAIN_ENABLED=false   # true reveals the alpha DJ Brain admin settings
+#                                  # Runtime flag; recreate the web container after changing.
 # SUBWAVE_HOMEPAGE=player          # or 'landing' for the marketing host
 # SUBWAVE_INDEX_ALL=1              # index the shared docs/news/catalog pages on
 #                                  # THIS domain too; default points their

--- a/docker-compose.byo.yml
+++ b/docker-compose.byo.yml
@@ -181,6 +181,7 @@ services:
     environment:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=${SUBWAVE_HOMEPAGE:-player}
+      - SUBWAVE_DJ_BRAIN_ENABLED=${SUBWAVE_DJ_BRAIN_ENABLED:-false}
       - SITE_URL=${SITE_URL:-}
       # Set to 1 to keep the shared product pages (landing, docs, news,
       # catalogs) self-canonical + in this install's sitemap instead of

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,6 +201,7 @@ services:
     environment:
       - NODE_ENV=production
       - SUBWAVE_HOMEPAGE=${SUBWAVE_HOMEPAGE:-player}
+      - SUBWAVE_DJ_BRAIN_ENABLED=${SUBWAVE_DJ_BRAIN_ENABLED:-false}
       # RUNTIME source of truth for absolute URLs (canonicals, og:url,
       # robots.txt, sitemap.xml) — the generic image serves any domain.
       - SITE_URL=${SITE_URL:-}

--- a/web/app/admin/settings/page.tsx
+++ b/web/app/admin/settings/page.tsx
@@ -1,10 +1,13 @@
 import type { Metadata } from 'next';
 import SettingsPanel from '../../../components/admin/SettingsPanel';
 
+// Resolve the alpha opt-in at runtime, including in prebuilt Docker images.
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: 'Settings',
 };
 
 export default function AdminSettingsPage() {
-  return <SettingsPanel />;
+  return <SettingsPanel djBrainEnabled={process.env.SUBWAVE_DJ_BRAIN_ENABLED === 'true'} />;
 }

--- a/web/components/admin/SettingsPanel.tsx
+++ b/web/components/admin/SettingsPanel.tsx
@@ -252,7 +252,11 @@ function rebaselineSavedPatch(
   return next;
 }
 
-export default function SettingsPanel() {
+export default function SettingsPanel({ djBrainEnabled = false }: { djBrainEnabled?: boolean }) {
+  const sections = useMemo(
+    () => SECTIONS.filter(s => s.id !== 'brain' || djBrainEnabled),
+    [djBrainEnabled],
+  );
   const { adminFetch, needsAuth, hydrated } = useAdminAuth();
   const settingsQuery = useSettingsQuery<SettingsData>({
     adminFetch,
@@ -297,8 +301,12 @@ export default function SettingsPanel() {
       router.replace(`/admin/imaging?tab=${s}`);
       return;
     }
-    if (s && SECTIONS.some(x => x.id === s)) setActiveSection(s as SectionId);
-  }, [router, searchParams]);
+    if (s === 'brain' && !djBrainEnabled) {
+      setActiveSection('station');
+      return;
+    }
+    if (s && sections.some(x => x.id === s)) setActiveSection(s as SectionId);
+  }, [router, searchParams, sections, djBrainEnabled]);
 
   useEffect(() => {
     if (!data?.values) return;
@@ -751,6 +759,7 @@ export default function SettingsPanel() {
 
   /** Search result → switch section, open Advanced if needed, scroll and flash. */
   const jumpTo = useCallback(({ section, anchor, advanced }: SettingsJump) => {
+    if (!sections.some(s => s.id === section)) return;
     setActiveSection(section);
     if (advanced) setAdvOpen(prev => ({ ...prev, [section]: true }));
     // The section swap and the disclosure both have to commit first.
@@ -766,7 +775,7 @@ export default function SettingsPanel() {
       window.setTimeout(() => el.removeAttribute('data-flash'), 2600);
     };
     window.requestAnimationFrame(settle);
-  }, []);
+  }, [sections]);
 
   const chrome = useMemo(() => ({
     saveSlot,
@@ -782,7 +791,7 @@ export default function SettingsPanel() {
         {SECTION_GROUPS.map(group => (
           <div key={group} className="grid gap-1">
             <span className="caption pb-1">{group}</span>
-            {SECTIONS.filter(s => s.group === group).map(s => {
+            {sections.filter(s => s.group === group).map(s => {
               const isActive = activeSection === s.id;
               const Icon = s.icon;
               // A section not on screen can only be dirty in form paths.
@@ -821,7 +830,7 @@ export default function SettingsPanel() {
       </aside>
 
       <div className="grid gap-4">
-        <SettingsSearch onJump={jumpTo} />
+        <SettingsSearch onJump={jumpTo} sections={sections} />
         {err && <ErrorState error={err} onRetry={refresh} />}
         {pendingRestart && (
           <div
@@ -881,7 +890,7 @@ export default function SettingsPanel() {
                 saveSettings={saveSettings} fieldErrors={fieldErrors} adminFetch={adminFetch} refresh={refresh}
               />
             )}
-            {activeSection === 'brain' && (
+            {djBrainEnabled && activeSection === 'brain' && (
               <BrainSection
                 data={data} form={form} setForm={updateForm} busy={busy}
                 saveSettings={saveSettings} fieldErrors={fieldErrors} adminFetch={adminFetch} refresh={refresh}

--- a/web/components/admin/settings/SettingsSearch.tsx
+++ b/web/components/admin/settings/SettingsSearch.tsx
@@ -11,7 +11,7 @@ import {
 import { Kbd } from '../../ui/kbd';
 import { Pill } from '../ui';
 import {
-  SETTINGS_INDEX, sectionById, isAdvancedCard, type SectionId,
+  SETTINGS_INDEX, sectionById, isAdvancedCard, type SectionId, type SectionSpec,
 } from './registry';
 import { cardAnchor } from '../ui';
 
@@ -24,6 +24,7 @@ export interface SettingsJump {
 }
 
 interface SettingsSearchProps {
+  sections: readonly SectionSpec[];
   onJump: (jump: SettingsJump) => void;
 }
 
@@ -52,7 +53,7 @@ function isOverlayOpen(): boolean {
   ].join(','));
 }
 
-export function SettingsSearch({ onJump }: SettingsSearchProps) {
+export function SettingsSearch({ onJump, sections }: SettingsSearchProps) {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -107,6 +108,7 @@ export function SettingsSearch({ onJump }: SettingsSearchProps) {
         <CommandList>
           <CommandEmpty>No matching settings.</CommandEmpty>
           {SETTINGS_INDEX.map((entry, index) => {
+            if (!sections.some(s => s.id === entry.section)) return null;
             const section = sectionById(entry.section);
             const anchor = cardAnchor(entry.card);
             return (


### PR DESCRIPTION
## What
Hide the DJ Brain section in admin settings by default. Set `SUBWAVE_DJ_BRAIN_ENABLED=true` to reveal it; navigation, search, and direct section links all respect the flag.

## Why
DJ Brain is still in alpha and should require an explicit operator opt-in.

## How tested
- `cd web && npm run lint` passed (ESLint and TypeScript), with five existing warnings in unrelated files.
- `git diff --check` passed.
- Browser behavior was not exercised.

## Notes for reviewers
The server reads the flag at request time. Both production Compose variants pass it to the web service, and `.env.example` documents it. After deploying this change, changing the flag requires recreating the web container, with no image rebuild. This gates the admin settings UI only; existing provider configuration and the onboarding preset are unchanged.
