### PR TITLE
fix(dj): close follow-up link safety gaps

### DIFF
--- a/controller/scripts/announce-fallback.test.ts
+++ b/controller/scripts/announce-fallback.test.ts
@@ -1,0 +1,100 @@
+// Regression coverage for the announce-only writer fallback.
+// The only mocked component is the external OpenAI-compatible HTTP boundary;
+// generateLink, provider selection, prompt composition and sampling all run.
+// Run: npm test -- announce-fallback
+
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test, { after } from 'node:test';
+
+process.env.STATE_DIR = mkdtempSync(join(tmpdir(), 'subwave-announce-fallback-'));
+
+const settings = await import('../src/settings.js');
+const { generateLink } = await import('../src/llm/internal/prompts/scripts.js');
+
+await settings.update({
+  llm: {
+    provider: 'openai-compatible',
+    model: 'fixture-model',
+    baseUrl: 'http://127.0.0.1:9/v1',
+    pickerAgent: false,
+    fallback: { enabled: false },
+  },
+});
+
+interface WireRequest {
+  messages?: unknown[];
+  temperature?: unknown;
+}
+
+const realFetch = globalThis.fetch;
+const requests: WireRequest[] = [];
+globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+  requests.push(JSON.parse(String(init?.body || '{}')) as WireRequest);
+  return new Response(JSON.stringify({
+    id: 'chatcmpl-fixture',
+    object: 'chat.completion',
+    created: 1,
+    model: 'fixture-model',
+    choices: [{
+      index: 0,
+      message: { role: 'assistant', content: 'A longer editorial link from the fixture model.' },
+      finish_reason: 'stop',
+    }],
+    usage: { prompt_tokens: 10, completion_tokens: 8, total_tokens: 18 },
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+}) as typeof fetch;
+
+after(() => {
+  globalThis.fetch = realFetch;
+});
+
+function lastWireRequest(): WireRequest {
+  assert.ok(requests.length > 0, 'the writer must reach the configured model boundary');
+  return requests.at(-1)!;
+}
+
+function assertAnnounceOnlyContract(request: WireRequest) {
+  const wire = JSON.stringify(request.messages ?? []);
+  assert.match(wire, /This is/);
+  assert.match(wire, /Next up/);
+  assert.doesNotMatch(wire, /Give a brief spoken introduction/,
+    'announce-only fallback must not silently use the natural editorial-link task');
+  assert.equal(request.temperature, 0.2, 'translation/romanisation is a low-variance task');
+}
+
+test('non-English announce fallback sends a constrained announce-only translation task', async () => {
+  requests.length = 0;
+  await generateLink({
+    previous: null,
+    current: { title: 'Dönence', artist: 'Barış Manço' },
+    context: {},
+    persona: {
+      name: 'Deniz',
+      soul: 'warm and direct',
+      language: 'Turkish',
+      linkStyle: 'announce',
+      scriptLength: 'concise',
+    },
+  });
+  assertAnnounceOnlyContract(lastWireRequest());
+});
+
+test('CJK announce fallback sends a constrained announce-only romanisation task', async () => {
+  requests.length = 0;
+  await generateLink({
+    previous: null,
+    current: { title: '稲妻', artist: 'ウルフルズ' },
+    context: {},
+    persona: {
+      name: 'Nova',
+      soul: 'warm and direct',
+      language: 'English',
+      linkStyle: 'announce',
+      scriptLength: 'concise',
+    },
+  });
+  assertAnnounceOnlyContract(lastWireRequest());
+});

--- a/controller/scripts/clock-policy-wiring.test.ts
+++ b/controller/scripts/clock-policy-wiring.test.ts
@@ -1,0 +1,169 @@
+// Regression coverage for pool/handover clock-policy wiring.
+// Runs the exported track-event entrypoint through the real pool picker, real
+// temporary library DB, real isolated link writer and real provider adapter.
+// Only external Navidrome/model HTTP is faked; no station or paid API is used.
+// Run: npm test -- clock-policy-wiring
+
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test, { after } from 'node:test';
+
+process.env.STATE_DIR = mkdtempSync(join(tmpdir(), 'subwave-clock-policy-wiring-'));
+
+const settings = await import('../src/settings.js');
+const library = await import('../src/music/library.js');
+const session = await import('../src/broadcast/session.js');
+const { showHandoverContext } = await import('../src/context.js');
+const { runTrackEvent } = await import('../src/broadcast/dj-agent.js');
+
+await settings.update({
+  djSpeakClock: false,
+  llm: {
+    provider: 'openai-compatible',
+    model: 'fixture-model',
+    baseUrl: 'http://127.0.0.1:9/v1',
+    pickerAgent: false,
+    fallback: { enabled: false },
+  },
+});
+
+await library.load();
+for (let i = 1; i <= 3; i++) {
+  library.set(`candidate-${i}`, {
+    title: `Candidate ${i}`,
+    artist: `Fixture Artist ${i}`,
+    album: `Fixture Album ${i}`,
+    duration: 240,
+    moods: ['calm'],
+    energy: 'medium',
+  });
+}
+
+interface ModelRequest {
+  tools?: unknown[];
+  messages?: unknown[];
+}
+
+const realFetch = globalThis.fetch;
+const modelRequests: ModelRequest[] = [];
+globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  if (!url.startsWith('http://127.0.0.1:9/')) {
+    return new Response(JSON.stringify({ error: 'isolated Navidrome fixture is offline' }), {
+      status: 503,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  const body = JSON.parse(String(init?.body || '{}')) as ModelRequest;
+  modelRequests.push(body);
+  const toolCall = Array.isArray(body.tools) && body.tools.length > 0;
+  const message = toolCall
+    ? {
+        role: 'assistant',
+        content: null,
+        tool_calls: [{
+          id: 'call_fixture_pick',
+          type: 'function',
+          function: {
+            name: 'emit',
+            arguments: JSON.stringify({ id: 'candidate-1', reason: 'fixture pool pick' }),
+          },
+        }],
+      }
+    : { role: 'assistant', content: 'A deterministic fixture link without a spoken time.' };
+  return new Response(JSON.stringify({
+    id: `chatcmpl-${modelRequests.length}`,
+    object: 'chat.completion',
+    created: 1,
+    model: 'fixture-model',
+    choices: [{ index: 0, message, finish_reason: toolCall ? 'tool_calls' : 'stop' }],
+    usage: { prompt_tokens: 10, completion_tokens: 8, total_tokens: 18 },
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+}) as typeof fetch;
+
+after(() => {
+  globalThis.fetch = realFetch;
+  library.shutdown();
+});
+
+const now = new Date();
+const boundary = new Date(now.getTime() + 10 * 60_000);
+const currentShow = {
+  id: 'show-current',
+  name: 'The Scenic Route',
+  persona: { name: 'Marlowe' },
+  moods: [], genres: [], eras: [], energies: [], vocals: '',
+  playlistIds: [], excludedPlaylistIds: [],
+};
+const nextShow = {
+  id: 'show-next',
+  name: 'Lunchtime Rocks',
+  persona: { name: 'Wren' },
+  moods: [], genres: [], eras: [], energies: [], vocals: '',
+  playlistIds: [], excludedPlaylistIds: [],
+};
+const resolveShow = (at: Date) => at.getTime() < boundary.getTime() ? currentShow : nextShow;
+const handover = showHandoverContext(now, resolveShow, [boundary.getTime()]);
+assert.ok(handover, 'fixture must resolve an actual final-quarter handover fact');
+
+const queued: Array<Record<string, unknown>> = [];
+const logs: unknown[][] = [];
+const queue = {
+  current: { track: { title: 'On Air Now', artist: '' } },
+  history: [],
+  log: (...args: unknown[]) => logs.push(args),
+  recentlyPlayed: () => ({ ids: new Set<string>(), keys: new Set<string>() }),
+  recentlyPlayedByCount: () => ({ ids: new Set<string>(), keys: new Set<string>() }),
+  recentArtistsSince: () => new Set<string>(),
+  recentAlbumKeys: () => new Set<string>(),
+  recentTransitionChoices: () => [],
+  getDjRecap: () => null,
+  getRecentTracks: () => [],
+  getRecentOpeners: () => [],
+  getLastLinkText: () => null,
+  push: async (item: Record<string, unknown>) => {
+    queued.push(item);
+    return 0;
+  },
+};
+
+session.start({
+  at: now.toISOString(),
+  activeShow: null,
+  dominantMood: 'calm',
+  time: { period: 'daytime', vibe: 'steady' },
+} as Parameters<typeof session.start>[0]);
+
+await runTrackEvent(queue, {
+  at: now.toISOString(),
+  dominantMood: 'calm',
+  date: { iso: now.toISOString().slice(0, 10), dayLabel: 'Thursday' },
+  clock: { hhmm: '10:50', display: '10:50 am' },
+  time: { period: 'daytime', vibe: 'steady' },
+  activeShow: currentShow,
+  showHandover: handover,
+}, {
+  wantLink: true,
+  // linkAirDate subtracts the two-minute show-attribution pad; five minutes
+  // leaves a valid three-minute runway, above LINK_CLOCK_MIN_RUNWAY_SEC.
+  showAt: new Date(Date.now() + 5 * 60_000),
+});
+
+const linkRequest = modelRequests.find((body) => !Array.isArray(body.tools) || body.tools.length === 0);
+assert.ok(linkRequest, `expected picker + link model requests, got ${modelRequests.length}`);
+const linkWire = JSON.stringify(linkRequest.messages ?? []);
+
+test('the real pool path with clock speech disabled does not offer an approximate air time', () => {
+  assert.doesNotMatch(linkWire, /Approximate air time:/);
+  assert.equal(queued.length, 1, `expected one queued pick; logs=${JSON.stringify(logs)}`);
+  assert.equal(queued[0].linkClockAt, null,
+    'the existing drift stamp correctly records that clock speech was disabled');
+});
+
+test('the real pool handover packet keeps show identity but withholds its start time when clock speech is disabled', () => {
+  assert.match(linkWire, /Following show: \\"Lunchtime Rocks\\" with Wren/);
+  assert.doesNotMatch(linkWire, new RegExp(String(handover!.nextShow.startsAt).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+});

--- a/controller/scripts/speech-bracket-titles.test.ts
+++ b/controller/scripts/speech-bracket-titles.test.ts
@@ -1,0 +1,39 @@
+// Regression coverage for bracketed-title speech-cue sanitation.
+// Unknown bracketed text can be a real title: it must remain readable in the
+// booth log, while the speech form removes cue-shaped brackets but keeps words.
+// Run: npm test -- speech-bracket-titles
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { normalizeForDisplay, normalizeForSpeech } from '../src/audio/speech-text.js';
+
+const terminal = 'That was Sigur Rós with [Untitled].';
+const middle = 'From [Untitled], this is track two.';
+const numbered = 'From [Track 2], this is the closing movement.';
+const production = 'On this track [fade out] keep talking.';
+
+test('display sanitation preserves a terminal bracketed title', () => {
+  assert.equal(normalizeForDisplay(terminal), terminal);
+});
+
+test('speech sanitation preserves terminal bracketed-title words without a cue-shaped tag', () => {
+  assert.equal(normalizeForSpeech(terminal), 'That was Sigur Rós with Untitled.');
+});
+
+test('display sanitation preserves a mid-sentence bracketed title', () => {
+  assert.equal(normalizeForDisplay(middle), middle);
+});
+
+test('speech sanitation preserves mid-sentence bracketed-title words without a cue-shaped tag', () => {
+  assert.equal(normalizeForSpeech(middle), 'From Untitled, this is track two.');
+});
+
+test('an explicit numbered title remains literal despite containing the word track', () => {
+  assert.equal(normalizeForDisplay(numbered), numbered);
+  assert.equal(normalizeForSpeech(numbered), 'From Track 2, this is the closing movement.');
+});
+
+test('title-like sentence context never rescues a known production action', () => {
+  assert.equal(normalizeForDisplay(production), 'On this track keep talking.');
+  assert.equal(normalizeForSpeech(production), 'On this track keep talking.');
+});

--- a/controller/scripts/speech-text.test.ts
+++ b/controller/scripts/speech-text.test.ts
@@ -137,10 +137,10 @@ async function main() {
     assert.equal(normalizeForSpeech('[gentle fade] A quiet word.'), 'A quiet word.');
   });
   await test('preserves bracketed title and edition qualifiers as spoken text', () => {
-    assert.equal(normalizeForSpeech('That was Song Title [Live].'), 'That was Song Title [Live].');
-    assert.equal(normalizeForSpeech('Here is Album Cut [Deluxe].'), 'Here is Album Cut [Deluxe].');
+    assert.equal(normalizeForSpeech('That was Song Title [Live].'), 'That was Song Title Live.');
+    assert.equal(normalizeForSpeech('Here is Album Cut [Deluxe].'), 'Here is Album Cut Deluxe.');
     assert.equal(normalizeForSpeech('Next, Song Title [Remastered 2011].'),
-      'Next, Song Title [Remastered 2011].');
+      'Next, Song Title Remastered 2011.');
     assert.equal(normalizeForSpeech('[Live fade out] Keep talking.'), 'Keep talking.',
       'a title-like prefix must not override the production-direction blocklist');
   });

--- a/controller/scripts/verified-facts-history.test.ts
+++ b/controller/scripts/verified-facts-history.test.ts
@@ -1,0 +1,51 @@
+// Regression coverage for the Verified Facts play-history packet.
+// Uses the real library facade and a temporary SQLite plays table so the
+// prompt is checked against the same lifetime play-count projection used on air.
+// Run: npm test -- verified-facts-history
+
+import assert from 'node:assert/strict';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+process.env.STATE_DIR = mkdtempSync(join(tmpdir(), 'subwave-verified-facts-history-'));
+
+const library = await import('../src/music/library.js');
+const { linkPrompt } = await import('../src/llm/internal/prompts/scripts.js');
+
+test('Verified Facts labels the real lifetime play count truthfully when a prior play was today', async () => {
+  const track = { id: 'same-day-replay', title: 'Second Spin', artist: 'The Fixtures' };
+
+  await library.load();
+  library.set(track.id, track);
+  await library.recordPlay({
+    trackId: track.id,
+    title: track.title,
+    artist: track.artist,
+    album: null,
+    playedAt: '2026-09-09T18:00:00.000Z',
+    source: 'ai',
+    requestedBy: null,
+    showId: null,
+    showName: null,
+  });
+  await library.recordPlay({
+    trackId: track.id,
+    title: track.title,
+    artist: track.artist,
+    album: null,
+    playedAt: '2026-09-10T08:00:00.000Z',
+    source: 'request',
+    requestedBy: 'listener',
+    showId: null,
+    showName: null,
+  });
+
+  assert.equal(library.trackPlayStatsFor(track)?.count, 2, 'the production projection is lifetime plays');
+
+  const prompt = linkPrompt({ current: track, context: {} });
+  assert.match(prompt, /Lifetime station plays: 2\./,
+    'a lifetime count must not be described as plays before today');
+  assert.doesNotMatch(prompt, /Station plays before today:/);
+});

--- a/controller/scripts/verified-facts.test.ts
+++ b/controller/scripts/verified-facts.test.ts
@@ -14,7 +14,7 @@ const track = (over: Record<string, unknown> = {}) => ({
 });
 
 assert.deepEqual(sleeveNotesFor(track(), 3), [
-  'Album: After Laughter Comes Tears.', 'Release year: 1964.', 'Station plays before today: 3.',
+  'Album: After Laughter Comes Tears.', 'Release year: 1964.', 'Lifetime station plays: 3.',
 ]);
 assert.deepEqual(contextSleeveNotesFor(track(), {
   date: { season: 'summer' }, weather: { condition: 'cloudy', location: 'The Ribble Valley' },
@@ -28,7 +28,7 @@ assert.deepEqual(selectSleeveNotes(sleeveNotesFor(track(), 3)), [
   'Album: After Laughter Comes Tears.', 'Release year: 1964.',
 ]);
 assert.deepEqual(selectSleeveNotes(sleeveNotesFor(track(), 3), Math.random, false), [
-  'Album: After Laughter Comes Tears.', 'Station plays before today: 3.',
+  'Album: After Laughter Comes Tears.', 'Lifetime station plays: 3.',
 ]);
 
 const yearGateContext = { date: { iso: '2026-09-08' }, clock: { hhmm: '11:30' } };

--- a/controller/src/audio/speech-text.ts
+++ b/controller/src/audio/speech-text.ts
@@ -84,10 +84,13 @@ const DOLLAR_AMOUNT = '\\d[\\d,]*(?:\\.\\d+)?';
 const PERFORMANCE_CUE_RE = /\[[^\]\r\n]{1,80}\]/g;
 const SPOKEN_CHAR_RE = /[\p{L}\p{N}]/u;
 const PRODUCTION_CUE_RE = /\b(?:cue|square|stage|direction|fad(?:e|es|ed|ing)|music|track|vocals?|sounds?|intro(?:duction)?|outro|transition|paus(?:e|es|ed|ing)|riff(?:ing)?|build(?:ing|s)?|seconds?|\d+s)\b/i;
+const PRODUCTION_ACTION_RE = /\b(?:cue|stage|direction|fad(?:e|es|ed|ing)|intro(?:duction)?|outro|transition|paus(?:e|es|ed|ing)|riff(?:ing)?|build(?:ing|s)?|\d+s)\b/i;
 const TITLE_QUALIFIER_RE = /^(?:live\b.*|deluxe\b.*|remaster(?:ed)?\b.*|radio edit\b.*|single edit\b.*|album version\b.*|original version\b.*|mono\b.*|stereo\b.*|acoustic\b.*|demo\b.*|bonus track\b.*|anniversary\b.*|expanded edition\b.*)$/i;
+const BRACKETED_TITLE_RE = /^(?:untitled(?:\s+(?:track\s*)?(?:no\.?\s*)?#?\d+)?|track\s*(?:no\.?\s*)?#?\d+)$/i;
+const TITLE_CONTEXT_RE = /\b(?:from|with|called|titled|track|song|album|record|version|mix|cut)\s*$/i;
 
 function isTitleQualifier(body: string): boolean {
-  return TITLE_QUALIFIER_RE.test(body) && !PRODUCTION_CUE_RE.test(body);
+  return TITLE_QUALIFIER_RE.test(body) && !PRODUCTION_ACTION_RE.test(body);
 }
 
 function isPerformanceCue(body: string): boolean {
@@ -96,6 +99,17 @@ function isPerformanceCue(body: string): boolean {
     && !body.startsWith('-')
     && !/\d/.test(body)
     && !PRODUCTION_CUE_RE.test(body);
+}
+
+// Real catalogue titles include names such as "[Untitled]". Preserve that
+// known form, common edition qualifiers, and any bracketed value introduced as
+// a title. Explicit title forms such as "from [Track 2]" are safe, but a title
+// context never overrides a recognised production direction. Everything else
+// keeps the existing loose performance-cue vocabulary and bounded removal.
+function isLiteralBracket(body: string, prefix: string): boolean {
+  return isTitleQualifier(body)
+    || BRACKETED_TITLE_RE.test(body)
+    || (TITLE_CONTEXT_RE.test(prefix) && !PRODUCTION_CUE_RE.test(body));
 }
 
 function stripUnmatchedCueBrackets(text: string): string {
@@ -129,11 +143,11 @@ export function sanitizePerformanceCues(text: string, maxCues = 2): string {
     const body = cue[0].slice(1, -1).trim();
     const hasFollowingWords = SPOKEN_CHAR_RE.test(safeText.slice(end, nextStart));
     out += safeText.slice(cursor, start);
-    if (isPerformanceCue(body) && hasFollowingWords && kept < maxCues) {
+    if (isLiteralBracket(body, safeText.slice(0, start))) {
+      out += cue[0];
+    } else if (isPerformanceCue(body) && hasFollowingWords && kept < maxCues) {
       out += cue[0];
       kept += 1;
-    } else if (isTitleQualifier(body)) {
-      out += cue[0];
     } else if (!hasFollowingWords && nextStart === safeText.length) {
       // A terminal cue can carry only punctuation after its closing bracket
       // (`[sigh].`). The cue is not valid without following spoken words, and
@@ -145,6 +159,13 @@ export function sanitizePerformanceCues(text: string, maxCues = 2): string {
     cursor = end;
   }
   return (out + safeText.slice(cursor)).replace(/\s+/g, ' ').trim();
+}
+
+function literalizeBracketedSpeech(text: string): string {
+  return text.replace(PERFORMANCE_CUE_RE, (cue, offset: number) => {
+    const body = cue.slice(1, -1).trim();
+    return isLiteralBracket(body, text.slice(0, offset)) ? body : cue;
+  });
 }
 
 // Markup + entity cleanup — everything in the pipeline that is safe for a
@@ -234,6 +255,11 @@ export function normalizeForSpeech(
 ): string {
   if (!text) return text;
   let t = stripMarkup(text);
+
+  // Keep literal bracket content in the reader-facing form, but remove the
+  // cue-shaped delimiters before TTS so an expressive engine cannot interpret
+  // a real title/version such as "[Untitled]" or "[Live]" as direction.
+  t = literalizeBracketedSpeech(t);
 
   t = normalizeTtsPunctuation(t);
 

--- a/controller/src/broadcast/dj-agent.ts
+++ b/controller/src/broadcast/dj-agent.ts
@@ -582,6 +582,7 @@ async function pickViaPool(queue, ctx, { wantLink, current, showAt = null }: { w
   // Resolved HERE rather than up in runTrackEvent: the pick call above has
   // already spent part of the runway, and linkClockAt reads the live clock, so
   // asking now is the most honest the forecast can be on this path (#1314).
+  const clockAllowed = speakClockAllowed();
   const airAt = linkClockAt(showAt, Date.now());
   if (wantLink && current) {
     try {
@@ -593,7 +594,7 @@ async function pickViaPool(queue, ctx, { wantLink, current, showAt = null }: { w
         // generation-time clocks aired a track late; #1314: forecast clocks
         // aired a filler track early).
         previous: current, current: result.song, context: linkAirContext(ctx, airAt),
-        clockIsAirTime: !!airAt,
+        clockIsAirTime: !!airAt && clockAllowed,
         // Name the speaker explicitly. Left unset, scripts.generateLink falls
         // back to getEffectivePersona() on the wall clock, which disagrees with
         // the session inside the look-ahead window — the incoming DJ's line
@@ -645,7 +646,7 @@ async function pickViaPool(queue, ctx, { wantLink, current, showAt = null }: { w
   // than on `airAt` itself, so linkAirContext still steps the daypart tags to
   // air time — "after dark" stays accurate even when the numerals are withheld.
   const queued = await enqueuePick(queue, result.song, result.reason, result.source || 'pool', link, current, fx, {
-    linkClockAt: linkClockStampFor(airAt, speakClockAllowed()),
+    linkClockAt: linkClockStampFor(airAt, clockAllowed),
   });
   // Even the pool landed on an already-queued track (a tiny library whose pool
   // collapsed to recents). Skip the session turn and let auto.m3u backstop the

--- a/controller/src/llm/internal/prompts/scripts.ts
+++ b/controller/src/llm/internal/prompts/scripts.ts
@@ -12,7 +12,7 @@ import { isNamedRequester } from '../../../util/request-guard.js';
 import { introBudgetPhrase, introMsFor, firstVocalMsFor } from './intro-budget.js';
 import { trackEraYear } from '../../../music/show-filter.js';
 import { trackFeelSuffix } from './track-feel.js';
-import { announceLine } from '../../../broadcast/announce-line.js';
+import { announceLine, nextAnnounceForm } from '../../../broadcast/announce-line.js';
 import * as library from '../../../music/library.js';
 import { contextSleeveNotesFor, releaseYearMentionEligible, selectSleeveNotes, stationHistoryNoteFor } from './sleeve-notes.js';
 import { stripRecapSpokenTags, stripSpokenTags } from './recent-speech.js';
@@ -96,10 +96,11 @@ function verifiedContextPacket(context: any, current: any = null, clockIsAirTime
   const showName = String(context?.activeShow?.name || "").trim();
   if (showName) moment.push("Current show: \"" + showName + "\".");
   const handover = context?.showHandover;
-  const hasFollowingShow = handover?.phase === "final-quarter-hour" && handover?.nextShow?.name && handover?.nextShow?.presenter && handover?.nextShow?.startsAt;
+  const hasFollowingShow = handover?.phase === "final-quarter-hour" && handover?.nextShow?.name && handover?.nextShow?.presenter;
   if (hasFollowingShow) {
     moment.push("Current show is approaching its scheduled close.");
-    moment.push("Following show: \"" + String(handover.nextShow.name).trim() + "\" with " + String(handover.nextShow.presenter).trim() + ", starting " + String(handover.nextShow.startsAt).trim() + ".");
+    const startsAt = clockIsAirTime ? String(handover.nextShow.startsAt || "").trim() : "";
+    moment.push("Following show: \"" + String(handover.nextShow.name).trim() + "\" with " + String(handover.nextShow.presenter).trim() + (startsAt ? ", starting " + startsAt : "") + ".");
   }
   const playStats = current ? library.trackPlayStatsFor(current) : null;
   const playCount = playStats?.count ?? null;
@@ -390,6 +391,35 @@ export function linkPrompt({
   return sections.join('\n\n');
 }
 
+// Announce mode normally never needs a model: announceLine composes the fixed
+// English frame in code. A non-English persona or CJK artist tag does need one
+// narrow translation/romanisation pass, but it must not inherit linkPrompt's
+// editorial task, sleeve notes, recap or high-variance sampling. Those inputs
+// turn a two-word continuity job back into a natural DJ link.
+export function announceFallbackPrompt({ artist, form, persona }: {
+  artist: unknown;
+  form: 'this-is' | 'next-up';
+  persona: unknown;
+}): string {
+  const name = String(artist ?? '').replace(/\s+/g, ' ').trim().slice(0, 180);
+  const language = String(
+    (persona as { language?: unknown } | null | undefined)?.language || '',
+  ).trim() || 'English';
+  const source = form === 'this-is' ? `This is ${name}.` : `Next up, ${name}.`;
+  return [
+    'Task: Write one announce-only artist identification for radio continuity.',
+    'The only permitted source frames are "This is <artist>." and "Next up, <artist>."',
+    `Use this source frame for this line: ${JSON.stringify(source)}`,
+    `Render that same meaning naturally in ${language}. Translate only the framing words; preserve the artist's identity, using its established spelling or a natural romanisation when the on-air language uses another script.`,
+    'Output exactly one short sentence and nothing else. Do not add a track title, opinion, description, fact, scene, weather, greeting, station ident, transition, or bracketed direction.',
+  ].join('\n');
+}
+
+function announceFallbackSystem(speaker: unknown): string {
+  return 'You are a radio continuity writer. Follow the announce-only contract exactly; do not turn it into DJ commentary.'
+    + settings.languageDirective(speaker);
+}
+
 export async function generateLink(args: any) {
   const speaker = args.persona || settings.getEffectivePersona();
   if (settings.announceLinks(speaker)) {
@@ -399,6 +429,17 @@ export async function generateLink(args: any) {
     });
     if (composed) return composed;
     if (!String(args.current?.artist ?? '').trim()) return '';
+    const form = args.currentIsOnAir ? 'this-is' : nextAnnounceForm(args.lastLink ?? null);
+    return djText({
+      system: announceFallbackSystem(speaker),
+      prompt: announceFallbackPrompt({ artist: args.current.artist, form, persona: speaker }),
+      temperature: 0.2,
+      topP: 0.8,
+      repeatPenalty: 1.05,
+      seed: randomSeed(),
+      maxOutputTokens: 64,
+      kind: 'generateAnnounceLinkFallback',
+    });
   }
   return djText({
     system: djSystem(speaker),

--- a/controller/src/llm/internal/prompts/sleeve-notes.ts
+++ b/controller/src/llm/internal/prompts/sleeve-notes.ts
@@ -25,7 +25,7 @@ export function sleeveNotesFor(track: any, playCount: number | null = null): str
     notes.push(`Release year: ${year}.`);
   }
   if (Number.isInteger(playCount) && playCount! > 0) {
-    notes.push(`Station plays before today: ${playCount}.`);
+    notes.push(`Lifetime station plays: ${playCount}.`);
   }
   return notes;
 }

--- a/web/components/admin/settings/DjBehaviourSection.tsx
+++ b/web/components/admin/settings/DjBehaviourSection.tsx
@@ -155,9 +155,10 @@ export function DjBehaviourSection({ form, setForm, busy, saveSettings, fieldErr
 
       <Card title="Extended Sleeve Notes" sub="coming soon">
         <p className="text-[13px] leading-[1.55] text-muted">
-          Soon, the DJ will be able to use a fuller packet of verified track facts—such as
-          album, trusted release year and station-play history—when writing links. This will
-          remain separate from show steering and other editorial context.
+          Soon, the DJ will be able to add optional, source-backed editorial notes—such as
+          release credits or wider artist context—with provider provenance. Album, trusted
+          release year and station-play history already come from today&apos;s Verified Facts
+          packet; this future layer will stay opt-in and separate from show steering.
         </p>
       </Card>
 

--- a/web/components/admin/settings/registry.ts
+++ b/web/components/admin/settings/registry.ts
@@ -264,7 +264,7 @@ export const SETTINGS_INDEX: readonly IndexEntry[] = [
   // ── dj behaviour ───────────────────────────────────────────────────────────
   { label: 'Talk placement', section: 'behaviour', card: 'Talk placement', keywords: 'between tracks boundary interrupt over song duck mid-song' },
   { label: 'Show changes', section: 'behaviour', card: 'Show changes', keywords: 'handoff presenter same host acknowledgement shift transition programme' },
-  { label: 'Extended Sleeve Notes', section: 'behaviour', card: 'Extended Sleeve Notes', keywords: 'verified facts album release year station plays coming soon' },
+  { label: 'Extended Sleeve Notes', section: 'behaviour', card: 'Extended Sleeve Notes', keywords: 'source backed editorial provenance provider credits artist context coming soon' },
   { label: 'Link style', section: 'behaviour', card: 'Link style', keywords: 'release year regular occasional rare metadata sleeve notes' },
 
   // ── library tagger ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Post-merge verification of #1633 found five remaining gaps in clock-policy wiring, play-history wording, announce-only fallback behavior, bracketed-title speech sanitation, and Extended Sleeve Notes copy.

## What changed

- apply the shared clock policy to pool-link and handover time facts
- label the SQLite lifetime play count accurately
- give non-English and CJK announce fallback a dedicated low-variance, announce-only prompt
- preserve literal bracketed titles for display and speech while continuing to remove known production cues
- describe Extended Sleeve Notes as a future opt-in, provenance-backed editorial layer
- add isolated regressions through the real pool/provider wiring and temporary SQLite state

## Validation

- promoted regression tests: 11 passed, 0 failed
- focused DJ-link tests: 38 passed, 0 failed
- full controller suite: 1,653 passed, 0 failed across 241 test files
- controller lint and TypeScript: passed with 0 errors
- web lint and TypeScript: passed with 0 errors
- local Ollama text probe: clock policy held in 3/3 samples and announce-only behavior held in 2/2 samples

No live station, account credentials, paid model requests, or TTS/audio runtime was used. The local-model result is text-only evidence for one finite model, not universal model or audio proof.