### PR TITLE
fix(analyzer): degrade gracefully when beat tracking fails

### DIFF
--- a/controller/scripts/analyze_worker.py
+++ b/controller/scripts/analyze_worker.py
@@ -1913,8 +1913,14 @@ def analyze(
     if y is None or len(y) == 0:
         raise RuntimeError("decoded empty audio")
 
-    tempo, beat_frames = librosa.beat.beat_track(y=y, sr=sr)
-    bpm = float(np.atleast_1d(tempo)[0])
+    bpm = None
+    beat_frames = []
+    try:
+        tempo, tracked_frames = librosa.beat.beat_track(y=y, sr=sr)
+        bpm = float(np.atleast_1d(tempo)[0])
+        beat_frames = tracked_frames
+    except Exception as e:  # noqa: BLE001 — tempo/grid are garnish, never a gate
+        log(f"main beat tracking failed: {e}")
 
     # Per-beat timestamps (ms) — already computed by beat_track, previously
     # discarded. Downbeats are a 4/4 heuristic (every 4th beat from the first):
@@ -1969,10 +1975,13 @@ def analyze(
 
     # Overall confidence: dominated by how cleanly the key resolved, nudged by
     # whether we got a plausible tempo. Kept conservative on purpose.
-    confidence = round(0.5 * key_sep + (0.5 if 40 <= bpm <= 220 else 0.0), 3)
+    confidence = round(
+        0.5 * key_sep + (0.5 if bpm is not None and 40 <= bpm <= 220 else 0.0),
+        3,
+    )
 
     result = {
-        "bpm": round(bpm, 1),
+        "bpm": round(bpm, 1) if bpm is not None else None,
         "key": key,
         "intro_ms": int(intro_ms) if intro_ms is not None else None,
         "confidence": confidence,

--- a/controller/scripts/analyzer-python.test.ts
+++ b/controller/scripts/analyzer-python.test.ts
@@ -2,7 +2,7 @@
 // auto-discovery, so they actually run with the rest of the suite instead of
 // only when someone remembers `python3 scripts/<file>.py`. Each suite is
 // lightweight and isolated from the analyzer runtime (no torch / demucs /
-// librosa / audio). Two numerical suites use NumPy; when it is unavailable,
+// librosa / audio). Three numerical suites use NumPy; when it is unavailable,
 // this shim installs the pinned test-only wheel into a temporary directory, so
 // a clean checkout's `npm test` is reproducible without modifying the user's
 // Python environment. A box without python3 still skips cleanly (exit 0).
@@ -24,6 +24,7 @@ const SUITES = [
   'tts_heavy_idle_test.py', // tts-heavy idle unload + cold-engine health (#1579)
   'analyzer_noise_test.py', // decode-noise filter + capability loss (#1300)
   'analyzer_silence_test.py', // edge dead-air measurement (silence trim)
+  'analyzer_beat_test.py', // main beat tracking is best-effort (#1647)
 ];
 
 const probe = spawnSync('python3', ['--version'], { stdio: 'ignore' });

--- a/controller/scripts/analyzer_beat_test.py
+++ b/controller/scripts/analyzer_beat_test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# Regression test for main/head beat tracking graceful degradation (#1647).
+# Run: `python3 scripts/analyzer_beat_test.py` (exit 0 = pass), and via
+# scripts/analyzer-python.test.ts as part of `npm test`.
+#
+# NumPy is the only dependency. The worker's remaining audio/model boundaries
+# are deterministic fakes so this drives real analyze() orchestration without
+# librosa, torch, model weights, audio files, or network access.
+
+import math
+import os
+import sys
+
+try:
+    import numpy as np
+except ImportError:
+    print("FAIL: numpy is required for this suite (pip install numpy)")
+    sys.exit(1)
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import analyze_worker as aw  # noqa: E402
+
+failures = 0
+
+
+def test(name, fn):
+    global failures
+    try:
+        fn()
+        print(f"  ✓ {name}")
+    except Exception as err:  # noqa: BLE001 — a failed assert is a reported case
+        failures += 1
+        print(f"  ✗ {name}\n      {err}")
+
+
+class _FailingBeat:
+    @staticmethod
+    def beat_track(*_args, **_kwargs):
+        raise ZeroDivisionError("float division by zero")
+
+
+class _SuccessfulBeat:
+    @staticmethod
+    def beat_track(*_args, **_kwargs):
+        return np.array([123.456]), np.array([0, 1, 2, 3, 4])
+
+
+class _Feature:
+    @staticmethod
+    def chroma_cqt(*_args, **_kwargs):
+        return np.zeros((12, 4), dtype=np.float32)
+
+
+class _FakeLibrosa:
+    feature = _Feature()
+
+    def __init__(self, beat):
+        self.beat = beat
+
+    @staticmethod
+    def get_duration(**_kwargs):
+        return 30.0
+
+    @staticmethod
+    def to_mono(y):
+        return y
+
+    @staticmethod
+    def frames_to_time(frames, **_kwargs):
+        return np.asarray(frames, dtype=np.float64) * 0.5
+
+
+def _analyze(beat):
+    y = np.ones(4096, dtype=np.float32)
+    logs = []
+    originals = {
+        "ensure_fast_decode": aw.ensure_fast_decode,
+        "load_audio": aw.load_audio,
+        "estimate_key": aw.estimate_key,
+        "estimate_key_ranges": aw.estimate_key_ranges,
+        "estimate_intro_ms": aw.estimate_intro_ms,
+        "silence_edges_ms": aw.silence_edges_ms,
+        "estimate_sections": aw.estimate_sections,
+        "estimate_pace": aw.estimate_pace,
+        "measure_loudness": aw.measure_loudness,
+        "log": aw.log,
+    }
+    try:
+        aw.ensure_fast_decode = lambda path: (path, None)
+        aw.load_audio = lambda *_args, **_kwargs: (y, aw.ANALYZE_SR)
+        aw.estimate_key = lambda _chroma: ("8A", 0.6)
+        aw.estimate_key_ranges = lambda *_args, **_kwargs: []
+        aw.estimate_intro_ms = lambda *_args, **_kwargs: 4321.0
+        aw.silence_edges_ms = lambda *_args, **_kwargs: (0.0, 0.0, 0.0)
+        aw.estimate_sections = lambda *_args, **_kwargs: [{"startMs": 0, "label": "intro"}]
+        aw.estimate_pace = lambda *_args, **_kwargs: [{"atMs": 0, "value": 0.4}]
+        aw.measure_loudness = lambda *_args, **_kwargs: (-9.5, -0.1)
+        aw.log = logs.append
+
+        result = aw.analyze(
+            _FakeLibrosa(beat), path="clipped-live-recording.wav", embed=False,
+            vocal=False, complete=False,
+        )
+        return result, logs
+    finally:
+        for name, value in originals.items():
+            setattr(aw, name, value)
+
+
+def t_main_beat_failure_keeps_independent_analysis():
+    result, logs = _analyze(_FailingBeat())
+
+    assert result["bpm"] is None, result
+    assert "beats" not in result, result
+    assert "bars" not in result, result
+    assert result["key"] == "8A", result
+    assert result["intro_ms"] == 4321, result
+    assert result["sections"] == [{"startMs": 0, "label": "intro"}], result
+    assert result["pace_curve"] == [{"atMs": 0, "value": 0.4}], result
+    assert result["loudness_lufs"] == -9.5, result
+    assert math.isfinite(result["confidence"]), result
+    assert result["confidence"] == 0.3, "unknown BPM must not receive the tempo confidence bonus"
+    assert any("float division by zero" in line for line in logs), logs
+
+
+def t_main_beat_success_keeps_numeric_bpm_and_grid():
+    result, logs = _analyze(_SuccessfulBeat())
+
+    assert result["bpm"] == 123.5, result
+    assert result["beats"] == [0, 500, 1000, 1500, 2000], result
+    assert result["bars"] == [0, 2000], result
+    assert result["confidence"] == 0.8, result
+    assert not logs, logs
+
+
+print("main beat tracking")
+test("a beat tracker exception keeps the rest of analysis", t_main_beat_failure_keeps_independent_analysis)
+test("a successful beat tracker keeps numeric BPM and grids", t_main_beat_success_keeps_numeric_bpm_and_grid)
+
+if failures:
+    print(f"✗ analyzer_beat_test.py: {failures} failure(s)")
+    sys.exit(1)
+print("✓ analyzer_beat_test.py passed")


### PR DESCRIPTION
## Problem

`librosa.beat.beat_track()` could raise `ZeroDivisionError` during main audio analysis. That error escaped the worker, returned a 500, and left the affected track unable to finish analysis.

## Change

- Catch ordinary exceptions around the main beat-tracking call and its tempo conversion.
- Continue the analysis with `bpm: null` and no beat or bar grid when tempo detection fails.
- Keep confidence calculation and response serialization safe when BPM is absent.
- Add and register a deterministic Python regression that injects `ZeroDivisionError("float division by zero")`, plus coverage for the unchanged successful path.

The scope stays within the analyzer. Retry rules, persistence, coverage metrics, and the worker protocol are unchanged.

## Acceptance criteria

- [x] A beat-tracker exception does not fail `analyze()` or produce an error worker response.
- [x] Failed beat tracking returns a successful result with `bpm: null`.
- [x] Failed beat tracking emits no fabricated `beats` or `bars`.
- [x] Independent outputs such as key and intro remain available, without a BPM confidence contribution.
- [x] Successful beat tracking retains numeric, one-decimal BPM and existing grids.
- [x] The regression is registered in the analyzer Python test shim.

Independent review approved all criteria.

## Verification

- `cd controller && npm test -- analyzer-python` passed.
- `cd controller && npm test` passed: 1610 tests passed, 0 failed, 0 skipped.
- `cd controller && npm run lint` passed with 0 errors. It reports 708 existing `no-explicit-any` warnings.
- `python3 -m py_compile controller/scripts/analyze_worker.py controller/scripts/analyzer_beat_test.py` passed.
- `git diff --check` passed.

The reporter audio file was unavailable, so the regression injects the reported error at the production `analyze()` orchestration seam. It failed on `develop` before the fix and passed on this branch.

Closes #1647